### PR TITLE
Refactor in page to be a class and get rid of some global variables

### DIFF
--- a/extension/app/inpage/output/injected_document_start.js
+++ b/extension/app/inpage/output/injected_document_start.js
@@ -271,8 +271,6 @@ class InterceptorMessageListener {
                 throw new Error('missing options field');
             if (!('method' in messageEvent.data.options))
                 throw new Error('missing method field');
-            if (!('param' in messageEvent.data.options))
-                throw new Error('missing param field');
             const forwardRequest = messageEvent.data; //use "as" here as we don't want to inject funtypes here
             if (forwardRequest.error !== undefined) {
                 if (forwardRequest.requestId === undefined || !this.outstandingRequests.has(forwardRequest.requestId))

--- a/extension/app/inpage/ts/document_start.ts
+++ b/extension/app/inpage/ts/document_start.ts
@@ -53,20 +53,4 @@ function injectScript(content: any) {
 	}
 }
 
-const injected_ts = `[[injected.ts]]`
-
-const capturer = `
-var interceptorCapturedDispatcher = window.dispatchEvent
-window.dispatchEvent = function (event) {
-    interceptorCapturedDispatcher(event)
-    if (event.type === 'ethereum#initialized') {
-		console.log('Interceptor: Detected MetaMask injection, reinject')
-		injectEthereumIntoWindow()
-		window.dispatchEvent = interceptorCapturedDispatcher
-	}
-}
-`
-
-const inpageContent = capturer + injected_ts
-
-injectScript(inpageContent)
+injectScript(`[[injected.ts]]`)

--- a/extension/app/inpage/ts/inpage.ts
+++ b/extension/app/inpage/ts/inpage.ts
@@ -93,209 +93,82 @@ type AnyCallBack =  ((message: ProviderMessage) => void)
 	| ( (error: ProviderRpcError) => void )
 	| ( (chainId: string) => void )
 
-interface Window {
-	dispatchEvent: any,
-	ethereum?: {
-		request: (options: { readonly method: string, readonly params?: unknown[] }) => Promise<unknown>,
-		send: unknown,
-		sendAsync: unknown,
-		on: (kind: OnMessage, callback: AnyCallBack) => Promise<void>,
-		removeListener: (kind: OnMessage, callback: AnyCallBack) => Promise<void>,
-		usingInterceptorWithoutSigner?: boolean, // are we using Interceptor as a wallet instead of an external signer
-		oldRequest?: (options: { readonly method: string, readonly params?: unknown[] }) => Promise<unknown>,
-		oldOn?: (kind: OnMessage, callback: AnyCallBack) => Promise<void>,
-		enable: () => void,
-		isBraveWallet?: boolean,
-		isMetaMask?: boolean,
-		isConnected: () => boolean,
-	},
-	interceptor: {
-		interceptorInjected: boolean,
-		connected: boolean,
-		requestId: number,
-		outstandingRequests: Map<number, InterceptorFuture<unknown> >,
-		onMessageCallBacks: Set<((message: ProviderMessage) => void)>,
-		onConnectCallBacks: Set<((connectInfo: ProviderConnectInfo) => void)>
-		onAccountsChangedCallBacks: Set<((accounts: string[]) => void)>,
-		onDisconnectCallBacks: Set<((error: ProviderRpcError) => void)>,
-		onChainChangedCallBacks: Set<((chainId: string) => void)>,
-	}
+type EthereumRequest = (options: { readonly method: string, readonly params?: unknown[] }) => Promise<unknown>
+
+type InjectFunctions = {
+	request: EthereumRequest,
+	send: unknown,
+	sendAsync: unknown,
+	on: (kind: OnMessage, callback: AnyCallBack) => Promise<void>,
+	removeListener: (kind: OnMessage, callback: AnyCallBack) => Promise<void>,
+	isConnected: () => boolean,
+	enable: () => void,
 }
 
-window.interceptor = {
-	interceptorInjected: false,
-	connected: false,
-	requestId: 0,
-	outstandingRequests: new Map(),
-	onMessageCallBacks: new Set(),
-	onConnectCallBacks: new Set(),
-	onAccountsChangedCallBacks: new Set(),
-	onDisconnectCallBacks: new Set(),
-	onChainChangedCallBacks: new Set(),
+type WindowEthereum = InjectFunctions & {
+	isBraveWallet?: boolean,
+	isMetaMask?: boolean,
+}
+
+interface Window {
+	dispatchEvent: any,
+	ethereum?: WindowEthereum
 }
 
 type OnMessage = "accountsChanged" | "message" | "connect" | "error" | "close" | "disconnect" | "chainChanged"
 
-function startListeningForMessages() {
-	async function requestAccounts() {
-		if( !('ethereum' in window) || !window.ethereum || !('oldRequest' in window.ethereum) || window.ethereum.oldRequest === undefined) return
-		const reply = await window.ethereum.oldRequest({method: 'eth_requestAccounts', params: []})
-
-		if ( Array.isArray(reply) ) {
-			window.postMessage({
-				interceptorRequest: true,
-				options: {
-					method: 'eth_accounts_reply',
-					params: reply,
-				},
-				usingInterceptorWithoutSigner: window.ethereum.usingInterceptorWithoutSigner,
-			}, '*')
-		}
-	}
-
-	async function requestChainId() {
-		if( !('ethereum' in window) || !window.ethereum || !('oldRequest' in window.ethereum) || window.ethereum.oldRequest === undefined) return
-		const reply = await window.ethereum.oldRequest( { method: 'eth_chainId', params: [] } )
-		if ( typeof reply === 'string') {
-			window.postMessage({
-				interceptorRequest: true,
-				options: {
-					method: 'signer_chainChanged',
-					params: [ reply ],
-				},
-				usingInterceptorWithoutSigner: window.ethereum.usingInterceptorWithoutSigner,
-			}, '*')
-		}
-	}
-
-	function checkErrorForCode(error: unknown): error is { code: number } {
-		if (typeof error !== 'object') return false
-		if (error === null) return false
-		if (!('code' in error)) return false
-		if (typeof (error as { code: unknown }).code !== 'number') return false
-		return true
-	}
-
-	async function requestChangeChain(chainId: string) {
-		if( !('ethereum' in window) || !window.ethereum || !('oldRequest' in window.ethereum) || window.ethereum.oldRequest === undefined) return
-
-		try {
-			const reply = await window.ethereum.oldRequest( { method: 'wallet_switchEthereumChain', params: [ { 'chainId': chainId } ] } )
-			if ( reply === null) {
-				window.postMessage({
-					interceptorRequest: true,
-					options: {
-						method: 'wallet_switchEthereumChain_reply',
-						params: [ { accept: true, chainId: chainId } ],
-					},
-					usingInterceptorWithoutSigner: window.ethereum.usingInterceptorWithoutSigner,
-				}, '*')
-			}
-		} catch (error) {
-			if( checkErrorForCode(error) && ( error.code === METAMASK_ERROR_USER_REJECTED_REQUEST || error.code === METAMASK_ERROR_CHAIN_NOT_ADDED_TO_METAMASK ) ) {
-				return window.postMessage({
-					interceptorRequest: true,
-					options: {
-						method: 'wallet_switchEthereumChain_reply',
-						params: [ { accept: false, chainId: chainId  } ],
-					},
-					usingInterceptorWithoutSigner: window.ethereum.usingInterceptorWithoutSigner,
-				}, '*')
-			}
-			throw error
-		}
-	}
-
-	async function onMessage(messageEvent: any) {
-		if (
-			typeof messageEvent !== 'object'
-			|| messageEvent === null
-			|| !('data' in messageEvent)
-			|| typeof messageEvent.data !== 'object'
-			|| messageEvent.data === null
-			|| !('interceptorApproved' in messageEvent.data)
-		) return
-		if (!('ethereum' in window) || !window.ethereum) throw 'window.ethereum changed'
-		if (!('options' in messageEvent.data || 'method' in messageEvent.data.options || 'params' in messageEvent.data.options)) throw 'missing fields'
-		const forwardRequest = messageEvent.data as InterceptedRequestForward //use "as" here as we don't want to inject funtypes here
-		if (forwardRequest.error !== undefined) {
-			if (forwardRequest.requestId === undefined || !window.interceptor.outstandingRequests.has(forwardRequest.requestId)) throw new EthereumJsonRpcError(forwardRequest.error.code, forwardRequest.error.message)
-			return window.interceptor.outstandingRequests.get(forwardRequest.requestId)!.reject(new EthereumJsonRpcError(forwardRequest.error.code, forwardRequest.error.message))
-		}
-		if (forwardRequest.result !== undefined) {
-			// if interceptor direclty sent us the result, just forward that to the dapp, otherwise ask the signer for the result
-			if (forwardRequest.subscription !== undefined) {
-				return window.interceptor.onMessageCallBacks.forEach( (f) => f( { type: 'eth_subscription', data: forwardRequest.result } ))
-			}
-			if (forwardRequest.options.method === 'accountsChanged') {
-				return window.interceptor.onAccountsChangedCallBacks.forEach( (f) => f( forwardRequest.result as string[] ) )
-			}
-			if (forwardRequest.options.method === 'connect') {
-				window.interceptor.connected = true
-				return window.interceptor.onConnectCallBacks.forEach( (f) => f( { chainId: forwardRequest.result as string } ) )
-			}
-			if (forwardRequest.options.method === 'disconnect') {
-				window.interceptor.connected = false
-				const resultArray = forwardRequest.result as { code: number, message: string }
-				return window.interceptor.onDisconnectCallBacks.forEach( (f) => f( { name: 'disconnect', ...resultArray } ) )
-			}
-			if (forwardRequest.options.method === 'chainChanged') {
-				return window.interceptor.onChainChangedCallBacks.forEach( (f) => f( forwardRequest.result as string ) )
-			}
-			if (forwardRequest.options.method === 'request_signer_to_eth_requestAccounts') {
-				// when dapp requsts eth_requestAccounts, interceptor needs to reply to it, but we also need to try to sign to the signer
-				return await requestAccounts()
-			}
-			if (forwardRequest.options.method === 'request_signer_to_wallet_switchEthereumChain') {
-				return await requestChangeChain( forwardRequest.result as string )
-			}
-			if (forwardRequest.options.method === 'request_signer_chainId') {
-				return await requestChainId()
-			}
-			if ( forwardRequest.requestId === undefined) return
-			return window.interceptor.outstandingRequests.get(forwardRequest.requestId)!.resolve(forwardRequest.result)
-		}
-
-		try {
-			if ( window.ethereum.usingInterceptorWithoutSigner ) throw 'Interceptor is in wallet mode and should not forward to an external wallet'
-			if ( window.ethereum.oldRequest === undefined) throw 'Old provider missing'
-			const reply = await window.ethereum.oldRequest(forwardRequest.options)
-
-			if ( forwardRequest.requestId === undefined) return
-			window.interceptor.outstandingRequests.get(forwardRequest.requestId)!.resolve(reply)
-		} catch (error) {
-			// if it is an Error, add context to it if context doesn't already exist
-			console.log(error)
-			console.log(messageEvent)
-			if (forwardRequest.requestId === undefined) throw error
-			if (error instanceof Error) {
-				if (!('code' in error)) (error as any).code = -32603
-				if (!('data' in error) || (error as any).data === undefined || (error as any).data === null) (error as any).data = { request: forwardRequest.options }
-				else if (!('request' in (error as any).data)) (error as any).data.request = forwardRequest.options
-				return window.interceptor.outstandingRequests.get(forwardRequest.requestId)!.reject(error)
-			}
-			if ((error as any).code !== undefined && (error as any).message !== undefined) {
-				return window.interceptor.outstandingRequests.get(forwardRequest.requestId)!.reject(new EthereumJsonRpcError((error as any).code, (error as any).message, { request: forwardRequest.options }))
-			}
-			// if the signer we are connected threw something besides an Error, wrap it up in an error
-			window.interceptor.outstandingRequests.get(forwardRequest.requestId)!.reject(new EthereumJsonRpcError(-32603, `Unexpected thrown value.`, { error: error, request: forwardRequest.options }))
-		}
-	}
-	window.addEventListener('message', onMessage)
+function checkErrorForCode(error: unknown): error is { code: number } {
+	if (typeof error !== 'object') return false
+	if (error === null) return false
+	if (!('code' in error)) return false
+	if (typeof (error as { code: unknown }).code !== 'number') return false
+	return true
 }
+class InterceptorMessageListener {
+	private connected: boolean = false
+	private requestId: number = 0
+	private signerRequest: EthereumRequest | undefined
+	private usingInterceptorWithoutSigner: boolean = true
+	private readonly outstandingRequests: Map<number, InterceptorFuture<unknown> > = new Map()
+	private readonly onMessageCallBacks: Set<((message: ProviderMessage) => void)> = new Set()
+	private readonly onConnectCallBacks: Set<((connectInfo: ProviderConnectInfo) => void)> = new Set()
+	private readonly onAccountsChangedCallBacks: Set<((accounts: string[]) => void)> = new Set()
+	private readonly onDisconnectCallBacks: Set<((error: ProviderRpcError) => void)> = new Set()
+	private readonly onChainChangedCallBacks: Set<((chainId: string) => void)> = new Set()
 
-function injectEthereumIntoWindow() {
-	const request = async (options: { readonly method: string, readonly params?: unknown[] }) => {
-		window.interceptor.requestId++
-		const currentRequestId = window.interceptor.requestId
+	public constructor() {
+		this.injectEthereumIntoWindow()
+
+		const interceptorCapturedDispatcher = window.dispatchEvent
+		window.dispatchEvent = (event: any) => {
+			interceptorCapturedDispatcher(event)
+			if (event.type === 'ethereum#initialized') {
+				console.log('Interceptor: Detected MetaMask reinject')
+				this.injectEthereumIntoWindow()
+				window.dispatchEvent = interceptorCapturedDispatcher
+			}
+		}
+		console.log('start listening...')
+		window.addEventListener('message', this.onMessage)
+	}
+
+	private isConnected = () => {
+		return this.connected
+	}
+
+	// sends messag to The Interceptor background page
+	private request = async (options: { readonly method: string, readonly params?: unknown[] }) => {
+		this.requestId++
+		const currentRequestId = this.requestId
 		const future = new InterceptorFuture<unknown>()
-		window.interceptor.outstandingRequests.set(currentRequestId, future)
+		this.outstandingRequests.set(currentRequestId, future)
+		console.log(`request: ${currentRequestId}: ${options.method}`)
 
 		try {
 			// make a message that the background script will catch and reply us. We'll wait until the background script replies to us and return only after that
 			window.postMessage({
 				interceptorRequest: true,
-				usingInterceptorWithoutSigner: window.ethereum!.usingInterceptorWithoutSigner,
+				usingInterceptorWithoutSigner: this.usingInterceptorWithoutSigner,
 				requestId: currentRequestId,
 				options: {
 					method: options.method,
@@ -315,81 +188,224 @@ function injectEthereumIntoWindow() {
 			// if someone threw something besides an Error, wrap it up in an error
 			throw new EthereumJsonRpcError(-32603, `Unexpected thrown value.`, { error: error, request: options })
 		} finally {
-			window.interceptor.outstandingRequests.delete(currentRequestId)
+			console.log(`delete request: ${currentRequestId}: ${options.method}`)
+			this.outstandingRequests.delete(currentRequestId)
 		}
 	}
 
 	// 🤬 Uniswap, among others, require `send` to be implemented even though it was never part of any final specification.
 	// To make matters worse, some versions of send will have a first parameter that is an object (like `request`) and others will have a first and second parameter.
 	// On top of all that, some applications have a mix of both!
-	const send = async (method: string | {method: string, params: unknown[]}, params: unknown[]) => {
+	private send = async (method: string | {method: string, params: unknown[]}, params: unknown[]) => {
 		if (typeof method === 'object') {
-			return await request({ method: method.method, params: method.params})
+			return await this.request({ method: method.method, params: method.params})
 		} else {
-			return await request({ method, params })
+			return await this.request({ method, params })
 		}
 	}
 
-	const sendAsync = async (payload: { id: string | number | null, method: string, params: unknown[] }, callback: (error: IJsonRpcError | null, response: IJsonRpcSuccess<unknown> | null) => void) => {
-		request(payload)
+	private sendAsync = async (payload: { id: string | number | null, method: string, params: unknown[] }, callback: (error: IJsonRpcError | null, response: IJsonRpcSuccess<unknown> | null) => void) => {
+		this.request(payload)
 			.then(result => callback(null, { jsonrpc: '2.0', id: payload.id, result }))
 			// since `request(...)` only throws things shaped like `JsonRpcError`, we can rely on it having those properties.
 			.catch(error => callback({ jsonrpc: '2.0', id: payload.id, error: { code: error.code, message: error.message, data: { ...error.data, stack: error.stack } } }, null))
 	}
 
-	const on = async (kind: OnMessage, callback: AnyCallBack) => {
+	private on = async (kind: OnMessage, callback: AnyCallBack) => {
 		switch (kind) {
 			case 'accountsChanged':
-				window.interceptor.onAccountsChangedCallBacks.add( callback as (accounts: string[]) => void )
+				this.onAccountsChangedCallBacks.add( callback as (accounts: string[]) => void )
 				return
 			case 'message':
-				window.interceptor.onMessageCallBacks.add(callback as (message: ProviderMessage) => void)
+				this.onMessageCallBacks.add(callback as (message: ProviderMessage) => void)
 				return
 			case 'connect':
-				window.interceptor.onConnectCallBacks.add(callback as (connectInfo: ProviderConnectInfo) => void)
+				this.onConnectCallBacks.add(callback as (connectInfo: ProviderConnectInfo) => void)
 				return
 			case 'close': //close is deprecated on eip-1193 by disconnect but its still used by dapps (MyEtherWallet)
-				window.interceptor.onDisconnectCallBacks.add(callback as (error: ProviderRpcError) => void)
+				this.onDisconnectCallBacks.add(callback as (error: ProviderRpcError) => void)
 				return
 			case 'disconnect':
-				window.interceptor.onDisconnectCallBacks.add(callback as (error: ProviderRpcError) => void)
+				this.onDisconnectCallBacks.add(callback as (error: ProviderRpcError) => void)
 				return
 			case 'chainChanged':
-				window.interceptor.onChainChangedCallBacks.add(callback as (chainId: string) => void)
+				this.onChainChangedCallBacks.add(callback as (chainId: string) => void)
 				return
 			default:
 		}
 	}
 
-	const removeListener = async (kind: OnMessage, callback: AnyCallBack) => {
+	private removeListener = async (kind: OnMessage, callback: AnyCallBack) => {
 		switch (kind) {
 			case 'accountsChanged':
-				window.interceptor.onAccountsChangedCallBacks.delete(callback as (accounts: string[]) => void)
+				this.onAccountsChangedCallBacks.delete(callback as (accounts: string[]) => void)
 				return
 			case 'message':
-				window.interceptor.onMessageCallBacks.delete(callback as (message: ProviderMessage) => void)
+				this.onMessageCallBacks.delete(callback as (message: ProviderMessage) => void)
 				return
 			case 'connect':
-				window.interceptor.onConnectCallBacks.delete(callback as (connectInfo: ProviderConnectInfo) => void)
+				this.onConnectCallBacks.delete(callback as (connectInfo: ProviderConnectInfo) => void)
 				return
 			case 'close': //close is deprecated on eip-1193 by disconnect but its still used by dapps (MyEtherWallet)
-				window.interceptor.onDisconnectCallBacks.delete(callback as (error: ProviderRpcError) => void)
+				this.onDisconnectCallBacks.delete(callback as (error: ProviderRpcError) => void)
 				return
 			case 'disconnect':
-				window.interceptor.onDisconnectCallBacks.delete(callback as (error: ProviderRpcError) => void)
+				this.onDisconnectCallBacks.delete(callback as (error: ProviderRpcError) => void)
 				return
 			case 'chainChanged':
-				window.interceptor.onChainChangedCallBacks.delete(callback as (chainId: string) => void)
+				this.onChainChangedCallBacks.delete(callback as (chainId: string) => void)
 				return
 			default:
 		}
 	}
 
-	const isConnected = () => {
-		return window.interceptor.connected
+	private enable = async () => {
+		this.request({ method: 'eth_requestAccounts' })
 	}
 
-	const sendConnectedMessage = (signerName: 'NoSigner' | 'NotRecognizedSigner' | 'MetaMask' | 'Brave' ) => {
+	// listens for Interceptor, DApps, and signers messaes
+	private async requestAccounts() {
+		if( !('ethereum' in window) || !window.ethereum || !('oldRequest' in window.ethereum) || this.signerRequest === undefined ) return
+		const reply = await this.signerRequest({ method: 'eth_requestAccounts', params: [] })
+
+		if ( Array.isArray(reply) ) {
+			window.postMessage({
+				interceptorRequest: true,
+				options: {
+					method: 'eth_accounts_reply',
+					params: reply,
+				},
+				usingInterceptorWithoutSigner: this.usingInterceptorWithoutSigner,
+			}, '*')
+		}
+	}
+
+	private async requestChainId() {
+		if( !('ethereum' in window) || !window.ethereum || !('oldRequest' in window.ethereum) || this.signerRequest === undefined ) return
+		const reply = await this.signerRequest( { method: 'eth_chainId', params: [] } )
+		if ( typeof reply === 'string') {
+			window.postMessage({
+				interceptorRequest: true,
+				options: {
+					method: 'signer_chainChanged',
+					params: [ reply ],
+				},
+				usingInterceptorWithoutSigner: this.usingInterceptorWithoutSigner,
+			}, '*')
+		}
+	}
+
+	private async requestChangeChain(chainId: string) {
+		if( !('ethereum' in window) || !window.ethereum || !('oldRequest' in window.ethereum) || this.signerRequest === undefined) return
+
+		try {
+			const reply = await this.signerRequest( { method: 'wallet_switchEthereumChain', params: [ { 'chainId': chainId } ] } )
+			if ( reply === null) {
+				window.postMessage({
+					interceptorRequest: true,
+					options: {
+						method: 'wallet_switchEthereumChain_reply',
+						params: [ { accept: true, chainId: chainId } ],
+					},
+					usingInterceptorWithoutSigner: this.usingInterceptorWithoutSigner,
+				}, '*')
+			}
+		} catch (error) {
+			if( checkErrorForCode(error) && ( error.code === METAMASK_ERROR_USER_REJECTED_REQUEST || error.code === METAMASK_ERROR_CHAIN_NOT_ADDED_TO_METAMASK ) ) {
+				return window.postMessage({
+					interceptorRequest: true,
+					options: {
+						method: 'wallet_switchEthereumChain_reply',
+						params: [ { accept: false, chainId: chainId  } ],
+					},
+					usingInterceptorWithoutSigner: this.usingInterceptorWithoutSigner,
+				}, '*')
+			}
+			throw error
+		}
+	}
+
+	private async onMessage(messageEvent: any) {
+		if (
+			typeof messageEvent !== 'object'
+			|| messageEvent === null
+			|| !('data' in messageEvent)
+			|| typeof messageEvent.data !== 'object'
+			|| messageEvent.data === null
+			|| !('interceptorApproved' in messageEvent.data)
+		) return
+		if (!('ethereum' in window) || !window.ethereum) throw 'window.ethereum changed'
+		if (!('options' in messageEvent.data || 'method' in messageEvent.data.options || 'params' in messageEvent.data.options)) throw 'missing fields'
+		const forwardRequest = messageEvent.data as InterceptedRequestForward //use "as" here as we don't want to inject funtypes here
+		console.log(`reply: ${forwardRequest.requestId}: ${forwardRequest.options.method}`)
+		console.log(this.outstandingRequests.keys())
+		if (forwardRequest.error !== undefined) {
+			if (forwardRequest.requestId === undefined || !this.outstandingRequests.has(forwardRequest.requestId)) throw new EthereumJsonRpcError(forwardRequest.error.code, forwardRequest.error.message)
+			return this.outstandingRequests.get(forwardRequest.requestId)!.reject(new EthereumJsonRpcError(forwardRequest.error.code, forwardRequest.error.message))
+		}
+		if (forwardRequest.result !== undefined) {
+			// if interceptor direclty sent us the result, just forward that to the dapp, otherwise ask the signer for the result
+			if (forwardRequest.subscription !== undefined) {
+				return this.onMessageCallBacks.forEach( (f) => f( { type: 'eth_subscription', data: forwardRequest.result } ))
+			}
+			if (forwardRequest.options.method === 'accountsChanged') {
+				return this.onAccountsChangedCallBacks.forEach( (f) => f( forwardRequest.result as string[] ) )
+			}
+			if (forwardRequest.options.method === 'connect') {
+				this.connected = true
+				return this.onConnectCallBacks.forEach( (f) => f( { chainId: forwardRequest.result as string } ) )
+			}
+			if (forwardRequest.options.method === 'disconnect') {
+				this.connected = false
+				const resultArray = forwardRequest.result as { code: number, message: string }
+				return this.onDisconnectCallBacks.forEach( (f) => f( { name: 'disconnect', ...resultArray } ) )
+			}
+			if (forwardRequest.options.method === 'chainChanged') {
+				return this.onChainChangedCallBacks.forEach( (f) => f( forwardRequest.result as string ) )
+			}
+			if (forwardRequest.options.method === 'request_signer_to_eth_requestAccounts') {
+				// when dapp requsts eth_requestAccounts, interceptor needs to reply to it, but we also need to try to sign to the signer
+				return await this.requestAccounts()
+			}
+			if (forwardRequest.options.method === 'request_signer_to_wallet_switchEthereumChain') {
+				return await this.requestChangeChain( forwardRequest.result as string )
+			}
+			if (forwardRequest.options.method === 'request_signer_chainId') {
+				return await this.requestChainId()
+			}
+			if ( forwardRequest.requestId === undefined) return
+			return this.outstandingRequests.get(forwardRequest.requestId)!.resolve(forwardRequest.result)
+		}
+
+		try {
+			if ( this.usingInterceptorWithoutSigner ) throw 'Interceptor is in wallet mode and should not forward to an external wallet'
+			if ( this.signerRequest == undefined) throw 'signer not found'
+			console.log('signer request')
+			const reply = await this.signerRequest(forwardRequest.options)
+
+			if ( forwardRequest.requestId === undefined) return
+			this.outstandingRequests.get(forwardRequest.requestId)!.resolve(reply)
+			console.log(`resolved: ${forwardRequest.requestId}: ${forwardRequest.options.method}`)
+		} catch (error) {
+			// if it is an Error, add context to it if context doesn't already exist
+			console.log(error)
+			console.log(messageEvent)
+			if (forwardRequest.requestId === undefined) throw error
+			if (error instanceof Error) {
+				if (!('code' in error)) (error as any).code = -32603
+				if (!('data' in error) || (error as any).data === undefined || (error as any).data === null) (error as any).data = { request: forwardRequest.options }
+				else if (!('request' in (error as any).data)) (error as any).data.request = forwardRequest.options
+				return this.outstandingRequests.get(forwardRequest.requestId)!.reject(error)
+			}
+			if ((error as any).code !== undefined && (error as any).message !== undefined) {
+				return this.outstandingRequests.get(forwardRequest.requestId)!.reject(new EthereumJsonRpcError((error as any).code, (error as any).message, { request: forwardRequest.options }))
+			}
+			// if the signer we are connected threw something besides an Error, wrap it up in an error
+			this.outstandingRequests.get(forwardRequest.requestId)!.reject(new EthereumJsonRpcError(-32603, `Unexpected thrown value.`, { error: error, request: forwardRequest.options }))
+		}
+	}
+
+	private sendConnectedMessage = (signerName: 'NoSigner' | 'NotRecognizedSigner' | 'MetaMask' | 'Brave') => {
 		if( !('ethereum' in window) || !window.ethereum) return
 		window.postMessage({
 			interceptorRequest: true,
@@ -397,79 +413,73 @@ function injectEthereumIntoWindow() {
 				method: 'connected_to_signer',
 				params: [signerName],
 			},
-			usingInterceptorWithoutSigner: window.ethereum.usingInterceptorWithoutSigner,
+			usingInterceptorWithoutSigner: signerName === 'NoSigner',
 		}, '*')
 	}
 
-	if(!('ethereum' in window) || !window.ethereum) {
-		// no existing signer found
-		window.ethereum = {
-			request: request,
-			on: on,
-			removeListener: removeListener,
-			send: send,
-			sendAsync: sendAsync,
-			usingInterceptorWithoutSigner: true,
-			enable: () => request({ method: 'eth_requestAccounts' }),
-			isConnected: isConnected,
+	public injectEthereumIntoWindow() {
+		if (!('ethereum' in window) || !window.ethereum) {
+
+			console.log('no signer')
+			// no existing signer found
+
+			window.ethereum = {
+				isConnected: this.isConnected,
+				request: this.request,
+				send: this.send,
+				sendAsync: this.sendAsync,
+				on: this.on,
+				removeListener: this.removeListener,
+				enable: this.enable
+			}
+			this.usingInterceptorWithoutSigner = true
+
+			return this.sendConnectedMessage('NoSigner')
 		}
-		window.interceptor.interceptorInjected =  true
-		startListeningForMessages()
-		sendConnectedMessage('NoSigner')
-		return
-	}
-	if('ethereum' in window && 'interceptor' in window.ethereum) {
-		return // already injected
-	}
 
-	if(window.ethereum.isBraveWallet) {
-		window.ethereum = {
-			oldRequest: window.ethereum.request, // store the request object to access Brave Wallet later on
-			oldOn: window.ethereum.on, // store the on object to access Brave Wallet later on
-			request: request,
-			on: on,
-			removeListener: removeListener,
-			send: send,
-			sendAsync: sendAsync,
-			usingInterceptorWithoutSigner: false,
-			enable: () => request({ method: 'eth_requestAccounts' }),
-			isConnected: isConnected,
-		}
-		sendConnectedMessage('Brave')
-	} else {
-		// we cannot inject window.ethereum alone here as it seems like window.ethereum is cached (maybe ethers.js does that?)
-		window.ethereum.oldRequest = window.ethereum.request // store the request object to access the signer later on
-		window.ethereum.oldOn = window.ethereum.on // store the on object to access the signer later on
-		window.ethereum.request = request
-		window.ethereum.on = on
-		window.ethereum.removeListener = removeListener
-		window.ethereum.send = send
-		window.ethereum.sendAsync = sendAsync
-		window.ethereum.usingInterceptorWithoutSigner = false
-		window.ethereum.enable = () => request({ method: 'eth_requestAccounts' })
-		sendConnectedMessage(window.ethereum.isMetaMask ? 'MetaMask' : 'NotRecognizedSigner')
-	}
+		console.log('injecting on top of existing')
 
-	if(!window.interceptor.interceptorInjected) {
-		startListeningForMessages()
-	}
-	window.interceptor.interceptorInjected = true
+		this.signerRequest = window.ethereum.request // store the request object to signer
 
-	if (window.ethereum.oldOn) {
 		// subscribe for signers events
-		window.ethereum.oldOn('accountsChanged', (accounts: string[]) => {
-			request( { method: 'eth_accounts_reply', params: accounts } )
+		window.ethereum.on('accountsChanged', (accounts: string[]) => {
+			this.request( { method: 'eth_accounts_reply', params: accounts } )
 		})
-		window.ethereum.oldOn('connect', (_connectInfo: ProviderConnectInfo) => {
+		window.ethereum.on('connect', (_connectInfo: ProviderConnectInfo) => {
 
 		})
-		window.ethereum.oldOn('disconnect', (_error: ProviderRpcError) => {
-			request( { method: 'eth_accounts_reply', params: [] } )
+		window.ethereum.on('disconnect', (_error: ProviderRpcError) => {
+			this.request( { method: 'eth_accounts_reply', params: [] } )
 		})
-		window.ethereum.oldOn('chainChanged', (chainId: string) => {
-			request( { method: 'signer_chainChanged', params: [chainId] } )
+		window.ethereum.on('chainChanged', (chainId: string) => {
+			this.request( { method: 'signer_chainChanged', params: [chainId] } )
 		})
+
+		if (window.ethereum.isBraveWallet) {
+			window.ethereum = {
+				isConnected: this.isConnected,
+				request: this.request,
+				send: this.send,
+				sendAsync: this.sendAsync,
+				on: this.on,
+				removeListener: this.removeListener,
+				enable: this.enable
+			}
+			this.sendConnectedMessage('Brave')
+		} else {
+			// we cannot inject window.ethereum alone here as it seems like window.ethereum is cached (maybe ethers.js does that?)
+			window.ethereum.request = this.request
+			window.ethereum.on = this.on
+			window.ethereum.removeListener = this.removeListener
+			window.ethereum.send = this.send
+			window.ethereum.sendAsync = this.sendAsync
+			window.ethereum.enable = this.enable
+			this.sendConnectedMessage(window.ethereum.isMetaMask ? 'MetaMask' : 'NotRecognizedSigner')
+		}
+
+		this.usingInterceptorWithoutSigner = false
 	}
+
 }
 
-injectEthereumIntoWindow()
+new InterceptorMessageListener()

--- a/extension/app/inpage/ts/inpage.ts
+++ b/extension/app/inpage/ts/inpage.ts
@@ -334,7 +334,6 @@ class InterceptorMessageListener {
 		if (!('ethereum' in window) || !window.ethereum) throw new Error('window.ethereum missing')
 		if (!('options' in messageEvent.data && typeof messageEvent.data.options === 'object' && messageEvent.data.options !== null)) throw new Error('missing options field')
 		if (!('method' in messageEvent.data.options)) throw new Error('missing method field')
-		if (!('param' in messageEvent.data.options)) throw new Error('missing param field')
 
 		const forwardRequest = messageEvent.data as InterceptedRequestForward //use "as" here as we don't want to inject funtypes here
 


### PR DESCRIPTION
- also clears the re-injection code from js side to ts
- removes `oldRequest` and `oldOn` methods away from `window.ethereum`