### PR TITLE
Fixes inline error by requiring hash and not using module type

### DIFF
--- a/extension/app/html/background.html
+++ b/extension/app/html/background.html
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <html>
 	<body>
-		<script src = '../vendor/es-module-shims/es-module-shims.wasm.js'></script>
+		<script async src = '../vendor/es-module-shims/es-module-shims.wasm.js'></script>
 		<script type = 'importmap'>
 		{
 			"imports": {

--- a/extension/app/html/background.html
+++ b/extension/app/html/background.html
@@ -1,11 +1,7 @@
 <!DOCTYPE html>
 <html>
-	<head>
-		<meta charset = 'utf-8'>
-		<link rel = 'icon' type = 'image/x-icon' href = 'favicon.ico'>
-	</head>
 	<body>
-		<script async type = 'module' src = '../vendor/es-module-shims/es-module-shims.wasm.js'></script>
+		<script src = '../vendor/es-module-shims/es-module-shims.wasm.js'></script>
 		<script type = 'importmap'>
 		{
 			"imports": {

--- a/extension/app/html/changeChain.html
+++ b/extension/app/html/changeChain.html
@@ -10,7 +10,7 @@
 		<link rel = 'stylesheet' type = 'text/css' href = '../css/bulma-divider.css' />
 		<link rel = 'stylesheet' type = 'text/css' href = '../css/interceptor.css' />
 		<script src = '../vendor/webextension-polyfill/browser-polyfill.js'></script>
-		<script async type = 'module' src = '../vendor/es-module-shims/es-module-shims.wasm.js'></script>
+		<script async src = '../vendor/es-module-shims/es-module-shims.wasm.js'></script>
 		<script type = 'importmap'>
 		{
 			"imports": {

--- a/extension/app/html/confirmTransaction.html
+++ b/extension/app/html/confirmTransaction.html
@@ -10,8 +10,8 @@
 		<link rel="stylesheet" type="text/css" href="../css/bulma-divider.css" />
 		<link rel="stylesheet" type="text/css" href="../css/interceptor.css" />
 		<script src='../vendor/webextension-polyfill/browser-polyfill.js'></script>
-		<script async type='module' src='../vendor/es-module-shims/es-module-shims.wasm.js'></script>
-		<script type='importmap'>
+		<script async src='../vendor/es-module-shims/es-module-shims.wasm.js'></script>
+		<script type = 'importmap'>
 		{
 			"imports": {
 				"ethers": "../vendor/ethers/ethers.esm.js",
@@ -28,7 +28,7 @@
 				"@darkflorist/address-metadata": "../vendor/@darkflorist/address-metadata/index.js"
 			}
 		}
-	</script>
+		</script>
 
 		<main>Loading...</main>
 

--- a/extension/app/html/interceptorAccess.html
+++ b/extension/app/html/interceptorAccess.html
@@ -24,7 +24,8 @@
 				"node-fetch": "../vendor/node-fetch/index.mjs",
 				"@zoltu/ethereum-abi-encoder": "../vendor/@zoltu/ethereum-abi-encoder/index.js",
 				"@zoltu/ethereum-crypto": "../vendor/@zoltu/ethereum-crypto/index.js",
-				"@zoltu/rlp-encoder": "../vendor/@zoltu/rlp-encoder/index.js"
+				"@zoltu/rlp-encoder": "../vendor/@zoltu/rlp-encoder/index.js",
+				"@darkflorist/address-metadata": "../vendor/@darkflorist/address-metadata/index.js"
 			}
 		}
 		</script>

--- a/extension/app/html/interceptorAccess.html
+++ b/extension/app/html/interceptorAccess.html
@@ -10,7 +10,7 @@
 		<link rel = 'stylesheet' type = 'text/css' href = '../css/bulma-divider.css' />
 		<link rel = 'stylesheet' type = 'text/css' href = '../css/interceptor.css' />
 		<script src = '../vendor/webextension-polyfill/browser-polyfill.js'></script>
-		<script async type = 'module' src = '../vendor/es-module-shims/es-module-shims.wasm.js'></script>
+		<script async src = '../vendor/es-module-shims/es-module-shims.wasm.js'></script>
 		<script type = 'importmap'>
 		{
 			"imports": {

--- a/extension/app/html/personalSign.html
+++ b/extension/app/html/personalSign.html
@@ -10,8 +10,8 @@
 		<link rel="stylesheet" type="text/css" href="../css/bulma-divider.css" />
 		<link rel="stylesheet" type="text/css" href="../css/interceptor.css" />
 		<script src='../vendor/webextension-polyfill/browser-polyfill.js'></script>
-		<script async type='module' src='../vendor/es-module-shims/es-module-shims.wasm.js'></script>
-		<script type='importmap'>
+		<script async src='../vendor/es-module-shims/es-module-shims.wasm.js'></script>
+		<script type = 'importmap'>
 		{
 			"imports": {
 				"ethers": "../vendor/ethers/ethers.esm.js",

--- a/extension/app/html/popup.html
+++ b/extension/app/html/popup.html
@@ -11,7 +11,7 @@
 		<link rel = 'stylesheet' type = 'text/css' href = '../css/bulma-badge.css' />
 		<link rel = 'stylesheet' type = 'text/css' href = '../css/interceptor.css' />
 		<script src = '../vendor/webextension-polyfill/browser-polyfill.js'></script>
-		<script async type = 'module' src = '../vendor/es-module-shims/es-module-shims.wasm.js'></script>
+		<script async src = '../vendor/es-module-shims/es-module-shims.wasm.js'></script>
 		<script type = 'importmap'>
 		{
 			"imports": {

--- a/extension/app/manifest.json
+++ b/extension/app/manifest.json
@@ -23,7 +23,7 @@
 		"webNavigation"
 	],
 	"web_accessible_resources": ["vendor/*", "js/*", "inpage/*"],
-	"content_security_policy": "script-src 'self' blob: 'unsafe-eval'; object-src 'self';",
+	"content_security_policy": "script-src 'self' 'sha256-Wt5bI4gKonDfzuTQo2amECh42QZMZy6vq93zZbd+q3M=' blob: 'unsafe-eval'; object-src 'self';",
 	"content_scripts": [
 		{
 			"matches": ["file://*/*", "http://*/*", "https://*/*"],


### PR DESCRIPTION
Fixes https://github.com/DarkFlorist/TheInterceptor/issues/15

The downside of this is, that when the vendor stuff is changed, the hash changes and developer needs to remember to update the hash to `content_security_policy`. Is there a better way for this?