### PR TITLE
Add version number as mandatory field to interceptor_getSimulationStack

### DIFF
--- a/extension/app/ts/background/simulationModeHanders.ts
+++ b/extension/app/ts/background/simulationModeHanders.ts
@@ -1,7 +1,7 @@
 import { Simulator } from '../simulation/simulator.js'
 import { bytes32String } from '../utils/bigint.js'
 import { InterceptedRequest } from '../utils/interceptor-messages.js'
-import { EstimateGasParams, EthBalanceParams, EthBlockByNumberParams, EthCallParams, EthereumAddress, EthereumData, EthereumQuantity, EthereumSignedTransactionWithBlockData, EthSubscribeParams, EthTransactionReceiptResponse, EthUnSubscribeParams, GetBlockReturn, GetCode, GetSimulationStack, GetTransactionCount, JsonRpcNewHeadsNotification, NewHeadsSubscriptionData, PersonalSignParams, RequestPermissions, SendTransactionParams, SignTypedDataV4Params, SwitchEthereumChainParams, TransactionByHashParams, TransactionReceiptParams } from '../utils/wire-types.js'
+import { EstimateGasParams, EthBalanceParams, EthBlockByNumberParams, EthCallParams, EthereumAddress, EthereumData, EthereumQuantity, EthereumSignedTransactionWithBlockData, EthSubscribeParams, EthTransactionReceiptResponse, EthUnSubscribeParams, GetBlockReturn, GetCode, GetSimulationStack, GetSimulationStackReply, GetTransactionCount, JsonRpcNewHeadsNotification, NewHeadsSubscriptionData, PersonalSignParams, RequestPermissions, SendTransactionParams, SignTypedDataV4Params, SwitchEthereumChainParams, TransactionByHashParams, TransactionReceiptParams } from '../utils/wire-types.js'
 import { postMessageIfStillConnected } from './background.js'
 import { WebsiteAccess } from './settings.js'
 import { openChangeChainDialog } from './windows/changeChain.js'
@@ -270,13 +270,24 @@ export async function getTransactionCount(simulator: Simulator, port: browser.ru
 }
 
 export async function getSimulationStack(simulator: Simulator, port: browser.runtime.Port, request: InterceptedRequest) {
+	const params = GetSimulationStack.parse(request.options)
+	if (params.params[0] !== '1.0.0') return postMessageIfStillConnected(port, {
+		interceptorApproved: true,
+		requestId: request.requestId,
+		options: request.options,
+		error: {
+			message: `Unsupported version number: ${ params.params[0] }`,
+			code: 400,
+		}
+	})
+
 	return postMessageIfStillConnected(port, {
 		interceptorApproved: true,
 		requestId: request.requestId,
 		options: request.options,
 		result: {
 			version: '1.0.0',
-			payload: GetSimulationStack.serialize(simulator.simulationModeNode.getSimulationStack()),
+			payload: GetSimulationStackReply.serialize(simulator.simulationModeNode.getSimulationStack()),
 		}
 	})
 }

--- a/extension/app/ts/utils/wire-types.ts
+++ b/extension/app/ts/utils/wire-types.ts
@@ -791,7 +791,13 @@ export const GetTransactionCount = t.Object({
 }).asReadonly()
 
 export type GetSimulationStack = t.Static<typeof GetSimulationStack>
-export const GetSimulationStack = t.ReadonlyArray(t.Intersect(
+export const GetSimulationStack = t.Object({
+	method: t.Literal('interceptor_getSimulationStack'),
+	params: t.Tuple(t.String),
+}).asReadonly()
+
+export type GetSimulationStackReply = t.Static<typeof GetSimulationStackReply>
+export const GetSimulationStackReply = t.ReadonlyArray(t.Intersect(
 	EthereumUnsignedTransaction,
 	SingleMulticallResponse,
 	t.Object({


### PR DESCRIPTION
now `interceptor_getSimulationStack` need to be called with version number param, like follows:

`
console.log(await window.ethereum.request({ 'method': 'interceptor_getSimulationStack', 'params': ['1.0.0'] }))
`

fixes https://github.com/DarkFlorist/TheInterceptor/issues/97
