### PR TITLE
Fix Error: No tab with id

### DIFF
--- a/extension/app/ts/background/iconHandler.ts
+++ b/extension/app/ts/background/iconHandler.ts
@@ -71,13 +71,10 @@ export async function retrieveWebsiteDetails(port: browser.runtime.Port, website
 		try {
 			return browser.tabs.get(tabId)
 		} catch (error) {
-			if (error instanceof Error) {
-				if (error.message?.includes('No tab with id')) {
-					// if tab is not found (user might have closed it)
-					return undefined
-				}
-			}
-			throw error
+			if (!(error instanceof Error)) throw error
+			if (!error.message?.includes('No tab with id')) throw error
+			// if tab is not found (user might have closed it)
+			return undefined
 		}
 	}
 

--- a/extension/app/ts/background/iconHandler.ts
+++ b/extension/app/ts/background/iconHandler.ts
@@ -81,7 +81,6 @@ export async function retrieveWebsiteDetails(port: browser.runtime.Port, website
 		}
 	}
 
-
 	const tabId = port.sender?.tab?.id
 	if (tabId === undefined) return  {
 		websiteOrigin: websiteOrigin,


### PR DESCRIPTION
When querying for icon for tab that user has already closed results in an error, this will get rid of that error by making icon and title undefined for such page