### PR TITLE
Fixes mew

### DIFF
--- a/extension/app/ts/background/background.ts
+++ b/extension/app/ts/background/background.ts
@@ -3,7 +3,7 @@ import 'webextension-polyfill'
 import { Simulator } from '../simulation/simulator.js'
 import { EIP2612Message, EthereumAddress, EthereumQuantity, EthereumUnsignedTransaction } from '../utils/wire-types.js'
 import { getSettings, saveActiveChain, saveActiveSigningAddress, saveActiveSimulationAddress, Settings } from './settings.js'
-import { blockNumber, call, chainId, estimateGas, gasPrice, getAccounts, getBalance, getBlockByNumber, getCode, getPermissions, getTransactionByHash, getTransactionReceipt, personalSign, requestPermissions, sendRawTransaction, sendTransaction, signTypedDataV4, subscribe, switchEthereumChain, unsubscribe } from './simulationModeHanders.js'
+import { blockNumber, call, chainId, estimateGas, gasPrice, getAccounts, getBalance, getBlockByNumber, getCode, getPermissions, getTransactionByHash, getTransactionCount, getTransactionReceipt, personalSign, requestPermissions, sendRawTransaction, sendTransaction, signTypedDataV4, subscribe, switchEthereumChain, unsubscribe } from './simulationModeHanders.js'
 import { changeActiveAddress, changeAddressInfos, changeMakeMeRich, changePage, resetSimulation, confirmDialog, RefreshSimulation, removeTransaction, requestAccountsFromSigner, refreshPopupConfirmTransactionSimulation, confirmPersonalSign, confirmRequestAccess, changeInterceptorAccess, changeChainDialog, popupChangeActiveChain, enableSimulationMode, reviewNotification, rejectNotification } from './popupMessageHandlers.js'
 import { AddressMetadata, SimResults, SimulationState, TokenPriceEstimate } from '../utils/visualizer-types.js'
 import { WebsiteApproval, SignerState } from '../utils/user-interface-types.js'
@@ -289,12 +289,12 @@ export const handlers = new Map<string, SimulationHandler >([
 	['eth_accounts', getAccounts.bind(undefined, getActiveAddressForDomain)],
 	['eth_requestAccounts', getAccounts.bind(undefined, getActiveAddressForDomain)],
 	['eth_sendRawTransaction', sendRawTransaction],
-	['eth_gasPrice', gasPrice]
+	['eth_gasPrice', gasPrice],
+	['eth_getTransactionCount', getTransactionCount],
 
 	/*
 	Missing methods:
 	['eth_getProof', ],
-	['eth_getTransactionCount', ],
 	['eth_getBlockTransactionCountByNumber', ],
 	['eth_getTransactionByBlockHashAndIndex', ],
 	['eth_getTransactionByBlockNumberAndIndex', ],

--- a/extension/app/ts/utils/wire-types.ts
+++ b/extension/app/ts/utils/wire-types.ts
@@ -784,3 +784,9 @@ export const EIP2612Message = t.Object({
 		deadline: t.Number,
 	}),
 })
+
+export type GetTransactionCount = t.Static<typeof GetTransactionCount>
+export const GetTransactionCount = t.Object({
+	method: t.Literal('eth_getTransactionCount'),
+	params: t.Tuple(EthereumAddress, EthereumBlockTag)
+}).asReadonly()


### PR DESCRIPTION
Fixes https://github.com/DarkFlorist/TheInterceptor/issues/51

- Fixes bug that Interceptor only supports single `window.ethereum.on()` callbacks, now it supports arbitrary many
- Add `window.ethereum.removeListener` to remove callback functions
- Adds `eth_getTransactionCount`
- When DApp asks to switch chain, and we are already on that chain, do not ask anything from user and just return
