### PR TITLE
Fixes getcode

### DIFF
--- a/extension/app/ts/simulation/protectors/eoaApproval.ts
+++ b/extension/app/ts/simulation/protectors/eoaApproval.ts
@@ -7,13 +7,13 @@ export async function eoaApproval(transaction: EthereumUnsignedTransaction, cont
 	if (approvalInfo === undefined) return
 	if (approvalInfo.name === 'approve') {
 		if (approvalInfo.arguments.value === 0n) return // approving 0 is allowed
-		const code = await controller.ethereum.getCode(approvalInfo.arguments.spender)
+		const code = await controller.simulationModeNode.getCode(approvalInfo.arguments.spender)
 		if (code.length > 0) return
 		return 'EOA_APPROVAL'
 	}
 	if (approvalInfo.name === 'setApprovalForAll') {
 		if (approvalInfo.arguments.approved === false) return // setting approval off is allowed
-		const code = await controller.ethereum.getCode(approvalInfo.arguments.operator)
+		const code = await controller.simulationModeNode.getCode(approvalInfo.arguments.operator)
 		if (code.length > 0) return
 		return 'EOA_APPROVAL'
 	}

--- a/extension/app/ts/simulation/protectors/eoaCalldata.ts
+++ b/extension/app/ts/simulation/protectors/eoaCalldata.ts
@@ -4,7 +4,7 @@ import { EthereumUnsignedTransaction } from '../../utils/wire-types.js'
 export async function eoaCalldata(transaction: EthereumUnsignedTransaction, simulator: Simulator) {
 	if (transaction.to === null) return
 	if (transaction.input.length === 0) return
-	const code = await simulator.ethereum.getCode(transaction.to)
+	const code = await simulator.simulationModeNode.getCode(transaction.to)
 	if (code.length > 0) return
 	return 'EOA_CALLDATA'
 }

--- a/extension/app/ts/simulation/protectors/tokenToContract.ts
+++ b/extension/app/ts/simulation/protectors/tokenToContract.ts
@@ -6,7 +6,7 @@ export async function tokenToContract(transaction: EthereumUnsignedTransaction, 
 	const transferInfo = parseTransaction(transaction)
 	if (transferInfo === undefined) return
 	if (transferInfo.name !== 'transfer' && transferInfo.name !== 'transferFrom') return
-	const code = await simulator.ethereum.getCode(transferInfo.arguments.to)
+	const code = await simulator.simulationModeNode.getCode(transferInfo.arguments.to)
 	if (code.length === 0) return
 	return 'ERC20_UNINTENDED_CONTRACT'
 }

--- a/extension/app/ts/simulation/services/SimulationModeEthereumClientService.ts
+++ b/extension/app/ts/simulation/services/SimulationModeEthereumClientService.ts
@@ -1,6 +1,6 @@
 import { EthereumClientService } from './EthereumClientService.js'
 import { EthGetLogsResponse, EthereumUnsignedTransaction, EthereumSignedTransactionWithBlockData, EthereumBlockTag, EthGetLogsRequest, EthTransactionReceiptResponse, EstimateGasParamsVariables, EthSubscribeParams, JsonRpcMessage, JsonRpcNewHeadsNotification, PersonalSignParams, SignTypedDataParams, EthereumSignedTransaction, GetBlockReturn, EthereumData, EthereumQuantity } from '../../utils/wire-types.js'
-import { bytes32String, max, min, stringToUint8Array } from '../../utils/bigint.js'
+import { addressString, bytes32String, max, min, stringToUint8Array } from '../../utils/bigint.js'
 import { MOCK_ADDRESS } from '../../utils/constants.js'
 import { ErrorWithData } from '../../utils/errors.js'
 import { Future } from '../../utils/future.js'
@@ -346,7 +346,7 @@ export class SimulationModeEthereumClientService {
 		const blockNum = await this.ethereumClientService.getBlockNumber()
 
 		const atInterface = new ethers.Interface(['function at(address) returns (uint256)'])
-		const input = stringToUint8Array(atInterface.encodeFunctionData('at', [address]))
+		const input = stringToUint8Array(atInterface.encodeFunctionData('at', [addressString(address)]))
 
 		const getCodeTransaction = {
 			type: '1559' as const,
@@ -368,7 +368,7 @@ export class SimulationModeEthereumClientService {
 			accessList: []
 		}
 		const multiCall = await this.multicall([getCodeTransaction], blockNum + 1n)
-		return multiCall[multiCall.length-1].returnValue
+		return multiCall[multiCall.length - 1].returnValue
 	}
 
 	private readonly getBaseFeePerGasForNewBlock = (parent_gas_used: bigint, parent_gas_limit: bigint, parent_base_fee_per_gas: bigint) => {


### PR DESCRIPTION
getcode was not working as ethers does not like bigints. Also protectors are now using getcode via simulation and not by directly calling the node (which was wrong if we are simulating)