### PR TITLE
Allow each tab have their own signer account

### DIFF
--- a/app/ts/background/backgroundUtils.ts
+++ b/app/ts/background/backgroundUtils.ts
@@ -1,9 +1,14 @@
 import { MessageToPopup, PopupMessage, Settings, WindowMessage } from '../utils/interceptor-messages.js'
 import { WebsiteSocket } from '../utils/user-interface-types.js'
 import { EthereumQuantity } from '../utils/wire-types.js'
+import { getTabState } from './storageVariables.js'
 
-export function getActiveAddress(settings: Settings) {
-	return settings.simulationMode ? settings.activeSimulationAddress : settings.activeSigningAddress
+export async function getActiveAddress(settings: Settings, tabId: number | undefined) {
+	if (settings.simulationMode && !settings.useSignersAddressAsActiveAddress) {
+		return settings.activeSimulationAddress
+	}
+	if (tabId === undefined) return undefined
+	return (await getTabState(tabId)).activeSigningAddress
 }
 
 export async function sendPopupMessageToOpenWindows(message: MessageToPopup) {

--- a/app/ts/background/popupMessageHandlers.ts
+++ b/app/ts/background/popupMessageHandlers.ts
@@ -302,6 +302,8 @@ export async function homeOpened(simulator: Simulator) {
 			makeMeRich: await getMakeMeRich(),
 			isConnected: await getIsConnected(),
 			useTabsInsteadOfPopup: await getUseTabsInsteadOfPopup(),
+			activeSigningAddressInThisTab: tabState?.activeSigningAddress,
+			tabId,
 		}
 	})
 }

--- a/app/ts/background/settings.ts
+++ b/app/ts/background/settings.ts
@@ -40,7 +40,6 @@ function parseAccessWithLegacySupport(data: unknown): WebsiteAccessArray {
 
 export async function getSettings() : Promise<Settings> {
 	const results = await browserStorageLocalGet([
-		'activeSigningAddress',
 		'activeSimulationAddress',
 		'addressInfos',
 		'page',
@@ -53,7 +52,6 @@ export async function getSettings() : Promise<Settings> {
 	const useSignersAddressAsActiveAddress = results.useSignersAddressAsActiveAddress !== undefined ? funtypes.Boolean.parse(results.useSignersAddressAsActiveAddress) : false
 	return {
 		activeSimulationAddress: results.activeSimulationAddress !== undefined ? EthereumAddressOrMissing.parse(results.activeSimulationAddress) : defaultAddresses[0].address,
-		activeSigningAddress: results.activeSigningAddress === undefined ? undefined : EthereumAddressOrMissing.parse(results.activeSigningAddress),
 		page: results.page !== undefined ? Page.parse(results.page) : 'Home',
 		useSignersAddressAsActiveAddress: useSignersAddressAsActiveAddress,
 		websiteAccess: results.websiteAccess !== undefined ? parseAccessWithLegacySupport(results.websiteAccess) : [],
@@ -131,7 +129,6 @@ export const ExportedSettings = funtypes.ReadonlyObject({
 	exportedDate: funtypes.String,
 	settings: funtypes.ReadonlyObject({
 		activeSimulationAddress: OptionalEthereumAddress,
-		activeSigningAddress: OptionalEthereumAddress,
 		activeChain: EthereumQuantity,
 		page: Page,
 		useSignersAddressAsActiveAddress: funtypes.Boolean,
@@ -149,7 +146,6 @@ export async function exportSettingsAndAddressBook() {
 		version: '1.0' as const,
 		exportedDate: (new Date).toISOString().split('T')[0],
 		settings: await browserStorageLocalGet([
-			'activeSigningAddress',
 			'activeSimulationAddress',
 			'addressInfos',
 			'page',
@@ -170,7 +166,7 @@ export async function importSettingsAndAddressBook(exportedSetings: ExportedSett
 		simulationMode: exportedSetings.settings.simulationMode,
 		activeChain: exportedSetings.settings.activeChain,
 		activeSimulationAddress: exportedSetings.settings.activeSimulationAddress,
-		activeSigningAddress: exportedSetings.settings.activeSigningAddress,
+		activeSigningAddress: undefined,
 	})
 	await setPage(exportedSetings.settings.page)
 	await updateAddressInfos(() => exportedSetings.settings.addressInfos)

--- a/app/ts/background/storageVariables.ts
+++ b/app/ts/background/storageVariables.ts
@@ -116,6 +116,7 @@ export async function getTabState(tabId: number) : Promise<TabState> {
 			icon: ICON_NOT_ACTIVE,
 			iconReason: 'No active address selected.',
 		},
+		activeSigningAddress: undefined
 	}
 }
 export async function setTabState(tabId: number, tabState: TabState) {
@@ -134,8 +135,11 @@ export async function clearTabStates() {
 
 const tabStateSemaphore = new Semaphore(1)
 export async function updateTabState(tabId: number, updateFunc: (prevState: TabState) => TabState) {
-	await tabStateSemaphore.execute(async () => {
-		await setTabState(tabId, updateFunc(await getTabState(tabId)))
+	return await tabStateSemaphore.execute(async () => {
+		const previousState = await getTabState(tabId)
+		const newState = updateFunc(previousState)
+		await setTabState(tabId, newState)
+		return { previousState, newState }
 	})
 }
 

--- a/app/ts/background/windows/confirmTransaction.ts
+++ b/app/ts/background/windows/confirmTransaction.ts
@@ -4,11 +4,10 @@ import { appendTransaction } from '../../simulation/services/SimulationModeEther
 import { bytes32String } from '../../utils/bigint.js'
 import { ERROR_INTERCEPTOR_NO_ACTIVE_ADDRESS, METAMASK_ERROR_NOT_CONNECTED_TO_CHAIN, METAMASK_ERROR_USER_REJECTED_REQUEST } from '../../utils/constants.js'
 import { Future } from '../../utils/future.js'
-import { ConfirmTransactionTransactionSingleVisualization, ExternalPopupMessage, InterceptedRequest, PendingTransaction, Settings, TransactionConfirmation } from '../../utils/interceptor-messages.js'
+import { ConfirmTransactionTransactionSingleVisualization, ExternalPopupMessage, InterceptedRequest, PendingTransaction, TransactionConfirmation } from '../../utils/interceptor-messages.js'
 import { Semaphore } from '../../utils/semaphore.js'
-import { Website, WebsiteSocket, WebsiteTabConnections } from '../../utils/user-interface-types.js'
+import { WebsiteSocket, WebsiteTabConnections } from '../../utils/user-interface-types.js'
 import { EstimateGasError, WebsiteCreatedEthereumUnsignedTransaction } from '../../utils/visualizer-types.js'
-import { getActiveAddressForDomain } from '../accessManagement.js'
 import { refreshConfirmTransactionSimulation, sendMessageToContentScript, updateSimulationState } from '../background.js'
 import { getHtmlFile, sendPopupMessageToOpenWindows } from '../backgroundUtils.js'
 import { appendPendingTransaction, clearPendingTransactions, getPendingTransactions, getSimulationResults, removePendingTransaction } from '../storageVariables.js'
@@ -63,10 +62,9 @@ export async function openConfirmTransactionDialog(
 	ethereumClientService: EthereumClientService,
 	socket: WebsiteSocket,
 	request: InterceptedRequest,
-	website: Website,
 	simulationMode: boolean,
 	transactionToSimulatePromise: () => Promise<WebsiteCreatedEthereumUnsignedTransaction | undefined | EstimateGasError>,
-	settings: Settings,
+	activeAddress: bigint | undefined,
 ) {
 	let justAddToPending = false
 	if (pendingTransactions.size !== 0) justAddToPending = true
@@ -81,7 +79,6 @@ export async function openConfirmTransactionDialog(
 		return sendPopupMessageToOpenWindows({ method: 'popup_update_confirm_transaction_dialog', data: (await appendPromise).map((p) => p.simulationResults) })
 	}
 	try {
-		const activeAddress = getActiveAddressForDomain(settings.websiteAccess, website.websiteOrigin, settings)
 		if (activeAddress === undefined) return ERROR_INTERCEPTOR_NO_ACTIVE_ADDRESS
 		const transactionToSimulate = await transactionToSimulatePromise()
 		if (transactionToSimulate === undefined) return rejectMessage

--- a/app/ts/background/windows/personalSign.ts
+++ b/app/ts/background/windows/personalSign.ts
@@ -222,6 +222,7 @@ export const openPersonalSignDialog = async (
 	simulationMode: boolean,
 	website: Website,
 	settings: Settings,
+	activeAddress: bigint | undefined
 ): Promise<HandleSimulationModeReturnValue> => {
 	if (pendingPersonalSign !== undefined) return reject()
 
@@ -232,7 +233,6 @@ export const openPersonalSignDialog = async (
 		return resolvePersonalSign(websiteTabConnections, rejectMessage(request.requestId))
 	}
 
-	const activeAddress = simulationMode ? settings.activeSimulationAddress : settings.activeSigningAddress
 	if (activeAddress === undefined) return reject()
 	const popupMessage = await craftPersonalSignPopupMessage(ethereumClientService, params, socket.tabId, activeAddress, settings.userAddressBook, simulationMode, request.requestId, await getSignerName(), website)
 

--- a/app/ts/utils/interceptor-messages.ts
+++ b/app/ts/utils/interceptor-messages.ts
@@ -463,6 +463,7 @@ export const PendingAccessRequest = funtypes.ReadonlyObject({
 	dialogId: funtypes.Number,
 	request: funtypes.Union(InterceptedRequest, funtypes.Undefined),
 	accessRequestId: funtypes.String,
+	activeAddress: OptionalEthereumAddress,
 }).asReadonly()
 
 export type InterceptorAccessReply = funtypes.Static<typeof InterceptorAccessReply>
@@ -501,7 +502,6 @@ export interface PendingAccessRequestWithMetadata extends PendingAccessRequest {
 export type Settings = funtypes.Static<typeof Settings>
 export const Settings = funtypes.ReadonlyObject({
 	activeSimulationAddress: OptionalEthereumAddress,
-	activeSigningAddress: OptionalEthereumAddress,
 	activeChain: EthereumQuantity,
 	page: Page,
 	useSignersAddressAsActiveAddress: funtypes.Boolean,
@@ -538,6 +538,8 @@ export const UpdateHomePage = funtypes.ReadonlyObject({
 		makeMeRich: funtypes.Boolean,
 		isConnected: IsConnected,
 		useTabsInsteadOfPopup: funtypes.Boolean,
+		activeSigningAddressInThisTab: OptionalEthereumAddress,
+		tabId: funtypes.Union(funtypes.Number, funtypes.Undefined),
 	})
 })
 
@@ -545,6 +547,15 @@ export type SettingsUpdated = funtypes.Static<typeof SettingsUpdated>
 export const SettingsUpdated = funtypes.ReadonlyObject({
 	method: funtypes.Literal('popup_settingsUpdated'),
 	data: Settings,
+})
+
+export type ActiveSigningAddressChanged = funtypes.Static<typeof ActiveSigningAddressChanged>
+export const ActiveSigningAddressChanged = funtypes.ReadonlyObject({
+	method: funtypes.Literal('popup_activeSigningAddressChanged'),
+	data: funtypes.ReadonlyObject({
+		tabId: funtypes.Number,
+		activeSigningAddress: OptionalEthereumAddress,
+	})
 })
 
 export type HandleSimulationModeReturnValue = {
@@ -605,6 +616,7 @@ export const TabState = funtypes.ReadonlyObject({
 	signerAccounts: funtypes.ReadonlyArray(EthereumAddress),
 	signerChain: funtypes.Union(EthereumQuantity, funtypes.Undefined),
 	tabIconDetails: TabIconDetails,
+	activeSigningAddress: OptionalEthereumAddress,
 })
 
 export type ChangeSettings = funtypes.Static<typeof ChangeSettings>
@@ -683,7 +695,8 @@ export const MessageToPopup = funtypes.Union(
 	UpdateAccessDialog,
 	ConfirmTransactionDialogPendingChanged,
 	funtypes.ReadonlyObject({ method: funtypes.Literal('popup_initiate_export_settings'), data: funtypes.ReadonlyObject({ fileContents: funtypes.String }) }),
-	ImportSettingsReply
+	ImportSettingsReply,
+	ActiveSigningAddressChanged,
 )
 
 export type ExternalPopupMessage = funtypes.Static<typeof MessageToPopup>


### PR DESCRIPTION
Currently interceptor forces signer to only have one address active at a time (and when this is not the case, interceptor behaves bit weirdly).

This change makes it so that every tab can have their own signer account.

This change also makes access management a bit simpler, now access is checked at the beginning of the RPC query and the active address doesn't change during lifespan of the request

Should fix https://github.com/DarkFlorist/TheInterceptor/issues/484