### PR TITLE
Correction on readme for development setup

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -29,7 +29,7 @@ Install:
 `npm ci --ignore-scripts`
 
 Build:
-`npm run build`
+`npm run vendor && npm run build`
 
 Then depending on your browser:
 - Chrome: Browse to `chrome://extensions/` and click `Load unpacked` and point to `\extension\app\manifest.json`.


### PR DESCRIPTION
The `vendor` directory is not present on clone and errors out during `Load unpacked` step during setup on Chrome. Running `npm run vendor` before build fixes the issue.