### PR TITLE
Big metadata refactoring

### DIFF
--- a/extension/app/ts/AddressBook.tsx
+++ b/extension/app/ts/AddressBook.tsx
@@ -133,7 +133,7 @@ export function ListElement(entry: ListElementParam) {
 						<button class = 'card-header-icon' style = 'padding: 0px; margin-left: auto;' aria-label = 'delete'>
 							<span class = 'icon' style = 'color: var(--text-color);' onClick = { entry.type != 'empty' && entry.category === 'My Active Addresses' ? () => entry.removeEntry(entry) : () => {} }> X </span>
 						</button>
-						<button class = 'button is-primary is-small' onClick = { entry.type != 'empty' ? () => entry.renameAddressCallBack(entry) : () => {} }>Edit</button>
+						<button class = 'button is-primary is-small' disabled = { true } onClick = { entry.type != 'empty' ? () => entry.renameAddressCallBack(entry) : () => {} }>Edit</button>
 					</div>
 				</div>
 			</div>

--- a/extension/app/ts/AddressBook.tsx
+++ b/extension/app/ts/AddressBook.tsx
@@ -72,8 +72,7 @@ export function ConfirmaddressBookEntryToBeRemoved(param: ConfirmaddressBookEntr
 				<div class = 'card' style = 'margin: 10px;'>
 					<div class = 'card-content'>
 						<BigAddress
-							address = { param.addressBookEntry.address }
-							nameAndLogo = { param.addressBookEntry }
+							addressBookEntry = { param.addressBookEntry }
 							renameAddressCallBack = { param.renameAddressCallBack }
 						/>
 					</div>
@@ -103,8 +102,7 @@ export function ListElement(entry: ListElementParam) {
 						<div style = 'padding-bottom: 10px; height: 40px'>
 							{ entry.type === 'empty' ? <></> :
 								<BigAddress
-									address = { entry.address }
-									nameAndLogo = { { name: `${ entry.name } ${ 'symbol' in entry ? `(${ entry.symbol })` : '' }`, logoUri: 'logoUri' in entry && entry.logoUri !== undefined ?  `${entry.logoUri }` : undefined } }
+									addressBookEntry = { { ...entry, ...{ name: `${ entry.name } ${ 'symbol' in entry ? `(${ entry.symbol })` : '' }`} } }
 									noCopying = { true }
 									renameAddressCallBack = { entry.renameAddressCallBack }
 								/>
@@ -135,7 +133,7 @@ export function ListElement(entry: ListElementParam) {
 						<button class = 'card-header-icon' style = 'padding: 0px; margin-left: auto;' aria-label = 'delete'>
 							<span class = 'icon' style = 'color: var(--text-color);' onClick = { entry.type != 'empty' && entry.category === 'My Active Addresses' ? () => entry.removeEntry(entry) : () => {} }> X </span>
 						</button>
-						<button class = 'button is-primary is-small' onClick = { () => {} } disabled = { true }>Edit</button>
+						<button class = 'button is-primary is-small' onClick = { entry.type != 'empty' ? () => entry.renameAddressCallBack(entry) : () => {} }>Edit</button>
 					</div>
 				</div>
 			</div>
@@ -347,10 +345,10 @@ export function AddressBook() {
 		setModalState('ConfirmaddressBookEntryToBeRemoved')
 	}
 
-	function renameAddressCallBack(name: string | undefined, address: string) {
+	function renameAddressCallBack(entry: AddressBookEntry) {
 		setModalState('addNewAddress')
-		setNameInput(name === undefined ? '' : name)
-		setAddressInput(ethers.utils.getAddress(address))
+		setNameInput(entry.name === undefined ? '' : entry.name)
+		setAddressInput(ethers.utils.getAddress(addressString(entry.address)))
 		setAddingNewAddress(false)
 	}
 

--- a/extension/app/ts/background/accessManagement.ts
+++ b/extension/app/ts/background/accessManagement.ts
@@ -1,14 +1,14 @@
 import { addressString } from '../utils/bigint.js'
-import { AddressMetadata } from '../utils/visualizer-types.js'
 import { EthereumAddress, SupportedETHRPCCalls } from '../utils/wire-types.js'
 import { postMessageIfStillConnected, setEthereumNodeBlockPolling } from './background.js'
 import { getActiveAddress } from './backgroundUtils.js'
-import { getAddressMetaData } from './metadataUtils.js'
+import { findAddressInfo } from './metadataUtils.js'
 import { Settings, WebsiteAccess, WebsiteAddressAccess } from './settings.js'
 import { requestAccessFromUser, retrieveIcon } from './windows/interceptorAccess.js'
 import { METAMASK_ERROR_USER_REJECTED_REQUEST } from '../utils/constants.js'
 import { EthereumQuantity } from '../utils/wire-types.js'
 import { updateExtensionIcon } from './iconHandler.js'
+import { AddressInfoEntry } from '../utils/user-interface-types.js'
 
 function setWebsitePortApproval(port: browser.runtime.Port, origin: string, approved: boolean) {
 	const tabId = port.sender?.tab?.id
@@ -251,12 +251,12 @@ function disconnectFromPort(port: browser.runtime.Port, origin: string): false {
 	return false
 }
 
-export function getAssociatedAddresses(settings: Settings, origin: string, activeAddress: string | undefined) : [string, AddressMetadata][]{
+export function getAssociatedAddresses(settings: Settings, origin: string, activeAddress: string | undefined) : [string, AddressInfoEntry][]{
 	const addressAccess = getAddressAccesses(settings.websiteAccess, origin).filter( (x) => x.access).map( (x) => x.address)
 	const allAccessAddresses = getAddressesThatDoNotNeedIndividualAccesses(settings)
 
 	const all = allAccessAddresses.map( (address) => addressString(address) ).concat(addressAccess).concat(activeAddress === undefined ? [] : [activeAddress])
-	return Array.from(new Set(all)).map(x => [x, getAddressMetaData(BigInt(x), settings.addressInfos)])
+	return Array.from(new Set(all)).map(x => [x, findAddressInfo(BigInt(x), settings.addressInfos)])
 }
 
 async function askUserForAccessOnConnectionUpdate(port: browser.runtime.Port, origin: string, activeAddress: string | undefined) {

--- a/extension/app/ts/background/background.ts
+++ b/extension/app/ts/background/background.ts
@@ -143,7 +143,7 @@ export async function updateSimulationState( getUpdatedSimulationState: () => Pr
 				if (metadata[1].decimals === undefined) return false
 				return true
 			}
-			function metadataRestructure([address, metadata]: [string, AddressBookEntry & { decimals: bigint } ] ) {
+			function metadataRestructure([address, metadata]: [string, AddressBookEntry &  { type: 'token', decimals: bigint } ] ) {
 				return { token: BigInt(address), decimals: BigInt(metadata.decimals) }
 			}
 			const tokenPrices = await priceEstimator.estimateEthereumPricesForTokens(addressBookEntries.filter(onlyTokensAndTokensWithKnownDecimals).map(metadataRestructure))

--- a/extension/app/ts/background/background.ts
+++ b/extension/app/ts/background/background.ts
@@ -5,13 +5,13 @@ import { EIP2612Message, EthereumQuantity, EthereumUnsignedTransaction, Personal
 import { getSettings, saveActiveChain, saveActiveSigningAddress, saveActiveSimulationAddress, Settings } from './settings.js'
 import { blockNumber, call, chainId, estimateGas, gasPrice, getAccounts, getBalance, getBlockByNumber, getCode, getPermissions, getSimulationStack, getTransactionByHash, getTransactionCount, getTransactionReceipt, personalSign, requestPermissions, sendTransaction, signTypedDataV4, subscribe, switchEthereumChain, unsubscribe } from './simulationModeHanders.js'
 import { changeActiveAddress, changeAddressInfos, changeMakeMeRich, changePage, resetSimulation, confirmDialog, RefreshSimulation, removeTransaction, requestAccountsFromSigner, refreshPopupConfirmTransactionSimulation, confirmPersonalSign, confirmRequestAccess, changeInterceptorAccess, changeChainDialog, popupChangeActiveChain, enableSimulationMode, reviewNotification, rejectNotification, addOrModifyAddressInfo, getAddressBookData, removeAddressBookEntry } from './popupMessageHandlers.js'
-import { AddressMetadata, SimResults, SimulationState, TokenPriceEstimate } from '../utils/visualizer-types.js'
-import { WebsiteApproval, SignerState, TabConnection } from '../utils/user-interface-types.js'
+import { SimResults, SimulationState, TokenPriceEstimate } from '../utils/visualizer-types.js'
+import { WebsiteApproval, SignerState, TabConnection, AddressBookEntry, AddressInfoEntry } from '../utils/user-interface-types.js'
 import { getAddressMetadataForAccess, setPendingAccessRequests } from './windows/interceptorAccess.js'
 import { CHAINS, ICON_NOT_ACTIVE, isSupportedChain, MAKE_YOU_RICH_TRANSACTION, METAMASK_ERROR_USER_REJECTED_REQUEST } from '../utils/constants.js'
 import { PriceEstimator } from '../simulation/priceEstimator.js'
 import { getActiveAddressForDomain, sendActiveAccountChangeToApprovedWebsitePorts, sendMessageToApprovedWebsitePorts, updateWebsiteApprovalAccesses, verifyAccess } from './accessManagement.js'
-import { getAddressMetadataForVisualiser } from './metadataUtils.js'
+import { getAddressBookEntriesForVisualiser } from './metadataUtils.js'
 import { getActiveAddress, sendPopupMessageToOpenWindows } from './backgroundUtils.js'
 import { updateExtensionIcon } from './iconHandler.js'
 import { connectedToSigner, ethAccountsReply, signerChainChanged, walletSwitchEthereumChainReply } from './providerMessageHandlers.js'
@@ -36,7 +36,7 @@ declare global {
 				simulationState: SimulationState | undefined,
 				isComputingSimulation: boolean,
 				visualizerResults: SimResults[] | undefined,
-				addressMetadata: [string, AddressMetadata][],
+				addressBookEntries: [string, AddressBookEntry][],
 				tokenPrices: TokenPriceEstimate[],
 				activeAddress: bigint,
 			}
@@ -46,14 +46,14 @@ declare global {
 				message: string,
 				account: string,
 				method: 'personalSign' | 'v4',
-				addressMetadata: [string, AddressMetadata][],
+				addressBookEntries: [string, AddressBookEntry][],
 				eip2612Message?: EIP2612Message,
 			}
 			interceptorAccessDialog?: {
 				origin: string,
 				icon: string | undefined,
 				requestAccessToAddress: string | undefined,
-				addressMetadata: [string, AddressMetadata][],
+				addressBookEntries: [string, AddressInfoEntry][],
 			}
 			changeChainDialog?: {
 				requestId: number,
@@ -67,11 +67,11 @@ declare global {
 				simulationState: SimulationState | undefined,
 				isComputingSimulation: boolean,
 				visualizerResults: SimResults[] | undefined,
-				addressMetadata: [string, AddressMetadata][],
+				addressBookEntries: [string, AddressBookEntry][],
 				tokenPrices: TokenPriceEstimate[],
 			}
-			websiteAccessAddressMetadata: [string, AddressMetadata][],
-			pendingAccessMetadata: [string, AddressMetadata][],
+			websiteAccessAddressMetadata: [string, AddressInfoEntry][],
+			pendingAccessMetadata: [string, AddressInfoEntry][],
 			prependTransactionMode: PrependTransactionMode,
 			signerAccounts: readonly bigint[] | undefined,
 			signerChain: bigint | undefined,
@@ -103,7 +103,7 @@ window.interceptor = {
 		simulationState: undefined,
 		isComputingSimulation: false,
 		visualizerResults: undefined,
-		addressMetadata: [],
+		addressBookEntries: [],
 		tokenPrices: [],
 	},
 	currentBlockNumber: undefined,
@@ -120,7 +120,7 @@ export async function updateSimulationState( getUpdatedSimulationState: () => Pr
 				simulationId: window.interceptor.simulation.simulationId,
 				simulationState: undefined,
 				isComputingSimulation: false,
-				addressMetadata: [],
+				addressBookEntries: [],
 				tokenPrices: [],
 				visualizerResults: [],
 			}
@@ -136,24 +136,24 @@ export async function updateSimulationState( getUpdatedSimulationState: () => Pr
 
 			const transactions = updatedSimulationState.simulatedTransactions.map(x => x.unsignedTransaction)
 			const visualizerResult = await simulator.visualizeTransactionChain(transactions, updatedSimulationState.blockNumber, updatedSimulationState.simulatedTransactions.map( x => x.multicallResponse))
-			const addressMetadata = await getAddressMetadataForVisualiser(simulator, visualizerResult.map( (x) => x.visualizerResults), updatedSimulationState, window.interceptor.settings?.addressInfos)
+			const addressBookEntries = await getAddressBookEntriesForVisualiser(simulator, visualizerResult.map( (x) => x.visualizerResults), updatedSimulationState, window.interceptor.settings?.addressInfos)
 
-			function onlyTokensAndTokensWithKnownDecimals(metadata: [string, AddressMetadata]) : metadata is [string, AddressMetadata & { metadataSource: 'token', decimals: `0x${ string }` } ] {
-				if (metadata[1].metadataSource !== 'token') return false
+			function onlyTokensAndTokensWithKnownDecimals(metadata: [string, AddressBookEntry]) : metadata is [string, AddressBookEntry & { type: 'token', decimals: `0x${ string }` } ] {
+				if (metadata[1].type !== 'token') return false
 				if (metadata[1].decimals === undefined) return false
 				return true
 			}
-			function metadataRestructure([address, metadata]: [string, AddressMetadata & { metadataSource: 'token', decimals: bigint } ] ) {
+			function metadataRestructure([address, metadata]: [string, AddressBookEntry & { decimals: bigint } ] ) {
 				return { token: BigInt(address), decimals: BigInt(metadata.decimals) }
 			}
-			const tokenPrices = await priceEstimator.estimateEthereumPricesForTokens(addressMetadata.filter(onlyTokensAndTokensWithKnownDecimals).map(metadataRestructure))
+			const tokenPrices = await priceEstimator.estimateEthereumPricesForTokens(addressBookEntries.filter(onlyTokensAndTokensWithKnownDecimals).map(metadataRestructure))
 
 			if (simId !== window.interceptor.simulation.simulationId) return // do not update state if we are already calculating a new one
 
 			window.interceptor.simulation = {
 				simulationId: window.interceptor.simulation.simulationId,
 				tokenPrices: tokenPrices,
-				addressMetadata: addressMetadata,
+				addressBookEntries: addressBookEntries,
 				visualizerResults: visualizerResult,
 				simulationState: updatedSimulationState,
 				isComputingSimulation: false,
@@ -161,7 +161,7 @@ export async function updateSimulationState( getUpdatedSimulationState: () => Pr
 		} else {
 			window.interceptor.simulation = {
 				simulationId: window.interceptor.simulation.simulationId,
-				addressMetadata: [],
+				addressBookEntries: [],
 				tokenPrices: [],
 				visualizerResults: [],
 				simulationState: updatedSimulationState,
@@ -193,10 +193,10 @@ export async function refreshConfirmTransactionSimulation() {
 	const appended = await newSimulator.appendTransaction(EthereumUnsignedTransaction.parse(window.interceptor.confirmTransactionDialog.transactionToSimulate))
 	const transactions = appended.simulationState.simulatedTransactions.map(x => x.unsignedTransaction)
 	const visualizerResult = await simulator.visualizeTransactionChain(transactions, appended.simulationState.blockNumber, appended.simulationState.simulatedTransactions.map( x => x.multicallResponse))
-	const addressMetadata = await getAddressMetadataForVisualiser(simulator, visualizerResult.map( (x) => x.visualizerResults), appended.simulationState, window.interceptor.settings?.addressInfos)
+	const addressMetadata = await getAddressBookEntriesForVisualiser(simulator, visualizerResult.map( (x) => x.visualizerResults), appended.simulationState, window.interceptor.settings?.addressInfos)
 	const tokenPrices = await priceEstimator.estimateEthereumPricesForTokens(
 		addressMetadata.map(
-			(x) => x[1].metadataSource === 'token' && x[1].decimals !== undefined ? { token: BigInt(x[0]), decimals: x[1].decimals } : { token: 0x0n, decimals: 0x0n }
+			(x) => x[1].type === 'token' && x[1].decimals !== undefined ? { token: BigInt(x[0]), decimals: x[1].decimals } : { token: 0x0n, decimals: 0x0n }
 		).filter( (x) => x.token !== 0x0n )
 	)
 
@@ -204,7 +204,7 @@ export async function refreshConfirmTransactionSimulation() {
 
 	window.interceptor.confirmTransactionDialog.tokenPrices = tokenPrices
 	window.interceptor.confirmTransactionDialog.simulationState = appended.simulationState
-	window.interceptor.confirmTransactionDialog.addressMetadata = addressMetadata
+	window.interceptor.confirmTransactionDialog.addressBookEntries = addressMetadata
 	window.interceptor.confirmTransactionDialog.visualizerResults = visualizerResult
 	window.interceptor.confirmTransactionDialog.isComputingSimulation = false
 	sendPopupMessageToOpenWindows({ message: 'popup_confirm_transaction_simulation_state_changed' })

--- a/extension/app/ts/background/backgroundUtils.ts
+++ b/extension/app/ts/background/backgroundUtils.ts
@@ -1,8 +1,15 @@
 import { MessageToPopup } from '../utils/interceptor-messages.js'
+import { findAddressInfo } from './metadataUtils.js'
 
 export function getActiveAddress() {
 	if (window.interceptor.settings === undefined) return undefined
 	return window.interceptor.settings.simulationMode ? window.interceptor.settings.activeSimulationAddress : window.interceptor.settings.activeSigningAddress
+}
+
+export function getActiveAddressInfo() {
+	const address = getActiveAddress()
+	if (address === undefined) return undefined
+	return findAddressInfo(address, window.interceptor.settings?.addressInfos)
 }
 
 export async function sendPopupMessageToOpenWindows(message: MessageToPopup) {

--- a/extension/app/ts/background/backgroundUtils.ts
+++ b/extension/app/ts/background/backgroundUtils.ts
@@ -1,15 +1,8 @@
 import { MessageToPopup } from '../utils/interceptor-messages.js'
-import { findAddressInfo } from './metadataUtils.js'
 
 export function getActiveAddress() {
 	if (window.interceptor.settings === undefined) return undefined
 	return window.interceptor.settings.simulationMode ? window.interceptor.settings.activeSimulationAddress : window.interceptor.settings.activeSigningAddress
-}
-
-export function getActiveAddressInfo() {
-	const address = getActiveAddress()
-	if (address === undefined) return undefined
-	return findAddressInfo(address, window.interceptor.settings?.addressInfos)
 }
 
 export async function sendPopupMessageToOpenWindows(message: MessageToPopup) {

--- a/extension/app/ts/background/windows/confirmTransaction.ts
+++ b/extension/app/ts/background/windows/confirmTransaction.ts
@@ -53,7 +53,7 @@ export async function openConfirmTransactionDialog(
 
 	window.interceptor.confirmTransactionDialog = {
 		requestId: requestId,
-		addressMetadata: [],
+		addressBookEntries: [],
 		visualizerResults: undefined,
 		simulationState: undefined,
 		simulationMode: simulationMode,

--- a/extension/app/ts/background/windows/interceptorAccess.ts
+++ b/extension/app/ts/background/windows/interceptorAccess.ts
@@ -87,13 +87,13 @@ export async function setPendingAccessRequests(pendingAccessRequest: readonly Pe
 	await updateExtensionBadge()
 }
 
-export async function changeAccess(access: Confirmation, origin: string, originIcon: string | undefined, accessAddress: bigint | undefined) {
+export async function changeAccess(access: Confirmation, origin: string, originIcon: string | undefined, accessAddress: string | undefined) {
 	if (window.interceptor.settings === undefined) return
 	if (access === 'NoResponse') return
 
 	await setPendingAccessRequests( window.interceptor.settings.pendingAccessRequests.filter( (x) => !(x.origin === origin && x.requestAccessToAddress === accessAddress) ) )
 
-	window.interceptor.settings.websiteAccess = setAccess(window.interceptor.settings.websiteAccess, origin, originIcon, access === 'Approved', accessAddress === undefined ? undefined : addressString(accessAddress))
+	window.interceptor.settings.websiteAccess = setAccess(window.interceptor.settings.websiteAccess, origin, originIcon, access === 'Approved', accessAddress)
 	window.interceptor.websiteAccessAddressMetadata = getAddressMetadataForAccess(window.interceptor.settings.websiteAccess)
 	saveWebsiteAccess(window.interceptor.settings.websiteAccess)
 	updateWebsiteApprovalAccesses()
@@ -152,7 +152,7 @@ export async function requestAccessFromUser(origin: string, icon: string | undef
 
 	const access = await pendingInterceptorAccess
 
-	await changeAccess(access, origin, icon, accessAddress === undefined ? undefined : BigInt(accessAddress))
+	await changeAccess(access, origin, icon, accessAddress)
 
 	return access === 'Approved'
 }

--- a/extension/app/ts/background/windows/interceptorAccess.ts
+++ b/extension/app/ts/background/windows/interceptorAccess.ts
@@ -1,12 +1,11 @@
 import { addressString } from '../../utils/bigint.js'
 import { Future } from '../../utils/future.js'
 import { imageToUri } from '../../utils/imageToUri.js'
-import { PendingAccessRequest } from '../../utils/user-interface-types.js'
-import { AddressMetadata } from '../../utils/visualizer-types.js'
+import { AddressInfoEntry, PendingAccessRequest } from '../../utils/user-interface-types.js'
 import { setAccess, updateWebsiteApprovalAccesses } from '../accessManagement.js'
 import { sendPopupMessageToOpenWindows } from '../backgroundUtils.js'
 import { updateExtensionBadge } from '../iconHandler.js'
-import { getAddressMetaData } from '../metadataUtils.js'
+import { findAddressInfo } from '../metadataUtils.js'
 import { savePendingAccessRequests, saveWebsiteAccess, WebsiteAccess } from '../settings.js'
 
 export type Confirmation = 'Approved' | 'Rejected' | 'NoResponse'
@@ -34,12 +33,12 @@ export async function resolveInterceptorAccess(confirmation: Confirmation) {
 	openedInterceptorAccessWindow = null
 }
 
-export function getAddressMetadataForAccess(websiteAccess: readonly WebsiteAccess[]) : [string, AddressMetadata][]{
+export function getAddressMetadataForAccess(websiteAccess: readonly WebsiteAccess[]) : [string, AddressInfoEntry][]{
 	if ( window.interceptor.settings === undefined) return []
 	const addresses = websiteAccess.map( (x) => x.addressAccess === undefined ? [] : x.addressAccess?.map( (addr) => addr.address) ).flat()
 	const addressSet = new Set(addresses)
 	const infos = window.interceptor.settings.addressInfos
-	return Array.from(addressSet).map( (x) => [x, getAddressMetaData(BigInt(x), infos)] )
+	return Array.from(addressSet).map( (x) => [x, findAddressInfo(BigInt(x), infos)] )
 }
 
 export async function retrieveIcon(tabId: number | undefined) {
@@ -83,25 +82,25 @@ export async function setPendingAccessRequests(pendingAccessRequest: readonly Pe
 	const addresses = window.interceptor.settings.pendingAccessRequests.map( (x) => x.requestAccessToAddress === undefined ? [] : x.requestAccessToAddress ).flat()
 	const addressSet = new Set(addresses)
 	const infos = window.interceptor.settings.addressInfos
-	window.interceptor.pendingAccessMetadata = Array.from(addressSet).map( (x) => [x, getAddressMetaData(BigInt(x), infos)] )
+	window.interceptor.pendingAccessMetadata = Array.from(addressSet).map( (x) => [x, findAddressInfo(BigInt(x), infos)] )
 	savePendingAccessRequests(window.interceptor.settings.pendingAccessRequests)
 	await updateExtensionBadge()
 }
 
-export async function changeAccess(access: Confirmation, origin: string, originIcon: string | undefined, accessAddress: string | undefined) {
+export async function changeAccess(access: Confirmation, origin: string, originIcon: string | undefined, accessAddress: bigint | undefined) {
 	if (window.interceptor.settings === undefined) return
 	if (access === 'NoResponse') return
 
 	await setPendingAccessRequests( window.interceptor.settings.pendingAccessRequests.filter( (x) => !(x.origin === origin && x.requestAccessToAddress === accessAddress) ) )
 
-	window.interceptor.settings.websiteAccess = setAccess(window.interceptor.settings.websiteAccess, origin, originIcon, access === 'Approved', accessAddress)
+	window.interceptor.settings.websiteAccess = setAccess(window.interceptor.settings.websiteAccess, origin, originIcon, access === 'Approved', accessAddress === undefined ? undefined : addressString(accessAddress))
 	window.interceptor.websiteAccessAddressMetadata = getAddressMetadataForAccess(window.interceptor.settings.websiteAccess)
 	saveWebsiteAccess(window.interceptor.settings.websiteAccess)
 	updateWebsiteApprovalAccesses()
 	sendPopupMessageToOpenWindows({ message: 'popup_websiteAccess_changed' })
 }
 
-export async function requestAccessFromUser(origin: string, icon: string | undefined, requestAccessToAddress: string | undefined = undefined, addressMetadata: [string, AddressMetadata][] = []) {
+export async function requestAccessFromUser(origin: string, icon: string | undefined, requestAccessToAddress: string | undefined = undefined, addressMetadata: [string, AddressInfoEntry][] = []) {
 	if (window.interceptor.settings === undefined) return false
 
 	// check if we need to ask address access or not. If address is put to never need to have address specific permision, we don't need to ask for it
@@ -132,7 +131,7 @@ export async function requestAccessFromUser(origin: string, icon: string | undef
 			origin: origin,
 			icon: icon,
 			requestAccessToAddress: accessAddress,
-			addressMetadata: addressMetadata,
+			addressBookEntries: addressMetadata,
 		}
 
 		openedInterceptorAccessWindow = await browser.windows.create(
@@ -153,7 +152,7 @@ export async function requestAccessFromUser(origin: string, icon: string | undef
 
 	const access = await pendingInterceptorAccess
 
-	await changeAccess(access, origin, icon, accessAddress)
+	await changeAccess(access, origin, icon, accessAddress === undefined ? undefined : BigInt(accessAddress))
 
 	return access === 'Approved'
 }

--- a/extension/app/ts/background/windows/personalSign.ts
+++ b/extension/app/ts/background/windows/personalSign.ts
@@ -2,8 +2,7 @@ import { addressString } from '../../utils/bigint.js'
 import { METAMASK_ERROR_USER_REJECTED_REQUEST } from '../../utils/constants.js'
 import { Future } from '../../utils/future.js'
 import { PersonalSign } from '../../utils/interceptor-messages.js'
-import { AddressInfo } from '../../utils/user-interface-types.js'
-import { AddressMetadata } from '../../utils/visualizer-types.js'
+import { AddressBookEntry, AddressInfo } from '../../utils/user-interface-types.js'
 import { EIP2612Message, EthereumAddress } from '../../utils/wire-types.js'
 import { personalSignWithSimulator } from '../background.js'
 import { getAddressMetaData } from '../metadataUtils.js'
@@ -23,7 +22,7 @@ export async function resolvePersonalSign(confirmation: PersonalSign) {
 	openedPersonalSignDialogWindow = null
 }
 
-function getAddressMetadataForEIP2612Message(message: EIP2612Message, addressInfos: readonly AddressInfo[] | undefined) : [string, AddressMetadata][] {
+function getAddressMetadataForEIP2612Message(message: EIP2612Message, addressInfos: readonly AddressInfo[] | undefined) : [string, AddressBookEntry][] {
 	return [
 		[addressString(message.message.owner), getAddressMetaData(message.message.owner, addressInfos)],
 		[addressString(message.message.spender), getAddressMetaData(message.message.spender, addressInfos)],
@@ -47,7 +46,7 @@ export async function openPersonalSignDialog(requestId: number, simulationMode: 
 			message: message,
 			account: addressString(account),
 			method: method,
-			addressMetadata: getAddressMetadataForEIP2612Message(parsed, window.interceptor.settings?.addressInfos),
+			addressBookEntries: getAddressMetadataForEIP2612Message(parsed, window.interceptor.settings?.addressInfos),
 			eip2612Message: parsed,
 		}
 	}
@@ -58,7 +57,7 @@ export async function openPersonalSignDialog(requestId: number, simulationMode: 
 			message: message,
 			account: addressString(account),
 			method: method,
-			addressMetadata: [],
+			addressBookEntries: [],
 		}
 	} else {
 		throw new Error('Unknown method');

--- a/extension/app/ts/components/App.tsx
+++ b/extension/app/ts/components/App.tsx
@@ -1,7 +1,7 @@
 import { useState, useEffect } from 'preact/hooks'
 import { defaultAddresses, WebsiteAccess } from '../background/settings.js'
 import { addressString } from '../utils/bigint.js'
-import { EthBalanceChangesWithMetadata, SimulatedAndVisualizedTransaction, SimulationAndVisualisationResults, TokenVisualizerResultWithMetadata } from '../utils/visualizer-types.js'
+import { SimulationAndVisualisationResults } from '../utils/visualizer-types.js'
 import { AddressList } from './pages/AddressList.js'
 import { ChangeActiveAddress } from './pages/ChangeActiveAddress.js'
 import { Home } from './pages/Home.js'
@@ -17,6 +17,7 @@ import { DEFAULT_TAB_CONNECTION } from '../utils/constants.js'
 import { SignerName } from '../utils/interceptor-messages.js'
 import { EthereumQuantity } from '../utils/wire-types.js'
 import { version, gitCommitSha } from '../version.js'
+import { formSimulatedAndVisualizedTransaction } from './formVisualizerResults.js'
 
 export function App() {
 	const [appPage, setAppPage] = useState(Page.Home)
@@ -91,69 +92,10 @@ export function App() {
 		const simState = backgroundPage.interceptor.simulation.simulationState
 		if (simState === undefined) return setSimVisResults(undefined)
 		if (backgroundPage.interceptor.settings?.activeSimulationAddress === undefined) return setSimVisResults(undefined)
+		if (backgroundPage.interceptor.simulation.visualizerResults === undefined) return setSimVisResults(undefined)
 
-		const addressMetadata = new Map(backgroundPage.interceptor.simulation.addressBookEntries.map( (x) => [x[0], x[1]]))
-
-		// todo, move this to background page (and refacor hard) to form when simulation is made and we can get rid of most of the validations done here
-		const txs: SimulatedAndVisualizedTransaction[] = simState.simulatedTransactions.map( (simulatedTx, index) => {
-			const from = addressMetadata.get(addressString(simulatedTx.unsignedTransaction.from))
-			if (from === undefined) throw new Error('missing metadata')
-
-			const to = simulatedTx.unsignedTransaction.to !== null ? addressMetadata.get(addressString(simulatedTx.unsignedTransaction.to)) : undefined
-			if (simulatedTx.unsignedTransaction.to !== null && to === undefined ) throw new Error('missing metadata')
-
-			if (backgroundPage.interceptor.simulation.visualizerResults === undefined) throw new Error('missing visualizerResults')
-			const visualiser = backgroundPage.interceptor.simulation.visualizerResults[index].visualizerResults
-
-			const ethBalanceChanges: EthBalanceChangesWithMetadata[] = visualiser === undefined ? [] : visualiser.ethBalanceChanges.map((change) => {
-				const entry = addressMetadata.get(addressString(change.address))
-				if (entry === undefined) throw new Error('missing metadata')
-				return {
-					...change,
-					address: entry,
-				}
-			})
-			const tokenResults: TokenVisualizerResultWithMetadata[] = visualiser === undefined ? [] : visualiser.tokenResults.map((change) => {
-				const fromEntry = addressMetadata.get(addressString(change.from))
-				const toEntry = addressMetadata.get(addressString(change.to))
-				const tokenEntry = addressMetadata.get(addressString(change.tokenAddress))
-				if (fromEntry === undefined || toEntry === undefined || tokenEntry === undefined) throw new Error('missing metadata')
-				if ( !(change.is721 && tokenEntry.type === 'NFT') ) throw new Error('wrong tokentype')
-				return {
-					...change,
-					from: fromEntry,
-					to: toEntry,
-					token: tokenEntry,
-				}
-			})
-			return {
-				from: from,
-				to: to,
-				value: simulatedTx.unsignedTransaction.value,
-				realizedGasPrice: simulatedTx.realizedGasPrice,
-				ethBalanceChanges: ethBalanceChanges,
-				tokenResults: tokenResults,
-				gasSpent: simulatedTx.multicallResponse.gasSpent,
-				quarantine: backgroundPage.interceptor.simulation.visualizerResults[index].quarantine,
-				quarantineCodes: backgroundPage.interceptor.simulation.visualizerResults[index].quarantineCodes,
-				chainId: simState.chain,
-				gas: simulatedTx.unsignedTransaction.gas,
-				input: simulatedTx.unsignedTransaction.input,
-				...(simulatedTx.unsignedTransaction.type === '1559' ? {
-					type: simulatedTx.unsignedTransaction.type,
-					maxFeePerGas: simulatedTx.unsignedTransaction.maxFeePerGas,
-					maxPriorityFeePerGas: simulatedTx.unsignedTransaction.maxPriorityFeePerGas,
-				} : { type: simulatedTx.unsignedTransaction.type } ),
-				hash: simulatedTx.signedTransaction.hash,
-				...(simulatedTx.multicallResponse.statusCode === 'failure' ? {
-					error: simulatedTx.multicallResponse.error,
-					statusCode: simulatedTx.multicallResponse.statusCode,
-				} : {
-					statusCode: simulatedTx.multicallResponse.statusCode,
-				}),
-			}
-		} )
-
+		const addressMetaData = new Map(backgroundPage.interceptor.simulation.addressBookEntries.map( (x) => [x[0], x[1]]))
+		const txs = formSimulatedAndVisualizedTransaction(simState, backgroundPage.interceptor.simulation.visualizerResults, addressMetaData)
 		setSimVisResults( {
 			blockNumber: simState.blockNumber,
 			blockTimestamp: simState.blockTimestamp,
@@ -164,6 +106,7 @@ export function App() {
 			activeAddress: BigInt(backgroundPage.interceptor.settings.activeSimulationAddress),
 			simulationMode: backgroundPage.interceptor.settings.simulationMode,
 			isComputingSimulation: backgroundPage.interceptor.simulation.isComputingSimulation,
+			addressMetaData: addressMetaData,
 		})
 	}
 

--- a/extension/app/ts/components/App.tsx
+++ b/extension/app/ts/components/App.tsx
@@ -1,11 +1,11 @@
 import { useState, useEffect } from 'preact/hooks'
 import { defaultAddresses, WebsiteAccess } from '../background/settings.js'
 import { addressString } from '../utils/bigint.js'
-import { AddressMetadata, SimulatedAndVisualizedTransaction, SimulationAndVisualisationResults } from '../utils/visualizer-types.js'
+import { SimulatedAndVisualizedTransaction, SimulationAndVisualisationResults } from '../utils/visualizer-types.js'
 import { AddressList } from './pages/AddressList.js'
 import { ChangeActiveAddress } from './pages/ChangeActiveAddress.js'
 import { Home } from './pages/Home.js'
-import { Page, AddressInfo, TabConnection } from '../utils/user-interface-types.js'
+import { Page, AddressInfo, TabConnection, AddressInfoEntry, AddressBookEntry } from '../utils/user-interface-types.js'
 import Hint from './subcomponents/Hint.js'
 import { AddNewAddress } from './pages/AddNewAddress.js'
 import { InterceptorAccessList } from './pages/InterceptorAccessList.js'
@@ -28,7 +28,7 @@ export function App() {
 	const [useSignersAddressAsActiveAddress, setUseSignersAddressAsActiveAddress] = useState(false)
 	const [simVisResults, setSimVisResults] = useState<SimulationAndVisualisationResults | undefined >(undefined)
 	const [websiteAccess, setWebsiteAccess] = useState<readonly WebsiteAccess[] | undefined>(undefined)
-	const [websiteAccessAddressMetadata, setWebsiteAccessAddressMetadata] = useState<[string, AddressMetadata][]>([])
+	const [websiteAccessAddressMetadata, setWebsiteAccessAddressMetadata] = useState<[string, AddressInfoEntry][]>([])
 	const [activeChain, setActiveChain] = useState<bigint>(1n)
 	const [addressInput, setAddressInput] = useState<string | undefined>(undefined)
 	const [nameInput, setNameInput] = useState<string | undefined>(undefined)
@@ -101,7 +101,7 @@ export function App() {
 			blockTimestamp: backgroundPage.interceptor.simulation.simulationState.blockTimestamp,
 			simulationConductedTimestamp: backgroundPage.interceptor.simulation.simulationState.simulationConductedTimestamp,
 			simulatedAndVisualizedTransactions: txs,
-			addressMetadata: new Map(backgroundPage.interceptor.simulation.addressMetadata.map( (x) => [x[0], x[1]])),
+			addressMetadata: new Map(backgroundPage.interceptor.simulation.addressBookEntries.map( (x) => [x[0], x[1]])),
 			chain: backgroundPage.interceptor.simulation.simulationState.chain,
 			tokenPrices: backgroundPage.interceptor.simulation.tokenPrices,
 			activeAddress: BigInt(backgroundPage.interceptor.settings.activeSimulationAddress),
@@ -169,10 +169,10 @@ export function App() {
 		setAddressInput(addressString)
 	}
 
-	function renameAddressCallBack(name: string | undefined, address: string) {
+	function renameAddressCallBack(entry: AddressBookEntry) {
 		setAndSaveAppPage(Page.ModifyAddress)
-		setNameInput(name === undefined ? '' : name)
-		setAddressInput(ethers.utils.getAddress(address))
+		setNameInput(entry.name === undefined ? '' : entry.name)
+		setAddressInput(ethers.utils.getAddress(addressString(entry.address)))
 	}
 
 	function openAddressBook() {

--- a/extension/app/ts/components/formVisualizerResults.ts
+++ b/extension/app/ts/components/formVisualizerResults.ts
@@ -1,0 +1,63 @@
+import { addressString } from '../utils/bigint.js'
+import { EthBalanceChangesWithMetadata, SimResults, SimulatedAndVisualizedTransaction, SimulationState, TokenVisualizerResultWithMetadata } from '../utils/visualizer-types.js'
+import { AddressBookEntry } from '../utils/user-interface-types.js'
+
+// todo, move this to background page (and refacor hard) to form when simulation is made and we can get rid of most of the validations done here
+export function formSimulatedAndVisualizedTransaction(simState: SimulationState, visualizerResults: SimResults[], addressMetaData: Map<string, AddressBookEntry> ) : SimulatedAndVisualizedTransaction[] {
+	return simState.simulatedTransactions.map( (simulatedTx, index) => {
+		const from = addressMetaData.get(addressString(simulatedTx.unsignedTransaction.from))
+		if (from === undefined) throw new Error('missing metadata')
+
+		const to = simulatedTx.unsignedTransaction.to !== null ? addressMetaData.get(addressString(simulatedTx.unsignedTransaction.to)) : undefined
+		if (simulatedTx.unsignedTransaction.to !== null && to === undefined ) throw new Error('missing metadata')
+		const visualiser = visualizerResults[index].visualizerResults
+
+		const ethBalanceChanges: EthBalanceChangesWithMetadata[] = visualiser === undefined ? [] : visualiser.ethBalanceChanges.map((change) => {
+			const entry = addressMetaData.get(addressString(change.address))
+			if (entry === undefined) throw new Error('missing metadata')
+			return {
+				...change,
+				address: entry,
+			}
+		})
+		const tokenResults: TokenVisualizerResultWithMetadata[] = visualiser === undefined ? [] : visualiser.tokenResults.map((change) => {
+			const fromEntry = addressMetaData.get(addressString(change.from))
+			const toEntry = addressMetaData.get(addressString(change.to))
+			const tokenEntry = addressMetaData.get(addressString(change.tokenAddress))
+			if (fromEntry === undefined || toEntry === undefined || tokenEntry === undefined) throw new Error('missing metadata')
+			if ( !(change.is721 && tokenEntry.type === 'NFT') ) throw new Error('wrong tokentype')
+			return {
+				...change,
+				from: fromEntry,
+				to: toEntry,
+				token: tokenEntry,
+			}
+		})
+		return {
+			from: from,
+			to: to,
+			value: simulatedTx.unsignedTransaction.value,
+			realizedGasPrice: simulatedTx.realizedGasPrice,
+			ethBalanceChanges: ethBalanceChanges,
+			tokenResults: tokenResults,
+			gasSpent: simulatedTx.multicallResponse.gasSpent,
+			quarantine: visualizerResults[index].quarantine,
+			quarantineCodes: visualizerResults[index].quarantineCodes,
+			chainId: simState.chain,
+			gas: simulatedTx.unsignedTransaction.gas,
+			input: simulatedTx.unsignedTransaction.input,
+			...(simulatedTx.unsignedTransaction.type === '1559' ? {
+				type: simulatedTx.unsignedTransaction.type,
+				maxFeePerGas: simulatedTx.unsignedTransaction.maxFeePerGas,
+				maxPriorityFeePerGas: simulatedTx.unsignedTransaction.maxPriorityFeePerGas,
+			} : { type: simulatedTx.unsignedTransaction.type } ),
+			hash: simulatedTx.signedTransaction.hash,
+			...(simulatedTx.multicallResponse.statusCode === 'failure' ? {
+				error: simulatedTx.multicallResponse.error,
+				statusCode: simulatedTx.multicallResponse.statusCode,
+			} : {
+				statusCode: simulatedTx.multicallResponse.statusCode,
+			}),
+		}
+	} )
+}

--- a/extension/app/ts/components/formVisualizerResults.ts
+++ b/extension/app/ts/components/formVisualizerResults.ts
@@ -25,13 +25,24 @@ export function formSimulatedAndVisualizedTransaction(simState: SimulationState,
 			const toEntry = addressMetaData.get(addressString(change.to))
 			const tokenEntry = addressMetaData.get(addressString(change.tokenAddress))
 			if (fromEntry === undefined || toEntry === undefined || tokenEntry === undefined) throw new Error('missing metadata')
-			if ( !(change.is721 && tokenEntry.type === 'NFT') ) throw new Error('wrong tokentype')
-			return {
-				...change,
-				from: fromEntry,
-				to: toEntry,
-				token: tokenEntry,
+
+			if (change.is721 && tokenEntry.type === 'NFT') {
+				return {
+					...change,
+					from: fromEntry,
+					to: toEntry,
+					token: tokenEntry
+				}
 			}
+			if (!change.is721 && tokenEntry.type === 'token') {
+				return {
+					...change,
+					from: fromEntry,
+					to: toEntry,
+					token: tokenEntry
+				}
+			}
+			throw new Error('wrong token type')
 		})
 		return {
 			from: from,

--- a/extension/app/ts/components/pages/ChangeActiveAddress.tsx
+++ b/extension/app/ts/components/pages/ChangeActiveAddress.tsx
@@ -79,8 +79,7 @@ export function ChangeActiveAddress(param: ChangeActiveAddressParam) {
 							<div class = 'card hoverable' onClick = { () => { ChangeAndStoreActiveAddress(addressInfo.address) } }>
 								<div class = 'card-content hoverable ' style = 'cursor: pointer;'>
 									<BigAddress
-										address = { addressInfo.address }
-										nameAndLogo = { { name: addressInfo.name, logoUri: undefined } }
+										addressBookEntry = { { ...addressInfo, type: 'addressInfo' as const } }
 										noCopying = { true }
 										renameAddressCallBack = { param.renameAddressCallBack }
 									/>

--- a/extension/app/ts/components/pages/ConfirmTransaction.tsx
+++ b/extension/app/ts/components/pages/ConfirmTransaction.tsx
@@ -62,7 +62,6 @@ export function ConfirmTransaction() {
 			isComputingSimulation: dialog.isComputingSimulation,
 			simulationConductedTimestamp: dialog.simulationState.simulationConductedTimestamp,
 			simulatedAndVisualizedTransactions: txs,
-			addressMetadata: new Map(dialog.addressBookEntries.map( (x) => [x[0], x[1]])),
 			chain: dialog.simulationState.chain,
 			tokenPrices: dialog.tokenPrices,
 			activeAddress: dialog.activeAddress,
@@ -86,8 +85,8 @@ export function ConfirmTransaction() {
 
 	function isConfirmDisabled() {
 		if (forceSend) return false
-		const success = simulationAndVisualisationResults && simulationAndVisualisationResults.simulatedAndVisualizedTransactions[simulationAndVisualisationResults.simulatedAndVisualizedTransactions.length - 1 ].multicallResponse.statusCode === 'success'
-		const noQuarantines = simulationAndVisualisationResults && simulationAndVisualisationResults.simulatedAndVisualizedTransactions.find( (x) => (x.simResults && x.simResults.quarantine)) === undefined
+		const success = simulationAndVisualisationResults && simulationAndVisualisationResults.simulatedAndVisualizedTransactions[simulationAndVisualisationResults.simulatedAndVisualizedTransactions.length - 1 ].statusCode === 'success'
+		const noQuarantines = simulationAndVisualisationResults && simulationAndVisualisationResults.simulatedAndVisualizedTransactions.find( (x) => x.quarantine) === undefined
 		return !success || !noQuarantines
 	}
 
@@ -131,12 +130,12 @@ export function ConfirmTransaction() {
 								renameAddressCallBack = { renameAddressCallBack }
 							/>
 							<div className = 'block' style = 'margin: 10px; padding: 10px; background-color: var(--card-bg-color);'>
-								{ simulationAndVisualisationResults && simulationAndVisualisationResults.simulatedAndVisualizedTransactions[simulationAndVisualisationResults.simulatedAndVisualizedTransactions.length - 1 ].multicallResponse.statusCode === 'success' ? <></> :
+								{ simulationAndVisualisationResults && simulationAndVisualisationResults.simulatedAndVisualizedTransactions[simulationAndVisualisationResults.simulatedAndVisualizedTransactions.length - 1 ].statusCode === 'success' ? <></> :
 									<div class = 'card-content'>
 										<ErrorCheckBox text = { 'I understand that the transaction will most likely fail but I want to send it anyway.' } checked = { forceSend } onInput = { setForceSend } />
 									</div>
 								}
-								{ simulationAndVisualisationResults && simulationAndVisualisationResults.simulatedAndVisualizedTransactions[simulationAndVisualisationResults.simulatedAndVisualizedTransactions.length - 1 ].simResults?.quarantine !== true ? <></> :
+								{ simulationAndVisualisationResults && simulationAndVisualisationResults.simulatedAndVisualizedTransactions[simulationAndVisualisationResults.simulatedAndVisualizedTransactions.length - 1 ].quarantine !== true ? <></> :
 									<div class = 'card-content'>
 										<ErrorCheckBox text = { 'I understand that there are issues with this transaction but I want to send it anyway against Interceptors recommendations.' } checked = { forceSend } onInput = { setForceSend } />
 									</div>

--- a/extension/app/ts/components/pages/ConfirmTransaction.tsx
+++ b/extension/app/ts/components/pages/ConfirmTransaction.tsx
@@ -8,6 +8,9 @@ import { Transactions } from '../simulationExplaining/Transactions.js'
 import { Spinner } from '../subcomponents/Spinner.js'
 import { getSignerName, SignerLogoText } from '../subcomponents/signers.js'
 import { AddNewAddress } from './AddNewAddress.js'
+import { AddressBookEntry } from '../../utils/user-interface-types.js'
+import { ethers } from 'ethers'
+import { addressString } from '../../utils/bigint.js'
 
 export function ConfirmTransaction() {
 	const [requestIdToConfirm, setRequestIdToConfirm] = useState<number | undefined>(undefined)
@@ -59,7 +62,7 @@ export function ConfirmTransaction() {
 			isComputingSimulation: dialog.isComputingSimulation,
 			simulationConductedTimestamp: dialog.simulationState.simulationConductedTimestamp,
 			simulatedAndVisualizedTransactions: txs,
-			addressMetadata: new Map(dialog.addressMetadata.map( (x) => [x[0], x[1]])),
+			addressMetadata: new Map(dialog.addressBookEntries.map( (x) => [x[0], x[1]])),
 			chain: dialog.simulationState.chain,
 			tokenPrices: dialog.tokenPrices,
 			activeAddress: dialog.activeAddress,
@@ -88,10 +91,10 @@ export function ConfirmTransaction() {
 		return !success || !noQuarantines
 	}
 
-	function renameAddressCallBack(name: string | undefined, address: string) {
+	function renameAddressCallBack(entry: AddressBookEntry) {
 		setEditAddressModelOpen(true)
-		setAddressInput(address)
-		setNameInput(name)
+		setNameInput(entry.name === undefined ? '' : entry.name)
+		setAddressInput(ethers.utils.getAddress(addressString(entry.address)))
 	}
 
 	return (

--- a/extension/app/ts/components/pages/Home.tsx
+++ b/extension/app/ts/components/pages/Home.tsx
@@ -211,7 +211,6 @@ export function Home(param: HomeParams) {
 
 			{ !simulationMode || activeSimulationAddress === undefined ? <></> :
 				<SimulationResults
-					addressMetadata = { param.simVisResults !== undefined ? param.simVisResults.addressMetadata : new Map() }
 					simulationAndVisualisationResults = { simulationAndVisualisationResults }
 					removeTransaction = { removeTransaction }
 					refreshSimulation = { refreshSimulation }

--- a/extension/app/ts/components/pages/Home.tsx
+++ b/extension/app/ts/components/pages/Home.tsx
@@ -75,8 +75,12 @@ function FirstCard(param: FirstCardParams) {
 				}
 				{ param.activeAddress !== undefined ?
 					<ActiveAddress
-						address = { param.activeAddress.address }
-						title = { param.activeAddress.name }
+						addressBookEntry = { {
+							type: 'addressInfo' as const,
+							name: param.activeAddress.name,
+							address: param.activeAddress.address,
+							askForAddressAccess: false, // TODO, when getting rid of window.interceptor, make active address an addressbook entry too
+						} }
 						simulationMode = { param.simulationMode }
 						changeActiveAddress = { param.changeActiveAddress }
 						renameAddressCallBack = { param.renameAddressCallBack }

--- a/extension/app/ts/components/pages/InterceptorAccessList.tsx
+++ b/extension/app/ts/components/pages/InterceptorAccessList.tsx
@@ -1,9 +1,9 @@
-import { InterceptorAccessListParams, Page } from '../../utils/user-interface-types.js'
+import { AddressInfoEntry, InterceptorAccessListParams, Page } from '../../utils/user-interface-types.js'
 import { useEffect, useState } from 'preact/hooks'
 import { WebsiteAccess, WebsiteAddressAccess } from '../../background/settings.js'
-import { AddressMetadata } from '../../utils/visualizer-types.js'
 import { SmallAddress } from '../subcomponents/address.js'
 import { CopyToClipboard } from '../subcomponents/CopyToClipboard.js'
+import { ethers } from 'ethers'
 
 interface ModifiedAddressAccess {
 	address: string,
@@ -21,7 +21,7 @@ interface EditableAccess {
 
 export function InterceptorAccessList(param: InterceptorAccessListParams) {
 	const [editableAccessList, setEditableAccessList] = useState<readonly EditableAccess[] | undefined>(undefined)
-	const [metadata, setMetadata] = useState<Map<string, AddressMetadata>>(new Map())
+	const [metadata, setMetadata] = useState<Map<string, AddressInfoEntry> >(new Map())
 
 	function updateEditableAccessList(websiteAccess: readonly WebsiteAccess[] | undefined = undefined) {
 		const newList = websiteAccess ? websiteAccess : param.websiteAccess
@@ -197,8 +197,12 @@ export function InterceptorAccessList(param: InterceptorAccessListParams) {
 													{ websiteAccessAddress.removed ? <p style = 'color: var(--negative-color)' > { `Forgot ${ websiteAccessAddress.address }`} </p> :
 														<div style = 'display: flex; width: 100%; overflow: hidden;'>
 															<SmallAddress
-																address = { BigInt(websiteAccessAddress.address) }
-																nameAndLogo = { metadata.get(websiteAccessAddress.address) }
+																addressBookEntry = { metadata.get(websiteAccessAddress.address) || { // TODO, refactor away when we are using messaging instead of globals for these
+																	type: 'addressInfo',
+																	name: ethers.utils.getAddress(websiteAccessAddress.address),
+																	address: BigInt(websiteAccessAddress.address),
+																	askForAddressAccess: false
+																}}
 																renameAddressCallBack = { param.renameAddressCallBack }
 															/>
 															<div style = 'margin-left: auto; flex-shrink: 0; display: flex'>

--- a/extension/app/ts/components/pages/NotificationCenter.tsx
+++ b/extension/app/ts/components/pages/NotificationCenter.tsx
@@ -2,6 +2,7 @@ import { useEffect, useState } from 'preact/hooks'
 import { AddressInfoEntry, NotificationCenterParams, Page } from '../../utils/user-interface-types.js'
 import { BigAddress } from '../subcomponents/address.js'
 import { ethers } from 'ethers'
+import { addressString } from '../../utils/bigint.js'
 
 export type PendingAccessRequestWithMetadata = AddressInfoEntry & {
 	origin: string,
@@ -54,14 +55,14 @@ export function NotificationCenter(param: NotificationCenterParams) {
 	function review(origin: string, requestAccessToAddress: bigint | undefined) {
 		browser.runtime.sendMessage( { method: 'popup_reviewNotification', options: {
 			origin: origin,
-			requestAccessToAddress: requestAccessToAddress
+			requestAccessToAddress: requestAccessToAddress !== undefined ? addressString(requestAccessToAddress) : undefined
 		} } )
 	}
 
 	function reject(origin: string, requestAccessToAddress: bigint | undefined, removeOnly: boolean) {
 		browser.runtime.sendMessage( { method: 'popup_rejectNotification', options: {
 			origin: origin,
-			requestAccessToAddress: requestAccessToAddress,
+			requestAccessToAddress: requestAccessToAddress !== undefined ? addressString(requestAccessToAddress) : undefined,
 			removeOnly: removeOnly
 		} } )
 	}

--- a/extension/app/ts/components/pages/PersonalSign.tsx
+++ b/extension/app/ts/components/pages/PersonalSign.tsx
@@ -1,13 +1,14 @@
 import { useState, useEffect, useRef } from 'preact/hooks'
-import { bigintToRoundedPrettyDecimalString, stringToUint8Array } from '../../utils/bigint.js'
+import { addressString, bigintToRoundedPrettyDecimalString, stringToUint8Array } from '../../utils/bigint.js'
 import { EthereumAddress } from '../../utils/wire-types.js'
 import { BigAddress, findAddressInfo } from '../subcomponents/address.js'
-import { AddressInfo } from '../../utils/user-interface-types.js'
+import { AddressBookEntry, AddressInfo } from '../../utils/user-interface-types.js'
 import Hint from '../subcomponents/Hint.js'
 import { Error as ErrorComponent} from '../subcomponents/Error.js'
 import { getAddressMetaData } from '../../background/metadataUtils.js'
 import { getChainName } from '../../utils/constants.js'
 import { AddNewAddress } from './AddNewAddress.js'
+import { ethers } from 'ethers'
 
 interface SignRequest {
 	simulationMode: boolean,
@@ -84,10 +85,10 @@ export function PersonalSign() {
 		browser.runtime.sendMessage( { method: 'popup_personalSign', options: { requestId: requestIdToConfirm, accept: false } } )
 	}
 
-	function renameAddressCallBack(name: string | undefined, address: string) {
+	function renameAddressCallBack(entry: AddressBookEntry) {
 		setEditAddressModelOpen(true)
-		setAddressInput(address)
-		setNameInput(name)
+		setNameInput(entry.name === undefined ? '' : entry.name)
+		setAddressInput(ethers.utils.getAddress(addressString(entry.address)))
 	}
 
 	return (
@@ -135,8 +136,12 @@ export function PersonalSign() {
 						</header>
 						<div class = 'card-content'>
 							<BigAddress
-								address = { signRequest.account }
-								nameAndLogo = { { name: signRequest.addressInfo.name, logoUri: undefined } }
+								addressBookEntry = { {
+									type: 'addressInfo' as const,
+									name: signRequest.addressInfo.name,
+									address: signRequest.account,
+									askForAddressAccess: false, // TODO, when getting rid of window.interceptor, make this  address an addressbook entry too
+								} }
 								renameAddressCallBack = { renameAddressCallBack }
 							/>
 						</div>

--- a/extension/app/ts/components/simulationExplaining/SimulationSummary.tsx
+++ b/extension/app/ts/components/simulationExplaining/SimulationSummary.tsx
@@ -143,7 +143,7 @@ export function Erc20ApprovalChanges(param: Erc20ApprovalChangesParams ) {
 	return <>
 		{ param.tokenApprovalChanges.map( (token) => (
 			token.approvals.map( (entryToApprove) => (
-				<Erc20ApprovalChange { {
+				<Erc20ApprovalChange { ...{
 					...token,
 					entryToApprove: entryToApprove,
 					change: entryToApprove.change,
@@ -523,8 +523,8 @@ export function SimulationSummary(param: SimulationSummaryParams) {
 	if (param.simulationAndVisualisationResults === undefined) return <></>
 
 	const VisResults = param.summarizeOnlyLastTransaction && param.simulationAndVisualisationResults.simulatedAndVisualizedTransactions.length > 0 ?
-		[param.simulationAndVisualisationResults.simulatedAndVisualizedTransactions.at(-1)?.simResults?.visualizerResults] :
-		param.simulationAndVisualisationResults.simulatedAndVisualizedTransactions.map( (x) => (x.simResults?.visualizerResults) )
+		[param.simulationAndVisualisationResults.simulatedAndVisualizedTransactions.at(-1)] :
+		param.simulationAndVisualisationResults.simulatedAndVisualizedTransactions
 
 	const logSummarizer = new LogSummarizer( VisResults )
 
@@ -551,8 +551,8 @@ export function SimulationSummary(param: SimulationSummaryParams) {
 						<div class = 'card-header-icon unset-cursor'>
 							<span class = 'icon'>
 								{ param.summarizeOnlyLastTransaction ?
-									<img src = { param.simulationAndVisualisationResults.simulatedAndVisualizedTransactions[param.simulationAndVisualisationResults.simulatedAndVisualizedTransactions.length - 1].multicallResponse.statusCode === 'success' ? ( param.simulationAndVisualisationResults.simulatedAndVisualizedTransactions[param.simulationAndVisualisationResults.simulatedAndVisualizedTransactions.length - 1].simResults?.quarantine === true ? '../img/warning-sign.svg' : '../img/success-icon.svg' ) : '../img/error-icon.svg' } /> :
-									<img src = { param.simulationAndVisualisationResults.simulatedAndVisualizedTransactions.find( (x) => x.multicallResponse.statusCode !== 'success') === undefined ? ( param.simulationAndVisualisationResults.simulatedAndVisualizedTransactions.find( (x) => x.simResults && x.simResults.quarantine ) !== undefined ? '../img/warning-sign.svg' : '../img/success-icon.svg' ) : '../img/error-icon.svg' } />
+									<img src = { param.simulationAndVisualisationResults.simulatedAndVisualizedTransactions[param.simulationAndVisualisationResults.simulatedAndVisualizedTransactions.length - 1].statusCode === 'success' ? ( param.simulationAndVisualisationResults.simulatedAndVisualizedTransactions[param.simulationAndVisualisationResults.simulatedAndVisualizedTransactions.length - 1].quarantine === true ? '../img/warning-sign.svg' : '../img/success-icon.svg' ) : '../img/error-icon.svg' } /> :
+									<img src = { param.simulationAndVisualisationResults.simulatedAndVisualizedTransactions.find( (x) => x.statusCode !== 'success') === undefined ? ( param.simulationAndVisualisationResults.simulatedAndVisualizedTransactions.find( (x) => x.quarantine ) !== undefined ? '../img/warning-sign.svg' : '../img/success-icon.svg' ) : '../img/error-icon.svg' } />
 								}
 							</span>
 						</div>

--- a/extension/app/ts/components/simulationExplaining/Transactions.tsx
+++ b/extension/app/ts/components/simulationExplaining/Transactions.tsx
@@ -181,18 +181,6 @@ function SendOrReceiveTokensImportanceBox(param: SendOrReceiveTokensImportanceBo
 								useFullTokenName = { false }
 							/>
 						</div>
-						<div class = 'log-cell'>
-							<p class = 'ellipsis' style = { `color: ${ param.textColor }; margin-bottom: 0px; display: inline-block` }>
-								&nbsp;{ param.sending ? 'to' : 'from' }&nbsp;
-							</p>
-						</div>
-						<div class = 'log-cell'>
-							<SmallAddress
-								addressBookEntry = { tokenEvent.to }
-								textColor = { param.textColor }
-								renameAddressCallBack = { param.renameAddressCallBack }
-							/>
-						</div>
 					</table>
 				</div>
 			</div>
@@ -224,8 +212,7 @@ function TransactionImportanceBlock( param: TransactionImportanceBlockParams ) {
 	const sendingTokenResults = param.tx.tokenResults.filter( (x) => x.from.address === msgSender)
 	const receivingTokenResults = param.tx.tokenResults.filter( (x) => x.to.address === msgSender)
 
-	// tokenApprovalChanges: Map<string, Map<string, bigint > > // token address, approved address, amount
-	const tokenApprovalChanges: TokenApprovalChange[] = sendingTokenResults.filter((x): x is TokenVisualizerERC20Event  => x.isApproval && !('isAllApproval' in x)).map((entry) => {
+	const erc20tokenApprovalChanges: TokenApprovalChange[] = sendingTokenResults.filter((x): x is TokenVisualizerERC20Event  => x.isApproval && !x.is721).map((entry) => {
 		return {
 			tokenName: entry.token.name,
 			tokenAddress: entry.token.address,
@@ -236,7 +223,7 @@ function TransactionImportanceBlock( param: TransactionImportanceBlockParams ) {
 		}
 	})
 
-	const operatorChanges: ERC721OperatorChange[] = sendingTokenResults.filter((x): x is TokenVisualizerERC721AllApprovalEvent  => 'isAllApproval' in x).map((entry) => {
+	const operatorChanges: ERC721OperatorChange[] = sendingTokenResults.filter((x): x is TokenVisualizerERC721AllApprovalEvent  => 'isAllApproval' in x && x.is721).map((entry) => {
 		return {
 			tokenName: entry.token.name,
 			tokenAddress: entry.token.address,
@@ -247,7 +234,7 @@ function TransactionImportanceBlock( param: TransactionImportanceBlockParams ) {
 	})
 
 	// token address, tokenId, approved address
-	const tokenIdApprovalChanges: ERC721TokenApprovalChange[] = sendingTokenResults.filter((x): x is TokenVisualizerERC721Event  => 'tokenId' in x).map((entry) => {
+	const tokenIdApprovalChanges: ERC721TokenApprovalChange[] = sendingTokenResults.filter((x): x is TokenVisualizerERC721Event  => 'tokenId' in x && x.isApproval).map((entry) => {
 		return {
 			token: {
 				tokenId: entry.tokenId,
@@ -280,7 +267,7 @@ function TransactionImportanceBlock( param: TransactionImportanceBlockParams ) {
 
 		{ /* us approving other addresses */ }
 		<Erc20ApprovalChanges
-			tokenApprovalChanges = { tokenApprovalChanges }
+			tokenApprovalChanges = { erc20tokenApprovalChanges }
 			textColor = { textColor }
 			negativeColor = { textColor }
 			isImportant = { true }
@@ -303,7 +290,7 @@ function TransactionImportanceBlock( param: TransactionImportanceBlockParams ) {
 
 		{ /* receiving tokens */ }
 		<SendOrReceiveTokensImportanceBox
-			tokenVisualizerResults = { receivingTokenResults?.filter( (x) => !x.isApproval) }
+			tokenVisualizerResults = { receivingTokenResults.filter( (x) => !x.isApproval) }
 			sending = { false }
 			textColor = { textColor }
 			renameAddressCallBack = { param.renameAddressCallBack }

--- a/extension/app/ts/components/simulationExplaining/identifyTransaction.tsx
+++ b/extension/app/ts/components/simulationExplaining/identifyTransaction.tsx
@@ -1,11 +1,12 @@
 import { get4Byte } from '../../utils/calldata.js'
 import { CHAINS, FourByteExplanations, isSupportedChain, MAKE_YOU_RICH_TRANSACTION } from '../../utils/constants.js'
-import { AddressMetadata, SimulatedAndVisualizedTransaction } from '../../utils/visualizer-types.js'
+import { AddressBookEntry } from '../../utils/user-interface-types.js'
+import { SimulatedAndVisualizedTransaction } from '../../utils/visualizer-types.js'
 import { getSwapName, identifySwap } from './SwapTransactions.js'
 
 type TRANSACTION_TYPE = 'MakeYouRichTransaction' | 'NormalTransaction'
 
-export function nameTransaction(transaction: SimulatedAndVisualizedTransaction, addressMetadata: Map<string, AddressMetadata>, activeAddress: bigint ) {
+export function nameTransaction(transaction: SimulatedAndVisualizedTransaction, addressMetadata: Map<string, AddressBookEntry>, activeAddress: bigint ) {
 	if (identifyTransaction(transaction, activeAddress) === 'MakeYouRichTransaction') {
 		return 'Simply making you rich'
 	}

--- a/extension/app/ts/components/simulationExplaining/identifyTransaction.tsx
+++ b/extension/app/ts/components/simulationExplaining/identifyTransaction.tsx
@@ -1,38 +1,35 @@
 import { get4Byte } from '../../utils/calldata.js'
 import { CHAINS, FourByteExplanations, isSupportedChain, MAKE_YOU_RICH_TRANSACTION } from '../../utils/constants.js'
-import { AddressBookEntry } from '../../utils/user-interface-types.js'
 import { SimulatedAndVisualizedTransaction } from '../../utils/visualizer-types.js'
 import { getSwapName, identifySwap } from './SwapTransactions.js'
 
 type TRANSACTION_TYPE = 'MakeYouRichTransaction' | 'NormalTransaction'
 
-export function nameTransaction(transaction: SimulatedAndVisualizedTransaction, addressMetadata: Map<string, AddressBookEntry>, activeAddress: bigint ) {
+export function nameTransaction(transaction: SimulatedAndVisualizedTransaction, activeAddress: bigint ) {
 	if (identifyTransaction(transaction, activeAddress) === 'MakeYouRichTransaction') {
 		return 'Simply making you rich'
 	}
-	if (transaction.signedTransaction.input.length == 0) return 'Ether Transfer'
+	if (transaction.input.length == 0) return 'Ether Transfer'
 
 	const identifiedSwap = identifySwap(transaction)
-	if (identifiedSwap) return getSwapName(identifiedSwap, addressMetadata)
+	if (identifiedSwap) return getSwapName(identifiedSwap, transaction.chainId)
 
-	const fourByte = get4Byte(transaction.signedTransaction.input)
+	const fourByte = get4Byte(transaction.input)
 	if (fourByte === undefined) return 'Contract Fallback Method'
 	const explanation = FourByteExplanations.get(fourByte)
 	return explanation !== undefined ? explanation : 'Contract Execution'
 }
 
-export function identifyTransaction(simulatedAndVisualizedTransaction: SimulatedAndVisualizedTransaction, activeAddress: bigint): TRANSACTION_TYPE {
-	if (simulatedAndVisualizedTransaction.unsignedTransaction.chainId === undefined) return 'NormalTransaction'
-
-	const chainString = simulatedAndVisualizedTransaction.unsignedTransaction.chainId.toString()
+export function identifyTransaction(transaction: SimulatedAndVisualizedTransaction, activeAddress: bigint): TRANSACTION_TYPE {
+	const chainString = transaction.chainId.toString()
 	if (!isSupportedChain(chainString)) return 'NormalTransaction'
-	if (CHAINS[chainString].eth_donator === simulatedAndVisualizedTransaction.unsignedTransaction.from
-		&& simulatedAndVisualizedTransaction.unsignedTransaction.to === activeAddress
-		&& simulatedAndVisualizedTransaction.unsignedTransaction.type === MAKE_YOU_RICH_TRANSACTION.type
-		&& simulatedAndVisualizedTransaction.unsignedTransaction.maxFeePerGas === MAKE_YOU_RICH_TRANSACTION.maxFeePerGas
-		&& simulatedAndVisualizedTransaction.unsignedTransaction.maxPriorityFeePerGas === MAKE_YOU_RICH_TRANSACTION.maxPriorityFeePerGas
-		&& simulatedAndVisualizedTransaction.unsignedTransaction.input.toString() === MAKE_YOU_RICH_TRANSACTION.input.toString()
-		&& simulatedAndVisualizedTransaction.unsignedTransaction.value === MAKE_YOU_RICH_TRANSACTION.value
+	if (CHAINS[chainString].eth_donator === transaction.from.address
+		&& transaction.to?.address === activeAddress
+		&& transaction.type === MAKE_YOU_RICH_TRANSACTION.type
+		&& transaction.maxFeePerGas === MAKE_YOU_RICH_TRANSACTION.maxFeePerGas
+		&& transaction.maxPriorityFeePerGas === MAKE_YOU_RICH_TRANSACTION.maxPriorityFeePerGas
+		&& transaction.input.toString() === MAKE_YOU_RICH_TRANSACTION.input.toString()
+		&& transaction.value === MAKE_YOU_RICH_TRANSACTION.value
 	) {
 		return 'MakeYouRichTransaction'
 	}

--- a/extension/app/ts/components/simulationExplaining/transactionExplainers.tsx
+++ b/extension/app/ts/components/simulationExplaining/transactionExplainers.tsx
@@ -25,15 +25,15 @@ export function makeYouRichTransaction(param: TransactionVisualizationParameters
 			<header class = 'card-header'>
 				<div class = 'card-header-icon unset-cursor'>
 					<span class = 'icon'>
-						<img src = { param.tx.multicallResponse.statusCode === 'success' ? ( param.tx.simResults && param.tx.simResults.quarantine ? '../img/warning-sign.svg' : '../img/success-icon.svg' ) : '../img/error-icon.svg' } />
+						<img src = { param.tx.statusCode === 'success' ? ( param.tx.quarantine ? '../img/warning-sign.svg' : '../img/success-icon.svg' ) : '../img/error-icon.svg' } />
 					</span>
 				</div>
 				<p class = 'card-header-title'>
 					<p className = 'paragraph'>
-						{ nameTransaction(param.tx, param.simulationAndVisualisationResults.addressMetadata, param.activeAddress) }
+						{ nameTransaction(param.tx, param.activeAddress) }
 					</p>
 				</p>
-				<button class = 'card-header-icon' aria-label = 'remove' onClick = { () => param.removeTransaction(param.tx.signedTransaction.hash) }>
+				<button class = 'card-header-icon' aria-label = 'remove' onClick = { () => param.removeTransaction(param.tx.hash) }>
 					<span class = 'icon' style = 'color: var(--text-color);'> X </span>
 				</button>
 			</header>
@@ -46,12 +46,12 @@ export function makeYouRichTransaction(param: TransactionVisualizationParameters
 							</div>
 							<div class = 'log-cell' style = 'justify-content: right;'>
 								<EtherAmount
-									amount = { param.tx.unsignedTransaction.value }
+									amount = { param.tx.value }
 								/>
 							</div>
 							<div class = 'log-cell'>
 								<EtherSymbol
-									amount = { param.tx.unsignedTransaction.value }
+									amount = { param.tx.value }
 									chain = { param.simulationAndVisualisationResults.chain }
 								/>
 							</div>

--- a/extension/app/ts/components/subcomponents/address.tsx
+++ b/extension/app/ts/components/subcomponents/address.tsx
@@ -1,8 +1,7 @@
 import { ethers } from 'ethers'
 import { addressString } from '../../utils/bigint.js'
-import { AddressMetadata } from '../../utils/visualizer-types.js'
 import Blockie from './PreactBlocky.js'
-import { AddressInfo, RenameAddressCallBack } from '../../utils/user-interface-types.js'
+import { AddressBookEntry, AddressInfo, RenameAddressCallBack } from '../../utils/user-interface-types.js'
 import { CopyToClipboard } from './CopyToClipboard.js'
 import { ApproveIcon, ArrowIcon } from '../subcomponents/icons.js'
 import RenameAddressButton from './RenameAddressButton.js'
@@ -43,15 +42,14 @@ function AddressIcon(param: AddressIconParams) {
 
 
 export type BigAddressParams = {
-	readonly address: bigint
+	readonly addressBookEntry: AddressBookEntry
 	readonly noCopying?: boolean
-	readonly nameAndLogo: Pick<AddressMetadata, 'name' | 'logoUri'> | undefined
 	readonly renameAddressCallBack: RenameAddressCallBack
 }
 
 export function BigAddress(params: BigAddressParams) {
-	const addrString = ethers.utils.getAddress(addressString(params.address))
-	const title = params.nameAndLogo === undefined || params.nameAndLogo.name === undefined ? addrString : params.nameAndLogo.name
+	const addrString = ethers.utils.getAddress(addressString(params.addressBookEntry.address))
+	const title = params.addressBookEntry.name
 	const subTitle = title != addrString ? addrString : ''
 
 	return <div class = 'media'>
@@ -60,8 +58,8 @@ export function BigAddress(params: BigAddressParams) {
 				<CopyToClipboard content = { addrString } copyMessage = 'Address copied!'>
 					<span class = 'noselect nopointer'>
 						<AddressIcon
-							address = { params.address }
-							logoUri = { params.nameAndLogo?.logoUri }
+							address = { params.addressBookEntry.address }
+							logoUri = { 'logoUri' in params.addressBookEntry ? params.addressBookEntry.logoUri : undefined}
 							isBig = { true }
 							backgroundColor = { 'var(--text-color)' }
 						/>
@@ -70,8 +68,8 @@ export function BigAddress(params: BigAddressParams) {
 			:
 				<span class = 'noselect nopointer'>
 					<AddressIcon
-						address = { params.address }
-						logoUri = { params.nameAndLogo?.logoUri }
+						address = { params.addressBookEntry.address }
+						logoUri = { 'logoUri' in params.addressBookEntry ? params.addressBookEntry.logoUri : undefined }
 						isBig = { true }
 						backgroundColor = { 'var(--text-color)' }
 					/>
@@ -81,9 +79,9 @@ export function BigAddress(params: BigAddressParams) {
 
 		<div class = 'media-content' style = 'overflow-y: hidden; overflow-x: clip; display: block;'>
 			<div style = 'display: flex; position: relative;'>
-				<RenameAddressButton renameAddress = { () => params.renameAddressCallBack(title, addressString(params.address)) }>
+				<RenameAddressButton renameAddress = { () => params.renameAddressCallBack(params.addressBookEntry) }>
 					{ !params.noCopying ?
-						<CopyToClipboard content = { ethers.utils.getAddress(addressString(params.address)) } copyMessage = 'Address copied!'>
+						<CopyToClipboard content = { ethers.utils.getAddress(addressString(params.addressBookEntry.address)) } copyMessage = 'Address copied!'>
 							<p class = 'title is-5 noselect nopointer is-spaced' style = 'text-overflow: ellipsis; white-space: nowrap;'>
 								{ title }
 							</p>
@@ -111,39 +109,37 @@ export function BigAddress(params: BigAddressParams) {
 }
 
 export type ActiveAddressParams = {
-	readonly address: bigint
-	readonly title?: string
-	readonly subtitle?: string
+	readonly addressBookEntry: AddressBookEntry
 	readonly simulationMode: boolean
 	readonly changeActiveAddress: () => void
 	readonly renameAddressCallBack: RenameAddressCallBack
 }
 
 export function ActiveAddress(params: ActiveAddressParams) {
-	const title = params.title === undefined ? ethers.utils.getAddress(addressString(params.address)): params.title
-	const addrString = ethers.utils.getAddress(addressString(params.address))
-	const subTitle = params.subtitle === undefined && title != addrString ? addrString : params.subtitle
+	const title = params.addressBookEntry.name
+	const addrString = ethers.utils.getAddress(addressString(params.addressBookEntry.address))
+	const subTitle = title != addrString ? addrString : ''
 
 	return <div class = 'media'>
 		<div class = 'media-left'>
-			<CopyToClipboard content = { ethers.utils.getAddress(addressString(params.address)) } copyMessage = 'Address copied!'>
+			<CopyToClipboard content = { ethers.utils.getAddress(addressString(params.addressBookEntry.address)) } copyMessage = 'Address copied!'>
 				<figure class = 'image noselect nopointer'>
-					<Blockie seed = { addressString(params.address).toLowerCase() } size = { 8 } scale = { 5 } />
+					<Blockie seed = { addressString(params.addressBookEntry.address).toLowerCase() } size = { 8 } scale = { 5 } />
 				</figure>
 			</CopyToClipboard>
 		</div>
 
 		<div class = 'media-content' style = 'overflow-y: hidden;'>
 			<div style = 'display: flex; position: relative;'>
-				<RenameAddressButton renameAddress = { () => params.renameAddressCallBack(title, addressString(params.address)) }>
-					<CopyToClipboard content = { ethers.utils.getAddress(addressString(params.address)) } copyMessage = 'Address copied!'>
+				<RenameAddressButton renameAddress = { () => params.renameAddressCallBack(params.addressBookEntry) }>
+					<CopyToClipboard content = { ethers.utils.getAddress(addressString(params.addressBookEntry.address)) } copyMessage = 'Address copied!'>
 						<p class = 'title is-5 noselect nopointer' style = 'text-overflow: ellipsis; white-space: nowrap;'>
 							{ title }
 						</p>
 					</CopyToClipboard>
 				</RenameAddressButton>
 			</div>
-			<CopyToClipboard content = { ethers.utils.getAddress(addressString(params.address)) } copyMessage = 'Address copied!'>
+			<CopyToClipboard content = { ethers.utils.getAddress(addressString(params.addressBookEntry.address)) } copyMessage = 'Address copied!'>
 				<p class = 'subtitle is-7 noselect nopointer'>
 					{ subTitle === undefined ? '' : subTitle }
 				</p>
@@ -159,34 +155,27 @@ export function ActiveAddress(params: ActiveAddressParams) {
 }
 
 export type SmallAddressParams = {
-	readonly address: bigint
-	readonly nameAndLogo: Pick<AddressMetadata, 'name' | 'logoUri'> | undefined
+	readonly addressBookEntry: AddressBookEntry
 	readonly textColor?: string
 	readonly renameAddressCallBack: RenameAddressCallBack
 }
 
-export function getAddressName(address: bigint, metadata: Pick<AddressMetadata, 'name' | 'logoUri'> | undefined) {
-	if ( metadata === undefined ) return ethers.utils.getAddress(addressString(address))
-	return metadata.name
-}
-
 export function SmallAddress(params: SmallAddressParams) {
-	const name = getAddressName(params.address, params.nameAndLogo)
 	const textColor = params.textColor === undefined ? 'var(--text-color)' : params.textColor
 
-	return	<CopyToClipboard content = { ethers.utils.getAddress(addressString(params.address)) } copyMessage = 'Address copied!'>
+	return	<CopyToClipboard content = { ethers.utils.getAddress(addressString(params.addressBookEntry.address)) } copyMessage = 'Address copied!'>
 		<div style = 'display: inline-flex; width: 100%; position: relative; background-color: var(--alpha-005); padding: 4px; margin: 2px; padding-right: 10px; border-radius: 10px 40px 40px 10px; overflow: inherit;'>
 			<span class = 'vertical-center noselect nopointer' style = 'margin-right: 5px'>
 				<AddressIcon
-					address = { params.address }
-					logoUri = { params.nameAndLogo?.logoUri }
+					address = { params.addressBookEntry.address }
+					logoUri = { 'logoUri' in params.addressBookEntry ? params.addressBookEntry.logoUri : undefined }
 					isBig = { false }
 					backgroundColor = { textColor }
 				/>
 			</span>
-			<RenameAddressButton renameAddress = { () => params.renameAddressCallBack(name, addressString(params.address)) }>
+			<RenameAddressButton renameAddress = { () => params.renameAddressCallBack(params.addressBookEntry) }>
 				<span class = 'noselect nopointer' style = { `color: ${ textColor }; overflow: hidden; text-overflow: ellipsis;` } >
-					{ name }
+					{ params.addressBookEntry.name }
 				</span>
 			</RenameAddressButton>
 		</div>
@@ -194,10 +183,8 @@ export function SmallAddress(params: SmallAddressParams) {
 }
 
 export type FromAddressToAddressParams = {
-	readonly from: bigint
-	readonly to: bigint
-	readonly fromAddressNameAndLogo: Pick<AddressMetadata, 'name' | 'logoUri'> | undefined
-	readonly toAddressNameAndLogo: Pick<AddressMetadata, 'name' | 'logoUri'> | undefined
+	readonly fromEntry: AddressBookEntry
+	readonly toEntry: AddressBookEntry
 	readonly isApproval: boolean
 	readonly renameAddressCallBack: RenameAddressCallBack
 }
@@ -206,8 +193,7 @@ export function FromAddressToAddress(params: FromAddressToAddressParams ) {
 	return  <div class = 'columns is-mobile' style = 'margin-bottom: 0px; color: var(--text-color);'>
 		<div class = 'column' style = 'width: 47.5%; flex: none; padding-bottom: 0px;'>
 			<BigAddress
-				address = { params.from }
-				nameAndLogo = { params.fromAddressNameAndLogo }
+				addressBookEntry = { params.fromEntry }
 				renameAddressCallBack = { params.renameAddressCallBack }
 			/>
 		</div>
@@ -216,8 +202,7 @@ export function FromAddressToAddress(params: FromAddressToAddressParams ) {
 		</div>
 		<div class = 'column' style = 'width: 47.5%; flex: none; padding-bottom: 0px;'>
 			<BigAddress
-				address = { params.to }
-				nameAndLogo = { params.toAddressNameAndLogo }
+				addressBookEntry = { params.toEntry }
 				renameAddressCallBack = { params.renameAddressCallBack }
 			/>
 		</div>

--- a/extension/app/ts/components/subcomponents/coins.tsx
+++ b/extension/app/ts/components/subcomponents/coins.tsx
@@ -91,8 +91,8 @@ export function TokenPrice(param: TokenPriceParams) {
 type TokenSymbolParams = {
 	textColor?: string,
 	tokenName: string
-    tokenAddress: bigint
-    tokenSymbol: string
+	tokenAddress: bigint
+	tokenSymbol: string
 	tokenLogoUri: string | undefined
 
 	useFullTokenName: boolean | undefined
@@ -167,7 +167,7 @@ export function Token(param: TokenParams) {
 			/>
 		</div>
 		<div class = 'log-cell'>
-			<TokenSymbol { ... param}/>
+			<TokenSymbol { ... param }/>
 		</div>
 	</table>
 }
@@ -203,7 +203,7 @@ type ERC721TokenParams = ERC721TokenDefinitionParams & {
 export function ERC721Token(param: ERC721TokenParams) {
 	return <table class = 'log-table'>
 		<div class = 'log-cell' style = 'justify-content: right;'>
-			<ERC721TokenNumber { ... param}/>
+			<ERC721TokenNumber { ... param }/>
 		</div>
 		<div class = 'log-cell'>
 			<TokenSymbol { ...param }/>

--- a/extension/app/ts/components/subcomponents/coins.tsx
+++ b/extension/app/ts/components/subcomponents/coins.tsx
@@ -3,7 +3,7 @@ import { getTokenAmountsWorth } from '../../simulation/priceEstimator.js'
 import { abs, addressString, bigintToDecimalString, bigintToRoundedPrettyDecimalString } from '../../utils/bigint.js'
 import { CHAINS } from '../../utils/constants.js'
 import { CHAIN } from '../../utils/user-interface-types.js'
-import { TokenPriceEstimate } from '../../utils/visualizer-types.js'
+import { ERC721TokenDefinitionParams, TokenDefinitionParams, TokenPriceEstimate } from '../../utils/visualizer-types.js'
 import { CopyToClipboard } from './CopyToClipboard.js'
 import Blockie from './PreactBlocky.js'
 
@@ -151,14 +151,6 @@ export function TokenAmount(param: TokenAmountParams) {
 	</>
 }
 
-export type TokenDefinitionParams = {
-	tokenName: string
-    tokenAddress: bigint
-    tokenSymbol: string
-    tokenDecimals: bigint
-	tokenLogoUri: string | undefined
-}
-
 type TokenParams = TokenDefinitionParams & {
 	amount: bigint
 	showSign?: boolean
@@ -199,14 +191,6 @@ export function ERC721TokenNumber(param: ERC721TokenNumberParams) {
 			{ `${ sign } NFT #${ truncate(param.tokenId.toString(), 9) }`}&nbsp;
 		</p>
 	</CopyToClipboard>
-}
-
-export type ERC721TokenDefinitionParams = {
-	tokenId: bigint
-	tokenName: string
-    tokenAddress: bigint
-    tokenSymbol: string
-	tokenLogoUri: string | undefined
 }
 
 type ERC721TokenParams = ERC721TokenDefinitionParams & {

--- a/extension/app/ts/components/subcomponents/coins.tsx
+++ b/extension/app/ts/components/subcomponents/coins.tsx
@@ -3,7 +3,7 @@ import { getTokenAmountsWorth } from '../../simulation/priceEstimator.js'
 import { abs, addressString, bigintToDecimalString, bigintToRoundedPrettyDecimalString } from '../../utils/bigint.js'
 import { CHAINS } from '../../utils/constants.js'
 import { CHAIN } from '../../utils/user-interface-types.js'
-import { TokenPriceEstimate, TokenVisualizerResult } from '../../utils/visualizer-types.js'
+import { TokenPriceEstimate } from '../../utils/visualizer-types.js'
 import { CopyToClipboard } from './CopyToClipboard.js'
 import Blockie from './PreactBlocky.js'
 

--- a/extension/app/ts/components/subcomponents/coins.tsx
+++ b/extension/app/ts/components/subcomponents/coins.tsx
@@ -3,33 +3,9 @@ import { getTokenAmountsWorth } from '../../simulation/priceEstimator.js'
 import { abs, addressString, bigintToDecimalString, bigintToRoundedPrettyDecimalString } from '../../utils/bigint.js'
 import { CHAINS } from '../../utils/constants.js'
 import { CHAIN } from '../../utils/user-interface-types.js'
-import { AddressMetadata, TokenPriceEstimate, TokenVisualizerResult } from '../../utils/visualizer-types.js'
+import { TokenPriceEstimate, TokenVisualizerResult } from '../../utils/visualizer-types.js'
 import { CopyToClipboard } from './CopyToClipboard.js'
 import Blockie from './PreactBlocky.js'
-
-type TokenData = {
-	decimals: bigint | undefined
-	name: string
-	symbol: string
-	logoUri?: string
-}
-
-export function getTokenData(token: bigint, metadata: AddressMetadata | undefined) : TokenData {
-	if (metadata === undefined) {
-		return {
-			decimals: undefined,
-			name: `Token (${ ethers.utils.getAddress(addressString(token)) })`,
-			symbol: '???',
-			logoUri: undefined
-		}
-	}
-	return {
-		decimals: 'decimals' in metadata ? metadata.decimals : undefined,
-		name: metadata.name,
-		symbol: 'symbol' in metadata ? metadata.symbol : '???',
-		logoUri: 'logoUri' in metadata && metadata.logoUri !== undefined ? metadata.logoUri : undefined
-	}
-}
 
 type EtherParams = {
 	amount: bigint
@@ -113,20 +89,22 @@ export function TokenPrice(param: TokenPriceParams) {
 }
 
 type TokenSymbolParams = {
-	token: bigint,
 	textColor?: string,
-	addressMetadata: AddressMetadata | undefined,
+	tokenName: string
+    tokenAddress: bigint
+    tokenSymbol: string
+	tokenLogoUri: string | undefined
+
 	useFullTokenName: boolean | undefined
 }
 
 export function TokenSymbol(param: TokenSymbolParams) {
-	const tokenData = getTokenData(param.token, param.addressMetadata)
-	const tokenString = ethers.utils.getAddress(addressString(param.token))
+	const tokenString = ethers.utils.getAddress(addressString(param.tokenAddress))
 	const color = param.textColor ? param.textColor : 'var(--text-color)'
 	return <>
 		<div style = 'overflow: initial; height: 28px;'>
 			<CopyToClipboard content = { tokenString } copyMessage = 'Token address copied!' >
-				{ tokenData.logoUri === undefined ?
+				{ param.tokenLogoUri === undefined ?
 					<Blockie
 						seed = { tokenString.toLowerCase() }
 						size = { 8 }
@@ -134,18 +112,18 @@ export function TokenSymbol(param: TokenSymbolParams) {
 						borderRadius = { '50%' }
 					/>
 				:
-				<img class = 'noselect nopointer vertical-center' style = 'max-height: 25px; max-width: 25px;' src = { tokenData.logoUri }/>
+				<img class = 'noselect nopointer vertical-center' style = 'max-height: 25px; max-width: 25px;' src = { param.tokenLogoUri }/>
 				}
 			</CopyToClipboard>
 		</div>
 		<CopyToClipboard content = { tokenString } copyMessage = 'Token address copied!' >
 			{ param.useFullTokenName ?
 				<p class = 'noselect nopointer' style = { `color: ${ color }; display: inline-block; overflow: hidden; text-overflow: ellipsis;` }>
-					{ `${ tokenData.name }` }
+					{ `${ param.tokenName === undefined ? tokenString : param.tokenName }` }
 				</p>
 			:
 				<p class = 'noselect nopointer' style = { `color: ${ color }; display: inline-block; overflow: hidden; text-overflow: ellipsis;` }>
-					{ `${ tokenData.symbol }` }
+					{ `${ param.tokenSymbol }` }
 				</p>
 			}
 		</CopyToClipboard>
@@ -156,30 +134,35 @@ type TokenAmountParams = {
 	amount: bigint
 	showSign?: boolean
 	textColor?: string
-	addressMetadata: AddressMetadata | undefined
+	tokenDecimals: bigint | undefined
 }
 
 export function TokenAmount(param: TokenAmountParams) {
 	const color = param.textColor ? param.textColor : 'var(--text-color)'
-	const decimals = param.addressMetadata && 'decimals' in param.addressMetadata ? param.addressMetadata.decimals : undefined
 	const sign = param.showSign ? (param.amount >= 0 ? ' + ' : ' - '): ''
 
-	if (decimals === undefined) {
+	if (param.tokenDecimals === undefined) {
 		return <p class = 'noselect nopointer ellipsis' style = { `display: inline-block; color: ${ color };` }> &nbsp;Unknown Amount&nbsp; </p>
 	}
 	return <>
-		<CopyToClipboard content = { bigintToDecimalString(abs(param.amount), decimals) } copyMessage = 'Token amount copied!' >
-			<p class = 'noselect nopointer' style = { `display: inline-block; color: ${ color };` }>{ `${ sign }${ bigintToRoundedPrettyDecimalString(abs(param.amount), decimals ) }` }&nbsp; </p>
+		<CopyToClipboard content = { bigintToDecimalString(abs(param.amount), param.tokenDecimals) } copyMessage = 'Token amount copied!' >
+			<p class = 'noselect nopointer' style = { `display: inline-block; color: ${ color };` }>{ `${ sign }${ bigintToRoundedPrettyDecimalString(abs(param.amount), param.tokenDecimals ) }` }&nbsp; </p>
 		</CopyToClipboard>
 	</>
 }
 
-type TokenParams = {
+export type TokenDefinitionParams = {
+	tokenName: string
+    tokenAddress: bigint
+    tokenSymbol: string
+    tokenDecimals: bigint
+	tokenLogoUri: string | undefined
+}
+
+type TokenParams = TokenDefinitionParams & {
 	amount: bigint
-	token: bigint
 	showSign?: boolean
 	textColor?: string
-	addressMetadata: AddressMetadata | undefined
 	useFullTokenName: boolean
 }
 
@@ -187,19 +170,12 @@ export function Token(param: TokenParams) {
 	return <table class = 'log-table' style = 'width: fit-content'>
 		<div class = 'log-cell' style = 'justify-content: right;'>
 			<TokenAmount
+				{ ...param }
 				amount = { param.amount }
-				showSign = { param.showSign }
-				textColor = { param.textColor }
-				addressMetadata = { param.addressMetadata }
 			/>
 		</div>
 		<div class = 'log-cell'>
-			<TokenSymbol
-				token = { param.token }
-				addressMetadata = { param.addressMetadata }
-				textColor = { param.textColor }
-				useFullTokenName = { param.useFullTokenName }
-			/>
+			<TokenSymbol { ... param}/>
 		</div>
 	</table>
 }
@@ -225,79 +201,47 @@ export function ERC721TokenNumber(param: ERC721TokenNumberParams) {
 	</CopyToClipboard>
 }
 
-type ERC72TokenParams = {
+export type ERC721TokenDefinitionParams = {
 	tokenId: bigint
-	token: bigint
+	tokenName: string
+    tokenAddress: bigint
+    tokenSymbol: string
+	tokenLogoUri: string | undefined
+}
+
+type ERC721TokenParams = ERC721TokenDefinitionParams & {
 	received: boolean
 	textColor?: string
-	addressMetadata: AddressMetadata | undefined
 	useFullTokenName: boolean
 	showSign?: boolean
 }
 
-export function ERC721Token(param: ERC72TokenParams) {
+export function ERC721Token(param: ERC721TokenParams) {
 	return <table class = 'log-table'>
 		<div class = 'log-cell' style = 'justify-content: right;'>
-			<ERC721TokenNumber
-				tokenId = { param.tokenId }
-				received = { param.received }
-				textColor = { param.textColor }
-				showSign = { param.showSign }
-			/>
+			<ERC721TokenNumber { ... param}/>
 		</div>
 		<div class = 'log-cell'>
-			<TokenSymbol
-				token = { param.token }
-				addressMetadata = { param.addressMetadata }
-				textColor = { param.textColor }
-				useFullTokenName = { param.useFullTokenName }
-			/>
+			<TokenSymbol { ...param }/>
 		</div>
 	</table>
 }
 
-type TokenTextParams = {
-	useFullTokenName: boolean,
+type Token721AmountFieldParams = { textColor: string } & ({
+	tokenId: bigint,
 	isApproval: boolean,
-	amount: bigint,
-	tokenAddress: bigint,
-	addressMetadata: AddressMetadata | undefined,
-	textColor: string,
-	negativeColor: string
-}
+} | {
+	isAllApproval: boolean
+	allApprovalAdded: boolean
+	isApproval: true
+})
 
-export function TokenText(param: TokenTextParams) {
-	if (param.isApproval && param.amount > 2n ** 100n) {
-		return <>
-			<p style = { `display: inline-block; color: ${ param.negativeColor };` } > <b>ALL</b> </p>
-			<TokenSymbol token = { param.tokenAddress } addressMetadata = { param.addressMetadata } textColor = { param.negativeColor }  useFullTokenName = { param.useFullTokenName }/>
-		</>
-	}
-	if (param.isApproval) {
-		return <p style = { `display: inline-block; color: ${ param.negativeColor };` } >
-			<Token amount = { param.amount } token = { param.tokenAddress } addressMetadata = { param.addressMetadata } textColor = { param.negativeColor } useFullTokenName = { param.useFullTokenName }/>
-		</p>
-	}
-	return <Token
-		amount = { param.amount }
-		token = { param.tokenAddress }
-		addressMetadata = { param.addressMetadata }
-		textColor = { param.textColor }
-		useFullTokenName = { param.useFullTokenName }
-	/>
-}
-
-type Token721AmountFieldParams = {
-	visResult: TokenVisualizerResult,
-	textColor: string,
-}
 
 export function Token721AmountField(param: Token721AmountFieldParams ) {
-	if (param.visResult.is721 !== true) throw `needs to be erc721`
 	const color = param.textColor ? param.textColor : 'var(--text-color)'
-	if (!param.visResult.isApproval || !('isAllApproval' in param.visResult)) {
-		return <p style = { `color: ${ color }` }>{ `NFT #${ truncate(param.visResult.tokenId.toString(), 9) }` }</p>
+	if (!param.isApproval || !('isAllApproval' in param)) {
+		return <p style = { `color: ${ color }` }>{ `NFT #${ truncate(param.tokenId.toString(), 9) }` }</p>
 	}
-	if (!param.visResult.allApprovalAdded) return <p style = { `color: ${ color }` }><b>NONE</b></p>
+	if (!param.allApprovalAdded) return <p style = { `color: ${ color }` }><b>NONE</b></p>
 	return <p style = { `color: ${ color }` }><b>ALL</b></p>
 }

--- a/extension/app/ts/utils/interceptor-messages.ts
+++ b/extension/app/ts/utils/interceptor-messages.ts
@@ -216,7 +216,7 @@ export const ReviewNotification = funtypes.Object({
 	method: funtypes.Literal('popup_reviewNotification'),
 	options: funtypes.Object({
 		origin: funtypes.String,
-		requestAccessToAddress: funtypes.Union(funtypes.String, funtypes.Undefined),
+		requestAccessToAddress: funtypes.Union(EthereumQuantity, funtypes.Undefined),
 	})
 }).asReadonly()
 
@@ -225,7 +225,7 @@ export const RejectNotification = funtypes.Object({
 	method: funtypes.Literal('popup_rejectNotification'),
 	options: funtypes.Object({
 		origin: funtypes.String,
-		requestAccessToAddress: funtypes.Union(funtypes.String, funtypes.Undefined),
+		requestAccessToAddress: funtypes.Union(EthereumQuantity, funtypes.Undefined),
 		removeOnly: funtypes.Boolean,
 	})
 }).asReadonly()

--- a/extension/app/ts/utils/interceptor-messages.ts
+++ b/extension/app/ts/utils/interceptor-messages.ts
@@ -216,7 +216,7 @@ export const ReviewNotification = funtypes.Object({
 	method: funtypes.Literal('popup_reviewNotification'),
 	options: funtypes.Object({
 		origin: funtypes.String,
-		requestAccessToAddress: funtypes.Union(EthereumQuantity, funtypes.Undefined),
+		requestAccessToAddress: funtypes.Union(funtypes.String, funtypes.Undefined),
 	})
 }).asReadonly()
 
@@ -225,7 +225,7 @@ export const RejectNotification = funtypes.Object({
 	method: funtypes.Literal('popup_rejectNotification'),
 	options: funtypes.Object({
 		origin: funtypes.String,
-		requestAccessToAddress: funtypes.Union(EthereumQuantity, funtypes.Undefined),
+		requestAccessToAddress: funtypes.Union(funtypes.String, funtypes.Undefined),
 		removeOnly: funtypes.Boolean,
 	})
 }).asReadonly()

--- a/extension/app/ts/utils/user-interface-types.ts
+++ b/extension/app/ts/utils/user-interface-types.ts
@@ -2,7 +2,7 @@ import { StateUpdater } from 'preact/hooks'
 import * as funtypes from 'funtypes'
 import { EthereumAccountsReply, EthereumAddress, EthereumQuantity, LiteralConverterParserFactory } from './wire-types.js'
 import { SimulatedAndVisualizedTransaction, SimulationAndVisualisationResults } from './visualizer-types.js'
-import { IdentifiedSwap, IdentifiedSwapWithMetadata } from '../components/simulationExplaining/SwapTransactions.js'
+import { IdentifiedSwapWithMetadata } from '../components/simulationExplaining/SwapTransactions.js'
 import { CHAINS } from './constants.js'
 import { SignerName } from './interceptor-messages.js'
 import { WebsiteAccess } from '../background/settings.js'
@@ -155,7 +155,6 @@ export type FirstCardParams = {
 export type SimulationStateParam = {
 	simulationAndVisualisationResults: SimulationAndVisualisationResults | undefined,
 	removeTransaction: (hash: bigint) => void,
-	addressMetadata: Map<string, AddressBookEntry>,
 	refreshSimulation: () => void,
 	currentBlockNumber: bigint | undefined,
 	renameAddressCallBack: RenameAddressCallBack,
@@ -163,7 +162,6 @@ export type SimulationStateParam = {
 
 export type LogAnalysisParams = {
 	simulatedAndVisualizedTransaction: SimulatedAndVisualizedTransaction,
-	addressMetadata: Map<string, AddressBookEntry>,
 	identifiedSwap: IdentifiedSwapWithMetadata,
 	renameAddressCallBack: RenameAddressCallBack,
 }

--- a/extension/app/ts/utils/visualizer-types.ts
+++ b/extension/app/ts/utils/visualizer-types.ts
@@ -32,33 +32,42 @@ export const TokenVisualizerResult = funtypes.Intersect(
 	)
 )
 
+export type TokenVisualizerERC20Event  = funtypes.Static<typeof TokenVisualizerERC20Event>
+export const TokenVisualizerERC20Event = funtypes.Object( {
+	from: AddressBookEntry,
+	to: AddressBookEntry,
+	token: TokenEntry,
+	amount: EthereumQuantity,
+	is721: funtypes.Literal(false),
+	isApproval: funtypes.Boolean,
+})
+
+export type TokenVisualizerERC721Event  = funtypes.Static<typeof TokenVisualizerERC721Event>
+export const TokenVisualizerERC721Event = funtypes.Object( {
+	from: AddressBookEntry,
+	to: AddressBookEntry,
+	token: NFTEntry,
+	tokenId: EthereumQuantity,
+	is721: funtypes.Literal(true),
+	isApproval: funtypes.Boolean,
+})
+
+export type TokenVisualizerERC721AllApprovalEvent  = funtypes.Static<typeof TokenVisualizerERC721AllApprovalEvent>
+export const TokenVisualizerERC721AllApprovalEvent = funtypes.Object( {
+	from: AddressBookEntry,
+	to: AddressBookEntry,
+	token: NFTEntry,
+	is721: funtypes.Literal(true),
+	isAllApproval: funtypes.Boolean,
+	allApprovalAdded: funtypes.Boolean, // true if approval is added, and false if removed
+	isApproval: funtypes.Literal(true),
+})
+
 export type TokenVisualizerResultWithMetadata = funtypes.Static<typeof TokenVisualizerResultWithMetadata>
-export const TokenVisualizerResultWithMetadata = funtypes.Intersect(
-	funtypes.Object( {
-		from: AddressBookEntry,
-		to: AddressBookEntry,
-	}),
-	funtypes.Union(
-		funtypes.Object({ // ERC20 transfer / approval
-			token: TokenEntry,
-			amount: EthereumQuantity,
-			is721: funtypes.Literal(false),
-			isApproval: funtypes.Boolean,
-		}),
-		funtypes.Object({ // ERC721 transfer / approval
-			token: NFTEntry,
-			tokenId: EthereumQuantity,
-			is721: funtypes.Literal(true),
-			isApproval: funtypes.Boolean,
-		}),
-		funtypes.Object({ // ERC721 all approval // all approval removal
-			token: NFTEntry,
-			is721: funtypes.Literal(true),
-			isAllApproval: funtypes.Boolean,
-			allApprovalAdded: funtypes.Boolean, // true if approval is added, and false if removed
-			isApproval: funtypes.Literal(true),
-		})
-	)
+export const TokenVisualizerResultWithMetadata = funtypes.Union(
+	TokenVisualizerERC20Event,
+	TokenVisualizerERC721Event,
+	TokenVisualizerERC721AllApprovalEvent,
 )
 
 export type VisualizerResult = {
@@ -123,25 +132,13 @@ export type SimulationAndVisualisationResults = {
 	blockNumber: bigint,
 	blockTimestamp: Date,
 	simulationConductedTimestamp: Date,
+	addressMetaData: Map<string, AddressBookEntry >
 	simulatedAndVisualizedTransactions: SimulatedAndVisualizedTransaction[],
 	chain: CHAIN,
 	tokenPrices: TokenPriceEstimate[],
 	activeAddress: bigint,
 	simulationMode: boolean,
 	isComputingSimulation: boolean,
-}
-
-export type BalanceChangeSummary = {
-	ERC721TokenBalanceChanges: Map<string, Map<string, boolean > >, // token address, token id, {true if received, false if sent}
-	ERC721OperatorChanges: Map<string, string | undefined> // token address, operator
-	ERC721TokenIdApprovalChanges: Map<string, Map<string, string > > // token address, tokenId, approved address
-
-	tokenBalanceChanges: Map<string, bigint>, // token address, amount
-	tokenApprovalChanges: Map<string, Map<string, bigint > > // token address, approved address, amount
-	etherResults: {
-		balanceBefore: bigint,
-		balanceAfter: bigint,
-	} | undefined
 }
 
 export type TokenPriceEstimate = funtypes.Static<typeof TokenPriceEstimate>
@@ -157,4 +154,34 @@ export type TransactionVisualizationParameters = {
 	removeTransaction: (hash: bigint) => void,
 	activeAddress: bigint,
 	renameAddressCallBack: RenameAddressCallBack,
+}
+
+export type TokenDefinitionParams = {
+	tokenName: string
+    tokenAddress: bigint
+    tokenSymbol: string
+    tokenDecimals: bigint
+	tokenLogoUri: string | undefined
+}
+
+export type TokenBalanceChange = TokenDefinitionParams & {
+	changeAmount: bigint
+	tokenPriceEstimate: TokenPriceEstimate | undefined
+}
+
+export type TokenApprovalChange = TokenDefinitionParams & {
+	approvals: (AddressBookEntry & { change: bigint })[]
+}
+
+export type ERC721TokenDefinitionParams = {
+	tokenId: bigint
+	tokenName: string
+    tokenAddress: bigint
+    tokenSymbol: string
+	tokenLogoUri: string | undefined
+}
+
+export type ERC721TokenApprovalChange = {
+	token: ERC721TokenDefinitionParams
+	approvedEntry: AddressBookEntry
 }

--- a/extension/app/ts/utils/visualizer-types.ts
+++ b/extension/app/ts/utils/visualizer-types.ts
@@ -88,20 +88,42 @@ export type SimulationState = {
 	simulationConductedTimestamp: Date,
 }
 
-export type SimulatedAndVisualizedTransaction = {
-	multicallResponse: SingleMulticallResponse
-	unsignedTransaction: EthereumUnsignedTransaction
-	signedTransaction: (IUnsignedTransaction & EthereumTransactionSignature)
-	realizedGasPrice: bigint
-	simResults: SimResults | undefined
+export type EthBalanceChangesWithMetadata = {
+	address: AddressBookEntry,
+	before: bigint,
+	after: bigint,
 }
+
+export type SimulatedAndVisualizedTransaction = {
+	from: AddressBookEntry
+	to: AddressBookEntry | undefined
+	value: EthereumQuantity
+	realizedGasPrice: EthereumQuantity
+	ethBalanceChanges: EthBalanceChangesWithMetadata[]
+	tokenResults: TokenVisualizerResultWithMetadata[]
+	gasSpent: EthereumQuantity
+	quarantine: boolean
+	quarantineCodes: QUARANTINE_CODE[]
+	input: Uint8Array
+	chainId: CHAIN
+	hash: bigint
+	gas: bigint
+} & ({
+	type: '1559'
+	maxFeePerGas: EthereumQuantity
+	maxPriorityFeePerGas: EthereumQuantity
+} | {
+	type: 'legacy' | '2930'
+}) & (
+	{ statusCode: 'failure', error: string } |
+	{ statusCode: 'success' }
+)
 
 export type SimulationAndVisualisationResults = {
 	blockNumber: bigint,
 	blockTimestamp: Date,
 	simulationConductedTimestamp: Date,
 	simulatedAndVisualizedTransactions: SimulatedAndVisualizedTransaction[],
-	addressMetadata: Map<string, AddressBookEntry>,
 	chain: CHAIN,
 	tokenPrices: TokenPriceEstimate[],
 	activeAddress: bigint,
@@ -131,8 +153,6 @@ export const TokenPriceEstimate = funtypes.Object({
 
 export type TransactionVisualizationParameters = {
 	tx: SimulatedAndVisualizedTransaction,
-	from: AddressBookEntry,
-	to: AddressBookEntry,
 	simulationAndVisualisationResults: SimulationAndVisualisationResults,
 	removeTransaction: (hash: bigint) => void,
 	activeAddress: bigint,

--- a/extension/app/ts/utils/visualizer-types.ts
+++ b/extension/app/ts/utils/visualizer-types.ts
@@ -158,9 +158,9 @@ export type TransactionVisualizationParameters = {
 
 export type TokenDefinitionParams = {
 	tokenName: string
-    tokenAddress: bigint
-    tokenSymbol: string
-    tokenDecimals: bigint
+	tokenAddress: bigint
+	tokenSymbol: string
+	tokenDecimals: bigint
 	tokenLogoUri: string | undefined
 }
 
@@ -176,8 +176,8 @@ export type TokenApprovalChange = TokenDefinitionParams & {
 export type ERC721TokenDefinitionParams = {
 	tokenId: bigint
 	tokenName: string
-    tokenAddress: bigint
-    tokenSymbol: string
+	tokenAddress: bigint
+	tokenSymbol: string
 	tokenLogoUri: string | undefined
 }
 


### PR DESCRIPTION
- gets rid of `AddressMetadata` variable type and replaces it with `AddressBookEntry` which is adressbook compatible
- In the UI code do not use `bigint` / `string`s as addresses anymore and then retrieve the name of the address from `addressMetadata` mapping, but instead move `AddressBookEntry`:s around. This enables that the UI will know where the address comes from and in the future, can rename and refer to it properly
- Instead of making big nested objects, make more flat objects with only the needed variables in them

Backgroundpage still require more refactoring to get rid of the `window.interceptor` global, but I kept that outside this PR