### PR TITLE
Confirm transaction saving

### DIFF
--- a/extension/app/inpage/ts/document_start.ts
+++ b/extension/app/inpage/ts/document_start.ts
@@ -1,18 +1,27 @@
-function listenInContentScript() {
+function listenInContentScript(conectionName: string | undefined) {
 	/**
 	 * this script executed within the context of the active tab when the user clicks the extension bar button
 	 * this script serves as a _very thin_ proxy between the page scripts (dapp) and the extension, simply forwarding messages between the two
 	*/
 	// the content script is a very thin proxy between the background script and the page script
-	const extensionPort = browser.runtime.connect()
-	let connected = true
+
+	const dec2hex = (dec: number) => dec.toString(16).padStart(2, '0')
+
+	function generateId (len: number) {
+		const arr = new Uint8Array((len || 40) / 2)
+		globalThis.crypto.getRandomValues(arr)
+		return Array.from(arr, dec2hex).join('')
+	}
+	const connectionNameNotUndefined = conectionName === undefined ? generateId(40) : conectionName
+
+	const extensionPort = browser.runtime.connect({ name: connectionNameNotUndefined })
 
 	// forward all message events to the background script, which will then filter and process them
-	globalThis.addEventListener('message', messageEvent => {
+	const listener = (messageEvent: MessageEvent<any>) => {
 		try {
 			// we only want the data element, if it exists, and postMessage will fail if it can't clone the object fully (and it cannot clone a MessageEvent)
 			if (!('data' in messageEvent)) return
-			if (connected) extensionPort.postMessage({ data: messageEvent.data })
+			extensionPort.postMessage({ data: messageEvent.data })
 		} catch (error) {
 			// CONSIDER: should we catch data clone error and then do `extensionPort.postMessage({data:JSON.parse(JSON.stringify(messageEvent.data))})`?
 			if (error instanceof Error) {
@@ -23,19 +32,21 @@ function listenInContentScript() {
 			}
 			throw error
 		}
-	})
+	}
+	globalThis.addEventListener('message', listener)
 
 	// forward all messages we get from the background script to the window so the page script can filter and process them
 	extensionPort.onMessage.addListener(response => {
 		try {
-			if (connected) globalThis.postMessage(response, '*')
+			globalThis.postMessage(response, '*')
 		} catch (error) {
 			console.error(error)
 		}
 	})
 
 	extensionPort.onDisconnect.addListener(() => {
-		connected = false
+		globalThis.removeEventListener('message', listener)
+		listenInContentScript(connectionNameNotUndefined)
 	})
 }
 
@@ -47,7 +58,7 @@ function injectScript(content: any) {
 		scriptTag.textContent = content
 		container.insertBefore(scriptTag, container.children[0])
 		container.removeChild(scriptTag)
-		listenInContentScript()
+		listenInContentScript(undefined)
 	} catch (error) {
 	  	console.error('Interceptor: Provider injection failed.', error)
 	}

--- a/extension/app/ts/background/popupMessageHandlers.ts
+++ b/extension/app/ts/background/popupMessageHandlers.ts
@@ -246,7 +246,7 @@ export async function homeOpened() {
 	if (tabs.length === 0 || tabs[0].id === undefined ) return
 	const signerState = globalThis.interceptor.websiteTabSignerStates.get(tabs[0].id)
 	const signerAccounts = signerState === undefined ? undefined : signerState.signerAccounts
-	const tabConnection = globalThis.interceptor.websiteTabConnection.get(tabs[0].id)
+	const tabIconDetails = globalThis.interceptor.websiteTabConnection.get(tabs[0].id)?.tabIconDetails
 	const tabApproved = globalThis.interceptor.websiteTabApprovals.get(tabs[0].id)?.approved === true
 
 	sendPopupMessageToOpenWindows({
@@ -265,7 +265,7 @@ export async function homeOpened() {
 			signerName: globalThis.interceptor.signerName,
 			currentBlockNumber: globalThis.interceptor.currentBlockNumber,
 			settings: globalThis.interceptor.settings,
-			tabConnection: tabConnection,
+			tabIconDetails: tabIconDetails,
 			tabApproved: tabApproved,
 		}
 	})

--- a/extension/app/ts/background/settings.ts
+++ b/extension/app/ts/background/settings.ts
@@ -1,5 +1,5 @@
 import { MOCK_PRIVATE_KEYS_ADDRESS } from '../utils/constants.js'
-import { AddressBookTabIdSetting, LegacyWebsiteAccessArray, Page, Settings, WebsiteAccessArray, WebsiteAccessArrayWithLegacy, pages } from '../utils/interceptor-messages.js'
+import { AddressBookTabIdSetting, LegacyWebsiteAccessArray, Page, PendingUserRequestPromise, Settings, WebsiteAccessArray, WebsiteAccessArrayWithLegacy, pages } from '../utils/interceptor-messages.js'
 import { AddressInfo, ContactEntries, PendingAccessRequestArray } from '../utils/user-interface-types.js'
 import { EthereumAddress, EthereumQuantity } from '../utils/wire-types.js'
 
@@ -109,4 +109,16 @@ export async function getOpenedAddressBookTabId() {
 	const tabIdData = await browser.storage.local.get(['addressbookTabId'])
 	if (!AddressBookTabIdSetting.test(tabIdData)) return undefined
 	return AddressBookTabIdSetting.parse(tabIdData).addressbookTabId
+}
+
+export async function getConfirmationWindowPromise(): Promise<PendingUserRequestPromise | undefined> {
+	const results = await browser.storage.local.get(['ConfirmationWindowPromise'])
+	return results.ConfirmationWindowPromise === undefined ? undefined : PendingUserRequestPromise.parse(results.ConfirmationWindowPromise)
+}
+
+export async function saveConfirmationWindowPromise(promise: PendingUserRequestPromise | undefined) {
+	if (promise === undefined) {
+		return await browser.storage.local.remove('ConfirmationWindowPromise')
+	}
+	return await browser.storage.local.set({ ConfirmationWindowPromise: PendingUserRequestPromise.serialize(promise) })
 }

--- a/extension/app/ts/background/windows/personalSign.ts
+++ b/extension/app/ts/background/windows/personalSign.ts
@@ -14,10 +14,6 @@ let openedPersonalSignDialogWindow: browser.windows.Window | null = null
 export async function resolvePersonalSign(confirmation: PersonalSign) {
 	if (pendingPersonalSign !== undefined) pendingPersonalSign.resolve(confirmation)
 	pendingPersonalSign = undefined
-
-	if (openedPersonalSignDialogWindow !== null && openedPersonalSignDialogWindow.id) {
-		await browser.windows.remove(openedPersonalSignDialogWindow.id)
-	}
 	openedPersonalSignDialogWindow = null
 }
 

--- a/extension/app/ts/components/App.tsx
+++ b/extension/app/ts/components/App.tsx
@@ -12,7 +12,7 @@ import { PasteCatcher } from './subcomponents/PasteCatcher.js'
 import { truncateAddr } from '../utils/ethereum.js'
 import { NotificationCenter } from './pages/NotificationCenter.js'
 import { DEFAULT_TAB_CONNECTION } from '../utils/constants.js'
-import { ExternalPopupMessage, SignerName, TabConnection, UpdateHomePage, Page, WebsiteAccessArray } from '../utils/interceptor-messages.js'
+import { ExternalPopupMessage, SignerName, TabIconDetails, UpdateHomePage, Page, WebsiteAccessArray } from '../utils/interceptor-messages.js'
 import { version, gitCommitSha } from '../version.js'
 import { formSimulatedAndVisualizedTransaction } from './formVisualizerResults.js'
 import { sendPopupMessageToBackgroundPage } from '../background/backgroundUtils.js'
@@ -34,7 +34,7 @@ export function App() {
 	const [simulationMode, setSimulationMode] = useState<boolean>(true)
 	const [pendingAccessRequests, setPendingAccessRequests] = useState<PendingAccessRequestArray | undefined>(undefined)
 	const [pendingAccessMetadata, setPendingAccessMetadata] = useState<readonly [string, AddressInfoEntry][]>([])
-	const [tabConnection, setTabConnection] = useState<TabConnection>(DEFAULT_TAB_CONNECTION)
+	const [tabIconDetails, setTabConnection] = useState<TabIconDetails>(DEFAULT_TAB_CONNECTION)
 	const [tabApproved, setTabApproved] = useState<boolean>(false)
 	const [isSettingsLoaded, setIsSettingsLoaded] = useState<boolean>(false)
 	const [currentBlockNumber, setCurrentBlockNumber] = useState<bigint | undefined>(undefined)
@@ -128,10 +128,10 @@ export function App() {
 		setCurrentBlockNumber(data.currentBlockNumber)
 
 		setSignerAccounts(data.signerAccounts)
-		if (data.tabConnection === undefined) {
+		if (data.tabIconDetails === undefined) {
 			setTabConnection(DEFAULT_TAB_CONNECTION)
 		} else {
-			setTabConnection(data.tabConnection)
+			setTabConnection(data.tabIconDetails)
 		}
 		setTabApproved(data.tabApproved)
 		setIsSettingsLoaded(true)
@@ -224,7 +224,7 @@ export function App() {
 							makeMeRich = { makeMeRich }
 							addressInfos = { addressInfos }
 							simulationMode = { simulationMode }
-							tabConnection = { tabConnection }
+							tabIconDetails = { tabIconDetails }
 							tabApproved = { tabApproved }
 							currentBlockNumber = { currentBlockNumber }
 							signerName = { signerName }

--- a/extension/app/ts/components/pages/ConfirmTransaction.tsx
+++ b/extension/app/ts/components/pages/ConfirmTransaction.tsx
@@ -145,13 +145,15 @@ export function ConfirmTransaction() {
 		sendPopupMessageToBackgroundPage( { method: 'popup_confirmTransactionReadyAndListening' } )
 	}, [])
 
-	function approve() {
+	async function approve() {
 		if (requestIdToConfirm === undefined) throw new Error('request id is not set')
-		sendPopupMessageToBackgroundPage( { method: 'popup_confirmDialog', options: { requestId: requestIdToConfirm, accept: true } } )
+		await sendPopupMessageToBackgroundPage( { method: 'popup_confirmDialog', options: { requestId: requestIdToConfirm, accept: true } } )
+		globalThis.close()
 	}
-	function reject() {
+	async function reject() {
 		if (requestIdToConfirm === undefined) throw new Error('request id is not set')
-		sendPopupMessageToBackgroundPage( { method: 'popup_confirmDialog', options: { requestId: requestIdToConfirm, accept: false } } )
+		await sendPopupMessageToBackgroundPage( { method: 'popup_confirmDialog', options: { requestId: requestIdToConfirm, accept: false } } )
+		globalThis.close()
 	}
 	const refreshSimulation = () => {
 		if (simulationAndVisualisationResults === undefined || requestIdToConfirm === undefined || transactionToSimulate === undefined) return

--- a/extension/app/ts/components/pages/Home.tsx
+++ b/extension/app/ts/components/pages/Home.tsx
@@ -6,7 +6,7 @@ import { SimulationSummary } from '../simulationExplaining/SimulationSummary.js'
 import { ChainSelector } from '../subcomponents/ChainSelector.js'
 import { Spinner } from '../subcomponents/Spinner.js'
 import { DEFAULT_TAB_CONNECTION, getChainName, ICON_NOT_ACTIVE, ICON_SIGNING, ICON_SIGNING_NOT_SUPPORTED, isSupportedChain } from '../../utils/constants.js'
-import { SignerName, TabConnection } from '../../utils/interceptor-messages.js'
+import { SignerName, TabIconDetails } from '../../utils/interceptor-messages.js'
 import { getSignerName, SignerLogoText, SignersLogoName } from '../subcomponents/signers.js'
 import { Error } from '../subcomponents/Error.js'
 import { ToolTip } from '../subcomponents/CopyToClipboard.js'
@@ -27,8 +27,8 @@ function FirstCard(param: FirstCardParams) {
 		<header class = 'card-header'>
 			<div class = 'card-header-icon unset-cursor'>
 				<span class = 'icon' style = 'height: 3rem; width: 3rem;'>
-					<ToolTip content = {  param.tabConnection.iconReason }>
-						<img className = 'noselect nopointer' src = { param.tabConnection.icon } />
+					<ToolTip content = {  param.tabIconDetails.iconReason }>
+						<img className = 'noselect nopointer' src = { param.tabIconDetails.icon } />
 					</ToolTip>
 				</span>
 			</div>
@@ -62,8 +62,8 @@ function FirstCard(param: FirstCardParams) {
 						Retrieving from&nbsp;
 						<SignersLogoName signerName = { param.signerName } />
 					</span>
-					{ param.signerAccounts !== undefined && param.signerAccounts.length > 0 && param.tabConnection.icon !== ICON_NOT_ACTIVE ? <span style = 'float: right; color: var(--primary-color);'> CONNECTED </span> :
-						param.tabConnection.icon === ICON_SIGNING || param.tabConnection.icon === ICON_SIGNING_NOT_SUPPORTED ? <span style = 'float: right; color: var(--negative-color);'> NOT CONNECTED </span> : <></>
+					{ param.signerAccounts !== undefined && param.signerAccounts.length > 0 && param.tabIconDetails.icon !== ICON_NOT_ACTIVE ? <span style = 'float: right; color: var(--primary-color);'> CONNECTED </span> :
+						param.tabIconDetails.icon === ICON_SIGNING || param.tabIconDetails.icon === ICON_SIGNING_NOT_SUPPORTED ? <span style = 'float: right; color: var(--negative-color);'> NOT CONNECTED </span> : <></>
 					}
 				</p>
 				: <></>
@@ -89,7 +89,7 @@ function FirstCard(param: FirstCardParams) {
 				</div>
 			}
 			{ !param.simulationMode ?
-				( (param.signerAccounts === undefined || param.signerAccounts.length == 0) && param.tabConnection.icon !== ICON_NOT_ACTIVE ) ?
+				( (param.signerAccounts === undefined || param.signerAccounts.length == 0) && param.tabIconDetails.icon !== ICON_NOT_ACTIVE ) ?
 					<div style = 'margin-top: 5px'>
 						<button className = 'button is-primary' onClick = { connectToSigner } >
 							<SignerLogoText
@@ -143,7 +143,7 @@ export function Home(param: HomeParams) {
 	const [simulationAndVisualisationResults, setSimulationAndVisualisationResults] = useState<SimulationAndVisualisationResults | undefined>(undefined)
 	const [activeChain, setActiveChain] = useState<bigint>(1n)
 	const [simulationMode, setSimulationMode] = useState<boolean>(true)
-	const [tabConnection, setTabConnection] = useState<TabConnection>( DEFAULT_TAB_CONNECTION )
+	const [tabIconDetails, setTabConnection] = useState<TabIconDetails>( DEFAULT_TAB_CONNECTION )
 	const [tabApproved, setTabApproved] = useState<boolean>(false)
 	const [signerAccounts, setSignerAccounts] = useState<readonly bigint[] | undefined>(undefined)
 	const [isLoaded, setLoaded] = useState<boolean>(false)
@@ -163,7 +163,7 @@ export function Home(param: HomeParams) {
 		setActiveChain(param.activeChain)
 		setSimulationMode(param.simulationMode)
 		setTabApproved(param.tabApproved)
-		setTabConnection(param.tabConnection)
+		setTabConnection(param.tabIconDetails)
 		setSignerAccounts(param.signerAccounts)
 		setCurrentBlockNumber(param.currentBlockNumber)
 		setSignerName(param.signerName)
@@ -175,7 +175,7 @@ export function Home(param: HomeParams) {
 		param.useSignersAddressAsActiveAddress,
 		param.activeChain,
 		param.simulationMode,
-		param.tabConnection,
+		param.tabIconDetails,
 		param.tabApproved,
 		param.currentBlockNumber,
 		param.signerName,
@@ -219,7 +219,7 @@ export function Home(param: HomeParams) {
 			changeActiveAddress = { changeActiveAddress }
 			makeMeRich = { param.makeMeRich }
 			signerAccounts = { signerAccounts }
-			tabConnection = { tabConnection }
+			tabIconDetails = { tabIconDetails }
 			tabApproved = { tabApproved }
 			signerName = { signerName }
 			renameAddressCallBack = { param.renameAddressCallBack }

--- a/extension/app/ts/components/pages/InterceptorAccess.tsx
+++ b/extension/app/ts/components/pages/InterceptorAccess.tsx
@@ -131,7 +131,7 @@ export function InterceptorAccess() {
 		return () => browser.runtime.onMessage.removeListener(popupMessageListener)
 	}, [])
 
-	function approve() {
+	async function approve() {
 		if (accessRequest === undefined) return
 		const options = {
 			type: 'approval' as const,
@@ -139,10 +139,11 @@ export function InterceptorAccess() {
 			websiteOrigin: accessRequest.website.websiteOrigin,
 			requestAccessToAddress: accessRequest.requestAccessToAddress?.address,
 		}
-		sendPopupMessageToBackgroundPage({ method: 'popup_interceptorAccess', options })
+		await sendPopupMessageToBackgroundPage({ method: 'popup_interceptorAccess', options })
+		globalThis.close()
 	}
 
-	function reject() {
+	async function reject() {
 		if (accessRequest === undefined) return
 		const options = {
 			type: 'approval' as const,
@@ -150,7 +151,8 @@ export function InterceptorAccess() {
 			websiteOrigin: accessRequest.website.websiteOrigin,
 			requestAccessToAddress: accessRequest.requestAccessToAddress?.address,
 		}
-		sendPopupMessageToBackgroundPage({ method: 'popup_interceptorAccess', options })
+		await sendPopupMessageToBackgroundPage({ method: 'popup_interceptorAccess', options })
+		globalThis.close()
 	}
 
 	function renameAddressCallBack(entry: AddressBookEntry) {

--- a/extension/app/ts/components/pages/PersonalSign.tsx
+++ b/extension/app/ts/components/pages/PersonalSign.tsx
@@ -87,14 +87,16 @@ export function PersonalSign() {
 		}
 	}
 
-	function approve() {
+	async function approve() {
 		if ( requestIdToConfirm === undefined) throw new Error('Request id is missing')
-		sendPopupMessageToBackgroundPage( { method: 'popup_personalSign', options: { requestId: requestIdToConfirm, accept: true } } )
+		await sendPopupMessageToBackgroundPage( { method: 'popup_personalSign', options: { requestId: requestIdToConfirm, accept: true } } )
+		globalThis.close()
 	}
 
-	function reject() {
+	async function reject() {
 		if ( requestIdToConfirm === undefined) throw new Error('Request id is missing')
-		sendPopupMessageToBackgroundPage( { method: 'popup_personalSign', options: { requestId: requestIdToConfirm, accept: false } } )
+		await sendPopupMessageToBackgroundPage( { method: 'popup_personalSign', options: { requestId: requestIdToConfirm, accept: false } } )
+		globalThis.close()
 	}
 
 	function renameAddressCallBack(entry: AddressBookEntry) {

--- a/extension/app/ts/listenContentScript.ts
+++ b/extension/app/ts/listenContentScript.ts
@@ -1,18 +1,27 @@
-function listenInContentScript() {
+function listenInContentScript(conectionName: string | undefined) {
 	/**
 	 * this script executed within the context of the active tab when the user clicks the extension bar button
 	 * this script serves as a _very thin_ proxy between the page scripts (dapp) and the extension, simply forwarding messages between the two
 	*/
 	// the content script is a very thin proxy between the background script and the page script
-	const extensionPort = browser.runtime.connect()
-	let connected = true
+
+	const dec2hex = (dec: number) => dec.toString(16).padStart(2, '0')
+
+	function generateId (len: number) {
+		const arr = new Uint8Array((len || 40) / 2)
+		globalThis.crypto.getRandomValues(arr)
+		return Array.from(arr, dec2hex).join('')
+	}
+	const connectionNameNotUndefined = conectionName === undefined ? generateId(40) : conectionName
+
+	const extensionPort = browser.runtime.connect({ name: connectionNameNotUndefined })
 
 	// forward all message events to the background script, which will then filter and process them
-	globalThis.addEventListener('message', messageEvent => {
+	const listener = (messageEvent: MessageEvent<any>) => {
 		try {
 			// we only want the data element, if it exists, and postMessage will fail if it can't clone the object fully (and it cannot clone a MessageEvent)
 			if (!('data' in messageEvent)) return
-			if (connected) extensionPort.postMessage({ data: messageEvent.data })
+			extensionPort.postMessage({ data: messageEvent.data })
 		} catch (error) {
 			// CONSIDER: should we catch data clone error and then do `extensionPort.postMessage({data:JSON.parse(JSON.stringify(messageEvent.data))})`?
 			if (error instanceof Error) {
@@ -23,19 +32,21 @@ function listenInContentScript() {
 			}
 			throw error
 		}
-	})
+	}
+	globalThis.addEventListener('message', listener)
 
 	// forward all messages we get from the background script to the window so the page script can filter and process them
 	extensionPort.onMessage.addListener(response => {
 		try {
-			if (connected) globalThis.postMessage(response, '*')
+			globalThis.postMessage(response, '*')
 		} catch (error) {
 			console.error(error)
 		}
 	})
 
 	extensionPort.onDisconnect.addListener(() => {
-		connected = false
+		globalThis.removeEventListener('message', listener)
+		listenInContentScript(connectionNameNotUndefined)
 	})
 }
-listenInContentScript()
+listenInContentScript(undefined)

--- a/extension/app/ts/utils/interceptor-messages.ts
+++ b/extension/app/ts/utils/interceptor-messages.ts
@@ -446,8 +446,8 @@ export const ConfirmTransactionSimulationStateChanged = funtypes.Object({
 	})
 })
 
-export type TabConnection = funtypes.Static<typeof TabConnection>
-export const TabConnection = funtypes.Object({
+export type TabIconDetails = funtypes.Static<typeof TabIconDetails>
+export const TabIconDetails = funtypes.Object({
 	icon: funtypes.String,
 	iconReason: funtypes.String,
 })
@@ -518,7 +518,7 @@ export const UpdateHomePage = funtypes.ReadonlyObject({
 		signerName: funtypes.Union(SignerName, funtypes.Undefined),
 		currentBlockNumber: funtypes.Union(EthereumQuantity, funtypes.Undefined),
 		settings: Settings,
-		tabConnection: funtypes.Union(TabConnection, funtypes.Undefined),
+		tabIconDetails: funtypes.Union(TabIconDetails, funtypes.Undefined),
 		tabApproved: funtypes.Boolean,
 	})
 })
@@ -564,3 +564,14 @@ export const WindowMessageSignerAccountsChanged = funtypes.Object({
 
 export type WindowMessage = funtypes.Static<typeof WindowMessage>
 export const WindowMessage = WindowMessageSignerAccountsChanged
+
+export type PendingUserRequestPromise = funtypes.Static<typeof PendingUserRequestPromise>
+export const PendingUserRequestPromise = funtypes.Object({
+	website: Website,
+	dialogId: funtypes.Number,
+	tabId: funtypes.Number,
+	connectionName: funtypes.String,
+	request: InterceptedRequest,
+	transactionToSimulate: EthereumUnsignedTransaction,
+	simulationMode: funtypes.Boolean,
+})

--- a/extension/app/ts/utils/user-interface-types.ts
+++ b/extension/app/ts/utils/user-interface-types.ts
@@ -4,7 +4,7 @@ import { EthereumAccountsReply, EthereumAddress, EthereumQuantity, LiteralConver
 import { SimulatedAndVisualizedTransaction, SimulationAndVisualisationResults } from './visualizer-types.js'
 import { IdentifiedSwapWithMetadata } from '../components/simulationExplaining/SwapTransactions.js'
 import { CHAINS } from './constants.js'
-import { Page, SignerName, TabConnection, WebsiteAccessArray } from './interceptor-messages.js'
+import { Page, SignerName, TabIconDetails, WebsiteAccessArray } from './interceptor-messages.js'
 
 export type Website = funtypes.Static<typeof Website>
 export const Website = funtypes.Object({
@@ -127,7 +127,7 @@ export type HomeParams = {
 	activeChain: bigint,
 	setActiveChainAndInformAboutIt: (network: bigint) => void,
 	simulationMode: boolean,
-	tabConnection: TabConnection,
+	tabIconDetails: TabIconDetails,
 	tabApproved: boolean,
 	currentBlockNumber: bigint | undefined,
 	signerName: SignerName | undefined,
@@ -154,7 +154,7 @@ export type FirstCardParams = {
 	changeActiveAddress: () => void,
 	makeMeRich: boolean,
 	signerAccounts: readonly bigint[] | undefined,
-	tabConnection: TabConnection,
+	tabIconDetails: TabIconDetails,
 	tabApproved: boolean,
 	signerName: SignerName | undefined,
 	renameAddressCallBack: RenameAddressCallBack,
@@ -206,3 +206,8 @@ export interface SignerState {
 }
 
 export type RenameAddressCallBack = (addressBookEntry: AddressBookEntry) => void
+
+export type TabConnection = {
+	tabIconDetails: TabIconDetails
+	portConnections: Record<string, browser.runtime.Port>
+}


### PR DESCRIPTION
- Reconnects after service worker disconnects
- Instead of using sockets to identify connection, use connection name (generated randomly) and tab id
- Saves confirm transaction dialog information to disk so on a reconnect, so if service worker is lost when the dialog is open, we can recover

still todos: other dialogs, saving other state stuff (like simulation state)