### PR TITLE
Add version number as mandatory field to interceptor_getSimulationStack

### DIFF
--- a/extension/app/ts/background/background.ts
+++ b/extension/app/ts/background/background.ts
@@ -306,7 +306,7 @@ async function handleSimulationMode(simulator: Simulator, port: browser.runtime.
 		case 'eth_requestAccounts': return await getAccounts(getActiveAddressForDomain, simulator, port)
 		case 'eth_gasPrice': return await gasPrice(simulator)
 		case 'eth_getTransactionCount': return await getTransactionCount(simulator, parsedRequest)
-		case 'interceptor_getSimulationStack': return await getSimulationStack(simulator)
+		case 'interceptor_getSimulationStack': return await getSimulationStack(simulator, parsedRequest)
 		/*
 		Missing methods:
 		case 'eth_sendRawTransaction': return

--- a/extension/app/ts/background/simulationModeHanders.ts
+++ b/extension/app/ts/background/simulationModeHanders.ts
@@ -1,7 +1,7 @@
 import { Simulator } from '../simulation/simulator.js'
 import { bytes32String } from '../utils/bigint.js'
 import { ERROR_INTERCEPTOR_UNKNOWN_ORIGIN } from '../utils/constants.js'
-import { EstimateGasParams, EthBalanceParams, EthBlockByNumberParams, EthCallParams, EthereumAddress, EthereumData, EthereumQuantity, EthereumSignedTransactionWithBlockData, EthSubscribeParams, EthTransactionReceiptResponse, EthUnSubscribeParams, GetBlockReturn, GetCode, GetSimulationStack, GetTransactionCount, JsonRpcNewHeadsNotification, NewHeadsSubscriptionData, PersonalSignParams, SendTransactionParams, SignTypedDataV4Params, SwitchEthereumChainParams, TransactionByHashParams, TransactionReceiptParams } from '../utils/wire-types.js'
+import { EstimateGasParams, EthBalanceParams, EthBlockByNumberParams, EthCallParams, EthereumAddress, EthereumData, EthereumQuantity, EthereumSignedTransactionWithBlockData, EthSubscribeParams, EthTransactionReceiptResponse, EthUnSubscribeParams, GetBlockReturn, GetCode, GetSimulationStack, GetSimulationStackReply, GetTransactionCount, JsonRpcNewHeadsNotification, NewHeadsSubscriptionData, PersonalSignParams, SendTransactionParams, SignTypedDataV4Params, SwitchEthereumChainParams, TransactionByHashParams, TransactionReceiptParams } from '../utils/wire-types.js'
 import { postMessageIfStillConnected } from './background.js'
 import { WebsiteAccess } from './settings.js'
 import { openChangeChainDialog } from './windows/changeChain.js'
@@ -161,11 +161,13 @@ export async function getTransactionCount(simulator: Simulator, request: GetTran
 	return { result: EthereumQuantity.serialize(await simulator.ethereum.getTransactionCount(request.params[0], request.params[1])) }
 }
 
-export async function getSimulationStack(simulator: Simulator) {
-	return {
-		result: {
-			version: '1.0.0',
-			payload: GetSimulationStack.serialize(simulator.simulationModeNode.getSimulationStack()),
+export async function getSimulationStack(simulator: Simulator, request: GetSimulationStack) {
+	switch (request.params[0]) {
+		case '1.0.0': return {
+			result: {
+				version: '1.0.0',
+				payload: GetSimulationStackReply.serialize(simulator.simulationModeNode.getSimulationStack()),
+			}
 		}
 	}
 }

--- a/extension/app/ts/utils/wire-types.ts
+++ b/extension/app/ts/utils/wire-types.ts
@@ -791,8 +791,8 @@ export const GetTransactionCount = t.Object({
 	params: t.Tuple(EthereumAddress, EthereumBlockTag)
 }).asReadonly()
 
-export type GetSimulationStack = t.Static<typeof GetSimulationStack>
-export const GetSimulationStack = t.ReadonlyArray(t.Intersect(
+export type GetSimulationStackReply = t.Static<typeof GetSimulationStackReply>
+export const GetSimulationStackReply = t.ReadonlyArray(t.Intersect(
 	EthereumUnsignedTransaction,
 	SingleMulticallResponse,
 	t.Object({
@@ -800,6 +800,12 @@ export const GetSimulationStack = t.ReadonlyArray(t.Intersect(
 		gasLimit: EthereumQuantity,
 	}).asReadonly(),
 ))
+
+export type GetSimulationStack = t.Static<typeof GetSimulationStack>
+export const GetSimulationStack = t.Object({
+	method: t.Literal('interceptor_getSimulationStack'),
+	params: t.Tuple(t.Union(t.Literal('1.0.0'))),
+}).asReadonly()
 
 export type SupportedETHRPCCall = t.Static<typeof SupportedETHRPCCall>
 export const SupportedETHRPCCall = t.Union(
@@ -825,7 +831,7 @@ export const SupportedETHRPCCall = t.Union(
 	t.Object({ method: t.Literal('eth_requestAccounts') }),
 	t.Object({ method: t.Literal('eth_gasPrice') }),
 	GetTransactionCount,
-	t.Object({ method: t.Literal('interceptor_getSimulationStack') }),
+	GetSimulationStack,
 )
 
 export const SupportedETHRPCCalls = [

--- a/extension/app/ts/utils/wire-types.ts
+++ b/extension/app/ts/utils/wire-types.ts
@@ -804,7 +804,7 @@ export const GetSimulationStackReply = t.ReadonlyArray(t.Intersect(
 export type GetSimulationStack = t.Static<typeof GetSimulationStack>
 export const GetSimulationStack = t.Object({
 	method: t.Literal('interceptor_getSimulationStack'),
-	params: t.Tuple(t.Union(t.Literal('1.0.0'))),
+	params: t.Tuple(t.Literal('1.0.0')),
 }).asReadonly()
 
 export type SupportedETHRPCCall = t.Static<typeof SupportedETHRPCCall>


### PR DESCRIPTION
new version of https://github.com/DarkFlorist/TheInterceptor/pull/100 as the internals of RPC method parsing was changed significantly

now interceptor_getSimulationStack need to be called with version number param, like follows:

`console.log(await window.ethereum.request({ 'method': 'interceptor_getSimulationStack', 'params': ['1.0.0'] }))`

fixes https://github.com/DarkFlorist/TheInterceptor/issues/97