### PR TITLE
Change simulation and signing controls UI behavior

### DIFF
--- a/extension/app/ts/components/pages/Home.tsx
+++ b/extension/app/ts/components/pages/Home.tsx
@@ -34,17 +34,13 @@ function FirstCard(param: FirstCardParams) {
 						<img src = { param.tabIcon } />
 					</span>
 				</div>
-				<div class = 'card-header-title'>
-					<input type = 'checkbox' id = 'toggle' style = 'display: none;' checked = { !param.simulationMode } class = 'toggleCheckbox' onInput = { e => { if (e.target instanceof HTMLInputElement && e.target !== null) { param.enableSimulationMode(!e.target.checked) } } } />
-					<label for = 'toggle' class = 'toggleContainer'>
-						<div style = 'font-weight: normal' >Simulating</div>
-						<div style = 'font-weight: normal;' >
-							<SignerLogoText
-								signerName = { param.signerName }
-								text = { 'Signing' }
-							/>
-						</div>
-					</label>
+				<div class = 'card-header-title px-0 is-justify-content-center'>
+					<div class='buttons has-addons'>
+						<button class={ `button is-primary${ param.simulationMode ? '' : ' is-outlined'}` } onClick={ () => param.enableSimulationMode(true) }>Simulating</button>
+						<button class={ `button is-primary${ param.simulationMode ? ' is-outlined' : ''}` } onClick={ () => param.enableSimulationMode(false) }>
+							<SignerLogoText signerName = { param.signerName } text = { 'Signing' } />
+						</button>
+					</div>
 				</div>
 				<div class = 'card-header-icon unset-cursor'>
 					<ChainSelector currentChain = { param.activeChain } changeChain = { (chainId: bigint) => { param.changeActiveChain(chainId) } }/>


### PR DESCRIPTION
Updated the simulation and signing controls to behave as per @MicahZoltu's description in issue #3. This change will require the user to deliberately click on the target mode to initiate the switch instead of toggling between the two when either side of the control is clicked.

Used built-in classes to get the design as close to the original without style attribute overrides

<img width="519" alt="Screenshot 2022-12-07 at 5 08 53 AM" src="https://user-images.githubusercontent.com/1169838/206023359-fec83ed6-515c-4e59-b58a-062ffa911314.png">
