### PR TITLE
Fix race condition, close popup listener is removed before event

### DIFF
--- a/extension/app/ts/background/simulationModeHanders.ts
+++ b/extension/app/ts/background/simulationModeHanders.ts
@@ -173,7 +173,7 @@ export async function personalSign(websiteTabConnections: WebsiteTabConnections,
 }
 
 export async function switchEthereumChain(websiteTabConnections: WebsiteTabConnections, socket: WebsiteSocket, ethereumClientService: EthereumClientService, params: SwitchEthereumChainParams, request: InterceptedRequest, simulationMode: boolean, website: Website) {
-	if (await ethereumClientService.getChainId() === params.params[0].chainId) {
+	if (ethereumClientService.getChainId() === params.params[0].chainId) {
 		// we are already on the right chain
 		return { result: null }
 	}

--- a/extension/app/ts/background/windows/changeChain.ts
+++ b/extension/app/ts/background/windows/changeChain.ts
@@ -120,6 +120,7 @@ export const openChangeChainDialog = async (
 		browser.windows.onRemoved.removeListener(onCloseWindow)
 		browser.windows.onRemoved.removeListener(changeChainWindowReadyAndListening)
 		pendForUserReply = undefined
+		openedWindow = null
 	}
 }
 


### PR DESCRIPTION
Fixes #347 
When `onCloseWindow` is called, it checks the closed window in event is the same  window.id and then sets `openedWindow = null`

On the finally block during cleanup, the onCloseWindow listener is removed before the popup event comes in.