### PR TITLE
Utilize new AddressBookEntry type and allow renaming `addressInfo` adresses

### DIFF
--- a/extension/app/ts/AddressBook.tsx
+++ b/extension/app/ts/AddressBook.tsx
@@ -5,7 +5,6 @@ import { GetAddressBookDataReply, MessageToPopup } from './utils/interceptor-mes
 import { arrayToChunks } from './utils/typed-arrays.js'
 import { AddNewAddress } from './components/pages/AddNewAddress.js'
 import { BigAddress } from './components/subcomponents/address.js'
-import { ethers } from 'ethers'
 import Hint from './components/subcomponents/Hint.js'
 
 type Modals = 'noModal' | 'addNewAddress' | 'ConfirmaddressBookEntryToBeRemoved'
@@ -133,7 +132,7 @@ export function ListElement(entry: ListElementParam) {
 						<button class = 'card-header-icon' style = 'padding: 0px; margin-left: auto;' aria-label = 'delete'>
 							<span class = 'icon' style = 'color: var(--text-color);' onClick = { entry.type != 'empty' && entry.category === 'My Active Addresses' ? () => entry.removeEntry(entry) : () => {} }> X </span>
 						</button>
-						<button class = 'button is-primary is-small' disabled = { true } onClick = { entry.type != 'empty' ? () => entry.renameAddressCallBack(entry) : () => {} }>Edit</button>
+						<button class = 'button is-primary is-small' disabled = { entry.type !== 'addressInfo' && entry.type !== 'empty' } onClick = { entry.type != 'empty' ? () => entry.renameAddressCallBack(entry) : () => {} }>Edit</button>
 					</div>
 				</div>
 			</div>
@@ -186,9 +185,7 @@ export function AddressBook() {
 	const searchStringRef = useRef<string | undefined>(searchString)
 	const currentPageRef = useRef<number>(currentPage)
 
-
-	const [nameInput, setNameInput] = useState<string | undefined>(undefined)
-	const [addressInput, setAddressInput] = useState<string | undefined>(undefined)
+	const [addressBookEntryInput, setAddressBookEntryInput] = useState<AddressBookEntry | undefined>(undefined)
 	const [addingNewAddress, setAddingNewAddress] = useState<boolean>(false)
 
 	const scrollTimer = useRef<NodeJS.Timeout | undefined>(undefined)
@@ -335,8 +332,7 @@ export function AddressBook() {
 
 	function openNewAddress() {
 		setModalState('addNewAddress')
-		setNameInput(undefined)
-		setAddressInput(undefined)
+		setAddressBookEntryInput(undefined)
 		setAddingNewAddress(true)
 	}
 
@@ -347,8 +343,7 @@ export function AddressBook() {
 
 	function renameAddressCallBack(entry: AddressBookEntry) {
 		setModalState('addNewAddress')
-		setNameInput(entry.name === undefined ? '' : entry.name)
-		setAddressInput(ethers.utils.getAddress(addressString(entry.address)))
+		setAddressBookEntryInput(entry)
 		setAddingNewAddress(false)
 	}
 
@@ -409,11 +404,9 @@ export function AddressBook() {
 					{ modalState === 'addNewAddress' ?
 						<AddNewAddress
 							setActiveAddressAndInformAboutIt = { undefined }
-							addressInput = { addressInput }
-							nameInput = { nameInput }
+							addressBookEntry = { addressBookEntryInput }
+							setAddressBookEntryInput = { setAddressBookEntryInput }
 							addingNewAddress = { addingNewAddress }
-							setAddressInput = { setAddressInput }
-							setNameInput = { setNameInput }
 							close = { () => setModalState('noModal') }
 							activeAddress = { undefined }
 						/>

--- a/extension/app/ts/background/background.ts
+++ b/extension/app/ts/background/background.ts
@@ -560,7 +560,7 @@ const popupMessageHandlers = new Map<string, PopupMessageHandler>([
 	['popup_enableSimulationMode', enableSimulationMode],
 	['popup_reviewNotification', reviewNotification],
 	['popup_rejectNotification', rejectNotification],
-	['popup_addOrModifyAddressInfo', addOrModifyAddressInfo],
+	['popup_addOrModifyAddressBookEntry', addOrModifyAddressInfo],
 	['popup_getAddressBookData', getAddressBookData],
 	['popup_removeAddressBookEntry', removeAddressBookEntry],
 ])

--- a/extension/app/ts/background/popupMessageHandlers.ts
+++ b/extension/app/ts/background/popupMessageHandlers.ts
@@ -83,6 +83,7 @@ export async function addOrModifyAddressInfo(_simulator: Simulator, payload: Pop
 	if (window.interceptor.settings === undefined) return
 	const addressInfosChanges = AddOrModifyAddresInfo.parse(payload)
 	for (const newEntry of addressInfosChanges.options) {
+		if (newEntry.type !== 'addressInfo') throw new Error('No support to modify this entry yet!')
 		if (window.interceptor.settings.addressInfos.find( (x) => x.address === newEntry.address) ) {
 			// replace in place to maintain the same order
 			window.interceptor.settings.addressInfos = window.interceptor.settings.addressInfos.map( (x) => x.address === newEntry.address ? newEntry : x )

--- a/extension/app/ts/components/App.tsx
+++ b/extension/app/ts/components/App.tsx
@@ -31,8 +31,7 @@ export function App() {
 	const [websiteAccess, setWebsiteAccess] = useState<readonly WebsiteAccess[] | undefined>(undefined)
 	const [websiteAccessAddressMetadata, setWebsiteAccessAddressMetadata] = useState<[string, AddressInfoEntry][]>([])
 	const [activeChain, setActiveChain] = useState<bigint>(1n)
-	const [addressInput, setAddressInput] = useState<string | undefined>(undefined)
-	const [nameInput, setNameInput] = useState<string | undefined>(undefined)
+	const [addressBookEntryInput, setAddressBookEntryInput] = useState<AddressBookEntry | undefined>(undefined)
 	const [simulationMode, setSimulationMode] = useState<boolean>(true)
 	const [notificationBadgeCount, setNotificationBadgeCount] = useState<number>(0)
 	const [tabConnection, setTabConnection] = useState<TabConnection>(DEFAULT_TAB_CONNECTION)
@@ -154,10 +153,10 @@ export function App() {
 		const trimmed = address.trim()
 		if ( !ethers.utils.isAddress(trimmed) ) return
 
-		const integerRepresentatio = BigInt(trimmed)
+		const bigIntReprentation = BigInt(trimmed)
 		// see if we have that address, if so, let's switch to it
 		for (const addressInfo of addressInfos) {
-			if ( addressInfo.address === integerRepresentatio) {
+			if ( addressInfo.address === bigIntReprentation) {
 				return await setActiveAddressAndInformAboutIt(addressInfo.address)
 			}
 		}
@@ -165,14 +164,17 @@ export function App() {
 		// address not found, let's promt user to create it
 		const addressString = ethers.utils.getAddress(trimmed)
 		setAndSaveAppPage(Page.AddNewAddress)
-		setNameInput(`Pasted ${ truncateAddr(addressString) }`)
-		setAddressInput(addressString)
+		setAddressBookEntryInput( {
+			type: 'addressInfo' as const,
+			name: `Pasted ${ truncateAddr(addressString) }`,
+			address: bigIntReprentation,
+			askForAddressAccess: true,
+		})
 	}
 
 	function renameAddressCallBack(entry: AddressBookEntry) {
 		setAndSaveAppPage(Page.ModifyAddress)
-		setNameInput(entry.name === undefined ? '' : entry.name)
-		setAddressInput(ethers.utils.getAddress(addressString(entry.address)))
+		setAddressBookEntryInput(entry)
 	}
 
 	function openAddressBook() {
@@ -258,11 +260,9 @@ export function App() {
 						{ appPage === Page.AddNewAddress || appPage === Page.ModifyAddress ?
 							<AddNewAddress
 								setActiveAddressAndInformAboutIt = { setActiveAddressAndInformAboutIt }
-								addressInput = { addressInput }
-								nameInput = { nameInput }
+								addressBookEntry = { addressBookEntryInput }
+								setAddressBookEntryInput = { setAddressBookEntryInput }
 								addingNewAddress = { appPage === Page.AddNewAddress }
-								setAddressInput = { setAddressInput }
-								setNameInput = { setNameInput }
 								close = { () => setAndSaveAppPage(Page.Home) }
 								activeAddress = { simulationMode ? activeSimulationAddress : activeSigningAddress }
 							/>

--- a/extension/app/ts/components/pages/AddNewAddress.tsx
+++ b/extension/app/ts/components/pages/AddNewAddress.tsx
@@ -113,7 +113,12 @@ export function AddNewAddress(param: AddAddressParam) {
 										onInput = { e => setNameInput((e.target as HTMLInputElement).value) }
 										maxLength = { 42 }
 									/>
-									<input disabled = { !param.addingNewAddress } className = 'input' type = 'text' value = { addressInput } placeholder = { '0x0...' }
+									<input
+										disabled = { !param.addingNewAddress }
+										className = 'input'
+										type = 'text'
+										value = { addressInput }
+										placeholder = { '0x0...' }
 										onInput = { e => setAddress((e.target as HTMLInputElement).value) }
 										style = { `${ addressInput === undefined || ethers.utils.isAddress(addressInput.trim()) ? '' : 'color: var(--negative-color);' }` } />
 									<label class = 'form-control'>

--- a/extension/app/ts/components/pages/AddNewAddress.tsx
+++ b/extension/app/ts/components/pages/AddNewAddress.tsx
@@ -105,7 +105,11 @@ export function AddNewAddress(param: AddAddressParam) {
 								</div>
 
 								<div class = 'media-content' style = 'overflow-y: unset; overflow-x: unset;'>
-									<input className = 'input' type = 'text' value = { nameInput } placeholder = { addressInput === undefined || addressInput === '' ? 'Name of the address' : addressInput }
+									<input
+										className = 'input'
+										type = 'text'
+										value = { nameInput }
+										placeholder = { addressInput === undefined || addressInput === '' ? 'Name of the address' : addressInput }
 										onInput = { e => setNameInput((e.target as HTMLInputElement).value) }
 										maxLength = { 42 }
 									/>

--- a/extension/app/ts/components/pages/AddNewAddress.tsx
+++ b/extension/app/ts/components/pages/AddNewAddress.tsx
@@ -1,10 +1,11 @@
 import { ethers } from 'ethers'
 import { useEffect, useState } from 'preact/hooks'
 import { EthereumAddress } from '../../utils/wire-types.js'
-import { AddAddressParam } from '../../utils/user-interface-types.js'
+import { AddAddressParam, AddressBookEntry } from '../../utils/user-interface-types.js'
 import Blockie from '../subcomponents/PreactBlocky.js'
 import { Notice } from '../subcomponents/Error.js'
 import { getIssueWithAddressString } from '../ui-utils.js'
+import { addressString } from '../../utils/bigint.js'
 
 export function AddNewAddress(param: AddAddressParam) {
 	const [addressInput, setAddressInput] = useState<string | undefined>(undefined)
@@ -12,20 +13,24 @@ export function AddNewAddress(param: AddAddressParam) {
 	const [askForAddressAccess, setAskForAddressAccess] = useState<boolean>(true)
 	const [errorString, setErrorString] = useState<string | undefined>(undefined)
 	const [activeAddress, setActiveAddress] = useState<bigint | undefined>(undefined)
+	const [addresBookEntryInput, setAddressBookEntryInput] = useState<AddressBookEntry | undefined>(undefined)
+	const [addressType, setAddressType] = useState<'contact' | 'addressInfo' | 'token' | 'NFT' | 'other contract'>('addressInfo')
 
 	function add() {
 		if (addressInput === undefined) return
 		if (!areInputValid()) return
 		param.close()
 		const newEntry = {
+			...addresBookEntryInput,
 			name: nameInput ? nameInput: ethers.utils.getAddress(addressInput),
 			address: EthereumAddress.serialize(BigInt(addressInput)),
 			askForAddressAccess: askForAddressAccess,
 		}
-		browser.runtime.sendMessage( { method: 'popup_addOrModifyAddressInfo', options: [newEntry] } )
+		browser.runtime.sendMessage( { method: 'popup_addOrModifyAddressBookEntry', options: [newEntry] } )
 
 		setAddress(undefined)
 		setNameInput(undefined)
+		setAskForAddressAccess(true)
 	}
 
 	function createAndSwitch() {
@@ -36,10 +41,20 @@ export function AddNewAddress(param: AddAddressParam) {
 	}
 
 	useEffect( () => {
-		setAddress(param.addressInput)
-		setNameInput(param.nameInput)
+		if (param.addressBookEntry !== undefined) {
+			setAddressInput(ethers.utils.getAddress(addressString(param.addressBookEntry.address)))
+			setNameInput(param.addressBookEntry.name)
+			setAddressType(param.addressBookEntry.type)
+			if (param.addressBookEntry.type === 'addressInfo') {
+				setAskForAddressAccess(param.addressBookEntry.askForAddressAccess)
+			}
+		} else {
+			setAddressType('addressInfo')
+		}
+		setAddressBookEntryInput(param.addressBookEntry)
 		setActiveAddress(param.activeAddress)
-	}, [param.addressInput, param.nameInput, param.activeAddress])
+
+	}, [param.addressBookEntry, param.activeAddress])
 
 	function areInputValid() {
 		if (addressInput === undefined) return false
@@ -52,6 +67,7 @@ export function AddNewAddress(param: AddAddressParam) {
 		setAddressInput(input)
 
 		if (input === undefined) return setErrorString(undefined)
+
 		if (ethers.utils.isAddress(input)) return setErrorString(undefined)
 
 		const issue = getIssueWithAddressString(input)
@@ -78,29 +94,31 @@ export function AddNewAddress(param: AddAddressParam) {
 			<section class = 'modal-card-body' style = 'overflow: visible;'>
 				<div class = 'card' style = 'margin: 10px;'>
 					<div class = 'card-content'>
-						<div class = 'media'>
-							<div class = 'media-left'>
-								<figure class = 'image'>
-									{ addressInput && ethers.utils.isAddress(addressInput.trim()) ?
-										<Blockie seed = { addressInput.trim().toLowerCase() } size = { 8 } scale = { 5 } />
-									: <div style = 'background-color: var(--unimportant-text-color); width: 40px; height: 40px; border-radius: 5px;'/> }
-								</figure>
-							</div>
+						{ addressType !== 'addressInfo' ? <p class = 'paragraph'> { `No support to rename this address type yet :( (${ addressType })` } </p> :
+							<div class = 'media'>
+								<div class = 'media-left'>
+									<figure class = 'image'>
+										{ addressInput && ethers.utils.isAddress(addressInput.trim()) ?
+											<Blockie seed = { addressInput.trim().toLowerCase() } size = { 8 } scale = { 5 } />
+										: <div style = 'background-color: var(--unimportant-text-color); width: 40px; height: 40px; border-radius: 5px;'/> }
+									</figure>
+								</div>
 
-							<div class = 'media-content' style = 'overflow-y: unset; overflow-x: unset;'>
-								<input className = 'input' type = 'text' value = { nameInput } placeholder = { addressInput === undefined || addressInput === '' ? 'Name of the address' : addressInput }
-									onInput = { e => param.setNameInput((e.target as HTMLInputElement).value) }
-									maxLength = { 42 }
-								/>
-								<input disabled = { !param.addingNewAddress } className = 'input' type = 'text' value = { addressInput } placeholder = { '0x0...' }
-									onInput = { e => param.setAddressInput((e.target as HTMLInputElement).value) }
-									style = { `${ addressInput === undefined || ethers.utils.isAddress(addressInput.trim()) ? '' : 'color: var(--negative-color);' }` } />
-								<label class = 'form-control'>
-									<input type = 'checkbox' checked = { !askForAddressAccess } onInput = { e => { if (e.target instanceof HTMLInputElement && e.target !== null) { setAskForAddressAccess(!e.target.checked) } } } />
-									Don't request for an access (unsecure)
-								</label>
+								<div class = 'media-content' style = 'overflow-y: unset; overflow-x: unset;'>
+									<input className = 'input' type = 'text' value = { nameInput } placeholder = { addressInput === undefined || addressInput === '' ? 'Name of the address' : addressInput }
+										onInput = { e => setNameInput((e.target as HTMLInputElement).value) }
+										maxLength = { 42 }
+									/>
+									<input disabled = { !param.addingNewAddress } className = 'input' type = 'text' value = { addressInput } placeholder = { '0x0...' }
+										onInput = { e => setAddress((e.target as HTMLInputElement).value) }
+										style = { `${ addressInput === undefined || ethers.utils.isAddress(addressInput.trim()) ? '' : 'color: var(--negative-color);' }` } />
+									<label class = 'form-control'>
+										<input type = 'checkbox' checked = { !askForAddressAccess } onInput = { e => { if (e.target instanceof HTMLInputElement && e.target !== null) { setAskForAddressAccess(!e.target.checked) } } } />
+										Don't request for an access (unsecure)
+									</label>
+								</div>
 							</div>
-						</div>
+						}
 					</div>
 				</div>
 				<div style = 'padding: 10px; height: 50px'>

--- a/extension/app/ts/components/pages/AddNewAddress.tsx
+++ b/extension/app/ts/components/pages/AddNewAddress.tsx
@@ -94,7 +94,7 @@ export function AddNewAddress(param: AddAddressParam) {
 			<section class = 'modal-card-body' style = 'overflow: visible;'>
 				<div class = 'card' style = 'margin: 10px;'>
 					<div class = 'card-content'>
-						{ addressType !== 'addressInfo' ? <p class = 'paragraph'> { `No support to rename this address type yet :( (${ addressType })` } </p> :
+						{ addressType !== 'addressInfo' ? <p class = 'paragraph'> { `No support to rename this address type yet 😢 (${ addressType })` } </p> :
 							<div class = 'media'>
 								<div class = 'media-left'>
 									<figure class = 'image'>

--- a/extension/app/ts/components/pages/ConfirmTransaction.tsx
+++ b/extension/app/ts/components/pages/ConfirmTransaction.tsx
@@ -9,8 +9,6 @@ import { Spinner } from '../subcomponents/Spinner.js'
 import { getSignerName, SignerLogoText } from '../subcomponents/signers.js'
 import { AddNewAddress } from './AddNewAddress.js'
 import { AddressBookEntry } from '../../utils/user-interface-types.js'
-import { ethers } from 'ethers'
-import { addressString } from '../../utils/bigint.js'
 import { formSimulatedAndVisualizedTransaction } from '../formVisualizerResults.js'
 
 export function ConfirmTransaction() {
@@ -20,8 +18,7 @@ export function ConfirmTransaction() {
 	const [currentBlockNumber, setCurrentBlockNumber] = useState<undefined | bigint>(undefined)
 	const [signerName, setSignerName] = useState<SignerName | undefined>(undefined)
 	const [isEditAddressModelOpen, setEditAddressModelOpen] = useState<boolean>(false)
-	const [addressInput, setAddressInput] = useState<string | undefined>(undefined)
-	const [nameInput, setNameInput] = useState<string | undefined>(undefined)
+	const [addressBookEntryInput, setAddressBookEntryInput] = useState<AddressBookEntry | undefined>(undefined)
 
 	useEffect( () => {
 		const updateTx = async () => {
@@ -92,8 +89,7 @@ export function ConfirmTransaction() {
 
 	function renameAddressCallBack(entry: AddressBookEntry) {
 		setEditAddressModelOpen(true)
-		setNameInput(entry.name === undefined ? '' : entry.name)
-		setAddressInput(ethers.utils.getAddress(addressString(entry.address)))
+		setAddressBookEntryInput(entry)
 	}
 
 	return (
@@ -103,11 +99,9 @@ export function ConfirmTransaction() {
 					<div class = { `modal ${ isEditAddressModelOpen? 'is-active' : ''}` }>
 						<AddNewAddress
 							setActiveAddressAndInformAboutIt = { undefined }
-							addressInput = { addressInput }
-							nameInput = { nameInput }
+							addressBookEntry = { addressBookEntryInput }
+							setAddressBookEntryInput = { setAddressBookEntryInput }
 							addingNewAddress = { false }
-							setAddressInput = { setAddressInput }
-							setNameInput = { setNameInput }
 							close = { () => { setEditAddressModelOpen(false) } }
 							activeAddress = { undefined }
 						/>

--- a/extension/app/ts/components/pages/InterceptorAccess.tsx
+++ b/extension/app/ts/components/pages/InterceptorAccess.tsx
@@ -2,8 +2,6 @@ import { useState, useEffect } from 'preact/hooks'
 import { BigAddress } from '../subcomponents/address.js'
 import { AddNewAddress } from './AddNewAddress.js'
 import { AddressInfoEntry, AddressBookEntry } from '../../utils/user-interface-types.js'
-import { ethers } from 'ethers'
-import { addressString } from '../../utils/bigint.js'
 
 interface InterceptorAccessRequest {
 	origin: string
@@ -15,8 +13,7 @@ interface InterceptorAccessRequest {
 export function InterceptorAccess() {
 	const [accessRequest, setAccessRequest] = useState<InterceptorAccessRequest | undefined>(undefined)
 	const [isEditAddressModelOpen, setEditAddressModelOpen] = useState<boolean>(false)
-	const [addressInput, setAddressInput] = useState<string | undefined>(undefined)
-	const [nameInput, setNameInput] = useState<string | undefined>(undefined)
+	const [addressBookEntryInput, setAddressBookEntryInput] = useState<AddressBookEntry | undefined>(undefined)
 
 	useEffect( () => {
 		function popupMessageListener(msg: unknown) {
@@ -67,8 +64,7 @@ export function InterceptorAccess() {
 
 	function renameAddressCallBack(entry: AddressBookEntry) {
 		setEditAddressModelOpen(true)
-		setNameInput(entry.name === undefined ? '' : entry.name)
-		setAddressInput(ethers.utils.getAddress(addressString(entry.address)))
+		setAddressBookEntryInput(entry)
 	}
 
 	return (
@@ -76,11 +72,9 @@ export function InterceptorAccess() {
 			<div class = { `modal ${ isEditAddressModelOpen? 'is-active' : ''}` }>
 				<AddNewAddress
 					setActiveAddressAndInformAboutIt = { undefined }
-					addressInput = { addressInput }
-					nameInput = { nameInput }
+					addressBookEntry = { addressBookEntryInput }
+					setAddressBookEntryInput = { setAddressBookEntryInput }
 					addingNewAddress = { false }
-					setAddressInput = { setAddressInput }
-					setNameInput = { setNameInput }
 					close = { () => { setEditAddressModelOpen(false) } }
 					activeAddress = { undefined }
 				/>

--- a/extension/app/ts/components/pages/PersonalSign.tsx
+++ b/extension/app/ts/components/pages/PersonalSign.tsx
@@ -1,5 +1,5 @@
 import { useState, useEffect, useRef } from 'preact/hooks'
-import { addressString, bigintToRoundedPrettyDecimalString, stringToUint8Array } from '../../utils/bigint.js'
+import { bigintToRoundedPrettyDecimalString, stringToUint8Array } from '../../utils/bigint.js'
 import { EthereumAddress } from '../../utils/wire-types.js'
 import { BigAddress, findAddressInfo } from '../subcomponents/address.js'
 import { AddressBookEntry, AddressInfo } from '../../utils/user-interface-types.js'
@@ -8,7 +8,6 @@ import { Error as ErrorComponent} from '../subcomponents/Error.js'
 import { getAddressMetaData } from '../../background/metadataUtils.js'
 import { MOCK_PRIVATE_KEYS_ADDRESS, getChainName } from '../../utils/constants.js'
 import { AddNewAddress } from './AddNewAddress.js'
-import { ethers } from 'ethers'
 
 interface SignRequest {
 	simulationMode: boolean,
@@ -22,8 +21,7 @@ export function PersonalSign() {
 	const [signRequest, setSignRequest] = useState<SignRequest | undefined>(undefined)
 	const textareaRef = useRef<HTMLTextAreaElement | null>(null)
 	const [isEditAddressModelOpen, setEditAddressModelOpen] = useState<boolean>(false)
-	const [addressInput, setAddressInput] = useState<string | undefined>(undefined)
-	const [nameInput, setNameInput] = useState<string | undefined>(undefined)
+	const [addressBookEntryInput, setAddressBookEntryInput] = useState<AddressBookEntry | undefined>(undefined)
 	const [activeSimulationAddress, setActiveSimulationAddress] = useState<bigint | undefined>(undefined)
 
 	useEffect( () => {
@@ -89,8 +87,7 @@ export function PersonalSign() {
 
 	function renameAddressCallBack(entry: AddressBookEntry) {
 		setEditAddressModelOpen(true)
-		setNameInput(entry.name === undefined ? '' : entry.name)
-		setAddressInput(ethers.utils.getAddress(addressString(entry.address)))
+		setAddressBookEntryInput(entry)
 	}
 
 	return (
@@ -99,11 +96,9 @@ export function PersonalSign() {
 				<div class = { `modal ${ isEditAddressModelOpen? 'is-active' : ''}` }>
 					<AddNewAddress
 						setActiveAddressAndInformAboutIt = { undefined }
-						addressInput = { addressInput }
-						nameInput = { nameInput }
+						addressBookEntry = { addressBookEntryInput }
+						setAddressBookEntryInput = { setAddressBookEntryInput }
 						addingNewAddress = { false }
-						setAddressInput = { setAddressInput }
-						setNameInput = { setNameInput }
 						close = { () => { setEditAddressModelOpen(false) } }
 						activeAddress = { undefined }
 					/>

--- a/extension/app/ts/utils/interceptor-messages.ts
+++ b/extension/app/ts/utils/interceptor-messages.ts
@@ -1,5 +1,5 @@
 import * as funtypes from 'funtypes'
-import { AddressBookEntries, AddressInfo } from './user-interface-types.js'
+import { AddressBookEntries, AddressBookEntry, AddressInfo } from './user-interface-types.js'
 import { EthereumAddress, EthereumQuantity } from './wire-types.js'
 
 
@@ -113,8 +113,8 @@ export const RemoveAddressBookEntry = funtypes.Object({
 
 export type AddOrModifyAddresInfo = funtypes.Static<typeof AddOrModifyAddresInfo>
 export const AddOrModifyAddresInfo = funtypes.Object({
-	method: funtypes.Literal('popup_addOrModifyAddressInfo'),
-	options: funtypes.ReadonlyArray(AddressInfo)
+	method: funtypes.Literal('popup_addOrModifyAddressBookEntry'),
+	options: funtypes.ReadonlyArray(AddressBookEntry)
 }).asReadonly()
 
 export type ChangePage = funtypes.Static<typeof ChangePage>

--- a/extension/app/ts/utils/user-interface-types.ts
+++ b/extension/app/ts/utils/user-interface-types.ts
@@ -98,10 +98,8 @@ export type InterceptorAccessListParams = {
 
 export type AddAddressParam = {
 	close: () => void,
-	addressInput: string | undefined,
-	nameInput: string | undefined,
-	setAddressInput: (address: string) => void,
-	setNameInput: (name: string) => void,
+	addressBookEntry: AddressBookEntry | undefined,
+	setAddressBookEntryInput: (entry: AddressBookEntry) => void,
 	setActiveAddressAndInformAboutIt: ((address: bigint | 'signer') => void) | undefined,
 	addingNewAddress: boolean,
 	activeAddress: bigint | undefined,


### PR DESCRIPTION
User can rename active addresses now. When trying to rename other addresses (tokens, nft's and such) they'll get a clean error for now as renaming for those:

![image](https://user-images.githubusercontent.com/13102010/214811176-852d8650-63a2-4341-86fa-cbb88c082abf.png)
