### PR TITLE
Parse and validate EIP-712 messages and show metadata on them

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 /app/js/
+/test/js/
 /app/vendor/
 node_modules/
 /app/inpage/build/

--- a/app/css/interceptor.css
+++ b/app/css/interceptor.css
@@ -667,3 +667,15 @@ svg.spinner > circle {
 	margin-top: 0px;
 	margin-bottom: 0px;
 }
+
+.eip-712-table {
+	display: grid;
+	grid-template-columns: max-content auto auto auto auto;
+	justify-content: center;
+	column-gap: 5px;
+	grid-template-columns: auto auto;
+	background-color: var(--alpha-005);
+	margin: 5px;
+	padding: 5px;
+	border-radius: 5px;
+}

--- a/app/ts/utils/eip712Parsing.ts
+++ b/app/ts/utils/eip712Parsing.ts
@@ -1,0 +1,340 @@
+import { UserAddressBook } from "./interceptor-messages.js"
+import { assertNever } from "./typescript.js"
+import { AddressBookEntry } from "./user-interface-types.js"
+import { EIP712Message, EthereumAddress, EthereumData, EthereumQuantity, JSONEncodeableObject, NonHexBigInt } from "./wire-types.js"
+import * as funtypes from 'funtypes'
+import { getAddressMetaData } from "../background/metadataUtils.js"
+
+type SolidityType = funtypes.Static<typeof SolidityType>
+const SolidityType = funtypes.Union(
+	funtypes.Literal('uint8'),
+	funtypes.Literal('uint16'),
+	funtypes.Literal('uint24'),
+	funtypes.Literal('uint32'),
+	funtypes.Literal('uint40'),
+	funtypes.Literal('uint48'),
+	funtypes.Literal('uint56'),
+	funtypes.Literal('uint64'),
+	funtypes.Literal('uint72'),
+	funtypes.Literal('uint80'),
+	funtypes.Literal('uint88'),
+	funtypes.Literal('uint96'),
+	funtypes.Literal('uint104'),
+	funtypes.Literal('uint112'),
+	funtypes.Literal('uint120'),
+	funtypes.Literal('uint128'),
+	funtypes.Literal('uint136'),
+	funtypes.Literal('uint144'),
+	funtypes.Literal('uint152'),
+	funtypes.Literal('uint160'),
+	funtypes.Literal('uint168'),
+	funtypes.Literal('uint176'),
+	funtypes.Literal('uint184'),
+	funtypes.Literal('uint192'),
+	funtypes.Literal('uint200'),
+	funtypes.Literal('uint208'),
+	funtypes.Literal('uint216'),
+	funtypes.Literal('uint224'),
+	funtypes.Literal('uint232'),
+	funtypes.Literal('uint240'),
+	funtypes.Literal('uint248'),
+	funtypes.Literal('uint256'),
+    funtypes.Literal('int8'),
+	funtypes.Literal('int16'),
+	funtypes.Literal('int24'),
+	funtypes.Literal('int32'),
+	funtypes.Literal('int40'),
+	funtypes.Literal('int48'),
+	funtypes.Literal('int56'),
+	funtypes.Literal('int64'),
+	funtypes.Literal('int72'),
+	funtypes.Literal('int80'),
+	funtypes.Literal('int88'),
+	funtypes.Literal('int96'),
+	funtypes.Literal('int104'),
+	funtypes.Literal('int112'),
+	funtypes.Literal('int120'),
+	funtypes.Literal('int128'),
+	funtypes.Literal('int136'),
+	funtypes.Literal('int144'),
+	funtypes.Literal('int152'),
+	funtypes.Literal('int160'),
+	funtypes.Literal('int168'),
+	funtypes.Literal('int176'),
+	funtypes.Literal('int184'),
+	funtypes.Literal('int192'),
+	funtypes.Literal('int200'),
+	funtypes.Literal('int208'),
+	funtypes.Literal('int216'),
+	funtypes.Literal('int224'),
+	funtypes.Literal('int232'),
+	funtypes.Literal('int240'),
+	funtypes.Literal('int248'),
+	funtypes.Literal('int256'),
+	funtypes.Literal('bytes1'),
+	funtypes.Literal('bytes2'),
+	funtypes.Literal('bytes3'),
+	funtypes.Literal('bytes4'),
+	funtypes.Literal('bytes5'),
+	funtypes.Literal('bytes6'),
+	funtypes.Literal('bytes7'),
+	funtypes.Literal('bytes8'),
+	funtypes.Literal('bytes9'),
+	funtypes.Literal('bytes10'),
+	funtypes.Literal('bytes11'),
+	funtypes.Literal('bytes12'),
+	funtypes.Literal('bytes13'),
+	funtypes.Literal('bytes14'),
+	funtypes.Literal('bytes15'),
+	funtypes.Literal('bytes16'),
+	funtypes.Literal('bytes17'),
+	funtypes.Literal('bytes18'),
+	funtypes.Literal('bytes19'),
+	funtypes.Literal('bytes20'),
+	funtypes.Literal('bytes21'),
+	funtypes.Literal('bytes22'),
+	funtypes.Literal('bytes23'),
+	funtypes.Literal('bytes24'),
+	funtypes.Literal('bytes25'),
+	funtypes.Literal('bytes26'),
+	funtypes.Literal('bytes27'),
+	funtypes.Literal('bytes28'),
+	funtypes.Literal('bytes29'),
+	funtypes.Literal('bytes30'),
+	funtypes.Literal('bytes31'),
+	funtypes.Literal('bytes32'),
+	funtypes.Literal('bool'),
+	funtypes.Literal('address'),
+	funtypes.Literal('string'),
+	funtypes.Literal('bytes'),
+)
+
+function findType(name: string, types: readonly { readonly name: string, readonly type: string}[]) {
+    return types.find((x) => x.name === name)?.type
+}
+
+function separateArraySuffix(typeWithMaybeArraySuffix: string) {
+	const splitted = typeWithMaybeArraySuffix.split('[]')
+	if (splitted.length === 1) return { arraylessType: typeWithMaybeArraySuffix, isArray: false }
+	return { arraylessType: splitted[0], isArray: true }
+}
+
+function validateEIP712TypesSubset(depth: number, message: JSONEncodeableObject, currentType: string, types: { [x: string]: readonly { readonly name: string, readonly type: string}[] | undefined }): boolean {
+    if (depth > 2) return false // do not allow too deep messages
+    const currentTypes = types[currentType]
+    if (currentTypes === undefined) return false
+    const keys = Object.keys(message)
+    for (const key of keys) {
+        const fullType = findType(key, currentTypes)
+        if (fullType === undefined) continue//TODO; PUT FALSE return false
+        const subMessage = message[key]
+        if (subMessage === undefined) return false
+		const arraylessType = separateArraySuffix(fullType)
+		if (arraylessType.isArray !== Array.isArray(subMessage)) return false
+        if (SolidityType.test(arraylessType.arraylessType)) continue
+		if (Array.isArray(subMessage)) {
+			if (subMessage.map((arrayElement) => validateEIP712TypesSubset(depth, arrayElement, arraylessType.arraylessType, types)).every((v) => v === true) === false) {
+				return false
+			}
+		} else {
+			if (!JSONEncodeableObject.test(subMessage)) return false
+       		if (validateEIP712TypesSubset(depth + 1, subMessage, arraylessType.arraylessType, types) === false) return false
+		}
+    }
+    return true
+}
+
+export function validateEIP712Types(message: EIP712Message) {
+    return validateEIP712TypesSubset(0, message.message, message.primaryType, message.types)
+}
+
+export type GroupedSolidityType = funtypes.Static<typeof GroupedSolidityType>
+export const GroupedSolidityType = funtypes.Union(
+    funtypes.ReadonlyObject({ type: funtypes.Literal('integer'), value: EthereumQuantity }),
+    funtypes.ReadonlyObject({ type: funtypes.Literal('bytes'), value: EthereumData }),
+	funtypes.ReadonlyObject({ type: funtypes.Literal('fixedBytes'), value: EthereumData }),
+    funtypes.ReadonlyObject({ type: funtypes.Literal('bool'), value: funtypes.Boolean }),
+    funtypes.ReadonlyObject({ type: funtypes.Literal('string'), value: funtypes.String }),
+    funtypes.ReadonlyObject({ type: funtypes.Literal('address'), value: AddressBookEntry }),
+	
+    funtypes.ReadonlyObject({ type: funtypes.Literal('integer[]'), value: funtypes.ReadonlyArray(EthereumQuantity) }),
+    funtypes.ReadonlyObject({ type: funtypes.Literal('bytes[]'), value: funtypes.ReadonlyArray(EthereumData) }),
+	funtypes.ReadonlyObject({ type: funtypes.Literal('fixedBytes[]'), value: funtypes.ReadonlyArray(EthereumData) }),
+    funtypes.ReadonlyObject({ type: funtypes.Literal('bool[]'), value: funtypes.ReadonlyArray(funtypes.Boolean) }),
+    funtypes.ReadonlyObject({ type: funtypes.Literal('string[]'), value: funtypes.ReadonlyArray(funtypes.String) }),
+    funtypes.ReadonlyObject({ type: funtypes.Literal('address[]'), value: funtypes.ReadonlyArray(AddressBookEntry) }),
+)
+
+type EnrichedEIP712MessageRecord = funtypes.Static<typeof EnrichedEIP712Message>
+const EnrichedEIP712MessageRecord = funtypes.ReadonlyRecord(
+    funtypes.String,
+    GroupedSolidityType
+)
+
+export type EnrichedEIP712Message = funtypes.Static<typeof EnrichedEIP712Message>
+export const EnrichedEIP712Message = funtypes.ReadonlyRecord(
+    funtypes.String,
+    funtypes.Union(
+        GroupedSolidityType,
+        funtypes.ReadonlyObject({ type: funtypes.Literal('record'), value: EnrichedEIP712MessageRecord }),
+        funtypes.ReadonlyObject({ type: funtypes.Literal('record[]'), value: funtypes.ReadonlyArray(EnrichedEIP712MessageRecord) })
+    )
+)
+
+function getSolidityTypeCategory(type: SolidityType) {
+	switch(type) {
+		case 'uint8': 
+		case 'uint16': 
+		case 'uint24': 
+		case 'uint32': 
+		case 'uint40': 
+		case 'uint48': 
+		case 'uint56': 
+		case 'uint64': 
+		case 'uint72': 
+		case 'uint80': 
+		case 'uint88': 
+		case 'uint96': 
+		case 'uint104': 
+		case 'uint112': 
+		case 'uint120': 
+		case 'uint128': 
+		case 'uint136': 
+		case 'uint144': 
+		case 'uint152': 
+		case 'uint160': 
+		case 'uint168': 
+		case 'uint176': 
+		case 'uint184': 
+		case 'uint192': 
+		case 'uint200': 
+		case 'uint208': 
+		case 'uint216': 
+		case 'uint224': 
+		case 'uint232': 
+		case 'uint240': 
+		case 'uint248': 
+		case 'uint256': 
+		case 'int8': 
+		case 'int16': 
+		case 'int24': 
+		case 'int32': 
+		case 'int40': 
+		case 'int48': 
+		case 'int56': 
+		case 'int64': 
+		case 'int72': 
+		case 'int80': 
+		case 'int88': 
+		case 'int96': 
+		case 'int104': 
+		case 'int112': 
+		case 'int120': 
+		case 'int128': 
+		case 'int136': 
+		case 'int144': 
+		case 'int152': 
+		case 'int160': 
+		case 'int168': 
+		case 'int176': 
+		case 'int184': 
+		case 'int192': 
+		case 'int200': 
+		case 'int208': 
+		case 'int216': 
+		case 'int224': 
+		case 'int232': 
+		case 'int240': 
+		case 'int248': 
+		case 'int256': return 'integer'
+		case 'bytes1': 
+		case 'bytes2': 
+		case 'bytes3': 
+		case 'bytes4': 
+		case 'bytes5': 
+		case 'bytes6': 
+		case 'bytes7': 
+		case 'bytes8': 
+		case 'bytes9': 
+		case 'bytes10': 
+		case 'bytes11': 
+		case 'bytes12': 
+		case 'bytes13': 
+		case 'bytes14': 
+		case 'bytes15': 
+		case 'bytes16': 
+		case 'bytes17': 
+		case 'bytes18': 
+		case 'bytes19': 
+		case 'bytes20': 
+		case 'bytes21': 
+		case 'bytes22': 
+		case 'bytes23': 
+		case 'bytes24': 
+		case 'bytes25': 
+		case 'bytes26': 
+		case 'bytes27': 
+		case 'bytes28': 
+		case 'bytes29': 
+		case 'bytes30': 
+		case 'bytes31': 
+		case 'bytes32': return 'fixedBytes'
+		case 'bool': return 'bool'
+		case 'address': return 'address'
+		case 'string': return 'string'
+		case 'bytes': return 'bytes'
+		default: assertNever(type)
+	}
+}
+
+function parseSolidityValueByType(type: SolidityType, value: unknown, userAddressBook: UserAddressBook, isArray: boolean): GroupedSolidityType {	
+	const categorized = getSolidityTypeCategory(type)
+	if (isArray) {
+		switch (categorized) {
+			case 'address': return { type: `${ categorized }[]`, value: funtypes.ReadonlyArray(EthereumAddress).parse(value).map((value) => getAddressMetaData(value, userAddressBook)) }
+			case 'bool': return { type: `${ categorized }[]`, value: funtypes.ReadonlyArray(NonHexBigInt).parse(value).map((a) => a === 1n) }
+			case 'bytes': return { type: `${ categorized }[]`, value: funtypes.ReadonlyArray(EthereumData).parse(value) }
+			case 'fixedBytes': return { type: `${ categorized }[]`, value: funtypes.ReadonlyArray(EthereumData).parse(value) }
+			case 'integer': return { type: `${ categorized }[]`, value: funtypes.ReadonlyArray(NonHexBigInt).parse(value) }
+			case 'string': return { type: `${ categorized }[]`, value: funtypes.ReadonlyArray(funtypes.String).parse(value) }
+			default: assertNever(categorized)
+		}
+
+	}
+	switch (categorized) {
+		case 'address': return { type: categorized, value: getAddressMetaData(EthereumAddress.parse(value), userAddressBook) }
+		case 'bool': return { type: categorized, value: NonHexBigInt.parse(value) === 1n }
+		case 'bytes': return { type: categorized, value: EthereumData.parse(value) }
+		case 'fixedBytes': return { type: categorized, value: EthereumData.parse(value) }
+		case 'integer': return { type: categorized, value: NonHexBigInt.parse(value) }
+		case 'string': return { type: categorized, value: funtypes.String.parse(value) }
+		default: assertNever(categorized)
+	}
+}
+
+function extractEIP712MessageSubset(depth: number, message: JSONEncodeableObject, currentType: string, types: { [x: string]: readonly { readonly name: string, readonly type: string}[] | undefined }, userAddressBook: UserAddressBook): EnrichedEIP712Message {
+    if (depth > 2) throw new Error('Too deep EIP712 message')
+    const currentTypes = types[currentType]
+    if (currentTypes === undefined) throw new Error(`Types not found: ${ currentType }`)
+    const keys = Object.keys(message)
+    return Object.fromEntries(Array.from(keys).map((key) => {
+        const fullType = findType(key, currentTypes)
+        if (fullType === undefined) return [key, { 'type': 'string', value: message[key] }]//TODO PUT ERROR BACK throw new Error(`Type not found for key: ${ key }`)
+		const arraylessType = separateArraySuffix(fullType)
+        if (SolidityType.test(arraylessType.arraylessType)) {
+			return [key, parseSolidityValueByType(SolidityType.parse(arraylessType.arraylessType), message[key], userAddressBook, arraylessType.isArray)]
+		}
+        const subMessage = message[key]
+        if (subMessage === undefined) throw new Error(`Subtype not found: ${ key }`)
+		if (arraylessType.isArray) {
+			if (!Array.isArray(subMessage)) throw new Error(`Type was defined to be an array but it was not: ${ subMessage }`)
+			return [key, { 'type': 'record[]', value: subMessage.map((subSubMessage) => extractEIP712MessageSubset(depth + 1, subSubMessage, arraylessType.arraylessType, types, userAddressBook)) }]
+		}
+        if (!JSONEncodeableObject.test(subMessage)) throw new Error(`Not a JSON type: ${ subMessage }`)
+        return [key, { 'type': 'record', value: extractEIP712MessageSubset(depth + 1, subMessage, fullType, types, userAddressBook) }]
+    }))
+}
+
+export function extractEIP712Message(message: EIP712Message, userAddressBook: UserAddressBook): EnrichedEIP712Message {
+    return extractEIP712MessageSubset(0, message.message, message.primaryType, message.types, userAddressBook)
+}

--- a/app/ts/utils/eip712Parsing.ts
+++ b/app/ts/utils/eip712Parsing.ts
@@ -39,7 +39,7 @@ const SolidityType = funtypes.Union(
 	funtypes.Literal('uint240'),
 	funtypes.Literal('uint248'),
 	funtypes.Literal('uint256'),
-    funtypes.Literal('int8'),
+	funtypes.Literal('int8'),
 	funtypes.Literal('int16'),
 	funtypes.Literal('int24'),
 	funtypes.Literal('int32'),
@@ -110,7 +110,7 @@ const SolidityType = funtypes.Union(
 )
 
 function findType(name: string, types: readonly { readonly name: string, readonly type: string}[]) {
-    return types.find((x) => x.name === name)?.type
+	return types.find((x) => x.name === name)?.type
 }
 
 function separateArraySuffix(typeWithMaybeArraySuffix: string) {
@@ -120,49 +120,49 @@ function separateArraySuffix(typeWithMaybeArraySuffix: string) {
 }
 
 function validateEIP712TypesSubset(depth: number, message: JSONEncodeableObject, currentType: string, types: { [x: string]: readonly { readonly name: string, readonly type: string}[] | undefined }): boolean {
-    if (depth > 2) return false // do not allow too deep messages
-    const currentTypes = types[currentType]
-    if (currentTypes === undefined) return false
-    const keys = Object.keys(message)
-    for (const key of keys) {
-        const fullType = findType(key, currentTypes)
-        if (fullType === undefined) return false
-        const subMessage = message[key]
-        if (subMessage === undefined) return false
+	if (depth > 2) return false // do not allow too deep messages
+	const currentTypes = types[currentType]
+	if (currentTypes === undefined) return false
+	const keys = Object.keys(message)
+	for (const key of keys) {
+		const fullType = findType(key, currentTypes)
+		if (fullType === undefined) return false
+		const subMessage = message[key]
+		if (subMessage === undefined) return false
 		const arraylessType = separateArraySuffix(fullType)
 		if (arraylessType.isArray !== Array.isArray(subMessage)) return false
-        if (SolidityType.test(arraylessType.arraylessType)) continue
+		if (SolidityType.test(arraylessType.arraylessType)) continue
 		if (Array.isArray(subMessage)) {
 			if (subMessage.map((arrayElement) => validateEIP712TypesSubset(depth, arrayElement, arraylessType.arraylessType, types)).every((v) => v === true) === false) {
 				return false
 			}
 		} else {
 			if (!JSONEncodeableObject.test(subMessage)) return false
-       		if (validateEIP712TypesSubset(depth + 1, subMessage, arraylessType.arraylessType, types) === false) return false
+			if (validateEIP712TypesSubset(depth + 1, subMessage, arraylessType.arraylessType, types) === false) return false
 		}
-    }
-    return true
+	}
+	return true
 }
 
 export function validateEIP712Types(message: EIP712Message) {
-    return validateEIP712TypesSubset(0, message.message, message.primaryType, message.types)
+	return validateEIP712TypesSubset(0, message.message, message.primaryType, message.types)
 }
 
 export type GroupedSolidityType = funtypes.Static<typeof GroupedSolidityType>
 export const GroupedSolidityType = funtypes.Union(
-    funtypes.ReadonlyObject({ type: funtypes.Literal('integer'), value: EthereumQuantity }),
-    funtypes.ReadonlyObject({ type: funtypes.Literal('bytes'), value: EthereumData }),
+	funtypes.ReadonlyObject({ type: funtypes.Literal('integer'), value: EthereumQuantity }),
+	funtypes.ReadonlyObject({ type: funtypes.Literal('bytes'), value: EthereumData }),
 	funtypes.ReadonlyObject({ type: funtypes.Literal('fixedBytes'), value: EthereumData }),
-    funtypes.ReadonlyObject({ type: funtypes.Literal('bool'), value: funtypes.Boolean }),
-    funtypes.ReadonlyObject({ type: funtypes.Literal('string'), value: funtypes.String }),
-    funtypes.ReadonlyObject({ type: funtypes.Literal('address'), value: AddressBookEntry }),
+	funtypes.ReadonlyObject({ type: funtypes.Literal('bool'), value: funtypes.Boolean }),
+	funtypes.ReadonlyObject({ type: funtypes.Literal('string'), value: funtypes.String }),
+	funtypes.ReadonlyObject({ type: funtypes.Literal('address'), value: AddressBookEntry }),
 	
-    funtypes.ReadonlyObject({ type: funtypes.Literal('integer[]'), value: funtypes.ReadonlyArray(EthereumQuantity) }),
-    funtypes.ReadonlyObject({ type: funtypes.Literal('bytes[]'), value: funtypes.ReadonlyArray(EthereumData) }),
+	funtypes.ReadonlyObject({ type: funtypes.Literal('integer[]'), value: funtypes.ReadonlyArray(EthereumQuantity) }),
+	funtypes.ReadonlyObject({ type: funtypes.Literal('bytes[]'), value: funtypes.ReadonlyArray(EthereumData) }),
 	funtypes.ReadonlyObject({ type: funtypes.Literal('fixedBytes[]'), value: funtypes.ReadonlyArray(EthereumData) }),
-    funtypes.ReadonlyObject({ type: funtypes.Literal('bool[]'), value: funtypes.ReadonlyArray(funtypes.Boolean) }),
-    funtypes.ReadonlyObject({ type: funtypes.Literal('string[]'), value: funtypes.ReadonlyArray(funtypes.String) }),
-    funtypes.ReadonlyObject({ type: funtypes.Literal('address[]'), value: funtypes.ReadonlyArray(AddressBookEntry) }),
+	funtypes.ReadonlyObject({ type: funtypes.Literal('bool[]'), value: funtypes.ReadonlyArray(funtypes.Boolean) }),
+	funtypes.ReadonlyObject({ type: funtypes.Literal('string[]'), value: funtypes.ReadonlyArray(funtypes.String) }),
+	funtypes.ReadonlyObject({ type: funtypes.Literal('address[]'), value: funtypes.ReadonlyArray(AddressBookEntry) }),
 )
 
 
@@ -176,8 +176,8 @@ const EnrichedEIP712MessageRecord: funtypes.Runtype<typeEnrichedEIP712MessageRec
 
 export type EnrichedEIP712Message = funtypes.Static<typeof EnrichedEIP712Message>
 export const EnrichedEIP712Message = funtypes.ReadonlyRecord(
-    funtypes.String,
-    EnrichedEIP712MessageRecord,
+	funtypes.String,
+	EnrichedEIP712MessageRecord,
 )
 
 function getSolidityTypeCategory(type: SolidityType) {
@@ -312,28 +312,28 @@ function parseSolidityValueByType(type: SolidityType, value: unknown, userAddres
 }
 
 function extractEIP712MessageSubset(depth: number, message: JSONEncodeableObject, currentType: string, types: { [x: string]: readonly { readonly name: string, readonly type: string}[] | undefined }, userAddressBook: UserAddressBook): EnrichedEIP712Message {
-    if (depth > 2) throw new Error('Too deep EIP712 message')
-    const currentTypes = types[currentType]
-    if (currentTypes === undefined) throw new Error(`Types not found: ${ currentType }`)
-    const messageEntries = Object.entries(message)
-    const pairArray: [string, EnrichedEIP712MessageRecord][] = Array.from(messageEntries).map(([key, messageEntry]) => {
-        if (messageEntry === undefined) throw new Error(`Subtype not found: ${ key }`)
-        const fullType = findType(key, currentTypes)
-        if (fullType === undefined) throw new Error(`Type not found for key: ${ key }`)
+	if (depth > 2) throw new Error('Too deep EIP712 message')
+	const currentTypes = types[currentType]
+	if (currentTypes === undefined) throw new Error(`Types not found: ${ currentType }`)
+	const messageEntries = Object.entries(message)
+	const pairArray: [string, EnrichedEIP712MessageRecord][] = Array.from(messageEntries).map(([key, messageEntry]) => {
+		if (messageEntry === undefined) throw new Error(`Subtype not found: ${ key }`)
+		const fullType = findType(key, currentTypes)
+		if (fullType === undefined) throw new Error(`Type not found for key: ${ key }`)
 		const arraylessType = separateArraySuffix(fullType)
-        if (SolidityType.test(arraylessType.arraylessType)) {
-			return [key, parseSolidityValueByType(SolidityType.parse(arraylessType.arraylessType), messageEntry, userAddressBook, arraylessType.isArray)]
-		}
-		if (arraylessType.isArray) {
-			if (!Array.isArray(messageEntry)) throw new Error(`Type was defined to be an array but it was not: ${ messageEntry }`)
-			return [key, { type: 'record[]', value: messageEntry.map((subSubMessage) => extractEIP712MessageSubset(depth + 1, subSubMessage, arraylessType.arraylessType, types, userAddressBook)) }]
-		}
-        if (!JSONEncodeableObject.test(messageEntry)) throw new Error(`Not a JSON type: ${ messageEntry }`)
-        return [key, { type: 'record', value: extractEIP712MessageSubset(depth + 1, messageEntry, fullType, types, userAddressBook) }]
-    })
+		if (SolidityType.test(arraylessType.arraylessType)) {
+				return [key, parseSolidityValueByType(SolidityType.parse(arraylessType.arraylessType), messageEntry, userAddressBook, arraylessType.isArray)]
+			}
+			if (arraylessType.isArray) {
+				if (!Array.isArray(messageEntry)) throw new Error(`Type was defined to be an array but it was not: ${ messageEntry }`)
+				return [key, { type: 'record[]', value: messageEntry.map((subSubMessage) => extractEIP712MessageSubset(depth + 1, subSubMessage, arraylessType.arraylessType, types, userAddressBook)) }]
+			}
+		if (!JSONEncodeableObject.test(messageEntry)) throw new Error(`Not a JSON type: ${ messageEntry }`)
+		return [key, { type: 'record', value: extractEIP712MessageSubset(depth + 1, messageEntry, fullType, types, userAddressBook) }]
+	})
 	return pairArray.reduce((accumulator, [key, value]) => ({ ...accumulator, [key]: value}), {} as EnrichedEIP712Message)
 }
 
 export function extractEIP712Message(message: EIP712Message, userAddressBook: UserAddressBook): EnrichedEIP712Message {
-    return extractEIP712MessageSubset(0, message.message, message.primaryType, message.types, userAddressBook)
+	return extractEIP712MessageSubset(0, message.message, message.primaryType, message.types, userAddressBook)
 }

--- a/app/ts/utils/personal-message-definitions.ts
+++ b/app/ts/utils/personal-message-definitions.ts
@@ -1,8 +1,9 @@
 import * as funtypes from 'funtypes'
-import { EIP712Message, EthereumAddress, EthereumBytes32, LiteralConverterParserFactory, NonHexBigInt, OldSignTypedDataParams, PersonalSignParams, SignTypedDataParams } from './wire-types.js'
+import { EthereumAddress, EthereumBytes32, LiteralConverterParserFactory, NonHexBigInt, OldSignTypedDataParams, PersonalSignParams, SignTypedDataParams } from './wire-types.js'
 import { AddressBookEntry, CHAIN, NFTEntry, SignerName, TokenEntry, Website } from './user-interface-types.js'
 import { QUARANTINE_CODE } from '../simulation/protectors/quarantine-codes.js'
 import { EthereumInput } from './wire-types.js'
+import { EnrichedEIP712Message } from './eip712Parsing.js'
 
 export type EIP2612Message = funtypes.Static<typeof EIP2612Message>
 export const EIP2612Message = funtypes.ReadonlyObject({
@@ -382,7 +383,7 @@ export const PersonalSignRequestDataEIP712 = funtypes.Intersect(
 	funtypes.ReadonlyObject({
 		originalParams: SignTypedDataParams,
 		type: funtypes.Literal('EIP712'),
-		message: EIP712Message,
+		message: EnrichedEIP712Message,
 	})
 )
 

--- a/app/ts/utils/wire-types.ts
+++ b/app/ts/utils/wire-types.ts
@@ -734,6 +734,9 @@ export const JSONEncodeable: funtypes.Runtype<typeJSONEncodeable> = funtypes.Laz
 export type JSONEncodeableObject = funtypes.Static<typeof JSONEncodeableObject>
 export const JSONEncodeableObject = funtypes.ReadonlyRecord(funtypes.String, JSONEncodeable)
 
+export type JSONEncodeableObjectOrArray = funtypes.Static<typeof JSONEncodeableObjectOrArray>
+export const JSONEncodeableObjectOrArray = funtypes.Union(funtypes.ReadonlyArray(JSONEncodeable), funtypes.ReadonlyRecord(funtypes.String, JSONEncodeable))
+
 export type EIP712MessageUnderlying = funtypes.Static<typeof EIP712MessageUnderlying>
 export const EIP712MessageUnderlying = funtypes.ReadonlyObject({
 	types: funtypes.Record(funtypes.String, funtypes.ReadonlyArray(

--- a/test/tests/signTypedData.ts
+++ b/test/tests/signTypedData.ts
@@ -1,6 +1,9 @@
 import { EIP712Message } from '../../app/ts/utils/wire-types.js'
-import { Permit2 } from '../../app/ts/utils/personal-message-definitions.js'
+import { Permit2, SafeTx } from '../../app/ts/utils/personal-message-definitions.js'
 import { describe, runIfRoot, should, run } from '../micro-should.js'
+import { extractEIP712Message, validateEIP712Types } from '../../app/ts/utils/eip712Parsing.js'
+import * as assert from 'assert'
+import { stringifyJSONWithBigInts } from '../../app/ts/utils/bigint.js'
 
 export async function main() {
 	const permit2Message = `{
@@ -69,12 +72,292 @@ export async function main() {
 			"sigDeadline": "1674745207"
 		}
 	}`
+
+	const safeTx = `{
+		"types": {
+			"SafeTx": [
+				{
+					"type": "address",
+					"name": "to"
+				},
+				{
+					"type": "uint256",
+					"name": "value"
+				},
+				{
+					"type": "bytes",
+					"name": "data"
+				},
+				{
+					"type": "uint8",
+					"name": "operation"
+				},
+				{
+					"type": "uint256",
+					"name": "safeTxGas"
+				},
+				{
+					"type": "uint256",
+					"name": "baseGas"
+				},
+				{
+					"type": "uint256",
+					"name": "gasPrice"
+				},
+				{
+					"type": "address",
+					"name": "gasToken"
+				},
+				{
+					"type": "address",
+					"name": "refundReceiver"
+				},
+				{
+					"type": "uint256",
+					"name": "nonce"
+				}
+			],
+			"EIP712Domain": [
+				{
+					"name": "chainId",
+					"type": "uint256"
+				},
+				{
+					"name": "verifyingContract",
+					"type": "address"
+				}
+			]
+		},
+		"domain": {
+			"chainId": "1",
+			"verifyingContract": "0x8e160c8e949967d6b797cdf2a2f38f6344a5c95f"
+		},
+		"primaryType": "SafeTx",
+		"message": {
+			"to": "0xa01fcd80503365406042456c7be1dd7e35b38f9c",
+			"value": "5000000000000000000",
+			"data": "0x",
+			"operation": "0",
+			"safeTxGas": "0",
+			"baseGas": "0",
+			"gasPrice": "0",
+			"gasToken": "0x0000000000000000000000000000000000000000",
+			"refundReceiver": "0x0000000000000000000000000000000000000000",
+			"nonce": "16"
+		}
+	}`
+
+	const openSeaWithTotalOriginalConsiderationItems = `{
+		"types": {
+			"EIP712Domain": [
+				{
+					"name": "name",
+					"type": "string"
+				},
+				{
+					"name": "version",
+					"type": "string"
+				},
+				{
+					"name": "chainId",
+					"type": "uint256"
+				},
+				{
+					"name": "verifyingContract",
+					"type": "address"
+				}
+			],
+			"OrderComponents": [
+				{
+					"name": "offerer",
+					"type": "address"
+				},
+				{
+					"name": "zone",
+					"type": "address"
+				},
+				{
+					"name": "offer",
+					"type": "OfferItem[]"
+				},
+				{
+					"name": "consideration",
+					"type": "ConsiderationItem[]"
+				},
+				{
+					"name": "orderType",
+					"type": "uint8"
+				},
+				{
+					"name": "startTime",
+					"type": "uint256"
+				},
+				{
+					"name": "endTime",
+					"type": "uint256"
+				},
+				{
+					"name": "zoneHash",
+					"type": "bytes32"
+				},
+				{
+					"name": "salt",
+					"type": "uint256"
+				},
+				{
+					"name": "conduitKey",
+					"type": "bytes32"
+				},
+				{
+					"name": "counter",
+					"type": "uint256"
+				}
+			],
+			"OfferItem": [
+				{
+					"name": "itemType",
+					"type": "uint8"
+				},
+				{
+					"name": "token",
+					"type": "address"
+				},
+				{
+					"name": "identifierOrCriteria",
+					"type": "uint256"
+				},
+				{
+					"name": "startAmount",
+					"type": "uint256"
+				},
+				{
+					"name": "endAmount",
+					"type": "uint256"
+				}
+			],
+			"ConsiderationItem": [
+				{
+					"name": "itemType",
+					"type": "uint8"
+				},
+				{
+					"name": "token",
+					"type": "address"
+				},
+				{
+					"name": "identifierOrCriteria",
+					"type": "uint256"
+				},
+				{
+					"name": "startAmount",
+					"type": "uint256"
+				},
+				{
+					"name": "endAmount",
+					"type": "uint256"
+				},
+				{
+					"name": "recipient",
+					"type": "address"
+				}
+			]
+		},
+		"primaryType": "OrderComponents",
+		"domain": {
+			"name": "Seaport",
+			"version": "1.5",
+			"chainId": "1",
+			"verifyingContract": "0x00000000000000ADc04C56Bf30aC9d3c0aAF14dC"
+		},
+		"message": {
+			"offerer": "0x2F2e108d5c3d8F63A6180FBBe570B24140c71bE5",
+			"offer": [
+				{
+					"itemType": "1",
+					"token": "0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2",
+					"identifierOrCriteria": "0",
+					"startAmount": "100000000000000000",
+					"endAmount": "100000000000000000"
+				}
+			],
+			"consideration": [
+				{
+					"itemType": "2",
+					"token": "0x79f1C4cF7266746698E91034d658E56913E6644f",
+					"identifierOrCriteria": "323",
+					"startAmount": "1",
+					"endAmount": "1",
+					"recipient": "0x2F2e108d5c3d8F63A6180FBBe570B24140c71bE5"
+				},
+				{
+					"itemType": "1",
+					"token": "0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2",
+					"identifierOrCriteria": "0",
+					"startAmount": "2500000000000000",
+					"endAmount": "2500000000000000",
+					"recipient": "0x0000a26b00c1F0DF003000390027140000fAa719"
+				}
+			],
+			"startTime": "1683538528",
+			"endTime": "1683797725",
+			"orderType": "0",
+			"zone": "0x004C00500000aD104D7DBd00e3ae0A5C00560C00",
+			"zoneHash": "0x0000000000000000000000000000000000000000000000000000000000000000",
+			"salt": "24446860302761739304752683030156737591518664810215442929802089001070662958770",
+			"conduitKey": "0x0000007b02230091a7ed01230072f7006a004d60a8d4e71d599b8104250f0000",
+			"counter": "0"
+		}
+	}`
+
+	const addressBook = {
+		addressInfos: [{
+			name: 'Receiver',
+			address: 0xa01fcd80503365406042456c7be1dd7e35b38f9cn,
+			askForAddressAccess: false
+		}],
+		contacts: []
+	}
+
 	describe('EIP712', () => {
 		should('can parse EIP712 message', () => {
 			EIP712Message.parse(permit2Message)
 		})
 		should('can parse Permit2 message', () => {
 			Permit2.parse(JSON.parse(permit2Message))
+		})
+		should('can parse safeTx message', () => {
+			SafeTx.parse(JSON.parse(safeTx))
+		})
+		
+		should('can validate safeTx message', () => {
+			const parsed = EIP712Message.parse(safeTx)
+			assert.equal(validateEIP712Types(parsed), true)
+		})
+		should('can validate permit2Message message', () => {
+			const parsed = EIP712Message.parse(permit2Message)
+			assert.equal(validateEIP712Types(parsed), true)
+		})
+		should('can validate openSea message', () => {
+			const parsed = EIP712Message.parse(openSeaWithTotalOriginalConsiderationItems)
+			assert.equal(validateEIP712Types(parsed), true)
+		})
+		should('can extract safeTx message', () => {
+			const parsed = EIP712Message.parse(safeTx)
+			const enrichedMessage = stringifyJSONWithBigInts(extractEIP712Message(parsed, addressBook))
+			const expected = `{"to":{"type":"address","value":{"name":"Receiver","address":"0xa01fcd80503365406042456c7be1dd7e35b38f9c","askForAddressAccess":false,"type":"addressInfo"}},"value":{"type":"integer","value":"0x4563918244f40000"},"data":{"type":"bytes","value":{}},"operation":{"type":"integer","value":"0x0"},"safeTxGas":{"type":"integer","value":"0x0"},"baseGas":{"type":"integer","value":"0x0"},"gasPrice":{"type":"integer","value":"0x0"},"gasToken":{"type":"address","value":{"address":"0x0","name":"0x0000000000000000000000000000000000000000","type":"contact"}},"refundReceiver":{"type":"address","value":{"address":"0x0","name":"0x0000000000000000000000000000000000000000","type":"contact"}},"nonce":{"type":"integer","value":"0x10"}}`
+			assert.equal(enrichedMessage, expected)
+		})
+		should('can extract permit2Message message', () => {
+			const parsed = EIP712Message.parse(permit2Message)
+			const enrichedMessage = stringifyJSONWithBigInts(extractEIP712Message(parsed, addressBook))
+			const expected = `{"details":{"type":"record","value":{"token":{"type":"address","value":{"name":"Tether","symbol":"USDT","decimals":"0x6","logoUri":"../vendor/@darkflorist/address-metadata/images/tokens/0xdac17f958d2ee523a2206206994597c13d831ec7.png","address":"0xdac17f958d2ee523a2206206994597c13d831ec7","type":"token"}},"amount":{"type":"integer","value":"0xffffffffffffffffffffffffffffffffffffffff"},"expiration":{"type":"integer","value":"0x63fa1b6f"},"nonce":{"type":"integer","value":"0x0"}}},"spender":{"type":"address","value":{"address":"0xef1c6e67703c7bd7107eed8303fbe6ec2554bf6b","name":"0xEf1c6E67703c7BD7107eed8303Fbe6EC2554BF6B","type":"contact"}},"sigDeadline":{"type":"integer","value":"0x63d29577"}}`
+			assert.equal(enrichedMessage, expected)
+		})
+		should('can extract openSea message', () => {
+			const parsed = EIP712Message.parse(openSeaWithTotalOriginalConsiderationItems)
+			const enrichedMessage = stringifyJSONWithBigInts(extractEIP712Message(parsed, addressBook))
+			const expected = `{"offerer":{"type":"address","value":{"address":"0x2f2e108d5c3d8f63a6180fbbe570b24140c71be5","name":"0x2F2e108d5c3d8F63A6180FBBe570B24140c71bE5","type":"contact"}},"offer":{"type":"record[]","value":[{"itemType":{"type":"integer","value":"0x1"},"token":{"type":"address","value":{"name":"WETH","symbol":"WETH","decimals":"0x12","logoUri":"../vendor/@darkflorist/address-metadata/images/tokens/0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2.png","address":"0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2","type":"token"}},"identifierOrCriteria":{"type":"integer","value":"0x0"},"startAmount":{"type":"integer","value":"0x16345785d8a0000"},"endAmount":{"type":"integer","value":"0x16345785d8a0000"}}]},"consideration":{"type":"record[]","value":[{"itemType":{"type":"integer","value":"0x2"},"token":{"type":"address","value":{"address":"0x79f1c4cf7266746698e91034d658e56913e6644f","name":"0x79f1C4cF7266746698E91034d658E56913E6644f","type":"contact"}},"identifierOrCriteria":{"type":"integer","value":"0x143"},"startAmount":{"type":"integer","value":"0x1"},"endAmount":{"type":"integer","value":"0x1"},"recipient":{"type":"address","value":{"address":"0x2f2e108d5c3d8f63a6180fbbe570b24140c71be5","name":"0x2F2e108d5c3d8F63A6180FBBe570B24140c71bE5","type":"contact"}}},{"itemType":{"type":"integer","value":"0x1"},"token":{"type":"address","value":{"name":"WETH","symbol":"WETH","decimals":"0x12","logoUri":"../vendor/@darkflorist/address-metadata/images/tokens/0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2.png","address":"0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2","type":"token"}},"identifierOrCriteria":{"type":"integer","value":"0x0"},"startAmount":{"type":"integer","value":"0x8e1bc9bf04000"},"endAmount":{"type":"integer","value":"0x8e1bc9bf04000"},"recipient":{"type":"address","value":{"name":"OpenSea: Fees 3","protocol":"OpenSea","address":"0xa26b00c1f0df003000390027140000faa719","type":"other contract"}}}]},"startTime":{"type":"integer","value":"0x6458c260"},"endTime":{"type":"integer","value":"0x645cb6dd"},"orderType":{"type":"integer","value":"0x0"},"zone":{"type":"address","value":{"address":"0x4c00500000ad104d7dbd00e3ae0a5c00560c00","name":"0x004C00500000aD104D7DBd00e3ae0A5C00560C00","type":"contact"}},"zoneHash":{"type":"fixedBytes","value":{"0":0,"1":0,"2":0,"3":0,"4":0,"5":0,"6":0,"7":0,"8":0,"9":0,"10":0,"11":0,"12":0,"13":0,"14":0,"15":0,"16":0,"17":0,"18":0,"19":0,"20":0,"21":0,"22":0,"23":0,"24":0,"25":0,"26":0,"27":0,"28":0,"29":0,"30":0,"31":0}},"salt":{"type":"integer","value":"0x360c6ebe000000000000000000000000000000000000000017ae0a4d2d66beb2"},"conduitKey":{"type":"fixedBytes","value":{"0":0,"1":0,"2":0,"3":123,"4":2,"5":35,"6":0,"7":145,"8":167,"9":237,"10":1,"11":35,"12":0,"13":114,"14":247,"15":0,"16":106,"17":0,"18":77,"19":96,"20":168,"21":212,"22":231,"23":29,"24":89,"25":155,"26":129,"27":4,"28":37,"29":15,"30":0,"31":0}},"counter":{"type":"integer","value":"0x0"}}`
+			assert.equal(enrichedMessage, expected)
 		})
 	})
 }


### PR DESCRIPTION
- parses message field: checks that the type information is available and then add address metadata to it.
- Visualize arbitrary EIP-712 messages
- This only applies o EIP-712 messages that we do not directly recognize
- Does not include domain fields parsing, I added issue about it (https://github.com/DarkFlorist/TheInterceptor/issues/404)

![image](https://user-images.githubusercontent.com/13102010/236831682-dd291230-b9f3-4a0d-b3a9-cbdae8f146fc.png)
![image](https://user-images.githubusercontent.com/13102010/236831695-b415a5c5-2d40-4713-9b9a-d8f0a249d4ce.png)
