### PR TITLE
Tab optionality

### DIFF
--- a/app/ts/background/background.ts
+++ b/app/ts/background/background.ts
@@ -105,6 +105,7 @@ export async function refreshConfirmTransactionSimulation(
 	simulationMode: boolean,
 	requestId: number,
 	transactionToSimulate: WebsiteCreatedEthereumUnsignedTransaction,
+	tabIdOpenedFrom: number,
 ): Promise<ConfirmTransactionTransactionSingleVisualization> {
 	const info = {
 		requestId: requestId,
@@ -112,6 +113,7 @@ export async function refreshConfirmTransactionSimulation(
 		simulationMode: simulationMode,
 		activeAddress: activeAddress,
 		signerName: await getSignerName(),
+		tabIdOpenedFrom,
 	}
 	if (simulator === undefined) return { statusCode: 'failed', data: info } as const
 	sendPopupMessageToOpenWindows({ method: 'popup_confirm_transaction_simulation_started' } as const)

--- a/app/ts/background/popupMessageHandlers.ts
+++ b/app/ts/background/popupMessageHandlers.ts
@@ -189,7 +189,7 @@ export async function refreshPopupConfirmTransactionMetadata(ethereumClientServi
 }
 
 export async function refreshPopupConfirmTransactionSimulation(ethereumClientService: EthereumClientService, { data }: RefreshConfirmTransactionDialogSimulation) {
-	const refreshMessage = await refreshConfirmTransactionSimulation(ethereumClientService, data.activeAddress, data.simulationMode, data.requestId, data.transactionToSimulate)
+	const refreshMessage = await refreshConfirmTransactionSimulation(ethereumClientService, data.activeAddress, data.simulationMode, data.requestId, data.transactionToSimulate, data.tabIdOpenedFrom)
 	const promises = await getPendingTransactions()
 	if (promises.length === 0) return
 	const first = promises[0]
@@ -349,6 +349,7 @@ export async function refreshPersonalSignMetadata(ethereumClientService: Ethereu
 	return await sendPopupMessageToOpenWindows(await craftPersonalSignPopupMessage(
 		ethereumClientService,
 		refreshPersonalSignMetadata.data.originalParams,
+		refreshPersonalSignMetadata.data.tabIdOpenedFrom,
 		refreshPersonalSignMetadata.data.activeAddress.address,
 		settings.userAddressBook,
 		refreshPersonalSignMetadata.data.simulationMode,

--- a/app/ts/background/settings.ts
+++ b/app/ts/background/settings.ts
@@ -298,3 +298,11 @@ export async function updateEthereumSubscriptions(updateFunc: (prevState: Ethere
 		return await browserStorageLocalSet('ethereumSubscriptions', EthereumSubscriptions.serialize(updateFunc(subscriptions)) as string)
 	})
 }
+
+export async function getUseTabsInsteadOfPopup() {
+	return funtypes.Boolean.parse(await browserStorageLocalSingleGetWithDefault('useTabsInsteadOfPopup', true))
+}
+
+export async function setUseTabsInsteadOfPopup(useTabsInsteadOfPopup: boolean) {
+	return await browserStorageLocalSet('useTabsInsteadOfPopup', funtypes.Boolean.serialize(useTabsInsteadOfPopup) as string)
+}

--- a/app/ts/background/settings.ts
+++ b/app/ts/background/settings.ts
@@ -300,7 +300,7 @@ export async function updateEthereumSubscriptions(updateFunc: (prevState: Ethere
 }
 
 export async function getUseTabsInsteadOfPopup() {
-	return funtypes.Boolean.parse(await browserStorageLocalSingleGetWithDefault('useTabsInsteadOfPopup', true))
+	return funtypes.Boolean.parse(await browserStorageLocalSingleGetWithDefault('useTabsInsteadOfPopup', false))
 }
 
 export async function setUseTabsInsteadOfPopup(useTabsInsteadOfPopup: boolean) {

--- a/app/ts/background/windows/changeChain.ts
+++ b/app/ts/background/windows/changeChain.ts
@@ -75,6 +75,7 @@ export const openChangeChainDialog = async (
 				chainId: chainId,
 				website: website,
 				simulationMode: simulationMode,
+				tabIdOpenedFrom: socket.tabId,
 			}
 		})
 	}

--- a/app/ts/background/windows/confirmTransaction.ts
+++ b/app/ts/background/windows/confirmTransaction.ts
@@ -97,7 +97,7 @@ export async function openConfirmTransactionDialog(
 					}
 				}
 			}
-			const refreshSimulationPromise = refreshConfirmTransactionSimulation(ethereumClientService, activeAddress, simulationMode, request.requestId, transactionToSimulate)
+			const refreshSimulationPromise = refreshConfirmTransactionSimulation(ethereumClientService, activeAddress, simulationMode, request.requestId, transactionToSimulate, socket.tabId)
 
 			const resolveAppendPromise = async (WindowId: number, simulationResults: ConfirmTransactionTransactionSingleVisualization) => {
 				appendPromise.resolve(await appendPendingTransaction({

--- a/app/ts/background/windows/confirmTransaction.ts
+++ b/app/ts/background/windows/confirmTransaction.ts
@@ -1,3 +1,4 @@
+import { PopupOrTab, addWindowTabListener, closePopupOrTab, getPopupOrTabOnlyById, openPopupOrTab, removeWindowTabListener } from '../../components/ui-utils.js'
 import { EthereumClientService } from '../../simulation/services/EthereumClientService.js'
 import { appendTransaction } from '../../simulation/services/SimulationModeEthereumClientService.js'
 import { bytes32String } from '../../utils/bigint.js'
@@ -13,7 +14,7 @@ import { getHtmlFile, sendPopupMessageToOpenWindows } from '../backgroundUtils.j
 import { appendPendingTransaction, clearPendingTransactions, getPendingTransactions, getSimulationResults, removePendingTransaction } from '../settings.js'
 
 export type Confirmation = 'Approved' | 'Rejected' | 'NoResponse'
-let openedConfirmTransactionDialogWindow: browser.windows.Window | null = null
+let openedDialog: PopupOrTab | undefined = undefined
 let pendingTransactions = new Map<number, Future<Confirmation>>()
 const pendingConfirmationSemaphore = new Semaphore(1)
 
@@ -25,14 +26,8 @@ async function updateConfirmTransactionViewWithPendingTransactionOrClose() {
 			data: promises.map((p) => p.simulationResults),
 		})
 	}
-	if (openedConfirmTransactionDialogWindow?.id !== undefined) {
-		try {
-			browser.windows.remove(openedConfirmTransactionDialogWindow.id)
-		} catch (error) {
-			console.warn(error)
-		}
-	}
-	openedConfirmTransactionDialogWindow = null
+	if (openedDialog) closePopupOrTab(openedDialog)
+	openedDialog = undefined
 }
 
 export async function resolvePendingTransaction(ethereumClientService: EthereumClientService, websiteTabConnections: WebsiteTabConnections, confirmation: TransactionConfirmation) {
@@ -46,17 +41,12 @@ export async function resolvePendingTransaction(ethereumClientService: EthereumC
 		// we have not been tracking this window, forward its message directly to content script (or signer)
 		const resolvedPromise = await resolve(ethereumClientService, pendingTransaction.simulationMode, pendingTransaction.activeAddress, pendingTransaction.transactionToSimulate, confirmation.options.accept)
 		sendMessageToContentScript(websiteTabConnections, pendingTransaction.socket, resolvedPromise, pendingTransaction.request)
-		try {
-			openedConfirmTransactionDialogWindow = await browser.windows.get(confirmation.options.windowId)
-		} catch(e) {
-			console.warn(e)
-		}
+		openedDialog = await getPopupOrTabOnlyById(confirmation.options.windowId)
 	}
 }
-
 const onCloseWindow = async (windowId: number) => { // check if user has closed the window on their own, if so, reject all signatures
-	if (openedConfirmTransactionDialogWindow === null || openedConfirmTransactionDialogWindow.id !== windowId) return
-	openedConfirmTransactionDialogWindow = null
+	if (openedDialog === undefined || openedDialog.windowOrTab.id !== windowId) return
+	openedDialog = undefined
 	await clearPendingTransactions()
 	pendingTransactions.forEach((pending) => pending.resolve('NoResponse'))
 	pendingTransactions.clear()
@@ -100,7 +90,7 @@ export async function openConfirmTransactionDialog(
 			if (!justAddToPending) {
 				const oldPromise = await getPendingTransactions()
 				if (oldPromise.length !== 0) {
-					if ((await browser.tabs.query({ windowId: oldPromise[0].dialogId })).length > 0) {
+					if (await getPopupOrTabOnlyById(oldPromise[0].dialogId) !== undefined) {
 						justAddToPending = true
 					} else {
 						await clearPendingTransactions()
@@ -123,16 +113,16 @@ export async function openConfirmTransactionDialog(
 
 			if (!justAddToPending) {
 				browser.runtime.onMessage.addListener(windowReadyAndListening)
-				browser.windows.onRemoved.addListener(onCloseWindow)
-				openedConfirmTransactionDialogWindow = await browser.windows.create({
+				addWindowTabListener(onCloseWindow)
+				openedDialog = await openPopupOrTab({
 					url: getHtmlFile('confirmTransaction'),
 					type: 'popup',
 					height: 800,
 					width: 600,
 				})
 			}
-			if (openedConfirmTransactionDialogWindow === null || openedConfirmTransactionDialogWindow.id === undefined) return false
-			await resolveAppendPromise(openedConfirmTransactionDialogWindow.id, await refreshSimulationPromise)
+			if (openedDialog?.windowOrTab.id === undefined) return false
+			await resolveAppendPromise(openedDialog.windowOrTab.id, await refreshSimulationPromise)
 			if (justAddToPending) sendPopupMessageToOpenWindows({ method: 'popup_confirm_transaction_dialog_pending_changed', data: (await getPendingTransactions()).map((p) => p.simulationResults) })
 			return true
 		})
@@ -141,8 +131,8 @@ export async function openConfirmTransactionDialog(
 		const resolvedPromise = await resolve(ethereumClientService, simulationMode, activeAddress, transactionToSimulate, reply === 'Approved' ? true : false)
 		return resolvedPromise
 	} finally {
-		browser.windows.onRemoved.removeListener(windowReadyAndListening)
-		browser.windows.onRemoved.removeListener(onCloseWindow)
+		browser.runtime.onMessage.removeListener(windowReadyAndListening)
+		removeWindowTabListener(onCloseWindow)
 		pendingTransactions.delete(request.requestId)
 		updateConfirmTransactionViewWithPendingTransactionOrClose()
 	}

--- a/app/ts/background/windows/interceptorAccess.ts
+++ b/app/ts/background/windows/interceptorAccess.ts
@@ -143,6 +143,7 @@ export async function requestAccessFromUser(
 				signerName: await getSignerName(),
 				simulationMode: settings.simulationMode,
 				socket: socket,
+				tabIdOpenedFrom: socket.tabId,
 			}
 		})
 	}
@@ -190,6 +191,7 @@ export async function requestAccessFromUser(
 							signerName: await getSignerName(),
 							simulationMode: settings.simulationMode,
 							socket: socket,
+							tabIdOpenedFrom: socket.tabId,
 						}
 					})
 					return await resolve(websiteTabConnections, await pendingInterceptorAccess.future)
@@ -296,6 +298,7 @@ export async function requestAddressChange(websiteTabConnections: WebsiteTabConn
 			signerName: await getSignerName(),
 			simulationMode: settings.simulationMode,
 			socket: message.options.socket,
+			tabIdOpenedFrom: message.options.socket.tabId,
 		}
 	})
 }
@@ -316,6 +319,7 @@ export async function interceptorAccessMetadataRefresh(message: RefreshIntercept
 			signerName: await getSignerName(),
 			simulationMode: settings.simulationMode,
 			socket: message.options.socket,
+			tabIdOpenedFrom: message.options.socket.tabId,
 		}
 	})
 }

--- a/app/ts/background/windows/personalSign.ts
+++ b/app/ts/background/windows/personalSign.ts
@@ -60,7 +60,7 @@ export async function addMetadataToOpenSeaOrder(ethereumClientService: EthereumC
 	 }
 }
 
-export async function craftPersonalSignPopupMessage(ethereumClientService: EthereumClientService, originalParams: PersonalSignParams | SignTypedDataParams | OldSignTypedDataParams, activeAddress: bigint, userAddressBook: UserAddressBook, simulationMode: boolean, requestId: number, signerName: SignerName, website: Website): Promise<PersonalSignRequest> {
+export async function craftPersonalSignPopupMessage(ethereumClientService: EthereumClientService, originalParams: PersonalSignParams | SignTypedDataParams | OldSignTypedDataParams, tabIdOpenedFrom: number, activeAddress: bigint, userAddressBook: UserAddressBook, simulationMode: boolean, requestId: number, signerName: SignerName, website: Website): Promise<PersonalSignRequest> {
 	const activeAddressWithMetadata = getAddressMetaData(activeAddress, userAddressBook)
 	const basicParams = {
 		activeAddress: activeAddressWithMetadata,
@@ -69,6 +69,7 @@ export async function craftPersonalSignPopupMessage(ethereumClientService: Ether
 		website,
 		signerName,
 		activeChainId: ethereumClientService.getChain(),
+		tabIdOpenedFrom,
 	}
 
 	const getQuarrantineCodes = async (messageChainId: bigint, account: AddressBookEntry, activeAddress: AddressBookEntry, owner: AddressBookEntry | undefined): Promise<{ quarantine: boolean, quarantineCodes: readonly QUARANTINE_CODE[] }> => {
@@ -131,7 +132,7 @@ export async function craftPersonalSignPopupMessage(ethereumClientService: Ether
 				type: 'EIP712',
 				message,
 				account,
-				...chainid === undefined ? { quarantine: false, quarantineCodes: [] } : await getQuarrantineCodes(chainid, account, activeAddressWithMetadata, undefined)
+				...chainid === undefined ? { quarantine: false, quarantineCodes: [] } : await getQuarrantineCodes(chainid, account, activeAddressWithMetadata, undefined),
 			}
 		}
 	}
@@ -232,7 +233,7 @@ export const openPersonalSignDialog = async (
 
 	const activeAddress = simulationMode ? settings.activeSimulationAddress : settings.activeSigningAddress
 	if (activeAddress === undefined) return reject()
-	const popupMessage = await craftPersonalSignPopupMessage(ethereumClientService, params, activeAddress, settings.userAddressBook, simulationMode, request.requestId, await getSignerName(), website)
+	const popupMessage = await craftPersonalSignPopupMessage(ethereumClientService, params, socket.tabId, activeAddress, settings.userAddressBook, simulationMode, request.requestId, await getSignerName(), website)
 
 	const personalSignWindowReadyAndListening = async function popupMessageListener(msg: unknown) {
 		const message = ExternalPopupMessage.parse(msg)

--- a/app/ts/components/pages/ChangeChain.tsx
+++ b/app/ts/components/pages/ChangeChain.tsx
@@ -4,7 +4,7 @@ import { Error as ErrorContainer, ErrorCheckBox } from '../subcomponents/Error.j
 import { ChangeChainRequest, ExternalPopupMessage } from '../../utils/interceptor-messages.js'
 import { sendPopupMessageToBackgroundPage } from '../../background/backgroundUtils.js'
 import { Website } from '../../utils/user-interface-types.js'
-import { tryFocusingWindow } from '../ui-utils.js'
+import { tryFocusingTab } from '../ui-utils.js'
 
 interface InterceptorChainChangeRequest {
 	isInterceptorSupport: boolean,
@@ -13,7 +13,7 @@ interface InterceptorChainChangeRequest {
 	website: Website,
 	simulationMode: boolean,
 	requestId: number,
-	windowIdOpenedFrom: number,
+	tabIdOpenedFrom: number,
 }
 
 export function ChangeChain() {
@@ -29,7 +29,7 @@ export function ChangeChain() {
 				website: message.data.website,
 				simulationMode: message.data.simulationMode,
 				requestId: message.data.requestId,
-				windowIdOpenedFrom: message.data.windowIdOpenedFrom,
+				tabIdOpenedFrom: message.data.tabIdOpenedFrom,
 			})
 		}
 
@@ -45,15 +45,15 @@ export function ChangeChain() {
 
 	async function approve() {
 		if (chainChangeData === undefined) return
+		await tryFocusingTab(chainChangeData.tabIdOpenedFrom)
 		await sendPopupMessageToBackgroundPage({ method: 'popup_changeChainDialog', options: { accept: true, requestId: chainChangeData.requestId, chainId: chainChangeData.chainId } })
-		await tryFocusingWindow(chainChangeData.windowIdOpenedFrom)
 		globalThis.close()
 	}
 
 	async function reject() {
 		if (chainChangeData === undefined) return
+		await tryFocusingTab(chainChangeData.tabIdOpenedFrom)
 		await sendPopupMessageToBackgroundPage({ method: 'popup_changeChainDialog', options: { accept: false, requestId: chainChangeData.requestId } })
-		await tryFocusingWindow(chainChangeData.windowIdOpenedFrom)
 		globalThis.close()
 	}
 

--- a/app/ts/components/pages/ChangeChain.tsx
+++ b/app/ts/components/pages/ChangeChain.tsx
@@ -4,6 +4,7 @@ import { Error as ErrorContainer, ErrorCheckBox } from '../subcomponents/Error.j
 import { ChangeChainRequest, ExternalPopupMessage } from '../../utils/interceptor-messages.js'
 import { sendPopupMessageToBackgroundPage } from '../../background/backgroundUtils.js'
 import { Website } from '../../utils/user-interface-types.js'
+import { tryFocusingWindow } from '../ui-utils.js'
 
 interface InterceptorChainChangeRequest {
 	isInterceptorSupport: boolean,
@@ -12,6 +13,7 @@ interface InterceptorChainChangeRequest {
 	website: Website,
 	simulationMode: boolean,
 	requestId: number,
+	windowIdOpenedFrom: number,
 }
 
 export function ChangeChain() {
@@ -27,6 +29,7 @@ export function ChangeChain() {
 				website: message.data.website,
 				simulationMode: message.data.simulationMode,
 				requestId: message.data.requestId,
+				windowIdOpenedFrom: message.data.windowIdOpenedFrom,
 			})
 		}
 
@@ -43,12 +46,14 @@ export function ChangeChain() {
 	async function approve() {
 		if (chainChangeData === undefined) return
 		await sendPopupMessageToBackgroundPage({ method: 'popup_changeChainDialog', options: { accept: true, requestId: chainChangeData.requestId, chainId: chainChangeData.chainId } })
+		await tryFocusingWindow(chainChangeData.windowIdOpenedFrom)
 		globalThis.close()
 	}
 
 	async function reject() {
 		if (chainChangeData === undefined) return
 		await sendPopupMessageToBackgroundPage({ method: 'popup_changeChainDialog', options: { accept: false, requestId: chainChangeData.requestId } })
+		await tryFocusingWindow(chainChangeData.windowIdOpenedFrom)
 		globalThis.close()
 	}
 

--- a/app/ts/components/pages/ConfirmTransaction.tsx
+++ b/app/ts/components/pages/ConfirmTransaction.tsx
@@ -14,6 +14,7 @@ import { identifyTransaction } from '../simulationExplaining/identifyTransaction
 import { SomeTimeAgo } from '../subcomponents/SomeTimeAgo.js'
 import { TIME_BETWEEN_BLOCKS } from '../../utils/constants.js'
 import { DinoSaysNotification } from '../subcomponents/DinoSays.js'
+import { tryFocusingWindow } from '../ui-utils.js'
 
 type UnderTransactionsParams = {
 	pendingTransactions: ConfirmTransactionTransactionSingleVisualizationArray
@@ -161,10 +162,13 @@ export function ConfirmTransaction() {
 			}
 			if (message.method === 'popup_confirm_transaction_dialog_pending_changed') {
 				setPendingTransactions(message.data.slice(1))
-				const currentWindow = await browser.windows.getCurrent()
-				if (currentWindow.id === undefined) throw new Error('could not get our own Id!')
+				const currentWindowId = (await browser.windows.getCurrent()).id
+				const currentTabId = (await browser.tabs.getCurrent()).id
+				if (currentWindowId === undefined) throw new Error('could not get current window Id!')
+				if (currentTabId === undefined) throw new Error('could not get current tab Id!')
 				setPendingTransactionAddedNotification(true)
-				browser.windows.update(currentWindow.id, { focused: true })
+				browser.windows.update(currentWindowId, { focused: true })
+				browser.tabs.update(currentTabId, { active: true })
 				return
 			}
 			if (message.method !== 'popup_update_confirm_transaction_dialog') return
@@ -191,12 +195,14 @@ export function ConfirmTransaction() {
 		const currentWindow = await browser.windows.getCurrent()
 		if (currentWindow.id === undefined) throw new Error('could not get our own Id!')
 		await sendPopupMessageToBackgroundPage({ method: 'popup_confirmDialog', options: { requestId: dialogState.data.requestId, accept: true, windowId: currentWindow.id } })
+		await tryFocusingWindow(dialogState.data.windowIdOpenedFrom)
 	}
 	async function reject() {
 		if (dialogState === undefined) throw new Error('dialogState is not set')
 		const currentWindow = await browser.windows.getCurrent()
 		if (currentWindow.id === undefined) throw new Error('could not get our own Id!')
 		await sendPopupMessageToBackgroundPage({ method: 'popup_confirmDialog', options: { requestId: dialogState.data.requestId, accept: false, windowId: currentWindow.id } })
+		await tryFocusingWindow(dialogState.data.windowIdOpenedFrom)
 	}
 	const refreshMetadata = () => {
 		if (dialogState === undefined || dialogState.state === 'failed') return

--- a/app/ts/components/pages/ConfirmTransaction.tsx
+++ b/app/ts/components/pages/ConfirmTransaction.tsx
@@ -14,7 +14,7 @@ import { identifyTransaction } from '../simulationExplaining/identifyTransaction
 import { SomeTimeAgo } from '../subcomponents/SomeTimeAgo.js'
 import { TIME_BETWEEN_BLOCKS } from '../../utils/constants.js'
 import { DinoSaysNotification } from '../subcomponents/DinoSays.js'
-import { tryFocusingWindow } from '../ui-utils.js'
+import { tryFocusingTab } from '../ui-utils.js'
 
 type UnderTransactionsParams = {
 	pendingTransactions: ConfirmTransactionTransactionSingleVisualizationArray
@@ -194,15 +194,15 @@ export function ConfirmTransaction() {
 		if (dialogState === undefined) throw new Error('dialogState is not set')
 		const currentWindow = await browser.windows.getCurrent()
 		if (currentWindow.id === undefined) throw new Error('could not get our own Id!')
+		if (pendingTransactions.length == 0) await tryFocusingTab(dialogState.data.tabIdOpenedFrom)
 		await sendPopupMessageToBackgroundPage({ method: 'popup_confirmDialog', options: { requestId: dialogState.data.requestId, accept: true, windowId: currentWindow.id } })
-		await tryFocusingWindow(dialogState.data.windowIdOpenedFrom)
 	}
 	async function reject() {
 		if (dialogState === undefined) throw new Error('dialogState is not set')
 		const currentWindow = await browser.windows.getCurrent()
 		if (currentWindow.id === undefined) throw new Error('could not get our own Id!')
+		if (pendingTransactions.length == 0) await tryFocusingTab(dialogState.data.tabIdOpenedFrom)
 		await sendPopupMessageToBackgroundPage({ method: 'popup_confirmDialog', options: { requestId: dialogState.data.requestId, accept: false, windowId: currentWindow.id } })
-		await tryFocusingWindow(dialogState.data.windowIdOpenedFrom)
 	}
 	const refreshMetadata = () => {
 		if (dialogState === undefined || dialogState.state === 'failed') return

--- a/app/ts/components/pages/InterceptorAccess.tsx
+++ b/app/ts/components/pages/InterceptorAccess.tsx
@@ -5,7 +5,7 @@ import { AddressInfoEntry, AddressBookEntry, AddingNewAddressType, RenameAddress
 import { ExternalPopupMessage } from '../../utils/interceptor-messages.js'
 import { sendPopupMessageToBackgroundPage } from '../../background/backgroundUtils.js'
 import Hint from '../subcomponents/Hint.js'
-import { convertNumberToCharacterRepresentationIfSmallEnough, tryFocusingWindow } from '../ui-utils.js'
+import { convertNumberToCharacterRepresentationIfSmallEnough, tryFocusingTab } from '../ui-utils.js'
 import { ChangeActiveAddress } from './ChangeActiveAddress.js'
 import { DinoSays } from '../subcomponents/DinoSays.js'
 import { getPrettySignerName } from '../subcomponents/signers.js'
@@ -114,7 +114,7 @@ interface InterceptorAccessRequest {
 	signerName: SignerName
 	simulationMode: boolean
 	socket: WebsiteSocket
-	windowIdOpenedFrom: number,
+	tabIdOpenedFrom: number,
 }
 
 const DISABLED_DELAY_MS = 3000
@@ -149,8 +149,8 @@ export function InterceptorAccess() {
 			requestAccessToAddress: accessRequest.requestAccessToAddress?.address,
 			originalRequestAccessToAddress: accessRequest.originalRequestAccessToAddress?.address,
 		}
+		await tryFocusingTab(accessRequest.tabIdOpenedFrom)
 		await sendPopupMessageToBackgroundPage({ method: 'popup_interceptorAccess', options })
-		await tryFocusingWindow(accessRequest.windowIdOpenedFrom)
 		globalThis.close()
 	}
 
@@ -162,8 +162,8 @@ export function InterceptorAccess() {
 			requestAccessToAddress: accessRequest.requestAccessToAddress?.address,
 			originalRequestAccessToAddress: accessRequest.originalRequestAccessToAddress?.address,
 		}
+		await tryFocusingTab(accessRequest.tabIdOpenedFrom)
 		await sendPopupMessageToBackgroundPage({ method: 'popup_interceptorAccess', options })
-		await tryFocusingWindow(accessRequest.windowIdOpenedFrom)
 		globalThis.close()
 	}
 

--- a/app/ts/components/pages/InterceptorAccess.tsx
+++ b/app/ts/components/pages/InterceptorAccess.tsx
@@ -5,7 +5,7 @@ import { AddressInfoEntry, AddressBookEntry, AddingNewAddressType, RenameAddress
 import { ExternalPopupMessage } from '../../utils/interceptor-messages.js'
 import { sendPopupMessageToBackgroundPage } from '../../background/backgroundUtils.js'
 import Hint from '../subcomponents/Hint.js'
-import { convertNumberToCharacterRepresentationIfSmallEnough } from '../ui-utils.js'
+import { convertNumberToCharacterRepresentationIfSmallEnough, tryFocusingWindow } from '../ui-utils.js'
 import { ChangeActiveAddress } from './ChangeActiveAddress.js'
 import { DinoSays } from '../subcomponents/DinoSays.js'
 import { getPrettySignerName } from '../subcomponents/signers.js'
@@ -114,6 +114,7 @@ interface InterceptorAccessRequest {
 	signerName: SignerName
 	simulationMode: boolean
 	socket: WebsiteSocket
+	windowIdOpenedFrom: number,
 }
 
 const DISABLED_DELAY_MS = 3000
@@ -149,6 +150,7 @@ export function InterceptorAccess() {
 			originalRequestAccessToAddress: accessRequest.originalRequestAccessToAddress?.address,
 		}
 		await sendPopupMessageToBackgroundPage({ method: 'popup_interceptorAccess', options })
+		await tryFocusingWindow(accessRequest.windowIdOpenedFrom)
 		globalThis.close()
 	}
 
@@ -161,6 +163,7 @@ export function InterceptorAccess() {
 			originalRequestAccessToAddress: accessRequest.originalRequestAccessToAddress?.address,
 		}
 		await sendPopupMessageToBackgroundPage({ method: 'popup_interceptorAccess', options })
+		await tryFocusingWindow(accessRequest.windowIdOpenedFrom)
 		globalThis.close()
 	}
 

--- a/app/ts/components/pages/PersonalSign.tsx
+++ b/app/ts/components/pages/PersonalSign.tsx
@@ -20,7 +20,7 @@ import { PersonalSignRequestData, PersonalSignRequestDataPermit, PersonalSignReq
 import { OrderComponents, OrderComponentsExtraDetails } from '../simulationExplaining/customExplainers/OpenSeaOrder.js'
 import { Ether } from '../subcomponents/coins.js'
 import { EnrichedEIP712, EnrichedEIP712Message, GroupedSolidityType } from '../../utils/eip712Parsing.js'
-import { tryFocusingWindow, humanReadableDate } from '../ui-utils.js'
+import { tryFocusingTab, humanReadableDate } from '../ui-utils.js'
 
 type SignatureCardParams = {
 	personalSignRequestData: PersonalSignRequestData
@@ -398,15 +398,15 @@ export function PersonalSign() {
 
 	async function approve() {
 		if (personalSignRequestData === undefined) throw new Error('personalSignRequestData is missing')
+		await tryFocusingTab(personalSignRequestData.tabIdOpenedFrom)
 		await sendPopupMessageToBackgroundPage({ method: 'popup_personalSign', options: { requestId: personalSignRequestData.requestId, accept: true } })
-		await tryFocusingWindow(personalSignRequestData.windowIdOpenedFrom)
 		globalThis.close()
 	}
 
 	async function reject() {
 		if (personalSignRequestData === undefined) throw new Error('personalSignRequestData is missing')
+		await tryFocusingTab(personalSignRequestData.tabIdOpenedFrom)
 		await sendPopupMessageToBackgroundPage({ method: 'popup_personalSign', options: { requestId: personalSignRequestData.requestId, accept: false } })
-		await tryFocusingWindow(personalSignRequestData.windowIdOpenedFrom)
 		globalThis.close()
 	}
 

--- a/app/ts/components/pages/PersonalSign.tsx
+++ b/app/ts/components/pages/PersonalSign.tsx
@@ -20,7 +20,7 @@ import { PersonalSignRequestData, PersonalSignRequestDataPermit, PersonalSignReq
 import { OrderComponents, OrderComponentsExtraDetails } from '../simulationExplaining/customExplainers/OpenSeaOrder.js'
 import { Ether } from '../subcomponents/coins.js'
 import { EnrichedEIP712, EnrichedEIP712Message, GroupedSolidityType } from '../../utils/eip712Parsing.js'
-import { humanReadableDate } from '../ui-utils.js'
+import { tryFocusingWindow, humanReadableDate } from '../ui-utils.js'
 
 type SignatureCardParams = {
 	personalSignRequestData: PersonalSignRequestData
@@ -375,7 +375,6 @@ type ButtonsParams = {
 }
 
 export function PersonalSign() {
-	const [requestIdToConfirm, setRequestIdToConfirm] = useState<number | undefined>(undefined)
 	const [addingNewAddress, setAddingNewAddress] = useState<AddingNewAddressType | 'renameAddressModalClosed'> ('renameAddressModalClosed')
 	const [personalSignRequestData, setPersonalSignRequestData] = useState<PersonalSignRequestData | undefined>(undefined)
 	const [forceSend, setForceSend] = useState<boolean>(false)
@@ -386,7 +385,6 @@ export function PersonalSign() {
 			if (message.method === 'popup_addressBookEntriesChanged') return refreshMetadata()
 			if (message.method !== 'popup_personal_sign_request') return
 			setPersonalSignRequestData(message.data)
-			setRequestIdToConfirm(message.data.requestId)
 		}
 		browser.runtime.onMessage.addListener(popupMessageListener)
 		sendPopupMessageToBackgroundPage({ method: 'popup_personalSignReadyAndListening' })
@@ -399,14 +397,16 @@ export function PersonalSign() {
 	}
 
 	async function approve() {
-		if ( requestIdToConfirm === undefined) throw new Error('Request id is missing')
-		await sendPopupMessageToBackgroundPage({ method: 'popup_personalSign', options: { requestId: requestIdToConfirm, accept: true } })
+		if (personalSignRequestData === undefined) throw new Error('personalSignRequestData is missing')
+		await sendPopupMessageToBackgroundPage({ method: 'popup_personalSign', options: { requestId: personalSignRequestData.requestId, accept: true } })
+		await tryFocusingWindow(personalSignRequestData.windowIdOpenedFrom)
 		globalThis.close()
 	}
 
 	async function reject() {
-		if ( requestIdToConfirm === undefined) throw new Error('Request id is missing')
-		await sendPopupMessageToBackgroundPage({ method: 'popup_personalSign', options: { requestId: requestIdToConfirm, accept: false } })
+		if (personalSignRequestData === undefined) throw new Error('personalSignRequestData is missing')
+		await sendPopupMessageToBackgroundPage({ method: 'popup_personalSign', options: { requestId: personalSignRequestData.requestId, accept: false } })
+		await tryFocusingWindow(personalSignRequestData.windowIdOpenedFrom)
 		globalThis.close()
 	}
 

--- a/app/ts/components/ui-utils.ts
+++ b/app/ts/components/ui-utils.ts
@@ -164,10 +164,11 @@ export async function removeWindowTabListener(onCloseWindow: (id: number) => voi
 	browser.tabs.onRemoved.addListener(onCloseWindow)
 }
 
-export async function tryFocusingWindow(windowId: number) {
+export async function tryFocusingTab(tabId: number) {
 	try {
-		await browser.windows.update(windowId, { focused: true })
+		browser.tabs.update(tabId, { active: true })
 	} catch(e) {
-
+		console.warn('failed to focus tab', tabId)
+		console.warn(e)
 	}
 }

--- a/app/ts/utils/interceptor-messages.ts
+++ b/app/ts/utils/interceptor-messages.ts
@@ -326,6 +326,7 @@ export const RefreshConfirmTransactionDialogSimulation = funtypes.ReadonlyObject
 		simulationMode: funtypes.Boolean,
 		requestId: funtypes.Number,
 		transactionToSimulate: WebsiteCreatedEthereumUnsignedTransaction,
+		tabIdOpenedFrom: funtypes.Number,
 	}),
 }).asReadonly()
 
@@ -390,14 +391,14 @@ export const ChangeChainRequest = funtypes.ReadonlyObject({
 		simulationMode: funtypes.Boolean,
 		chainId: EthereumQuantity,
 		website: Website,
-		windowIdOpenedFrom: funtypes.Number,
+		tabIdOpenedFrom: funtypes.Number,
 	})
 })
 
 export type RefreshPersonalSignMetadata = funtypes.Static<typeof RefreshPersonalSignMetadata>
 export const RefreshPersonalSignMetadata = funtypes.ReadonlyObject({
 	method: funtypes.Literal('popup_refreshPersonalSignMetadata'),
-	data: PersonalSignRequestData
+	data: PersonalSignRequestData,
 })
 
 export type InterceptorAccessDialog = funtypes.Static<typeof InterceptorAccessDialog>
@@ -413,7 +414,7 @@ export const InterceptorAccessDialog = funtypes.ReadonlyObject({
 		signerName: SignerName,
 		simulationMode: funtypes.Boolean,
 		socket: WebsiteSocket,
-		windowIdOpenedFrom: funtypes.Number,
+		tabIdOpenedFrom: funtypes.Number,
 	})
 })
 
@@ -424,7 +425,7 @@ export const ConfirmTransactionSimulationBaseData = funtypes.ReadonlyObject({
 	requestId: funtypes.Number,
 	transactionToSimulate: WebsiteCreatedEthereumUnsignedTransaction,
 	signerName: SignerName,
-	windowIdOpenedFrom: funtypes.Number,
+	tabIdOpenedFrom: funtypes.Number,
 })
 
 export type ConfirmTransactionDialogState = funtypes.Static<typeof ConfirmTransactionDialogState>

--- a/app/ts/utils/interceptor-messages.ts
+++ b/app/ts/utils/interceptor-messages.ts
@@ -390,6 +390,7 @@ export const ChangeChainRequest = funtypes.ReadonlyObject({
 		simulationMode: funtypes.Boolean,
 		chainId: EthereumQuantity,
 		website: Website,
+		windowIdOpenedFrom: funtypes.Number,
 	})
 })
 
@@ -412,6 +413,7 @@ export const InterceptorAccessDialog = funtypes.ReadonlyObject({
 		signerName: SignerName,
 		simulationMode: funtypes.Boolean,
 		socket: WebsiteSocket,
+		windowIdOpenedFrom: funtypes.Number,
 	})
 })
 
@@ -422,6 +424,7 @@ export const ConfirmTransactionSimulationBaseData = funtypes.ReadonlyObject({
 	requestId: funtypes.Number,
 	transactionToSimulate: WebsiteCreatedEthereumUnsignedTransaction,
 	signerName: SignerName,
+	windowIdOpenedFrom: funtypes.Number,
 })
 
 export type ConfirmTransactionDialogState = funtypes.Static<typeof ConfirmTransactionDialogState>

--- a/app/ts/utils/personal-message-definitions.ts
+++ b/app/ts/utils/personal-message-definitions.ts
@@ -364,6 +364,7 @@ export const PersonalSignRequestBase = funtypes.Intersect(
 		quarantineCodes: funtypes.ReadonlyArray(QUARANTINE_CODE),
 		quarantine: funtypes.Boolean,
 		account: AddressBookEntry,
+		windowIdOpenedFrom: funtypes.Number,
 	}),
 )
 

--- a/app/ts/utils/personal-message-definitions.ts
+++ b/app/ts/utils/personal-message-definitions.ts
@@ -364,7 +364,7 @@ export const PersonalSignRequestBase = funtypes.Intersect(
 		quarantineCodes: funtypes.ReadonlyArray(QUARANTINE_CODE),
 		quarantine: funtypes.Boolean,
 		account: AddressBookEntry,
-		windowIdOpenedFrom: funtypes.Number,
+		tabIdOpenedFrom: funtypes.Number,
 	}),
 )
 

--- a/app/ts/utils/typescript.ts
+++ b/app/ts/utils/typescript.ts
@@ -72,6 +72,7 @@ type StorageKey = 'activeSigningAddress'
 	| `tabState_${ number }`
 	| 'isConnectedToNode'
 	| 'ethereumSubscriptions'
+	| 'useTabsInsteadOfPopup'
 
 export async function browserStorageLocalGet(keys: StorageKey | StorageKey[]) {
 	return await browser.storage.local.get(keys) as Promise<Partial<Record<StorageKey, JSONEncodeable>>>


### PR DESCRIPTION
Fix https://github.com/DarkFlorist/TheInterceptor/issues/372

- adds option to open all popups in a tab instead
- when the tab or popup is closed with reject/approval, activate the tab that made the request
- this PR does not add possibility to enable tab mode in the UI. You can enable it in console with: `await browser.storage.local.set({ useTabsInsteadOfPopup: true })`. I'll add settings menu in a future PR.