### PR TITLE
make removing transactions fast, disable reset on click

### DIFF
--- a/extension/app/ts/components/simulationExplaining/SimulationSummary.tsx
+++ b/extension/app/ts/components/simulationExplaining/SimulationSummary.tsx
@@ -9,7 +9,6 @@ import { SomeTimeAgo } from '../subcomponents/SomeTimeAgo.js'
 import { CHAINS, MAKE_YOU_RICH_TRANSACTION } from '../../utils/constants.js'
 import { addressString } from '../../utils/bigint.js'
 import { identifyTransaction } from './identifyTransaction.js'
-import { sendPopupMessageToBackgroundPage } from '../../background/backgroundUtils.js'
 import { identifySwap } from './SwapTransactions.js'
 import { useState } from 'preact/hooks'
 import { convertNumberToCharacterRepresentationIfSmallEnough, upperCaseFirstCharacter } from '../ui-utils.js'
@@ -571,7 +570,6 @@ export function SimulatedInBlockNumber({ simulationBlockNumber, currentBlockNumb
 
 type SimulationSummaryParams = {
 	simulationAndVisualisationResults: SimulationAndVisualisationResults,
-	resetButton: boolean,
 	currentBlockNumber: bigint | undefined,
 	renameAddressCallBack: RenameAddressCallBack,
 }
@@ -579,13 +577,12 @@ type SimulationSummaryParams = {
 export function SimulationSummary(param: SimulationSummaryParams) {
 	if (param.simulationAndVisualisationResults === undefined) return <></>
 
-	const logSummarizer = new LogSummarizer( param.simulationAndVisualisationResults.simulatedAndVisualizedTransactions )
-	const addressMetaData = new Map(param.simulationAndVisualisationResults.addressMetaData.map( (x) => [addressString(x.address), x]))
+	const logSummarizer = new LogSummarizer(param.simulationAndVisualisationResults.simulatedAndVisualizedTransactions)
+	const addressMetaData = new Map(param.simulationAndVisualisationResults.addressMetaData.map((x) => [addressString(x.address), x]))
 	const originalSummary = logSummarizer.getSummary(addressMetaData, param.simulationAndVisualisationResults.tokenPrices)
 	const [ownAddresses, notOwnAddresses] = splitToOwnAndNotOwnAndCleanSummary(param.simulationAndVisualisationResults.simulatedAndVisualizedTransactions.at(0), originalSummary, param.simulationAndVisualisationResults.activeAddress, param.simulationAndVisualisationResults.chain)
 
 	const [showOtherAccountChanges, setShowOtherAccountChange] = useState<boolean>(false)
-	const resetSimulation = () => sendPopupMessageToBackgroundPage( { method: 'popup_resetSimulation' } )
 
 	return (
 		<div class = 'card' style = 'background-color: var(--card-bg-color); margin: 10px;'>
@@ -644,14 +641,6 @@ export function SimulationSummary(param: SimulationSummaryParams) {
 						currentBlockNumber = { param.currentBlockNumber }
 						simulationConductedTimestamp = { param.simulationAndVisualisationResults.simulationConductedTimestamp }
 					/>
-					<button className = 'button is-primary is-small' style = 'margin-left: 5px; background-color: var(--negative-color);' onClick = { resetSimulation } >
-						<span class = 'icon'>
-							<img src = '../../img/broom.svg'/>
-						</span>
-						<span>
-							Reset
-						</span>
-					</button>
 				</p>
 			</div>
 		</div>

--- a/extension/app/ts/components/simulationExplaining/SwapTransactions.tsx
+++ b/extension/app/ts/components/simulationExplaining/SwapTransactions.tsx
@@ -77,7 +77,7 @@ export function formSwapAsset(tokenResult: TokenVisualizerERC20Event[] | TokenVi
 			type: 'NFT',
 			tokenAddress: tokenResult.token,
 			tokenId: tokenResult.tokenId
-		}	
+		}
 	}
 }
 
@@ -130,7 +130,7 @@ export function identifySwap(simTransaction: SimulatedAndVisualizedTransaction):
 			sender: simTransaction.transaction.from,
 			sendAsset: formSwapAsset(tokensSent[0].type === 'NFT' ? tokensSent[0] : tokensSent.filter((token): token is TokenVisualizerERC20Event => token.type === 'Token'), sendBalanceAfter),
 			receiveAsset: {
-				type: 'Ether', 
+				type: 'Ether',
 				amount: ethDiff,
 				beforeAfterBalance: {
 					previousBalance: etherChange[0].before,
@@ -147,7 +147,7 @@ export function identifySwap(simTransaction: SimulatedAndVisualizedTransaction):
 		return {
 			sender: simTransaction.transaction.from,
 			sendAsset: {
-				type: 'Ether', 
+				type: 'Ether',
 				amount: -ethDiff,
 				beforeAfterBalance: {
 					previousBalance: etherChange[0].before,
@@ -318,15 +318,15 @@ export function VisualizeSwapAsset({ swapAsset, chain }: { swapAsset: SwapAsset,
 							amount = { swapAsset.amount }
 							style = { tokenStyle }
 						/>
-						</div>
-						<div class = 'log-cell' style = 'justify-content: right;'>
-							<EtherSymbol
-								amount = { swapAsset.amount }
-								chain = { chain }
-								useFullTokenName = { false }
-								style = { tokenStyle}
-							/>
-						</div>		
+					</div>
+					<div class = 'log-cell' style = 'justify-content: right;'>
+						<EtherSymbol
+							amount = { swapAsset.amount }
+							chain = { chain }
+							useFullTokenName = { false }
+							style = { tokenStyle}
+						/>
+					</div>
 				</span>
 				<span class = 'grid swap-grid'>
 					<div class = 'log-cell'/>

--- a/extension/app/ts/components/simulationExplaining/Transactions.tsx
+++ b/extension/app/ts/components/simulationExplaining/Transactions.tsx
@@ -143,11 +143,12 @@ type TransactionsParams = {
 	removeTransaction: (tx: SimulatedAndVisualizedTransaction) => void,
 	activeAddress: bigint,
 	renameAddressCallBack: RenameAddressCallBack,
+	removeTransactionHashes: bigint[],
 }
 
 export function Transactions(param: TransactionsParams) {
 	return <ul>
-		{ param.simulationAndVisualisationResults.simulatedAndVisualizedTransactions.map((simTx, _index) => (
+		{ param.simulationAndVisualisationResults.simulatedAndVisualizedTransactions.filter((tx) => !param.removeTransactionHashes.includes(tx.transaction.hash)).map((simTx, _index) => (
 			<li>
 				<Transaction
 					simTx = { simTx }

--- a/extension/app/ts/utils/user-interface-types.ts
+++ b/extension/app/ts/utils/user-interface-types.ts
@@ -172,6 +172,9 @@ export type SimulationStateParam = {
 	removeTransaction: (tx: SimulatedAndVisualizedTransaction) => void,
 	currentBlockNumber: bigint | undefined,
 	renameAddressCallBack: RenameAddressCallBack,
+	disableReset: boolean,
+	resetSimulation: () => void,
+	removeTransactionHashes: bigint[],
 }
 
 export type LogAnalysisParams = {


### PR DESCRIPTION
Fix https://github.com/DarkFlorist/TheInterceptor/issues/243

I moved reset button higher, where it makes more sense, and renamed it to `clear` instead, that sounds more clear (no pun intended)
![image](https://user-images.githubusercontent.com/13102010/231772225-ef128bed-1627-4312-8931-593febb8bb21.png)
