### PR TITLE
Requires brackets when using UUID in manifest mozilla id

### DIFF
--- a/app/manifestV2.json
+++ b/app/manifestV2.json
@@ -11,7 +11,7 @@
 	},
 	"browser_specific_settings": {
 		"gecko": {
-			"id": "3c236fbc-9114-43ed-a224-0cd1834aec4d",
+			"id": "{3c236fbc-9114-43ed-a224-0cd1834aec4d}",
 			"strict_min_version": "110.0"
 		}
 	},


### PR DESCRIPTION
I guess that WASN'T the id....... it requires brackets

<img width="782" alt="Screenshot 2023-06-12 at 22 56 34" src="https://github.com/DarkFlorist/TheInterceptor/assets/361654/59533bd7-0843-467d-8e6e-fbe905cd1121">
