### PR TITLE
confirm transaction and simulation state connection errors

### DIFF
--- a/extension/app/ts/background/background.ts
+++ b/extension/app/ts/background/background.ts
@@ -121,12 +121,9 @@ export async function refreshConfirmTransactionSimulation(
 			data: { ...info, ...await visualizeSimulatorState(simulationStateWithNewTransaction, simulator) }
 		}
 	} catch(error) {
-		if (error instanceof Error) {
-			if (isFailedToFetchError(error)) {
-				return { method: 'popup_confirm_transaction_simulation_failed' as const, data: info }
-			}
-		}
-		throw error
+		if (!(error instanceof Error)) throw error
+		if (!isFailedToFetchError(error)) throw error
+		return { method: 'popup_confirm_transaction_simulation_failed' as const, data: info }
 	}
 }
 

--- a/extension/app/ts/background/background.ts
+++ b/extension/app/ts/background/background.ts
@@ -19,6 +19,7 @@ import { assertNever, assertUnreachable } from '../utils/typescript.js'
 import { EthereumClientService } from '../simulation/services/EthereumClientService.js'
 import { appendTransaction, copySimulationState, setPrependTransactionsQueue, simulatePersonalSign } from '../simulation/services/SimulationModeEthereumClientService.js'
 import { Semaphore } from '../utils/semaphore.js'
+import { isFailedToFetchError } from '../utils/errors.js'
 
 const websiteTabConnections = new Map<number, TabConnection>()
 
@@ -58,26 +59,35 @@ async function visualizeSimulatorState(simulationState: SimulationState, simulat
 export async function updateSimulationState(getUpdatedSimulationState: () => Promise<SimulationState | undefined>, activeAddress: bigint | undefined) {
 	if (simulator === undefined) return
 	const simId = (await getSimulationResults()).simulationId + 1
-	const updatedSimulationState = await getUpdatedSimulationState()
-
-	if (updatedSimulationState !== undefined) {
-		await updateSimulationResults({
-			simulationId: simId,
-			...await visualizeSimulatorState(updatedSimulationState, simulator),
-			activeAddress: activeAddress,
-		})
-	} else {
-		await updateSimulationResults({
-			simulationId: simId,
-			addressBookEntries: [],
-			tokenPrices: [],
-			visualizerResults: [],
-			simulationState: updatedSimulationState,
-			activeAddress: activeAddress,
-		})
+	try {
+		const updatedSimulationState = await getUpdatedSimulationState()
+		if (updatedSimulationState !== undefined) {
+			await updateSimulationResults({
+				simulationId: simId,
+				...await visualizeSimulatorState(updatedSimulationState, simulator),
+				activeAddress: activeAddress,
+			})
+		} else {
+			await updateSimulationResults({
+				simulationId: simId,
+				addressBookEntries: [],
+				tokenPrices: [],
+				visualizerResults: [],
+				simulationState: updatedSimulationState,
+				activeAddress: activeAddress,
+			})
+		}
+		sendPopupMessageToOpenWindows({ method: 'popup_simulation_state_changed' })
+		return updatedSimulationState
+	} catch(error) {
+		if (error instanceof Error) {
+			if (isFailedToFetchError(error)) {
+				await sendPopupMessageToOpenWindows({ method: 'popup_failed_to_update_simulation_state' })
+				return undefined
+			}
+		}
+		throw error
 	}
-	sendPopupMessageToOpenWindows({ method: 'popup_simulation_state_changed' })
-	return updatedSimulationState
 }
 
 export function setEthereumNodeBlockPolling(enabled: boolean) {
@@ -94,20 +104,29 @@ export async function refreshConfirmTransactionSimulation(
 	transactionToSimulate: EthereumUnsignedTransaction,
 	website: Website,
 ) {
-	if (simulator === undefined) return undefined
+	const info = {
+		requestId: requestId,
+		transactionToSimulate: transactionToSimulate,
+		simulationMode: simulationMode,
+		activeAddress: activeAddress,
+		signerName: await getSignerName(),
+		website: website,
+	}
+	if (simulator === undefined) return { method: 'popup_confirm_transaction_simulation_failed' as const, data: info }
 	sendPopupMessageToOpenWindows({ method: 'popup_confirm_transaction_simulation_started' })
-	const simulationStateWithNewTransaction = await appendTransaction(ethereumClientService, copySimulationState(simulationState), { transaction: transactionToSimulate, website: website })
-	return {
-		method: 'popup_confirm_transaction_simulation_state_changed' as const,
-		data: {
-			requestId: requestId,
-			transactionToSimulate: transactionToSimulate,
-			simulationMode: simulationMode,
-			...await visualizeSimulatorState(simulationStateWithNewTransaction, simulator),
-			activeAddress: activeAddress,
-			signerName: await getSignerName(),
-			website: website,
+	try {
+		const simulationStateWithNewTransaction = await appendTransaction(ethereumClientService, copySimulationState(simulationState), { transaction: transactionToSimulate, website: website })
+		return {
+			method: 'popup_confirm_transaction_simulation_state_changed' as const,
+			data: { ...info, ...await visualizeSimulatorState(simulationStateWithNewTransaction, simulator) }
 		}
+	} catch(error) {
+		if (error instanceof Error) {
+			if (isFailedToFetchError(error)) {
+				return { method: 'popup_confirm_transaction_simulation_failed' as const, data: info }
+			}
+		}
+		throw error
 	}
 }
 
@@ -296,8 +315,9 @@ async function newBlockCallback(blockNumber: bigint, ethereumClientService: Ethe
 	refreshSimulation(ethereumClientService, await getSettings())
 }
 
-async function onErrorBlockCallback(_ethereumClientService: EthereumClientService, _error: Error) {
-	sendPopupMessageToOpenWindows({ method: 'popup_failed_to_get_block' })
+async function onErrorBlockCallback(_ethereumClientService: EthereumClientService, error: Error) {
+	if (isFailedToFetchError(error)) return await sendPopupMessageToOpenWindows({ method: 'popup_failed_to_get_block' })
+	throw error
 }
 
 const changeActiveAddressAndChainAndResetSimulationSemaphore = new Semaphore(1)

--- a/extension/app/ts/background/backgroundUtils.ts
+++ b/extension/app/ts/background/backgroundUtils.ts
@@ -19,7 +19,6 @@ export async function sendPopupMessageToOpenWindows(message: MessageToPopup) {
 			if (error?.message?.includes('A listener indicated an asynchronous response by returning true, but the message channel closed before a response was received')) {
 				return
 			}
-			if (error) return console.error(`Popup message error: ${ error.message }`);
 		}
 		throw error
 	}

--- a/extension/app/ts/background/popupMessageHandlers.ts
+++ b/extension/app/ts/background/popupMessageHandlers.ts
@@ -286,11 +286,9 @@ export async function homeOpened(simulator: Simulator) {
 	try {
 		blockNumber = await simulator.ethereum.getBlockNumber()
 	} catch (error) {
-		if (error instanceof Error) {
-			if (isFailedToFetchError(error)) await sendPopupMessageToOpenWindows({ method: 'popup_failed_to_get_block' })
-		} else {
-			throw error
-		}
+		if (!(error instanceof Error)) throw error
+		if (!isFailedToFetchError(error)) throw error
+		await sendPopupMessageToOpenWindows({ method: 'popup_failed_to_get_block' })
 	}
 
 	await sendPopupMessageToOpenWindows({

--- a/extension/app/ts/background/windows/confirmTransaction.ts
+++ b/extension/app/ts/background/windows/confirmTransaction.ts
@@ -88,11 +88,7 @@ export async function openConfirmTransactionDialog(
 			const message = ExternalPopupMessage.parse(msg)
 			if (message.method !== 'popup_confirmTransactionReadyAndListening') return
 			browser.runtime.onMessage.removeListener(windowReadyAndListening)
-			const refreshMessage = await refreshSimulationPromise
-			if (openedConfirmTransactionDialogWindow !== null && openedConfirmTransactionDialogWindow.id) {
-				if (refreshMessage === undefined) return await browser.windows.remove(openedConfirmTransactionDialogWindow.id)
-				return sendPopupMessageToOpenWindows(refreshMessage)
-			}
+			return sendPopupMessageToOpenWindows(await refreshSimulationPromise)
 		}
 
 		try {
@@ -138,7 +134,7 @@ async function resolve(ethereumClientService: EthereumClientService, reply: Conf
 		if (simulationState === undefined) return undefined
 		return await appendTransaction(ethereumClientService, simulationState, { transaction: transactionToSimulate, website: website })
 	}, activeAddress)
-	if (newState?.simulatedTransactions === undefined || newState.simulatedTransactions.length === 0) {
+	if (newState === undefined || newState.simulatedTransactions === undefined || newState.simulatedTransactions.length === 0) {
 		return {
 			error: {
 				code: METAMASK_ERROR_NOT_CONNECTED_TO_CHAIN,

--- a/extension/app/ts/components/App.tsx
+++ b/extension/app/ts/components/App.tsx
@@ -71,7 +71,7 @@ export function App() {
 		}
 	}
 
-	useEffect( () => {
+	useEffect(() => {
 		const setSimulationState = (
 			simState: SimulationState | undefined,
 			visualizerResults: readonly SimResults[] | undefined,
@@ -145,6 +145,7 @@ export function App() {
 			const message = ExternalPopupMessage.parse(msg)
 			if (message.method === 'popup_settingsUpdated') return updateHomePageSettings(message.data, true)
 			if (message.method === 'popup_websiteIconChanged') return updateTabIcon(message)
+			if (message.method === 'popup_failed_to_get_block') return
 			if (message.method !== 'popup_UpdateHomePage') return await sendPopupMessageToBackgroundPage( { method: 'popup_requestNewHomeData' } )
 			return updateHomePage(message)
 		}
@@ -152,15 +153,15 @@ export function App() {
 		return () => {
 			browser.runtime.onMessage.removeListener(popupMessageListener)
 		}
-	}, [])
+	})
 
-	useEffect( () => {
-		sendPopupMessageToBackgroundPage( { method: 'popup_requestNewHomeData' } )
+	useEffect(() => {
+		sendPopupMessageToBackgroundPage({ method: 'popup_requestNewHomeData' })
 	}, [])
 
 	function setAndSaveAppPage(page: Page) {
 		setAppPage(page)
-		sendPopupMessageToBackgroundPage( { method: 'popup_changePage', options: page } )
+		sendPopupMessageToBackgroundPage({ method: 'popup_changePage', options: page })
 	}
 
 	async function addressPaste(address: string) {

--- a/extension/app/ts/components/pages/Home.tsx
+++ b/extension/app/ts/components/pages/Home.tsx
@@ -238,6 +238,11 @@ export function Home(param: HomeParams) {
 			browser.runtime.onMessage.removeListener(popupMessageListener)
 		}
 	})
+	useEffect(() => {
+		if (param.currentBlockNumber === undefined) {
+			setConnectedToNetwork({ connected: false, timestamp: Date.now() })
+		}
+	}, [param.currentBlockNumber])
 
 	function changeActiveAddress() {
 		param.setAndSaveAppPage('ChangeActiveAddress')
@@ -301,7 +306,9 @@ export function Home(param: HomeParams) {
 				</div>
 			</div>
 		: <></> }
-		{ !simulationMode || activeSimulationAddress === undefined ? <></> :
+
+		{ simulationMode && currentBlockNumber === undefined ? <div style = 'padding: 10px'> <DinoSays text = { 'Not connected to a network..' } /> </div> : <></> }
+		{ !simulationMode || activeSimulationAddress === undefined || currentBlockNumber === undefined ? <></> :
 			<SimulationResults
 				simulationAndVisualisationResults = { simulationAndVisualisationResults }
 				removeTransaction = { removeTransaction }

--- a/extension/app/ts/components/subcomponents/DinoSays.tsx
+++ b/extension/app/ts/components/subcomponents/DinoSays.tsx
@@ -2,7 +2,7 @@
 export function DinoSays( { text } : { text: string }) {
 	return <div class = 'media'>
 		<div class = 'media-left' style = 'margin-right: 0.2rem;'>
-			<img style = 'transform: scaleX(-1); justify-content: center; display: flex;' src = '../img/LOGOA.svg' width = '16'/>
+			<img style = 'transform: scaleX(-1); justify-content: center; display: flex;' src = '../img/LOGOA.svg' width = '24'/>
 		</div>
 		<div class = 'media-content' style = 'overflow-y: hidden; overflow-x: clip; display: block; margin: auto;'>
 			<span class = 'paragraph addressText'> - { text } </span>

--- a/extension/app/ts/utils/errors.ts
+++ b/extension/app/ts/utils/errors.ts
@@ -17,6 +17,11 @@ export class JsonRpcResponseError extends ErrorWithData {
 	}
 }
 
+export function isFailedToFetchError(error: Error) {
+	if (error.message.includes('Failed to fetch')) return true
+	return false
+}
+
 export function exitOnError<P extends unknown[], R>(func: (...params: P) => R): (...params: P) => R {
 	return (...params: P) => {
 		try {

--- a/extension/app/ts/utils/interceptor-messages.ts
+++ b/extension/app/ts/utils/interceptor-messages.ts
@@ -325,7 +325,6 @@ export const GetAddressBookDataReply = funtypes.ReadonlyObject({
 	data: GetAddressBookDataReplyData,
 }).asReadonly()
 
-
 export type RefreshConfirmTransactionDialogSimulation = funtypes.Static<typeof RefreshConfirmTransactionDialogSimulation>
 export const RefreshConfirmTransactionDialogSimulation = funtypes.ReadonlyObject({
 	method: funtypes.Literal('popup_refreshConfirmTransactionDialogSimulation'),
@@ -473,19 +472,23 @@ export const InterceptorAccessDialog = funtypes.ReadonlyObject({
 	})
 })
 
-export type ConfirmTransactionDialogState = funtypes.Static<typeof ConfirmTransactionDialogState>
-export const ConfirmTransactionDialogState = funtypes.ReadonlyObject({
+export type ConfirmTransactionSimulationBaseData = funtypes.Static<typeof ConfirmTransactionSimulationBaseData>
+export const ConfirmTransactionSimulationBaseData = funtypes.ReadonlyObject({
+	activeAddress: EthereumAddress,
+	simulationMode: funtypes.Boolean,
 	requestId: funtypes.Number,
 	transactionToSimulate: EthereumUnsignedTransaction,
-	simulationMode: funtypes.Boolean,
+	website: Website,
+	signerName: SignerName,
+})
+
+export type ConfirmTransactionDialogState = funtypes.Static<typeof ConfirmTransactionDialogState>
+export const ConfirmTransactionDialogState = funtypes.Intersect(ConfirmTransactionSimulationBaseData, funtypes.ReadonlyObject({
 	simulationState: SimulationState,
 	visualizerResults: funtypes.ReadonlyArray(SimResults),
 	addressBookEntries: AddressBookEntries,
 	tokenPrices: funtypes.ReadonlyArray(TokenPriceEstimate),
-	activeAddress: EthereumAddress,
-	signerName: SignerName,
-	website: Website,
-})
+}))
 
 export type ConfirmTransactionSimulationStateChanged = funtypes.Static<typeof ConfirmTransactionSimulationStateChanged>
 export const ConfirmTransactionSimulationStateChanged = funtypes.ReadonlyObject({
@@ -497,6 +500,12 @@ export type RefreshConfirmTransactionMetadata = funtypes.Static<typeof RefreshCo
 export const RefreshConfirmTransactionMetadata = funtypes.ReadonlyObject({
 	method: funtypes.Literal('popup_refreshConfirmTransactionMetadata'),
 	data: ConfirmTransactionDialogState
+}).asReadonly()
+
+export type ConfirmTransactionSimulationFailed = funtypes.Static<typeof ConfirmTransactionSimulationFailed>
+export const ConfirmTransactionSimulationFailed = funtypes.ReadonlyObject({
+	method: funtypes.Literal('popup_confirm_transaction_simulation_failed'),
+	data: ConfirmTransactionSimulationBaseData,
 }).asReadonly()
 
 export type WebsiteAddressAccess = funtypes.Static<typeof WebsiteAddressAccess>
@@ -708,6 +717,8 @@ export const MessageToPopup = funtypes.Union(
 	UpdateHomePage,
 	SettingsUpdated,
 	funtypes.ReadonlyObject({ method: funtypes.Literal('popup_failed_to_get_block') }),
+	funtypes.ReadonlyObject({ method: funtypes.Literal('popup_failed_to_update_simulation_state') }),
+	ConfirmTransactionSimulationFailed,
 )
 
 export type ExternalPopupMessage = funtypes.Static<typeof MessageToPopup>


### PR DESCRIPTION
Work towards https://github.com/DarkFlorist/TheInterceptor/issues/335
- Now if you lose connection when forming transaction you get an error and forming transaction is retryed when new block arrives
- Show error on simulation stack too if we cannot update it

still todo:
1) If dapp queries the extension we don't manage the error nicely
2) we should change our icon as not connected if no connection