### PR TITLE
interceptor_getSimulatedUnsignedTransactions_v1

### DIFF
--- a/extension/app/ts/background/background.ts
+++ b/extension/app/ts/background/background.ts
@@ -3,7 +3,7 @@ import 'webextension-polyfill'
 import { Simulator } from '../simulation/simulator.js'
 import { EIP2612Message, EthereumAddress, EthereumQuantity, EthereumUnsignedTransaction } from '../utils/wire-types.js'
 import { getSettings, saveActiveChain, saveActiveSigningAddress, saveActiveSimulationAddress, Settings } from './settings.js'
-import { blockNumber, call, chainId, estimateGas, gasPrice, getAccounts, getBalance, getBlockByNumber, getCode, getPermissions, getTransactionByHash, getTransactionCount, getTransactionReceipt, personalSign, requestPermissions, sendRawTransaction, sendTransaction, signTypedDataV4, subscribe, switchEthereumChain, unsubscribe } from './simulationModeHanders.js'
+import { blockNumber, call, chainId, estimateGas, gasPrice, getAccounts, getBalance, getBlockByNumber, getCode, getPermissions, getSimulatedUnsignedTransactions, getTransactionByHash, getTransactionCount, getTransactionReceipt, personalSign, requestPermissions, sendRawTransaction, sendTransaction, signTypedDataV4, subscribe, switchEthereumChain, unsubscribe } from './simulationModeHanders.js'
 import { changeActiveAddress, changeAddressInfos, changeMakeMeRich, changePage, resetSimulation, confirmDialog, RefreshSimulation, removeTransaction, requestAccountsFromSigner, refreshPopupConfirmTransactionSimulation, confirmPersonalSign, confirmRequestAccess, changeInterceptorAccess, changeChainDialog, popupChangeActiveChain, enableSimulationMode, reviewNotification, rejectNotification, addOrModifyAddressInfo } from './popupMessageHandlers.js'
 import { AddressMetadata, SimResults, SimulationState, TokenPriceEstimate } from '../utils/visualizer-types.js'
 import { WebsiteApproval, SignerState, TabConnection } from '../utils/user-interface-types.js'
@@ -291,6 +291,7 @@ export const handlers = new Map<string, SimulationHandler >([
 	['eth_sendRawTransaction', sendRawTransaction],
 	['eth_gasPrice', gasPrice],
 	['eth_getTransactionCount', getTransactionCount],
+	['interceptor_getSimulatedUnsignedTransactions_v1', getSimulatedUnsignedTransactions],
 
 	/*
 	Missing methods:

--- a/extension/app/ts/background/simulationModeHanders.ts
+++ b/extension/app/ts/background/simulationModeHanders.ts
@@ -1,7 +1,7 @@
 import { Simulator } from '../simulation/simulator.js'
 import { bytes32String } from '../utils/bigint.js'
 import { InterceptedRequest } from '../utils/interceptor-messages.js'
-import { EstimateGasParams, EthBalanceParams, EthBlockByNumberParams, EthCallParams, EthereumAddress, EthereumData, EthereumQuantity, EthereumSignedTransactionWithBlockData, EthSubscribeParams, EthTransactionReceiptResponse, EthUnSubscribeParams, GetBlockReturn, GetCode, GetTransactionCount, JsonRpcNewHeadsNotification, NewHeadsSubscriptionData, PersonalSignParams, RequestPermissions, SendTransactionParams, SignTypedDataV4Params, SwitchEthereumChainParams, TransactionByHashParams, TransactionReceiptParams } from '../utils/wire-types.js'
+import { EstimateGasParams, EthBalanceParams, EthBlockByNumberParams, EthCallParams, EthereumAddress, EthereumData, EthereumQuantity, EthereumSignedTransactionWithBlockData, EthereumUnsignedTransactionArray, EthSubscribeParams, EthTransactionReceiptResponse, EthUnSubscribeParams, GetBlockReturn, GetCode, GetTransactionCount, JsonRpcNewHeadsNotification, NewHeadsSubscriptionData, PersonalSignParams, RequestPermissions, SendTransactionParams, SignTypedDataV4Params, SwitchEthereumChainParams, TransactionByHashParams, TransactionReceiptParams } from '../utils/wire-types.js'
 import { postMessageIfStillConnected } from './background.js'
 import { WebsiteAccess } from './settings.js'
 import { openChangeChainDialog } from './windows/changeChain.js'
@@ -266,5 +266,14 @@ export async function getTransactionCount(simulator: Simulator, port: browser.ru
 		requestId: request.requestId,
 		options: request.options,
 		result: EthereumQuantity.serialize(await simulator.ethereum.getTransactionCount(params.params[0], params.params[1]))
+	})
+}
+
+export async function getSimulatedUnsignedTransactions(simulator: Simulator, port: browser.runtime.Port, request: InterceptedRequest) {
+	return postMessageIfStillConnected(port, {
+		interceptorApproved: true,
+		requestId: request.requestId,
+		options: request.options,
+		result: EthereumUnsignedTransactionArray.serialize(simulator.simulationModeNode.getSimulatedUnsignedTransactions())
 	})
 }

--- a/extension/app/ts/simulation/services/SimulationModeEthereumClientService.ts
+++ b/extension/app/ts/simulation/services/SimulationModeEthereumClientService.ts
@@ -52,6 +52,11 @@ export class SimulationModeEthereumClientService {
 		return newSimulation
 	}
 
+	public getSimulatedUnsignedTransactions = () => {
+		if (this.simulationState === undefined) return []
+		return this.simulationState.simulatedTransactions.map( (x) => x.unsignedTransaction )
+	}
+
 	public transactionQueueTotalGasLimit = () => {
 		if ( this.simulationState === undefined) return 0n
 		return this.simulationState.simulatedTransactions.reduce((a, b) => a + b.unsignedTransaction.gas, 0n)

--- a/extension/app/ts/utils/wire-types.ts
+++ b/extension/app/ts/utils/wire-types.ts
@@ -199,6 +199,9 @@ export const EthereumUnsignedTransaction1559 = t.Intersect(
 export type EthereumUnsignedTransaction = t.Static<typeof EthereumUnsignedTransaction>
 export const EthereumUnsignedTransaction = t.Union(EthereumUnsignedTransactionLegacy, EthereumUnsignedTransaction2930, EthereumUnsignedTransaction1559)
 
+export type EthereumUnsignedTransactionArray = t.Static<typeof EthereumUnsignedTransactionArray>
+export const EthereumUnsignedTransactionArray = t.ReadonlyArray(EthereumUnsignedTransaction)
+
 export type EthereumTransactionSignature = t.Static<typeof EthereumTransactionSignature>
 export const EthereumTransactionSignature = t.Intersect(
 	t.Object({
@@ -711,7 +714,6 @@ export const RequestPermissions = t.Object({
 	method: t.Literal('wallet_requestPermissions'),
 	params: t.Tuple( t.Object({ eth_accounts: t.Object({ }) }) )
 }).asReadonly()
-
 
 const BigIntParserNonHex: t.ParsedValue<t.String, bigint>['config'] = {
 	parse: value => {


### PR DESCRIPTION
Adds method `interceptor_getSimulatedUnsignedTransactions_v1` that can be used to retrieve simulation stack. This can be called as follows:

```ts
console.log(await window.ethereum.request({ 'method': 'interceptor_getSimulatedUnsignedTransactions_v1' }))
```

this returns list of unsigned transactions
```ts
[
	{
		accessList:  []
		chainId:  "0x1"
		from: "0xda9dfa130df4de4673b89022ee50ff26f6ea73cf"
		gas: "0x5208"
		input: "0x"
		maxFeePerGas: "0x0"
		maxPriorityFeePerGas: "0x0"
		nonce: "0x18"
		to: "0xd8da6bf26964af9d7eed9e03e53415d37aa96045"
		type: "0x2"
		value: "0x2a5a058fc295ed000000"
	}
]
```

If no simulation mode is disabled or the stack is empty, it just returns empty array.