### PR TITLE
When not used with a wallet, emulate the experimental Metamask APIs

### DIFF
--- a/extension/app/inpage/ts/inpage.ts
+++ b/extension/app/inpage/ts/inpage.ts
@@ -120,6 +120,9 @@ type InjectFunctions = {
 	removeListener: (kind: OnMessage, callback: AnyCallBack) => Promise<void>,
 	isConnected: () => boolean,
 	enable: () => void,
+	_metamask?: {
+		isUnlocked: () => boolean
+	}
 }
 
 type WindowEthereum = InjectFunctions & {
@@ -396,7 +399,11 @@ class InterceptorMessageListener {
 				sendAsync: this.WindowEthereumSendAsync,
 				on: this.WindowEthereumOn,
 				removeListener: this.WindowEthereumRemoveListener,
-				enable: this.WindowEthereumEnable
+				enable: this.WindowEthereumEnable,
+				// Emulate Metamask experimental methods
+				_metamask: {
+					isUnlocked: () => true
+				}
 			}
 			this.connected = true
 


### PR DESCRIPTION
When there is no wallet, include mock Metamask experimental methods. Tested with and without Metamask on both Brave and Firefox and works as expected - the Browser/Metamask connection actually connects.