### PR TITLE
Set r=0, s=0 and yParity = 'even' for simulated tx's

### DIFF
--- a/extension/app/ts/background/background.ts
+++ b/extension/app/ts/background/background.ts
@@ -15,6 +15,7 @@ import { getAddressMetadataForVisualiser } from './metadataUtils.js'
 import { getActiveAddress, sendPopupMessageToOpenWindows } from './backgroundUtils.js'
 import { updateExtensionIcon } from './iconHandler.js'
 import { connectedToSigner, ethAccountsReply, signerChainChanged, walletSwitchEthereumChainReply } from './providerMessageHandlers.js'
+import { SimulationModeEthereumClientService } from '../simulation/services/SimulationModeEthereumClientService.js'
 
 browser.runtime.onConnect.addListener(port => onContentScriptConnected(port).catch(console.error))
 
@@ -255,7 +256,7 @@ export async function appendTransactionToSimulator(transaction: EthereumUnsigned
 	if ( simulator === undefined) return
 	const simulationState = await updateSimulationState(async () => (await simulator?.simulationModeNode.appendTransaction(transaction))?.simulationState)
 	return {
-		signed: await simulator.simulationModeNode.mockSignTransaction(transaction),
+		signed: await SimulationModeEthereumClientService.mockSignTransaction(transaction),
 		simulationState: simulationState,
 	}
 }

--- a/extension/app/ts/simulation/services/SimulationModeEthereumClientService.ts
+++ b/extension/app/ts/simulation/services/SimulationModeEthereumClientService.ts
@@ -1,7 +1,6 @@
 import { EthereumClientService } from './EthereumClientService.js'
 import { EthGetLogsResponse, EthereumUnsignedTransaction, EthereumSignedTransactionWithBlockData, EthereumBlockHeader, EthereumBlockTag, EthGetLogsRequest, EthereumTransactionSignature, EthTransactionReceiptResponse, EstimateGasParamsVariables, EthSubscribeParams, JsonRpcMessage, JsonRpcNewHeadsNotification, EthereumAddress, EthereumBlockHeaderWithTransactionHashes } from '../../utils/wire-types.js'
-import { IUnsignedTransaction, signTransaction } from '../../utils/ethereum.js'
-import { EthereumUnsignedTransactionToUnsingnedTransaction } from '../../utils/ethereum.js'
+import { EthereumUnsignedTransactionToUnsignedTransaction, IUnsignedTransaction, serializeTransactionToBytes } from '../../utils/ethereum.js'
 import { bytes32String, dataString, max, min } from '../../utils/bigint.js'
 import { MOCK_ADDRESS } from '../../utils/constants.js'
 import { ErrorWithData } from '../../utils/errors.js'
@@ -99,12 +98,15 @@ export class SimulationModeEthereumClientService {
 		return min(baseFee + transaction.maxPriorityFeePerGas, transaction.maxFeePerGas)
 	}
 
-	public mockSignTransaction = async (transaction: EthereumUnsignedTransaction) => {
-		return await signTransaction(MOCK_PRIVATE_KEY , EthereumUnsignedTransactionToUnsingnedTransaction(transaction))
+	public static mockSignTransaction = async (transaction: EthereumUnsignedTransaction) => {
+		const signatureParams = { r: 0n, s: 0n, yParity: 'even' as const }
+		const unsignedTransaction = EthereumUnsignedTransactionToUnsignedTransaction(transaction)
+		const hash = await keccak256.hash(serializeTransactionToBytes({ ...unsignedTransaction, ...signatureParams }))
+		return { ...unsignedTransaction, ...signatureParams, hash }
 	}
 
 	public appendTransaction = async (transaction: EthereumUnsignedTransaction) => {
-		const signed = await this.mockSignTransaction(transaction)
+		const signed = await SimulationModeEthereumClientService.mockSignTransaction(transaction)
 		const parentBlock = await this.ethereumClientService.getBlock()
 		if ( this.simulationState === undefined ) {
 			const multicallResult = await this.multicall([transaction], parentBlock.number)
@@ -159,7 +161,7 @@ export class SimulationModeEthereumClientService {
 
 		let signedTxs: (IUnsignedTransaction & EthereumTransactionSignature)[] = []
 		for (const transaction of unsignedTxts) {
-			signedTxs.push(await this.mockSignTransaction(transaction))
+			signedTxs.push(await SimulationModeEthereumClientService.mockSignTransaction(transaction))
 		}
 		const parentBlock = await this.ethereumClientService.getBlock()
 		const multicallResult = await this.ethereumClientService.multicall(unsignedTxts, parentBlock.number)

--- a/extension/test/micro-should.ts
+++ b/extension/test/micro-should.ts
@@ -8,7 +8,7 @@ const red = '\x1b[31m'
 const green = '\x1b[32m'
 const reset = '\x1b[0m'
 
-type TestFunction = () => void
+type TestFunction = (() => void) | (() => Promise<void>)
 
 type TestCase = {
 	message: string
@@ -30,7 +30,7 @@ async function runOne({ message, test, skip }: TestCase) {
 		return true
 	}
 	try {
-		test()
+		await test()
 		console.log(`${ green }√ ${ output }${ reset }`)
 		return true
 	} catch (error) {

--- a/extension/test/tests/SimulationModeEthereumClientService.ts
+++ b/extension/test/tests/SimulationModeEthereumClientService.ts
@@ -1,0 +1,47 @@
+import { ethers } from 'ethers'
+import { SimulationModeEthereumClientService } from '../../app/ts/simulation/services/SimulationModeEthereumClientService.js'
+import { describe, runIfRoot, should, run } from '../micro-should.js'
+import * as assert from 'assert'
+import { getV, serializeTransactionToBytes } from '../../app/ts/utils/ethereum.js'
+import { bytes32String } from '../../app/ts/utils/bigint.js'
+
+export async function main() {
+	describe('SimulationModeEthereumClientService', () => {
+		const exampleTransaction = {
+			type: '1559' as const,
+			from: 0xd8da6bf26964af9d7eed9e03e53415d37aa96045n,
+			nonce: 0n,
+			maxFeePerGas: 1n,
+			maxPriorityFeePerGas: 1n,
+			gas: 21000n,
+			to: 0xda9dfa130df4de4673b89022ee50ff26f6ea73cfn,
+			value: 10n,
+			input: new Uint8Array(0),
+			chainId: 1n,
+		}
+
+		should('mockSignTransaction should have r=0, s=0 and yParity = "even"', async () => {
+			const signed = await SimulationModeEthereumClientService.mockSignTransaction(exampleTransaction)
+			assert.equal(signed.r, 0n)
+			assert.equal(signed.s, 0n)
+			assert.equal(signed.yParity, 'even')
+		})
+
+		should('ethers.utils.recoverAddress should fail for mocked transaction', async () => {
+			const signed = await SimulationModeEthereumClientService.mockSignTransaction(exampleTransaction)
+			const digest = serializeTransactionToBytes(signed)
+			assert.throws(() => ethers.utils.recoverAddress(digest, {
+					r: bytes32String(signed.r),
+					s: bytes32String(signed.s),
+					v: Number(getV(signed)),
+				}),
+				'Error: invalid point'
+			)
+		})
+	})
+}
+
+await runIfRoot(async  () => {
+	await main()
+	await run()
+}, import.meta)


### PR DESCRIPTION
Fixes https://github.com/DarkFlorist/TheInterceptor/issues/84

I also checked that with these params, Ethers eRecover fails and produces error `Error: invalid point` as expected. I added test about this