### PR TITLE
Refactor `IdentifiedSwapWithMetadata` to have two `SwapAsset`s that are swapped instead of one big object that has cumbersome separate send and receive types

### DIFF
--- a/extension/app/css/interceptor.css
+++ b/extension/app/css/interceptor.css
@@ -622,3 +622,15 @@ svg.spinner > circle {
 	max-width: fit-content;
 	color: var(--text-color)
 }
+
+.swap-box {
+	background-color: var(--alpha-005);
+	box-shadow: unset;
+	margin-bottom: 0px;
+	display: grid;
+}
+
+.swap-grid {
+	grid-template-columns: auto auto;
+	display: grid;
+}


### PR DESCRIPTION
no visual changes, just refactoring