### PR TITLE
Remove window.interceptor.changeChainDialog global. Fix chain changing bugs and add handleSigningMode

### DIFF
--- a/extension/app/ts/background/providerMessageHandlers.ts
+++ b/extension/app/ts/background/providerMessageHandlers.ts
@@ -50,13 +50,14 @@ export function signerChainChanged(port: browser.runtime.Port, request: Provider
 
 export function walletSwitchEthereumChainReply(port: browser.runtime.Port, request: ProviderMessage) {
 	const params = WalletSwitchEthereumChainReply.parse(request.options).params[0]
+	if (params.accept) changeSignerChain(port, params.chainId )
 	resolveSignerChainChange({
-		method: 'popup_changeChainDialog',
+		method: 'popup_signerChangeChainDialog',
 		options: {
-			accept: params.accept
+			chainId: params.chainId,
+			accept: params.accept,
 		}
 	})
-	if (params.accept) changeSignerChain(port, params.chainId )
 }
 
 export function connectedToSigner(_port: browser.runtime.Port, request: ProviderMessage) {

--- a/extension/app/ts/background/simulationModeHanders.ts
+++ b/extension/app/ts/background/simulationModeHanders.ts
@@ -122,27 +122,27 @@ export async function gasPrice(simulator: Simulator) {
 	return { result: EthereumQuantity.serialize(await simulator.ethereum.getGasPrice()) }
 }
 
-export async function personalSign(_simulator: Simulator, request: PersonalSignParams, requestId: number | undefined, simulationMode: boolean = true) {
+export async function personalSign(_simulator: Simulator, request: PersonalSignParams, requestId: number | undefined, simulationMode: boolean) {
 	if (requestId === undefined) throw new Error('personalSign requires known requestId')
 	return await openPersonalSignDialog(requestId, simulationMode, request)
 }
 
-export async function signTypedData(_simulator: Simulator, request: SignTypedDataParams, requestId: number | undefined, simulationMode: boolean = true) {
+export async function signTypedData(_simulator: Simulator, request: SignTypedDataParams, requestId: number | undefined, simulationMode: boolean) {
 	if (requestId === undefined) throw new Error('signTypedData requires known requestId')
 	return await openPersonalSignDialog(requestId, simulationMode, request)
 }
 
-export async function switchEthereumChain(simulator: Simulator, request: SwitchEthereumChainParams, port: browser.runtime.Port, requestId: number | undefined) {
+export async function switchEthereumChain(simulator: Simulator, request: SwitchEthereumChainParams, port: browser.runtime.Port, requestId: number | undefined, simulationMode: boolean) {
 	if (await simulator.ethereum.getChainId() === request.params[0].chainId) {
 		// we are already on the right chain
-		return { result: [] }
+		return { result: null }
 	}
 	const origin = port.sender?.url
 	if (origin === undefined) return ERROR_INTERCEPTOR_UNKNOWN_ORIGIN
 	if (requestId === undefined) throw new Error('switchEthereumChain requires known requestId')
 
 	const favicon = port.sender?.tab?.favIconUrl
-	return await openChangeChainDialog(requestId, origin, favicon, request.params[0].chainId)
+	return await openChangeChainDialog(requestId, simulationMode, origin, favicon, request.params[0].chainId)
 }
 
 export async function getCode(simulator: Simulator, request: GetCode) {

--- a/extension/app/ts/background/windows/changeChain.ts
+++ b/extension/app/ts/background/windows/changeChain.ts
@@ -29,14 +29,16 @@ function rejectMessage(requestId: number) {
 	} as const
 }
 
+const userDeniedChange = {
+	error: {
+		code: METAMASK_ERROR_USER_REJECTED_REQUEST,
+		message: 'User denied the chain change.',
+	}
+} as const
+
 export const openChangeChainDialog = async (requestId: number, simulationMode: boolean, origin: string, favIconUrl: string | undefined, chainId: bigint) => {
 	if (openedWindow !== null || pendForUserReply || pendForSignerReply) {
-		return {
-			error: {
-				code: METAMASK_ERROR_USER_REJECTED_REQUEST,
-				message: 'User denied the chain change.'
-			}
-		}
+		return userDeniedChange
 	}
 	pendForUserReply = new Future<ChainChangeConfirmation>()
 
@@ -93,10 +95,5 @@ export const openChangeChainDialog = async (requestId: number, simulationMode: b
 			return { result: null }
 		}
 	}
-	return {
-		error: {
-			code: METAMASK_ERROR_USER_REJECTED_REQUEST,
-			message: 'User denied the chain change.'
-		}
-	}
+	return userDeniedChange
 }

--- a/extension/app/ts/utils/interceptor-messages.ts
+++ b/extension/app/ts/utils/interceptor-messages.ts
@@ -185,7 +185,7 @@ export const ChainChangeConfirmation = funtypes.Object({
 	method: funtypes.Literal('popup_changeChainDialog'),
 	options: funtypes.Object({
 		requestId: funtypes.Number,
-		accept: funtypes.Boolean
+		accept: funtypes.Boolean,
 	})
 }).asReadonly()
 
@@ -194,7 +194,7 @@ export const SignerChainChangeConfirmation = funtypes.Object({
 	method: funtypes.Literal('popup_signerChangeChainDialog'),
 	options: funtypes.Object({
 		chainId: EthereumQuantity,
-		accept: funtypes.Boolean
+		accept: funtypes.Boolean,
 	})
 }).asReadonly()
 


### PR DESCRIPTION
- Removes `window.interceptor.changeChainDialog` global
- Fixes https://github.com/DarkFlorist/TheInterceptor/issues/126
- Add `handleSigningMode` that is similar to `handleSimulationMode` to make more explicit which methods are forward and which are not. Handling these things vaguely was also one cause of #126 bug