### PR TITLE
don't show request queued if dapp just asks requests again for the same

### DIFF
--- a/app/ts/background/windows/interceptorAccess.ts
+++ b/app/ts/background/windows/interceptorAccess.ts
@@ -179,7 +179,12 @@ export async function requestAccessFromUser(
 			}
 			return
 		}
-		if (justAddToPending) return await sendPopupMessageToOpenWindows({ method: 'popup_interceptor_access_dialog_pending_changed', data: requests })
+		if (justAddToPending) {
+			if (requests.findIndex((x) => x.accessRequestId === accessRequestId) === 0) {
+				await sendPopupMessageToOpenWindows({ method: 'popup_interceptorAccessDialog', data: requests })
+			}
+			return await sendPopupMessageToOpenWindows({ method: 'popup_interceptor_access_dialog_pending_changed', data: requests })
+		}
 		pendingAccessRequests.resolve(requests)
 	})
 }


### PR DESCRIPTION
don't show "- Hey! A new request was queued. Accept or Reject the previous request to see the new one.", if dapp just asks permissions for the same thing