### PR TITLE
add ERC721 to fourbyte explanation for Transfer Form

### DIFF
--- a/app/ts/utils/constants.ts
+++ b/app/ts/utils/constants.ts
@@ -84,7 +84,7 @@ function get4Byte(functionAbi: string) {
 }
 
 export const FourByteExplanations = new Map<number, string >([
-	[get4Byte('transferFrom(address,address,uint256)'), 'ERC20 Transfer From'],
+	[get4Byte('transferFrom(address,address,uint256)'), 'ERC20/ERC721 Transfer From'],
 	[get4Byte('transfer(address,uint256)'), 'ERC20 Transfer'],
 	[get4Byte('approve(address,uint256)'), 'ERC20 Approval'],
 	[get4Byte('setApprovalForAll(address,bool)'), 'ERC721 Approval For All'],


### PR DESCRIPTION
Fix https://github.com/DarkFlorist/TheInterceptor/issues/467

Other option is just call it "Transfer From" but I am not sure if "ERC20/ERC721 Transfer From" is more clear