### PR TITLE
Fixes curves issues

### DIFF
--- a/extension/app/ts/utils/constants.ts
+++ b/extension/app/ts/utils/constants.ts
@@ -204,3 +204,7 @@ export const CHAIN_NAMES = new Map<string, string>( [
 export function getChainName(chainId: bigint) { return CHAIN_NAMES.get(chainId.toString()) || `Chain: ${chainId.toString()}` }
 
 export const MOCK_PRIVATE_KEYS_ADDRESS = 0x7E5F4552091A69125d5DfCb7b8C2659029395Bdfn // an address represeting 0x1 privatekey
+
+export const KNOWN_CONTRACT_CALLER_ADDRESSES = [
+	0xca11bde05977b3631167028862be2a173976ca11n // curve multicaller
+]


### PR DESCRIPTION
- Fixes `eth_call` to replace missing values correctly
- If we get `'sender has deployed code'` error, retry the call with different caller (fixes issues like curve)
- If we already know common contract callers (like curve), we can just swap the address without making that additional call
- If call fails, return errors correctly and don't just return the error return value