### PR TITLE
Use interceptors rpc when possible

### DIFF
--- a/app/inpage/ts/inpage.ts
+++ b/app/inpage/ts/inpage.ts
@@ -62,7 +62,7 @@ type MessageMethodAndParams = {
 }
 
 interface InterceptedRequestForward {
-	readonly interceptorApproved: boolean,
+	readonly interceptorApproved: true,
 	readonly usingInterceptorWithoutSigner?: boolean,
 	readonly requestId: number,
 	options: MessageMethodAndParams,

--- a/app/ts/AddressBook.tsx
+++ b/app/ts/AddressBook.tsx
@@ -229,22 +229,22 @@ export function AddressBook() {
 			if (parsed.method !== 'popup_getAddressBookDataReply') return
 			const reply = GetAddressBookDataReply.parse(msg)
 			setAddressBookState((previousState) => {
-				if ( activeFilterRef.current !== reply.data.options.filter || searchStringRef.current !== reply.data.options.searchString) return previousState
+				if ( activeFilterRef.current !== reply.data.data.filter || searchStringRef.current !== reply.data.data.searchString) return previousState
 
-				const startPageIndex = Math.ceil(reply.data.options.startIndex / PAGE_SIZE)
+				const startPageIndex = Math.ceil(reply.data.data.startIndex / PAGE_SIZE)
 				const chunkedresults = arrayToChunks(reply.data.entries, PAGE_SIZE)
 
 				const newPages = (previousState !== undefined
-					&& reply.data.options.filter === previousState.activeFilter
-					&& reply.data.options.searchString === previousState.searchString ? new Map(previousState.pages) : new Map())
+					&& reply.data.data.filter === previousState.activeFilter
+					&& reply.data.data.searchString === previousState.searchString ? new Map(previousState.pages) : new Map())
 
 				Array.from(chunkedresults).forEach((entries, pageOffset) => newPages.set(startPageIndex + pageOffset, entries))
 				const newData = {
 					pages: newPages,
 					maxIndex: reply.data.maxDataLength,
 					maxPages: Math.ceil( (reply.data.maxDataLength) / PAGE_SIZE),
-					searchString: reply.data.options.searchString,
-					activeFilter: reply.data.options.filter,
+					searchString: reply.data.data.searchString,
+					activeFilter: reply.data.data.filter,
 				}
 				return newData
 			})
@@ -293,7 +293,7 @@ export function AddressBook() {
 	}
 
 	function sendQuery(filter: ActiveFilter, searchString: string | undefined, startPage: number, endPage: number) {
-		sendPopupMessageToBackgroundPage({ method: 'popup_getAddressBookData', options: {
+		sendPopupMessageToBackgroundPage({ method: 'popup_getAddressBookData', data: {
 			filter: filter,
 			searchString: searchString,
 			startIndex: startPage * PAGE_SIZE,
@@ -365,7 +365,7 @@ export function AddressBook() {
 	function removeAddressBookEntry(entry: AddressBookEntry) {
 		sendPopupMessageToBackgroundPage({
 			method: 'popup_removeAddressBookEntry',
-			options: {
+			data: {
 				address: entry.address,
 				addressBookCategory: activeFilter,
 			}

--- a/app/ts/background/accessManagement.ts
+++ b/app/ts/background/accessManagement.ts
@@ -20,7 +20,9 @@ function setWebsitePortApproval(websiteTabConnections: WebsiteTabConnections, so
 	connection.approved = approved
 }
 
-export function verifyAccess(websiteTabConnections: WebsiteTabConnections, socket: WebsiteSocket, isEthRequestAccounts: boolean, websiteOrigin: string, requestAccessForAddress: bigint | undefined, settings: Settings): 'hasAccess' | 'noAccess' | 'askAccess' {
+export type ApprovalState = 'hasAccess' | 'noAccess' | 'askAccess'
+
+export function verifyAccess(websiteTabConnections: WebsiteTabConnections, socket: WebsiteSocket, isEthRequestAccounts: boolean, websiteOrigin: string, requestAccessForAddress: bigint | undefined, settings: Settings): ApprovalState {
 	const connection = getConnectionDetails(websiteTabConnections, socket)
 	if (connection && connection.approved) return 'hasAccess'
 	const access = requestAccessForAddress !== undefined ? hasAddressAccess(settings.websiteAccess, websiteOrigin, requestAccessForAddress, settings) : hasAccess(settings.websiteAccess, websiteOrigin)

--- a/app/ts/background/accessManagement.ts
+++ b/app/ts/background/accessManagement.ts
@@ -1,4 +1,4 @@
-import { postMessageIfStillConnected, postMessageToPortIfConnectedWithoutRequestId } from './background.js'
+import { postMessageIfStillConnected } from './background.js'
 import { getActiveAddress, websiteSocketToString } from './backgroundUtils.js'
 import { findAddressInfo } from './metadataUtils.js'
 import { requestAccessFromUser } from './windows/interceptorAccess.js'
@@ -33,7 +33,7 @@ export function sendMessageToApprovedWebsitePorts(websiteTabConnections: Website
 	// inform all the tabs about the address change
 	for (const [_tab, tabConnection] of websiteTabConnections.entries() ) {
 		for (const [_string, connection] of Object.entries(tabConnection.connections) ) {
-			if ( !connection.approved ) continue
+			if (!connection.approved) continue
 			postMessageIfStillConnected(websiteTabConnections, connection.socket, message)
 		}
 	}
@@ -170,16 +170,16 @@ function connectToPort(websiteTabConnections: WebsiteTabConnections, socket: Web
 
 	if (settings.activeChain === undefined) return true
 
-	postMessageToPortIfConnectedWithoutRequestId(websiteTabConnections, socket, { options: { method: 'connect', params: [] } as const, result: [settings.activeChain] })
+	postMessageIfStillConnected(websiteTabConnections, socket, { method: 'connect', result: [settings.activeChain] })
 
 	// seems like dapps also want to get account changed and chain changed events after we connect again, so let's send them too
-	postMessageToPortIfConnectedWithoutRequestId(websiteTabConnections, socket, { options: { method: 'accountsChanged', params: [] } as const, result: connectWithActiveAddress !== undefined ? [connectWithActiveAddress] : [] })
+	postMessageIfStillConnected(websiteTabConnections, socket, { method: 'accountsChanged', result: connectWithActiveAddress !== undefined ? [connectWithActiveAddress] : [] })
 
-	postMessageToPortIfConnectedWithoutRequestId(websiteTabConnections, socket, { options: { method: 'chainChanged', params: [] } as const, result: settings.activeChain })
+	postMessageIfStillConnected(websiteTabConnections, socket, { method: 'chainChanged', result: settings.activeChain })
 
 	if (!settings.simulationMode || settings.useSignersAddressAsActiveAddress) {
-		postMessageToPortIfConnectedWithoutRequestId(websiteTabConnections, socket, { options: { method: 'request_signer_to_eth_requestAccounts', params: [] } })
-		postMessageToPortIfConnectedWithoutRequestId(websiteTabConnections, socket, { options: { method: 'request_signer_chainId', params: [] } })
+		postMessageIfStillConnected(websiteTabConnections, socket, { method: 'request_signer_to_eth_requestAccounts', result: [] })
+		postMessageIfStillConnected(websiteTabConnections, socket, { method: 'request_signer_chainId', result: [] })
 	}
 	return true
 }
@@ -187,7 +187,7 @@ function connectToPort(websiteTabConnections: WebsiteTabConnections, socket: Web
 function disconnectFromPort(websiteTabConnections: WebsiteTabConnections, socket: WebsiteSocket, websiteOrigin: string): false {
 	setWebsitePortApproval(websiteTabConnections, socket, false)
 	updateExtensionIcon(websiteTabConnections, socket, websiteOrigin)
-	postMessageToPortIfConnectedWithoutRequestId(websiteTabConnections, socket, { method: 'disconnect' })
+	postMessageIfStillConnected(websiteTabConnections, socket, { method: 'disconnect', result: [] })
 	return false
 }
 

--- a/app/ts/background/background.ts
+++ b/app/ts/background/background.ts
@@ -226,8 +226,8 @@ async function handleRPCRequest(
 		case 'eth_signTypedData_v1':
 		case 'eth_signTypedData_v2':
 		case 'eth_signTypedData_v3':
-		case 'eth_signTypedData_v4': return await personalSign(ethereumClientService, websiteTabConnections, socket, parsedRequest, request, true, website, settings, activeAddress)
-		case 'wallet_switchEthereumChain': return await switchEthereumChain(websiteTabConnections, socket, ethereumClientService, parsedRequest, request, true, website)
+		case 'eth_signTypedData_v4': return await personalSign(ethereumClientService, websiteTabConnections, socket, parsedRequest, request, settings.simulationMode, website, settings, activeAddress)
+		case 'wallet_switchEthereumChain': return await switchEthereumChain(websiteTabConnections, socket, ethereumClientService, parsedRequest, request, settings.simulationMode, website)
 		case 'wallet_requestPermissions': return await getAccounts(activeAddress)
 		case 'wallet_getPermissions': return await getPermissions()
 		case 'eth_accounts': return await getAccounts(activeAddress)

--- a/app/ts/background/background.ts
+++ b/app/ts/background/background.ts
@@ -456,7 +456,7 @@ async function onContentScriptConnected(port: browser.runtime.Port, websiteTabCo
 	const websitePromise = retrieveWebsiteDetails(port, websiteOrigin)
 	const identifier = websiteSocketToString(socket)
 
-	console.log(`content script connected ${websiteOrigin}`)
+	console.log(`content script connected ${ websiteOrigin }`)
 
 	const tabConnection = websiteTabConnections.get(socket.tabId)
 	const newConnection = {

--- a/app/ts/background/popupMessageHandlers.ts
+++ b/app/ts/background/popupMessageHandlers.ts
@@ -57,7 +57,7 @@ export async function changeActiveAddress(websiteTabConnections: WebsiteTabConne
 		const signerAccount = await getSignerAccount()
 		await setUseSignersAddressAsActiveAddress(addressChange.data.activeAddress === 'signer', signerAccount)
 
-		sendMessageToApprovedWebsitePorts(websiteTabConnections, { method: 'request_signer_to_eth_requestAccounts', result: [] })
+		sendMessageToApprovedWebsitePorts(websiteTabConnections, { method: 'request_signer_to_eth_accounts', result: [] })
 		sendMessageToApprovedWebsitePorts(websiteTabConnections, { method: 'request_signer_chainId', result: [] } )
 		
 		await changeActiveAddressAndChainAndResetSimulation(websiteTabConnections, {
@@ -216,7 +216,7 @@ export async function enableSimulationMode(websiteTabConnections: WebsiteTabConn
 	const settings = await getSettings()
 	// if we are on unsupported chain, force change to a supported one
 	if (settings.useSignersAddressAsActiveAddress || params.data === false) {
-		sendMessageToApprovedWebsitePorts(websiteTabConnections, { method: 'request_signer_to_eth_requestAccounts', result: [] })
+		sendMessageToApprovedWebsitePorts(websiteTabConnections, { method: 'request_signer_to_eth_accounts', result: [] })
 		sendMessageToApprovedWebsitePorts(websiteTabConnections, { method: 'request_signer_chainId', result: [] })
 		const tabId = await getLastKnownCurrentTabId()
 		const chainToSwitch = tabId === undefined ? undefined : (await getTabState(tabId)).signerChain

--- a/app/ts/background/popupMessageHandlers.ts
+++ b/app/ts/background/popupMessageHandlers.ts
@@ -57,8 +57,8 @@ export async function changeActiveAddress(websiteTabConnections: WebsiteTabConne
 		const signerAccount = await getSignerAccount()
 		await setUseSignersAddressAsActiveAddress(addressChange.options.activeAddress === 'signer', signerAccount)
 
-		sendMessageToApprovedWebsitePorts(websiteTabConnections, 'request_signer_to_eth_requestAccounts', [])
-		sendMessageToApprovedWebsitePorts(websiteTabConnections, 'request_signer_chainId', [])
+		sendMessageToApprovedWebsitePorts(websiteTabConnections, { method: 'request_signer_to_eth_requestAccounts', result: [] })
+		sendMessageToApprovedWebsitePorts(websiteTabConnections, { method: 'request_signer_chainId', result: [] })
 		
 		await changeActiveAddressAndChainAndResetSimulation(websiteTabConnections, {
 			simulationMode: addressChange.options.simulationMode,
@@ -144,8 +144,8 @@ export async function changePage(page: ChangePage) {
 
 export async function requestAccountsFromSigner(websiteTabConnections: WebsiteTabConnections, params: RequestAccountsFromSigner) {
 	if (params.options) {
-		sendMessageToApprovedWebsitePorts(websiteTabConnections, 'request_signer_to_eth_requestAccounts', [])
-		sendMessageToApprovedWebsitePorts(websiteTabConnections, 'request_signer_chainId', [])
+		sendMessageToApprovedWebsitePorts(websiteTabConnections, { method: 'request_signer_to_eth_requestAccounts', result: [] })
+		sendMessageToApprovedWebsitePorts(websiteTabConnections, { method: 'request_signer_chainId', result: [] })
 	}
 }
 
@@ -216,8 +216,8 @@ export async function enableSimulationMode(websiteTabConnections: WebsiteTabConn
 	const settings = await getSettings()
 	// if we are on unsupported chain, force change to a supported one
 	if (settings.useSignersAddressAsActiveAddress || params.options === false) {
-		sendMessageToApprovedWebsitePorts(websiteTabConnections, 'request_signer_to_eth_requestAccounts', [])
-		sendMessageToApprovedWebsitePorts(websiteTabConnections, 'request_signer_chainId', [])
+		sendMessageToApprovedWebsitePorts(websiteTabConnections, { method: 'request_signer_to_eth_requestAccounts' as const, result: [] })
+		sendMessageToApprovedWebsitePorts(websiteTabConnections, { method: 'request_signer_chainId' as const, result: [] })
 		const tabId = await getLastKnownCurrentTabId()
 		const chainToSwitch = tabId === undefined ? undefined : (await getTabState(tabId)).signerChain
 		await changeActiveAddressAndChainAndResetSimulation(websiteTabConnections, {

--- a/app/ts/background/popupMessageHandlers.ts
+++ b/app/ts/background/popupMessageHandlers.ts
@@ -57,8 +57,8 @@ export async function changeActiveAddress(websiteTabConnections: WebsiteTabConne
 		const signerAccount = await getSignerAccount()
 		await setUseSignersAddressAsActiveAddress(addressChange.options.activeAddress === 'signer', signerAccount)
 
-		sendMessageToApprovedWebsitePorts(websiteTabConnections, { method: 'request_signer_to_eth_requestAccounts', result: [] })
-		sendMessageToApprovedWebsitePorts(websiteTabConnections, { method: 'request_signer_chainId', result: [] })
+		sendMessageToApprovedWebsitePorts(websiteTabConnections, { options: { method: 'request_signer_to_eth_requestAccounts', params: [] } })
+		sendMessageToApprovedWebsitePorts(websiteTabConnections, { options: { method: 'request_signer_chainId', params: [] } })
 		
 		await changeActiveAddressAndChainAndResetSimulation(websiteTabConnections, {
 			simulationMode: addressChange.options.simulationMode,
@@ -144,8 +144,8 @@ export async function changePage(page: ChangePage) {
 
 export async function requestAccountsFromSigner(websiteTabConnections: WebsiteTabConnections, params: RequestAccountsFromSigner) {
 	if (params.options) {
-		sendMessageToApprovedWebsitePorts(websiteTabConnections, { method: 'request_signer_to_eth_requestAccounts', result: [] })
-		sendMessageToApprovedWebsitePorts(websiteTabConnections, { method: 'request_signer_chainId', result: [] })
+		sendMessageToApprovedWebsitePorts(websiteTabConnections, { options: { method: 'request_signer_to_eth_requestAccounts', params: [] } })
+		sendMessageToApprovedWebsitePorts(websiteTabConnections, { options: { method: 'request_signer_chainId', params: [] } })
 	}
 }
 
@@ -216,8 +216,8 @@ export async function enableSimulationMode(websiteTabConnections: WebsiteTabConn
 	const settings = await getSettings()
 	// if we are on unsupported chain, force change to a supported one
 	if (settings.useSignersAddressAsActiveAddress || params.options === false) {
-		sendMessageToApprovedWebsitePorts(websiteTabConnections, { method: 'request_signer_to_eth_requestAccounts' as const, result: [] })
-		sendMessageToApprovedWebsitePorts(websiteTabConnections, { method: 'request_signer_chainId' as const, result: [] })
+		sendMessageToApprovedWebsitePorts(websiteTabConnections, { options: { method: 'request_signer_to_eth_requestAccounts' as const, params: [] } })
+		sendMessageToApprovedWebsitePorts(websiteTabConnections, { options: { method: 'request_signer_chainId' as const, params: [] } })
 		const tabId = await getLastKnownCurrentTabId()
 		const chainToSwitch = tabId === undefined ? undefined : (await getTabState(tabId)).signerChain
 		await changeActiveAddressAndChainAndResetSimulation(websiteTabConnections, {

--- a/app/ts/background/popupMessageHandlers.ts
+++ b/app/ts/background/popupMessageHandlers.ts
@@ -29,7 +29,7 @@ export async function confirmPersonalSign(websiteTabConnections: WebsiteTabConne
 }
 
 export async function confirmRequestAccess(websiteTabConnections: WebsiteTabConnections, confirmation: InterceptorAccess) {
-	await resolveInterceptorAccess(websiteTabConnections, confirmation.options)
+	await resolveInterceptorAccess(websiteTabConnections, confirmation.data)
 }
 
 export async function getLastKnownCurrentTabId() {
@@ -53,63 +53,63 @@ export async function getSignerAccount() {
 export async function changeActiveAddress(websiteTabConnections: WebsiteTabConnections, addressChange: ChangeActiveAddress) {
 
 	// if using signers address, set the active address to signers address if available, otherwise we don't know active address and set it to be undefined
-	if (addressChange.options.activeAddress === 'signer') {
+	if (addressChange.data.activeAddress === 'signer') {
 		const signerAccount = await getSignerAccount()
-		await setUseSignersAddressAsActiveAddress(addressChange.options.activeAddress === 'signer', signerAccount)
+		await setUseSignersAddressAsActiveAddress(addressChange.data.activeAddress === 'signer', signerAccount)
 
-		sendMessageToApprovedWebsitePorts(websiteTabConnections, { options: { method: 'request_signer_to_eth_requestAccounts', params: [] } })
-		sendMessageToApprovedWebsitePorts(websiteTabConnections, { options: { method: 'request_signer_chainId', params: [] } })
+		sendMessageToApprovedWebsitePorts(websiteTabConnections, { method: 'request_signer_to_eth_requestAccounts', result: [] })
+		sendMessageToApprovedWebsitePorts(websiteTabConnections, { method: 'request_signer_chainId', result: [] } )
 		
 		await changeActiveAddressAndChainAndResetSimulation(websiteTabConnections, {
-			simulationMode: addressChange.options.simulationMode,
+			simulationMode: addressChange.data.simulationMode,
 			activeAddress: signerAccount,
 		})
 	} else {
 		await setUseSignersAddressAsActiveAddress(false)
 		await changeActiveAddressAndChainAndResetSimulation(websiteTabConnections, {
-			simulationMode: addressChange.options.simulationMode,
-			activeAddress: addressChange.options.activeAddress,
+			simulationMode: addressChange.data.simulationMode,
+			activeAddress: addressChange.data.activeAddress,
 		})
 	}
 }
 
 export async function changeMakeMeRich(ethereumClientService: EthereumClientService, makeMeRichChange: ChangeMakeMeRich, settings: Settings) {
-	await setMakeMeRich(makeMeRichChange.options)
+	await setMakeMeRich(makeMeRichChange.data)
 	await updateSimulationState(async () => {
 		const simulationState = (await getSimulationResults()).simulationState
 		if (simulationState === undefined) return undefined
-		const prependQueue = await getPrependTrasactions(ethereumClientService, settings, makeMeRichChange.options)
+		const prependQueue = await getPrependTrasactions(ethereumClientService, settings, makeMeRichChange.data)
 		return await resetSimulationState(ethereumClientService, { ...simulationState, prependTransactionsQueue: prependQueue })
 	}, settings.activeSimulationAddress)
 }
 
 export async function removeAddressBookEntry(websiteTabConnections: WebsiteTabConnections, removeAddressBookEntry: RemoveAddressBookEntry) {
-	switch(removeAddressBookEntry.options.addressBookCategory) {
+	switch(removeAddressBookEntry.data.addressBookCategory) {
 		case 'My Active Addresses': {
-			await updateAddressInfos((previousAddressInfos) => previousAddressInfos.filter((info) => info.address !== removeAddressBookEntry.options.address))
+			await updateAddressInfos((previousAddressInfos) => previousAddressInfos.filter((info) => info.address !== removeAddressBookEntry.data.address))
 			updateWebsiteApprovalAccesses(websiteTabConnections, undefined, await getSettings())
 			return await sendPopupMessageToOpenWindows({ method: 'popup_addressBookEntriesChanged' })
 		}
 		case 'My Contacts': {
-			await updateContacts((previousContacts) => previousContacts.filter((contact) => contact.address !== removeAddressBookEntry.options.address))
+			await updateContacts((previousContacts) => previousContacts.filter((contact) => contact.address !== removeAddressBookEntry.data.address))
 			return await sendPopupMessageToOpenWindows({ method: 'popup_addressBookEntriesChanged' })
 		}
 		case 'Non Fungible Tokens':
 		case 'Other Contracts':
 		case 'Tokens': throw new Error('Tried to remove addressbook category that is not supported yet!')
-		default: assertUnreachable(removeAddressBookEntry.options.addressBookCategory)
+		default: assertUnreachable(removeAddressBookEntry.data.addressBookCategory)
 	}
 }
 
 export async function addOrModifyAddressInfo(websiteTabConnections: WebsiteTabConnections, entry: AddOrEditAddressBookEntry) {
-	const newEntry = entry.options
+	const newEntry = entry.data
 	switch (newEntry.type) {
 		case 'NFT':
 		case 'other contract':
 		case 'token': throw new Error(`No support to modify this entry yet! ${ newEntry.type }`)
 		case 'addressInfo': {
 			await updateAddressInfos((previousAddressInfos) => {
-				if (previousAddressInfos.find((x) => x.address === entry.options.address) ) {
+				if (previousAddressInfos.find((x) => x.address === entry.data.address) ) {
 					return previousAddressInfos.map((x) => x.address === newEntry.address ? newEntry : x )
 				} else {
 					return previousAddressInfos.concat([newEntry])
@@ -120,7 +120,7 @@ export async function addOrModifyAddressInfo(websiteTabConnections: WebsiteTabCo
 		}
 		case 'contact': {
 			await updateContacts((previousContacts) => {
-				if (previousContacts.find( (x) => x.address === entry.options.address) ) {
+				if (previousContacts.find( (x) => x.address === entry.data.address) ) {
 					return previousContacts.map( (x) => x.address === newEntry.address ? newEntry : x )
 				} else {
 					return previousContacts.concat([newEntry])
@@ -133,19 +133,19 @@ export async function addOrModifyAddressInfo(websiteTabConnections: WebsiteTabCo
 }
 
 export async function changeInterceptorAccess(websiteTabConnections: WebsiteTabConnections, accessChange: ChangeInterceptorAccess) {
-	await updateWebsiteAccess(() => accessChange.options) // TODO: update 'popup_changeInterceptorAccess' to return list of changes instead of a new list
+	await updateWebsiteAccess(() => accessChange.data) // TODO: update 'popup_changeInterceptorAccess' to return list of changes instead of a new list
 	updateWebsiteApprovalAccesses(websiteTabConnections, undefined, await getSettings())
 	return await sendPopupMessageToOpenWindows({ method: 'popup_interceptor_access_changed' })
 }
 
 export async function changePage(page: ChangePage) {
-	await setPage(page.options)
+	await setPage(page.data)
 }
 
 export async function requestAccountsFromSigner(websiteTabConnections: WebsiteTabConnections, params: RequestAccountsFromSigner) {
-	if (params.options) {
-		sendMessageToApprovedWebsitePorts(websiteTabConnections, { options: { method: 'request_signer_to_eth_requestAccounts', params: [] } })
-		sendMessageToApprovedWebsitePorts(websiteTabConnections, { options: { method: 'request_signer_chainId', params: [] } })
+	if (params.data) {
+		sendMessageToApprovedWebsitePorts(websiteTabConnections, { method: 'request_signer_to_eth_requestAccounts', result: [] })
+		sendMessageToApprovedWebsitePorts(websiteTabConnections, { method: 'request_signer_chainId', result: [] })
 	}
 }
 
@@ -161,7 +161,7 @@ export async function removeTransaction(ethereumClientService: EthereumClientSer
 	await updateSimulationState(async () => {
 		const simulationState = (await getSimulationResults()).simulationState
 		if (simulationState === undefined) return
-		return await removeTransactionAndUpdateTransactionNonces(ethereumClientService, simulationState, params.options)
+		return await removeTransactionAndUpdateTransactionNonces(ethereumClientService, simulationState, params.data)
 	}, settings.activeSimulationAddress)
 }
 
@@ -205,7 +205,7 @@ export async function refreshPopupConfirmTransactionSimulation(ethereumClientSer
 }
 
 export async function popupChangeActiveChain(websiteTabConnections: WebsiteTabConnections, params: ChangeActiveChain, settings: Settings) {
-	return await changeActiveChain(websiteTabConnections, params.options, settings.simulationMode)
+	return await changeActiveChain(websiteTabConnections, params.data, settings.simulationMode)
 }
 
 export async function changeChainDialog(websiteTabConnections: WebsiteTabConnections, chainChange: ChainChangeConfirmation) {
@@ -215,20 +215,20 @@ export async function changeChainDialog(websiteTabConnections: WebsiteTabConnect
 export async function enableSimulationMode(websiteTabConnections: WebsiteTabConnections, params: EnableSimulationMode) {
 	const settings = await getSettings()
 	// if we are on unsupported chain, force change to a supported one
-	if (settings.useSignersAddressAsActiveAddress || params.options === false) {
-		sendMessageToApprovedWebsitePorts(websiteTabConnections, { options: { method: 'request_signer_to_eth_requestAccounts' as const, params: [] } })
-		sendMessageToApprovedWebsitePorts(websiteTabConnections, { options: { method: 'request_signer_chainId' as const, params: [] } })
+	if (settings.useSignersAddressAsActiveAddress || params.data === false) {
+		sendMessageToApprovedWebsitePorts(websiteTabConnections, { method: 'request_signer_to_eth_requestAccounts', result: [] })
+		sendMessageToApprovedWebsitePorts(websiteTabConnections, { method: 'request_signer_chainId', result: [] })
 		const tabId = await getLastKnownCurrentTabId()
 		const chainToSwitch = tabId === undefined ? undefined : (await getTabState(tabId)).signerChain
 		await changeActiveAddressAndChainAndResetSimulation(websiteTabConnections, {
-			simulationMode: params.options,
+			simulationMode: params.data,
 			activeAddress: await getSignerAccount(),
 			...chainToSwitch === undefined ? {} :  { activeChain: chainToSwitch },
 		})
 	} else {
 		const chainToSwitch = isSupportedChain(settings.activeChain.toString()) ? settings.activeChain : 1n
 		await changeActiveAddressAndChainAndResetSimulation(websiteTabConnections, {
-			simulationMode: params.options,
+			simulationMode: params.data,
 			...settings.activeChain === chainToSwitch ? {} : { activeChain: chainToSwitch }
 		})
 	}
@@ -236,11 +236,11 @@ export async function enableSimulationMode(websiteTabConnections: WebsiteTabConn
 
 export async function getAddressBookData(parsed: GetAddressBookData, userAddressBook: UserAddressBook | undefined) {
 	if (userAddressBook === undefined) throw new Error('Interceptor is not ready')
-	const data = getMetadataForAddressBookData(parsed.options, userAddressBook)
+	const data = getMetadataForAddressBookData(parsed.data, userAddressBook)
 	await sendPopupMessageToOpenWindows({
 		method: 'popup_getAddressBookDataReply',
 		data: {
-			options: parsed.options,
+			data: parsed.data,
 			entries: data.entries,
 			maxDataLength: data.maxDataLength,
 		}

--- a/app/ts/background/providerMessageHandlers.ts
+++ b/app/ts/background/providerMessageHandlers.ts
@@ -80,12 +80,10 @@ export async function connectedToSigner(_websiteTabConnections: WebsiteTabConnec
 	const settings = await getSettings()
 	if (!settings.simulationMode || settings.useSignersAddressAsActiveAddress) {
 		postMessageToPortIfConnected(port, {
-			interceptorApproved: true,
 			options: { method: 'request_signer_to_eth_requestAccounts' },
 			result: []
 		})
 		postMessageToPortIfConnected(port, {
-			interceptorApproved: true,
 			options: { method: 'request_signer_chainId' },
 			result: []
 		})

--- a/app/ts/background/providerMessageHandlers.ts
+++ b/app/ts/background/providerMessageHandlers.ts
@@ -6,12 +6,14 @@ import { getSocketFromPort, sendInternalWindowMessage, sendPopupMessageToOpenWin
 import { getTabState, setSignerName, updateTabState } from './storageVariables.js'
 import { getSettings } from './settings.js'
 import { resolveSignerChainChange } from './windows/changeChain.js'
+import { ApprovalState } from './accessManagement.js'
 
-export async function ethAccountsReply(websiteTabConnections: WebsiteTabConnections, port: browser.runtime.Port, request: ProviderMessage) {
+export async function ethAccountsReply(websiteTabConnections: WebsiteTabConnections, port: browser.runtime.Port, request: ProviderMessage, _connectInfoapproval: ApprovalState) {
 	if (!('params' in request)) return
 	if (port.sender?.tab?.id === undefined) return
 
-	const signerAccounts = EthereumAccountsReply.parse(request.params)
+	const signerAccountsReply = EthereumAccountsReply.parse(request.params)
+	const signerAccounts = signerAccountsReply[0]
 	const activeSigningAddress = signerAccounts.length > 0 ? signerAccounts[0] : undefined
 	const tabStateChange = await updateTabState(port.sender.tab.id, (previousState: TabState) => {
 		return {
@@ -34,7 +36,8 @@ export async function ethAccountsReply(websiteTabConnections: WebsiteTabConnecti
 	}
 }
 
-async function changeSignerChain(websiteTabConnections: WebsiteTabConnections, port: browser.runtime.Port, signerChain: bigint) {
+async function changeSignerChain(websiteTabConnections: WebsiteTabConnections, port: browser.runtime.Port, signerChain: bigint, approval: ApprovalState) {
+	if (approval !== 'hasAccess') return
 	if (port.sender?.tab?.id === undefined) return
 	if ((await getTabState(port.sender.tab.id)).signerChain === signerChain) return
 
@@ -56,15 +59,16 @@ async function changeSignerChain(websiteTabConnections: WebsiteTabConnections, p
 	sendPopupMessageToOpenWindows({ method: 'popup_chain_update' })
 }
 
-export async function signerChainChanged(websiteTabConnections: WebsiteTabConnections, port: browser.runtime.Port, request: ProviderMessage) {
+export async function signerChainChanged(websiteTabConnections: WebsiteTabConnections, port: browser.runtime.Port, request: ProviderMessage, approval: ApprovalState) {
 	if (!('params' in request)) return
 	const signerChain = EthereumChainReply.parse(request.params)[0]
-	await changeSignerChain(websiteTabConnections, port, signerChain)
+	await changeSignerChain(websiteTabConnections, port, signerChain, approval)
 }
 
-export async function walletSwitchEthereumChainReply(websiteTabConnections: WebsiteTabConnections, port: browser.runtime.Port, request: ProviderMessage) {
+export async function walletSwitchEthereumChainReply(websiteTabConnections: WebsiteTabConnections, port: browser.runtime.Port, request: ProviderMessage, approval: ApprovalState) {
+	if (approval !== 'hasAccess') return
 	const params = WalletSwitchEthereumChainReply.parse(request).params[0]
-	if (params.accept) await changeSignerChain(websiteTabConnections, port, params.chainId)
+	if (params.accept) await changeSignerChain(websiteTabConnections, port, params.chainId, approval)
 	await resolveSignerChainChange({
 		method: 'popup_signerChangeChainDialog',
 		data: {
@@ -74,12 +78,16 @@ export async function walletSwitchEthereumChainReply(websiteTabConnections: Webs
 	})
 }
 
-export async function connectedToSigner(_websiteTabConnections: WebsiteTabConnections, port: browser.runtime.Port, request: ProviderMessage) {
+export async function connectedToSigner(_websiteTabConnections: WebsiteTabConnections, port: browser.runtime.Port, request: ProviderMessage, approval: ApprovalState) {
 	await setSignerName(ConnectedToSigner.parse(request).params[0])
 	await sendPopupMessageToOpenWindows({ method: 'popup_signer_name_changed' })
 	const settings = await getSettings()
 	if (!settings.simulationMode || settings.useSignersAddressAsActiveAddress) {
-		postMessageToPortIfConnected(port, { method: 'request_signer_to_eth_requestAccounts' as const, result: [] })
+		if (approval === 'hasAccess') {
+			postMessageToPortIfConnected(port, { method: 'request_signer_to_eth_requestAccounts' as const, result: [] })
+		} else {
+			postMessageToPortIfConnected(port, { method: 'request_signer_to_eth_accounts' as const, result: [] })
+		}
 		postMessageToPortIfConnected(port, { method: 'request_signer_chainId' as const, result: [] })
 	}
 }

--- a/app/ts/background/providerMessageHandlers.ts
+++ b/app/ts/background/providerMessageHandlers.ts
@@ -79,13 +79,7 @@ export async function connectedToSigner(_websiteTabConnections: WebsiteTabConnec
 	await sendPopupMessageToOpenWindows({ method: 'popup_signer_name_changed' })
 	const settings = await getSettings()
 	if (!settings.simulationMode || settings.useSignersAddressAsActiveAddress) {
-		postMessageToPortIfConnected(port, {
-			options: { method: 'request_signer_to_eth_requestAccounts' },
-			result: []
-		})
-		postMessageToPortIfConnected(port, {
-			options: { method: 'request_signer_chainId' },
-			result: []
-		})
+		postMessageToPortIfConnected(port, { requestId: request.requestId, options: { method: 'request_signer_to_eth_requestAccounts' as const, params: [] } })
+		postMessageToPortIfConnected(port, { requestId: request.requestId, options: { method: 'request_signer_chainId' as const, params: [] } })
 	}
 }

--- a/app/ts/background/simulationModeHanders.ts
+++ b/app/ts/background/simulationModeHanders.ts
@@ -4,7 +4,7 @@ import { createEthereumSubscription, removeEthereumSubscription } from '../simul
 import { simulationGasLeft, getSimulatedBalance, getSimulatedBlock, getSimulatedBlockNumber, getSimulatedCode, getSimulatedLogs, getSimulatedStack, getSimulatedTransactionByHash, getSimulatedTransactionCount, getSimulatedTransactionReceipt, simulatedCall, simulateEstimateGas, getInputFieldFromDataOrInput } from '../simulation/services/SimulationModeEthereumClientService.js'
 import { dataStringWith0xStart, stringToUint8Array } from '../utils/bigint.js'
 import { CANNOT_SIMULATE_OFF_LEGACY_BLOCK, ERROR_INTERCEPTOR_GAS_ESTIMATION_FAILED, ERROR_INTERCEPTOR_GET_CODE_FAILED, KNOWN_CONTRACT_CALLER_ADDRESSES } from '../utils/constants.js'
-import { InterceptedRequest, Settings } from '../utils/interceptor-messages.js'
+import { InterceptedRequest, RPCReply, Settings } from '../utils/interceptor-messages.js'
 import { Website, WebsiteSocket, WebsiteTabConnections } from '../utils/user-interface-types.js'
 import { SimulationState } from '../utils/visualizer-types.js'
 import { EstimateGasParams, EthBalanceParams, EthBlockByNumberParams, EthCallParams, EthereumAddress, EthGetLogsParams, EthSubscribeParams, EthUnSubscribeParams, GetCode, GetSimulationStack, GetTransactionCount, OldSignTypedDataParams, PersonalSignParams, SendRawTransaction, SendTransactionParams, SignTypedDataParams, SwitchEthereumChainParams, TransactionByHashParams, TransactionReceiptParams } from '../utils/wire-types.js'
@@ -18,18 +18,18 @@ import { assertNever } from '../utils/typescript.js'
 const defaultCallAddress = 0x1n
 
 export async function getBlockByNumber(ethereumClientService: EthereumClientService, simulationState: SimulationState | undefined, request: EthBlockByNumberParams) {
-	return { options: request, result: await getSimulatedBlock(ethereumClientService, simulationState, request.params[0], request.params[1]) }
+	return { method: request.method, result: await getSimulatedBlock(ethereumClientService, simulationState, request.params[0], request.params[1]) }
 }
 export async function getBalance(ethereumClientService: EthereumClientService, simulationState: SimulationState | undefined, request: EthBalanceParams) {
-	return { options: request, result: await getSimulatedBalance(ethereumClientService, simulationState, request.params[0]) }
+	return { method: request.method, result: await getSimulatedBalance(ethereumClientService, simulationState, request.params[0]) }
 }
 export async function getTransactionByHash(ethereumClientService: EthereumClientService, simulationState: SimulationState | undefined, request: TransactionByHashParams) {
 	const result = await getSimulatedTransactionByHash(ethereumClientService, simulationState, request.params[0])
-	if (result === undefined) return { options: request, result: undefined }
-	return { options: request, result: result }
+	if (result === undefined) return { method: request.method, result: undefined }
+	return { method: request.method, result: result }
 }
 export async function getTransactionReceipt(ethereumClientService: EthereumClientService, simulationState: SimulationState | undefined, request: TransactionReceiptParams) {
-	return { options: request, result: await getSimulatedTransactionReceipt(ethereumClientService, simulationState, request.params[0]) }
+	return { method: request.method, result: await getSimulatedTransactionReceipt(ethereumClientService, simulationState, request.params[0]) }
 }
 
 function getFromField(websiteTabConnections: WebsiteTabConnections, simulationMode: boolean, transactionFrom: bigint | undefined, activeAddress: bigint | undefined, socket: WebsiteSocket) {
@@ -91,15 +91,18 @@ export async function sendTransaction(
 			transactionSendingFormat: 'eth_sendTransaction' as const,
 		}
 	}
-	return { options: sendTransactionParams, ...await openConfirmTransactionDialog(
-		ethereumClientService,
-		socket,
-		request,
-		simulationMode,
-		formTransaction,
-		activeAddress,
-		sendTransactionParams,
-	) }
+	return {
+		method: sendTransactionParams.method,
+		...await openConfirmTransactionDialog(
+			ethereumClientService,
+			socket,
+			request,
+			sendTransactionParams,
+			simulationMode,
+			formTransaction,
+			activeAddress,
+		)
+	}
 }
 
 export async function sendRawTransaction(
@@ -150,15 +153,17 @@ export async function sendRawTransaction(
 			transactionSendingFormat: 'eth_sendRawTransaction' as const,
 		}
 	}
-	return { options: sendRawTransactionParams, ...await openConfirmTransactionDialog(
-		ethereumClientService,
-		socket,
-		request,
-		simulationMode,
-		formTransaction,
-		activeAddress,
-		sendRawTransactionParams,
-	) }
+	return { method: sendRawTransactionParams.method,
+		...await openConfirmTransactionDialog(
+			ethereumClientService,
+			socket,
+			request,
+			sendRawTransactionParams,
+			simulationMode,
+			formTransaction,
+			activeAddress,
+		)
+	}
 }
 
 async function singleCallWithFromOverride(ethereumClientService: EthereumClientService, simulationState: SimulationState | undefined, request: EthCallParams, from: bigint) {
@@ -189,81 +194,82 @@ export async function call(ethereumClientService: EthereumClientService, simulat
 	const from = callParams.from !== undefined && !KNOWN_CONTRACT_CALLER_ADDRESSES.includes(callParams.from) ? callParams.from : defaultCallAddress
 	const callResult = await singleCallWithFromOverride(ethereumClientService, simulationState, request, from)
 
-	if (callResult.error !== undefined && callResult.error.code === ERROR_INTERCEPTOR_GAS_ESTIMATION_FAILED ) {
-		return callResult
-	}
+	if (callResult.error !== undefined && callResult.error.code === ERROR_INTERCEPTOR_GAS_ESTIMATION_FAILED ) return { method: request.method, ...callResult }
 
 	// if we fail our call because we are calling from a contract, retry and change address to our default calling address
 	// TODO: Remove this logic and KNOWN_CONTRACT_CALLER_ADDRESSES when multicall supports calling from contracts
 	if (callResult.error !== undefined && 'data' in callResult.error && callResult.error?.data === 'sender has deployed code' && from !== defaultCallAddress) {
 		const callerChangeResult = await singleCallWithFromOverride(ethereumClientService, simulationState, request, defaultCallAddress)
-		if (callerChangeResult.error !== undefined) return callerChangeResult
-		return { options: request, ...callerChangeResult }
+		if (callerChangeResult.error !== undefined) return { method: request.method, ...callerChangeResult }
+		return { method: request.method, ...callerChangeResult }
 	}
-	return { options: request, ...callResult }
+	return { method: request.method, ...callResult }
 }
 
 export async function blockNumber(ethereumClientService: EthereumClientService, simulationState: SimulationState | undefined) {
-	return { options: { method: 'eth_blockNumber' } as const, result: await getSimulatedBlockNumber(ethereumClientService, simulationState) }
+	return { method: 'eth_blockNumber' as const, result: await getSimulatedBlockNumber(ethereumClientService, simulationState) }
 }
 
-export async function estimateGas(ethereumClientService: EthereumClientService, simulationState: SimulationState | undefined, request: EstimateGasParams) {
+export async function estimateGas(ethereumClientService: EthereumClientService, simulationState: SimulationState | undefined, request: EstimateGasParams){
 	const estimatedGas = await simulateEstimateGas(ethereumClientService, simulationState, request.params[0])
-	if ('error' in estimatedGas) return estimatedGas
-	return { options: request, result: estimatedGas.gas }
+	if ('error' in estimatedGas) return { method: request.method, ...estimatedGas }
+	return { method: request.method, result: estimatedGas.gas }
 }
 
 export async function subscribe(socket: WebsiteSocket, request: EthSubscribeParams) {
-	return { options: request, result: await createEthereumSubscription(request, socket) }
+	return { method: request.method, result: await createEthereumSubscription(request, socket) }
 }
 
 export async function unsubscribe(socket: WebsiteSocket, request: EthUnSubscribeParams) {
-	return { options: request, result: await removeEthereumSubscription(socket, request.params[0]) }
+	return { method: request.method, result: await removeEthereumSubscription(socket, request.params[0]) }
 }
 
 export async function getAccounts(activeAddress: bigint | undefined) {
-	if (activeAddress === undefined) return { options: { method: 'eth_accounts' } as const, result: [] }
-	return { options: { method: 'eth_accounts' } as const, result: [activeAddress] }
+	if (activeAddress === undefined) return { method: 'eth_accounts' as const, result: [] }
+	return { method: 'eth_accounts' as const, result: [activeAddress] }
 }
 
 export async function chainId(ethereumClientService: EthereumClientService) {
-	return { options: { method: 'eth_chainId' } as const, result: ethereumClientService.getChainId() }
+	return { method: 'eth_chainId' as const, result: ethereumClientService.getChainId() }
 }
 
 export async function gasPrice(ethereumClientService: EthereumClientService) {
-	return { options: { method: 'eth_gasPrice' } as const, result: await ethereumClientService.getGasPrice() }
+	return { method: 'eth_gasPrice' as const, result: await ethereumClientService.getGasPrice() }
 }
 
-export async function personalSign(ethereumClientService: EthereumClientService, websiteTabConnections: WebsiteTabConnections, socket: WebsiteSocket, params: PersonalSignParams | SignTypedDataParams | OldSignTypedDataParams, request: InterceptedRequest, simulationMode: boolean, website: Website, settings: Settings, activeAddress: bigint | undefined) {
-	return await openPersonalSignDialog(ethereumClientService, websiteTabConnections, socket, params, request, simulationMode, website, settings, activeAddress)
+export async function personalSign(ethereumClientService: EthereumClientService, websiteTabConnections: WebsiteTabConnections, socket: WebsiteSocket, params: PersonalSignParams | SignTypedDataParams | OldSignTypedDataParams, request: InterceptedRequest, simulationMode: boolean, website: Website, settings: Settings, activeAddress: bigint | undefined): Promise<RPCReply> {
+	return {
+		method: params.method,
+		...await openPersonalSignDialog(ethereumClientService, websiteTabConnections, socket, params, request, simulationMode, website, settings, activeAddress),
+	}
 }
 
 export async function switchEthereumChain(websiteTabConnections: WebsiteTabConnections, socket: WebsiteSocket, ethereumClientService: EthereumClientService, params: SwitchEthereumChainParams, request: InterceptedRequest, simulationMode: boolean, website: Website) {
 	if (ethereumClientService.getChainId() === params.params[0]) {
 		// we are already on the right chain
-		return { options: params, result: null }
+		return { method: params.method, result: null }
 	}
-	return { options: params, ... await openChangeChainDialog(websiteTabConnections, socket, request, simulationMode, website, params) }
+	return {  method: params.method, ... await openChangeChainDialog(websiteTabConnections, socket, request, simulationMode, website, params) }
 }
 
 export async function getCode(ethereumClientService: EthereumClientService, simulationState: SimulationState | undefined, request: GetCode) {
 	const code = await getSimulatedCode(ethereumClientService, simulationState, request.params[0], request.params[1])
-	if (code.statusCode === 'failure') return ERROR_INTERCEPTOR_GET_CODE_FAILED
-	return { options: request, result: code.getCodeReturn }
+	if (code.statusCode === 'failure') return { method: request.method, ...ERROR_INTERCEPTOR_GET_CODE_FAILED }
+	return { method: request.method, result: code.getCodeReturn }
 }
 
 export async function getPermissions() {
-	return { options: { method: 'wallet_getPermissions' } as const, result: [ { "eth_accounts": {} } ] } as const
+	return { method: 'wallet_getPermissions', params: [], result: [ { "eth_accounts": {} } ] } as const
 }
 
 export async function getTransactionCount(ethereumClientService: EthereumClientService, simulationState: SimulationState | undefined, request: GetTransactionCount) {
-	return { options: request, result: await getSimulatedTransactionCount(ethereumClientService, simulationState, request.params[0], request.params[1]) }
+	return { method: request.method, result: await getSimulatedTransactionCount(ethereumClientService, simulationState, request.params[0], request.params[1]) }
 }
 
 export async function getSimulationStack(simulationState: SimulationState | undefined, request: GetSimulationStack) {
 	switch (request.params[0]) {
 		case '1.0.0': return {
-			options: request,
+			method: request.method,
 			result: {
 				version: '1.0.0',
 				payload: simulationState === undefined ? [] : getSimulatedStack(simulationState),
@@ -274,5 +280,5 @@ export async function getSimulationStack(simulationState: SimulationState | unde
 }
 
 export async function getLogs(ethereumClientService: EthereumClientService, simulationState: SimulationState | undefined, request: EthGetLogsParams) {
-	return { options: request, result: await getSimulatedLogs(ethereumClientService, simulationState, request.params[0]) }
+	return { method: request.method, result: await getSimulatedLogs(ethereumClientService, simulationState, request.params[0]) }
 }

--- a/app/ts/background/simulationModeHanders.ts
+++ b/app/ts/background/simulationModeHanders.ts
@@ -245,11 +245,12 @@ export async function personalSign(ethereumClientService: EthereumClientService,
 }
 
 export async function switchEthereumChain(websiteTabConnections: WebsiteTabConnections, socket: WebsiteSocket, ethereumClientService: EthereumClientService, params: SwitchEthereumChainParams, request: InterceptedRequest, simulationMode: boolean, website: Website) {
-	if (ethereumClientService.getChainId() === params.params[0]) {
+	if (ethereumClientService.getChainId() === params.params[0].chainId) {
 		// we are already on the right chain
 		return { method: params.method, result: null }
 	}
-	return {  method: params.method, ... await openChangeChainDialog(websiteTabConnections, socket, request, simulationMode, website, params) }
+	const change = await openChangeChainDialog(websiteTabConnections, socket, request, simulationMode, website, params)
+	return { method: params.method, ...change }
 }
 
 export async function getCode(ethereumClientService: EthereumClientService, simulationState: SimulationState | undefined, request: GetCode) {

--- a/app/ts/background/storageVariables.ts
+++ b/app/ts/background/storageVariables.ts
@@ -193,9 +193,11 @@ export async function getEthereumSubscriptions() {
 
 const ethereumSubscriptionsSemaphore = new Semaphore(1)
 export async function updateEthereumSubscriptions(updateFunc: (prevState: EthereumSubscriptions) => EthereumSubscriptions) {
-	await ethereumSubscriptionsSemaphore.execute(async () => {
-		const subscriptions = EthereumSubscriptions.parse(await browserStorageLocalSingleGetWithDefault('ethereumSubscriptions', []))
-		return await browserStorageLocalSet('ethereumSubscriptions', EthereumSubscriptions.serialize(updateFunc(subscriptions)) as string)
+	return await ethereumSubscriptionsSemaphore.execute(async () => {
+		const oldSubscriptions = EthereumSubscriptions.parse(await browserStorageLocalSingleGetWithDefault('ethereumSubscriptions', []))
+		const newSubscriptions = updateFunc(oldSubscriptions)
+		await browserStorageLocalSet('ethereumSubscriptions', EthereumSubscriptions.serialize(newSubscriptions) as string)
+		return { oldSubscriptions, newSubscriptions }
 	})
 }
 

--- a/app/ts/background/windows/changeChain.ts
+++ b/app/ts/background/windows/changeChain.ts
@@ -131,13 +131,13 @@ async function resolve(websiteTabConnections: WebsiteTabConnections, reply: Chai
 	if (reply.options.accept) {
 		if (simulationMode) {
 			await changeActiveChain(websiteTabConnections, reply.options.chainId, simulationMode)
-			return { result: null }
+			return { method: 'wallet_switchEthereumChain' as const, result: null }
 		}
 		pendForSignerReply = new Future<SignerChainChangeConfirmation>() // when not in simulation mode, we need to get reply from the signer too
 		await changeActiveChain(websiteTabConnections, reply.options.chainId, simulationMode)
 		const signerReply = await pendForSignerReply
 		if (signerReply.options.accept && signerReply.options.chainId === reply.options.chainId) {
-			return { result: null }
+			return { method: 'wallet_switchEthereumChain' as const, result: null }
 		}
 	}
 	return userDeniedChange

--- a/app/ts/background/windows/changeChain.ts
+++ b/app/ts/background/windows/changeChain.ts
@@ -63,7 +63,7 @@ export const openChangeChainDialog = async (
 		if (openedDialog === undefined || openedDialog.windowOrTab.id !== windowId) return
 		openedDialog = undefined
 		if (pendForUserReply === undefined) return
-		resolveChainChange(websiteTabConnections, rejectMessage(params.params[0], request.requestId))
+		resolveChainChange(websiteTabConnections, rejectMessage(params.params[0].chainId, request.requestId))
 	}
 
 	const changeChainWindowReadyAndListening = async function popupMessageListener(msg: unknown) {
@@ -74,7 +74,7 @@ export const openChangeChainDialog = async (
 			method: 'popup_ChangeChainRequest',
 			data: {
 				requestId: request.requestId,
-				chainId: params.params[0],
+				chainId: params.params[0].chainId,
 				website: website,
 				simulationMode: simulationMode,
 				tabIdOpenedFrom: socket.tabId,
@@ -112,7 +112,7 @@ export const openChangeChainDialog = async (
 				simulationMode: simulationMode,
 			})
 		} else {
-			resolveChainChange(websiteTabConnections, rejectMessage(params.params[0], request.requestId))
+			resolveChainChange(websiteTabConnections, rejectMessage(params.params[0].chainId, request.requestId))
 		}
 		pendForSignerReply = undefined
 

--- a/app/ts/background/windows/changeChain.ts
+++ b/app/ts/background/windows/changeChain.ts
@@ -3,7 +3,8 @@ import { METAMASK_ERROR_USER_REJECTED_REQUEST } from '../../utils/constants.js'
 import { Future } from '../../utils/future.js'
 import { ChainChangeConfirmation, InterceptedRequest, ExternalPopupMessage, SignerChainChangeConfirmation } from '../../utils/interceptor-messages.js'
 import { Website, WebsiteSocket, WebsiteTabConnections } from '../../utils/user-interface-types.js'
-import { changeActiveChain, sendMessageToContentScript } from '../background.js'
+import { SwitchEthereumChainParams } from '../../utils/wire-types.js'
+import { changeActiveChain, postMessageIfStillConnected } from '../background.js'
 import { getHtmlFile, sendPopupMessageToOpenWindows } from '../backgroundUtils.js'
 import { getChainChangeConfirmationPromise, setChainChangeConfirmationPromise } from '../storageVariables.js'
 
@@ -20,7 +21,7 @@ export async function resolveChainChange(websiteTabConnections: WebsiteTabConnec
 	const data = await getChainChangeConfirmationPromise()
 	if (data === undefined || confirmation.options.requestId !== data.request.requestId) return
 	const resolved = await resolve(websiteTabConnections, confirmation, data.simulationMode)
-	sendMessageToContentScript(websiteTabConnections, data.socket, resolved, data.request)
+	postMessageIfStillConnected(websiteTabConnections, data.socket, { options: { method: 'wallet_switchEthereumChain' as const, params: [confirmation.options.chainId] }, ...resolved, requestId: data.request.requestId })
 }
 
 export async function resolveSignerChainChange(confirmation: SignerChainChangeConfirmation) {
@@ -28,10 +29,11 @@ export async function resolveSignerChainChange(confirmation: SignerChainChangeCo
 	pendForSignerReply = undefined
 }
 
-function rejectMessage(requestId: number) {
+function rejectMessage(chainId: bigint, requestId: number) {
 	return {
 		method: 'popup_changeChainDialog',
 		options: {
+			chainId,
 			requestId,
 			accept: false,
 		},
@@ -51,7 +53,7 @@ export const openChangeChainDialog = async (
 	request: InterceptedRequest,
 	simulationMode: boolean,
 	website: Website,
-	chainId: bigint
+	params: SwitchEthereumChainParams,
 ) => {
 	if (openedDialog !== undefined || pendForUserReply || pendForSignerReply) return userDeniedChange
 
@@ -61,7 +63,7 @@ export const openChangeChainDialog = async (
 		if (openedDialog === undefined || openedDialog.windowOrTab.id !== windowId) return
 		openedDialog = undefined
 		if (pendForUserReply === undefined) return
-		resolveChainChange(websiteTabConnections, rejectMessage(request.requestId))
+		resolveChainChange(websiteTabConnections, rejectMessage(params.params[0], request.requestId))
 	}
 
 	const changeChainWindowReadyAndListening = async function popupMessageListener(msg: unknown) {
@@ -72,7 +74,7 @@ export const openChangeChainDialog = async (
 			method: 'popup_ChangeChainRequest',
 			data: {
 				requestId: request.requestId,
-				chainId: chainId,
+				chainId: params.params[0],
 				website: website,
 				simulationMode: simulationMode,
 				tabIdOpenedFrom: socket.tabId,
@@ -110,7 +112,7 @@ export const openChangeChainDialog = async (
 				simulationMode: simulationMode,
 			})
 		} else {
-			resolveChainChange(websiteTabConnections, rejectMessage(request.requestId))
+			resolveChainChange(websiteTabConnections, rejectMessage(params.params[0], request.requestId))
 		}
 		pendForSignerReply = undefined
 
@@ -131,13 +133,13 @@ async function resolve(websiteTabConnections: WebsiteTabConnections, reply: Chai
 	if (reply.options.accept) {
 		if (simulationMode) {
 			await changeActiveChain(websiteTabConnections, reply.options.chainId, simulationMode)
-			return { method: 'wallet_switchEthereumChain' as const, result: null }
+			return { result: null }
 		}
 		pendForSignerReply = new Future<SignerChainChangeConfirmation>() // when not in simulation mode, we need to get reply from the signer too
 		await changeActiveChain(websiteTabConnections, reply.options.chainId, simulationMode)
 		const signerReply = await pendForSignerReply
 		if (signerReply.options.accept && signerReply.options.chainId === reply.options.chainId) {
-			return { method: 'wallet_switchEthereumChain' as const, result: null }
+			return { result: null }
 		}
 	}
 	return userDeniedChange

--- a/app/ts/background/windows/changeChain.ts
+++ b/app/ts/background/windows/changeChain.ts
@@ -19,9 +19,9 @@ export async function resolveChainChange(websiteTabConnections: WebsiteTabConnec
 		return
 	}
 	const data = await getChainChangeConfirmationPromise()
-	if (data === undefined || confirmation.options.requestId !== data.request.requestId) return
+	if (data === undefined || confirmation.data.requestId !== data.request.requestId) return
 	const resolved = await resolve(websiteTabConnections, confirmation, data.simulationMode)
-	postMessageIfStillConnected(websiteTabConnections, data.socket, { options: { method: 'wallet_switchEthereumChain' as const, params: [confirmation.options.chainId] }, ...resolved, requestId: data.request.requestId })
+	postMessageIfStillConnected(websiteTabConnections, data.socket, { method: 'wallet_switchEthereumChain' as const, ...resolved, requestId: data.request.requestId })
 }
 
 export async function resolveSignerChainChange(confirmation: SignerChainChangeConfirmation) {
@@ -32,7 +32,7 @@ export async function resolveSignerChainChange(confirmation: SignerChainChangeCo
 function rejectMessage(chainId: bigint, requestId: number) {
 	return {
 		method: 'popup_changeChainDialog',
-		options: {
+		data: {
 			chainId,
 			requestId,
 			accept: false,
@@ -130,15 +130,15 @@ export const openChangeChainDialog = async (
 
 async function resolve(websiteTabConnections: WebsiteTabConnections, reply: ChainChangeConfirmation, simulationMode: boolean) {
 	await setChainChangeConfirmationPromise(undefined)
-	if (reply.options.accept) {
+	if (reply.data.accept) {
 		if (simulationMode) {
-			await changeActiveChain(websiteTabConnections, reply.options.chainId, simulationMode)
+			await changeActiveChain(websiteTabConnections, reply.data.chainId, simulationMode)
 			return { result: null }
 		}
 		pendForSignerReply = new Future<SignerChainChangeConfirmation>() // when not in simulation mode, we need to get reply from the signer too
-		await changeActiveChain(websiteTabConnections, reply.options.chainId, simulationMode)
+		await changeActiveChain(websiteTabConnections, reply.data.chainId, simulationMode)
 		const signerReply = await pendForSignerReply
-		if (signerReply.options.accept && signerReply.options.chainId === reply.options.chainId) {
+		if (signerReply.data.accept && signerReply.data.chainId === reply.data.chainId) {
 			return { result: null }
 		}
 	}

--- a/app/ts/background/windows/confirmTransaction.ts
+++ b/app/ts/background/windows/confirmTransaction.ts
@@ -1,7 +1,6 @@
 import { PopupOrTab, addWindowTabListener, closePopupOrTab, getPopupOrTabOnlyById, openPopupOrTab, removeWindowTabListener } from '../../components/ui-utils.js'
 import { EthereumClientService } from '../../simulation/services/EthereumClientService.js'
 import { appendTransaction } from '../../simulation/services/SimulationModeEthereumClientService.js'
-import { bytes32String } from '../../utils/bigint.js'
 import { ERROR_INTERCEPTOR_NO_ACTIVE_ADDRESS, METAMASK_ERROR_NOT_CONNECTED_TO_CHAIN, METAMASK_ERROR_USER_REJECTED_REQUEST } from '../../utils/constants.js'
 import { Future } from '../../utils/future.js'
 import { ConfirmTransactionTransactionSingleVisualization, ExternalPopupMessage, InterceptedRequest, PendingTransaction, TransactionConfirmation } from '../../utils/interceptor-messages.js'
@@ -147,5 +146,5 @@ async function resolve(ethereumClientService: EthereumClientService, simulationM
 	if (newState === undefined || newState.simulatedTransactions === undefined || newState.simulatedTransactions.length === 0) {
 		return METAMASK_ERROR_NOT_CONNECTED_TO_CHAIN
 	}
-	return { result: bytes32String(newState.simulatedTransactions[newState.simulatedTransactions.length - 1].signedTransaction.hash) }
+	return { method: transactionToSimulate.transactionSendingFormat, result: newState.simulatedTransactions[newState.simulatedTransactions.length - 1].signedTransaction.hash }
 }

--- a/app/ts/background/windows/interceptorAccess.ts
+++ b/app/ts/background/windows/interceptorAccess.ts
@@ -70,10 +70,7 @@ async function askForSignerAccountsFromSignerIfNotAvailable(websiteTabConnection
 	const channel = new BroadcastChannel(INTERNAL_CHANNEL_NAME)
 	try {
 		channel.addEventListener('message', listener)
-		const messageSent = postMessageIfStillConnected(websiteTabConnections, socket, {
-			options: { method: 'request_signer_to_eth_requestAccounts' },
-			result: []
-		})
+		const messageSent = postMessageIfStillConnected(websiteTabConnections, socket, { method: 'request_signer_to_eth_requestAccounts' })
 		if (messageSent) await future
 	} finally {
 		channel.removeEventListener('message', listener)
@@ -175,7 +172,7 @@ export async function requestAccessFromUser(
 				postMessageIfStillConnected(websiteTabConnections, socket, {
 					requestId: request.requestId,
 					options: request.options,
-					error: METAMASK_ERROR_ALREADY_PENDING.error
+					error: METAMASK_ERROR_ALREADY_PENDING.error,
 				})
 			}
 			return

--- a/app/ts/background/windows/interceptorAccess.ts
+++ b/app/ts/background/windows/interceptorAccess.ts
@@ -71,7 +71,6 @@ async function askForSignerAccountsFromSignerIfNotAvailable(websiteTabConnection
 	try {
 		channel.addEventListener('message', listener)
 		const messageSent = postMessageIfStillConnected(websiteTabConnections, socket, {
-			interceptorApproved: true,
 			options: { method: 'request_signer_to_eth_requestAccounts' },
 			result: []
 		})
@@ -174,7 +173,6 @@ export async function requestAccessFromUser(
 		if (requests.find((x) => x.accessRequestId === accessRequestId) === undefined) {
 			if (request !== undefined) {
 				postMessageIfStillConnected(websiteTabConnections, socket, {
-					interceptorApproved: false,
 					requestId: request.requestId,
 					options: request.options,
 					error: METAMASK_ERROR_ALREADY_PENDING.error

--- a/app/ts/background/windows/personalSign.ts
+++ b/app/ts/background/windows/personalSign.ts
@@ -8,13 +8,14 @@ import { OpenSeaOrderMessage, PersonalSignRequestIdentifiedEIP712Message } from 
 import { assertNever } from '../../utils/typescript.js'
 import { AddressBookEntry, SignerName, Website, WebsiteSocket, WebsiteTabConnections } from '../../utils/user-interface-types.js'
 import { OldSignTypedDataParams, PersonalSignParams, SignTypedDataParams } from '../../utils/wire-types.js'
-import { personalSignWithSimulator, sendMessageToContentScript } from '../background.js'
+import { sendMessageToContentScript } from '../background.js'
 import { getHtmlFile, sendPopupMessageToOpenWindows } from '../backgroundUtils.js'
 import { extractEIP712Message, validateEIP712Types } from '../../utils/eip712Parsing.js'
 import { getAddressMetaData, getTokenMetadata } from '../metadataUtils.js'
 import { getPendingPersonalSignPromise, getSignerName, setPendingPersonalSignPromise } from '../storageVariables.js'
 import { getSettings } from '../settings.js'
 import { PopupOrTab, addWindowTabListener, openPopupOrTab, removeWindowTabListener } from '../../components/ui-utils.js'
+import { simulatePersonalSign } from '../../simulation/services/SimulationModeEthereumClientService.js'
 
 let pendingPersonalSign: Future<PersonalSign> | undefined = undefined
 
@@ -292,9 +293,9 @@ async function resolve(reply: PersonalSign, simulationMode: boolean, params: Per
 	// forward message to content script
 	if (reply.options.accept) {
 		if (simulationMode) {
-			const result = await personalSignWithSimulator(params)
+			const result = await simulatePersonalSign(params)
 			if (result === undefined) return reject()
-			return { result: result }
+			return { method: params.method, result: result }
 		}
 		return { forward: true } as const
 	}

--- a/app/ts/background/windows/personalSign.ts
+++ b/app/ts/background/windows/personalSign.ts
@@ -3,7 +3,7 @@ import { EthereumClientService } from '../../simulation/services/EthereumClientS
 import { stringifyJSONWithBigInts } from '../../utils/bigint.js'
 import { METAMASK_ERROR_USER_REJECTED_REQUEST } from '../../utils/constants.js'
 import { Future } from '../../utils/future.js'
-import { HandleSimulationModeReturnValue, InterceptedRequest, PersonalSign, ExternalPopupMessage, Settings, UserAddressBook, PersonalSignRequest } from '../../utils/interceptor-messages.js'
+import { InterceptedRequest, PersonalSign, ExternalPopupMessage, Settings, UserAddressBook, PersonalSignRequest, HandleRPCRequestReturnValue } from '../../utils/interceptor-messages.js'
 import { OpenSeaOrderMessage, PersonalSignRequestIdentifiedEIP712Message } from '../../utils/personal-message-definitions.js'
 import { assertNever } from '../../utils/typescript.js'
 import { AddressBookEntry, SignerName, Website, WebsiteSocket, WebsiteTabConnections } from '../../utils/user-interface-types.js'
@@ -223,7 +223,7 @@ export const openPersonalSignDialog = async (
 	website: Website,
 	settings: Settings,
 	activeAddress: bigint | undefined
-): Promise<HandleSimulationModeReturnValue> => {
+): Promise<HandleRPCRequestReturnValue> => {
 	if (pendingPersonalSign !== undefined) return reject()
 
 	const onCloseWindow = (windowId: number) => {

--- a/app/ts/background/windows/personalSign.ts
+++ b/app/ts/background/windows/personalSign.ts
@@ -3,12 +3,11 @@ import { EthereumClientService } from '../../simulation/services/EthereumClientS
 import { stringifyJSONWithBigInts } from '../../utils/bigint.js'
 import { METAMASK_ERROR_USER_REJECTED_REQUEST } from '../../utils/constants.js'
 import { Future } from '../../utils/future.js'
-import { InterceptedRequest, PersonalSign, ExternalPopupMessage, Settings, UserAddressBook, PersonalSignRequest, HandleRPCRequestReturnValue } from '../../utils/interceptor-messages.js'
+import { InterceptedRequest, PersonalSign, ExternalPopupMessage, Settings, UserAddressBook, PersonalSignRequest } from '../../utils/interceptor-messages.js'
 import { OpenSeaOrderMessage, PersonalSignRequestIdentifiedEIP712Message } from '../../utils/personal-message-definitions.js'
 import { assertNever } from '../../utils/typescript.js'
 import { AddressBookEntry, SignerName, Website, WebsiteSocket, WebsiteTabConnections } from '../../utils/user-interface-types.js'
 import { OldSignTypedDataParams, PersonalSignParams, SignTypedDataParams } from '../../utils/wire-types.js'
-import { sendMessageToContentScript } from '../background.js'
 import { getHtmlFile, sendPopupMessageToOpenWindows } from '../backgroundUtils.js'
 import { extractEIP712Message, validateEIP712Types } from '../../utils/eip712Parsing.js'
 import { getAddressMetaData, getTokenMetadata } from '../metadataUtils.js'
@@ -16,6 +15,7 @@ import { getPendingPersonalSignPromise, getSignerName, setPendingPersonalSignPro
 import { getSettings } from '../settings.js'
 import { PopupOrTab, addWindowTabListener, openPopupOrTab, removeWindowTabListener } from '../../components/ui-utils.js'
 import { simulatePersonalSign } from '../../simulation/services/SimulationModeEthereumClientService.js'
+import { postMessageIfStillConnected } from '../background.js'
 
 let pendingPersonalSign: Future<PersonalSign> | undefined = undefined
 
@@ -26,9 +26,9 @@ export async function resolvePersonalSign(websiteTabConnections: WebsiteTabConne
 		pendingPersonalSign.resolve(confirmation)
 	} else {
 		const data = await getPendingPersonalSignPromise()
-		if (data === undefined || confirmation.options.requestId !== data.request.requestId) return
+		if (data === undefined || confirmation.data.requestId !== data.request.requestId) return
 		const resolved = await resolve(confirmation, data.simulationMode, data.params)
-		sendMessageToContentScript(websiteTabConnections, data.socket, resolved, data.request)
+		postMessageIfStillConnected(websiteTabConnections, data.socket, { method: data.params.method, ...resolved, requestId: confirmation.data.requestId })
 	}
 	openedDialog = undefined
 }
@@ -36,7 +36,7 @@ export async function resolvePersonalSign(websiteTabConnections: WebsiteTabConne
 function rejectMessage(requestId: number) {
 	return {
 		method: 'popup_personalSign',
-		options: {
+		data: {
 			requestId,
 			accept: false,
 		},
@@ -218,13 +218,13 @@ export const openPersonalSignDialog = async (
 	ethereumClientService: EthereumClientService,
 	websiteTabConnections: WebsiteTabConnections,
 	socket: WebsiteSocket,
-	params: PersonalSignParams | SignTypedDataParams | OldSignTypedDataParams,
+	signingParams: PersonalSignParams | SignTypedDataParams | OldSignTypedDataParams,
 	request: InterceptedRequest,
 	simulationMode: boolean,
 	website: Website,
 	settings: Settings,
 	activeAddress: bigint | undefined
-): Promise<HandleRPCRequestReturnValue> => {
+) => {
 	if (pendingPersonalSign !== undefined) return reject()
 
 	const onCloseWindow = (windowId: number) => {
@@ -235,7 +235,7 @@ export const openPersonalSignDialog = async (
 	}
 
 	if (activeAddress === undefined) return reject()
-	const popupMessage = await craftPersonalSignPopupMessage(ethereumClientService, params, socket.tabId, activeAddress, settings.userAddressBook, simulationMode, request.requestId, await getSignerName(), website)
+	const popupMessage = await craftPersonalSignPopupMessage(ethereumClientService, signingParams, socket.tabId, activeAddress, settings.userAddressBook, simulationMode, request.requestId, await getSignerName(), website)
 
 	const personalSignWindowReadyAndListening = async function popupMessageListener(msg: unknown) {
 		const message = ExternalPopupMessage.parse(msg)
@@ -272,7 +272,7 @@ export const openPersonalSignDialog = async (
 				socket: socket,
 				request: request,
 				simulationMode: simulationMode,
-				params: params,
+				params: signingParams,
 			})
 		} else {
 			await resolvePersonalSign(websiteTabConnections, rejectMessage(request.requestId))
@@ -280,7 +280,7 @@ export const openPersonalSignDialog = async (
 
 		const reply = await pendingPersonalSign
 
-		return resolve(reply, simulationMode, params)
+		return resolve(reply, simulationMode, signingParams)
 	} finally {
 		browser.runtime.onMessage.removeListener(personalSignWindowReadyAndListening)
 		removeWindowTabListener(onCloseWindow)
@@ -288,14 +288,14 @@ export const openPersonalSignDialog = async (
 	}
 }
 
-async function resolve(reply: PersonalSign, simulationMode: boolean, params: PersonalSignParams | SignTypedDataParams | OldSignTypedDataParams) {
+async function resolve(reply: PersonalSign, simulationMode: boolean, params: PersonalSignParams | SignTypedDataParams | OldSignTypedDataParams): Promise<{ forward: true } | { error: { code: number, message: string } } | { result: string }> {
 	await setPendingPersonalSignPromise(undefined)
 	// forward message to content script
-	if (reply.options.accept) {
+	if (reply.data.accept) {
 		if (simulationMode) {
 			const result = await simulatePersonalSign(params)
 			if (result === undefined) return reject()
-			return { method: params.method, result: result }
+			return { result: result }
 		}
 		return { forward: true } as const
 	}

--- a/app/ts/components/App.tsx
+++ b/app/ts/components/App.tsx
@@ -42,13 +42,13 @@ export function App() {
 	async function setActiveAddressAndInformAboutIt(address: bigint | 'signer') {
 		setUseSignersAddressAsActiveAddress(address === 'signer')
 		if (address === 'signer') {
-			sendPopupMessageToBackgroundPage({ method: 'popup_changeActiveAddress', options: { activeAddress: 'signer', simulationMode: simulationMode } })
+			sendPopupMessageToBackgroundPage({ method: 'popup_changeActiveAddress', data: { activeAddress: 'signer', simulationMode: simulationMode } })
 			if (simulationMode) {
 				return setActiveSimulationAddress(signerAccounts && signerAccounts.length > 0 ? signerAccounts[0] : undefined)
 			}
 			return setActiveSigningAddress(signerAccounts && signerAccounts.length > 0 ? signerAccounts[0] : undefined)
 		}
-		sendPopupMessageToBackgroundPage({ method: 'popup_changeActiveAddress', options: { activeAddress: address, simulationMode: simulationMode } })
+		sendPopupMessageToBackgroundPage({ method: 'popup_changeActiveAddress', data: { activeAddress: address, simulationMode: simulationMode } })
 		if (simulationMode) {
 			return setActiveSimulationAddress(address)
 		}
@@ -64,7 +64,7 @@ export function App() {
 	}
 
 	async function setActiveChainAndInformAboutIt(chainId: bigint) {
-		sendPopupMessageToBackgroundPage( { method: 'popup_changeActiveChain', options: chainId } )
+		sendPopupMessageToBackgroundPage( { method: 'popup_changeActiveChain', data: chainId } )
 		if(!isSignerConnected()) {
 			setActiveChain(chainId)
 		}
@@ -156,7 +156,7 @@ export function App() {
 
 	function setAndSaveAppPage(page: Page) {
 		setAppPage(page)
-		sendPopupMessageToBackgroundPage({ method: 'popup_changePage', options: page })
+		sendPopupMessageToBackgroundPage({ method: 'popup_changePage', data: page })
 	}
 
 	async function addressPaste(address: string) {

--- a/app/ts/components/pages/AddNewAddress.tsx
+++ b/app/ts/components/pages/AddNewAddress.tsx
@@ -150,7 +150,7 @@ export function AddNewAddress(param: AddAddressParam) {
 			case 'contact': {
 				await sendPopupMessageToBackgroundPage({
 					method: 'popup_addOrModifyAddressBookEntry',
-					options: {
+					data: {
 						type: 'contact',
 						name: nameInput ? nameInput : ethers.getAddress(addressInput),
 						address: BigInt(addressInput),
@@ -161,7 +161,7 @@ export function AddNewAddress(param: AddAddressParam) {
 			case 'addressInfo': {
 				await sendPopupMessageToBackgroundPage({
 					method: 'popup_addOrModifyAddressBookEntry',
-					options: {
+					data: {
 						type: 'addressInfo',
 						name: nameInput ? nameInput : ethers.getAddress(addressInput),
 						address: BigInt(addressInput),

--- a/app/ts/components/pages/ChangeChain.tsx
+++ b/app/ts/components/pages/ChangeChain.tsx
@@ -46,14 +46,14 @@ export function ChangeChain() {
 	async function approve() {
 		if (chainChangeData === undefined) return
 		await tryFocusingTab(chainChangeData.tabIdOpenedFrom)
-		await sendPopupMessageToBackgroundPage({ method: 'popup_changeChainDialog', options: { accept: true, requestId: chainChangeData.requestId, chainId: chainChangeData.chainId } })
+		await sendPopupMessageToBackgroundPage({ method: 'popup_changeChainDialog', data: { accept: true, requestId: chainChangeData.requestId, chainId: chainChangeData.chainId } })
 		globalThis.close()
 	}
 
 	async function reject() {
 		if (chainChangeData === undefined) return
 		await tryFocusingTab(chainChangeData.tabIdOpenedFrom)
-		await sendPopupMessageToBackgroundPage({ method: 'popup_changeChainDialog', options: { accept: false, requestId: chainChangeData.requestId } })
+		await sendPopupMessageToBackgroundPage({ method: 'popup_changeChainDialog', data: { accept: false, requestId: chainChangeData.requestId, chainId: chainChangeData.chainId } })
 		globalThis.close()
 	}
 

--- a/app/ts/components/pages/ConfirmTransaction.tsx
+++ b/app/ts/components/pages/ConfirmTransaction.tsx
@@ -196,7 +196,7 @@ export function ConfirmTransaction() {
 		const currentWindow = await browser.windows.getCurrent()
 		if (currentWindow.id === undefined) throw new Error('could not get our own Id!')
 		if (pendingTransactions.length === 0) await tryFocusingTab(dialogState.data.tabIdOpenedFrom)
-		await sendPopupMessageToBackgroundPage({ method: 'popup_confirmDialog', options: { requestId: dialogState.data.requestId, accept: true, windowId: currentWindow.id } })
+		await sendPopupMessageToBackgroundPage({ method: 'popup_confirmDialog', data: { requestId: dialogState.data.requestId, accept: true, windowId: currentWindow.id } })
 	}
 	async function reject() {
 		if (dialogState === undefined) throw new Error('dialogState is not set')
@@ -204,7 +204,7 @@ export function ConfirmTransaction() {
 		const currentWindow = await browser.windows.getCurrent()
 		if (currentWindow.id === undefined) throw new Error('could not get our own Id!')
 		if (pendingTransactions.length === 0) await tryFocusingTab(dialogState.data.tabIdOpenedFrom)
-		await sendPopupMessageToBackgroundPage({ method: 'popup_confirmDialog', options: { requestId: dialogState.data.requestId, accept: false, windowId: currentWindow.id } })
+		await sendPopupMessageToBackgroundPage({ method: 'popup_confirmDialog', data: { requestId: dialogState.data.requestId, accept: false, windowId: currentWindow.id } })
 	}
 	const refreshMetadata = () => {
 		if (dialogState === undefined || dialogState.state === 'failed') return

--- a/app/ts/components/pages/Home.tsx
+++ b/app/ts/components/pages/Home.tsx
@@ -17,7 +17,7 @@ import { identifyTransaction } from '../simulationExplaining/identifyTransaction
 import { SomeTimeAgo } from '../subcomponents/SomeTimeAgo.js'
 
 async function enableMakeMeRich(enabled: boolean) {
-	sendPopupMessageToBackgroundPage( { method: 'popup_changeMakeMeRich', options: enabled } )
+	sendPopupMessageToBackgroundPage( { method: 'popup_changeMakeMeRich', data: enabled } )
 }
 
 type SignerExplanationParams = {
@@ -84,7 +84,7 @@ function FirstCardHeader(param: FirstCardParams) {
 
 function FirstCard(param: FirstCardParams) {
 	function connectToSigner() {
-		sendPopupMessageToBackgroundPage({ method: 'popup_requestAccountsFromSigner', options: true })
+		sendPopupMessageToBackgroundPage({ method: 'popup_requestAccountsFromSigner', data: true })
 	}
 
 	if (param.signerName === 'NoSigner' && param.simulationMode === false) {
@@ -249,7 +249,7 @@ export function Home(param: HomeParams) {
 	}
 
 	function enableSimulationMode(enabled: boolean ) {
-		sendPopupMessageToBackgroundPage( { method: 'popup_enableSimulationMode', options: enabled } )
+		sendPopupMessageToBackgroundPage( { method: 'popup_enableSimulationMode', data: enabled } )
 		setSimulationMode(enabled)
 	}
 
@@ -263,7 +263,7 @@ export function Home(param: HomeParams) {
 		if (identifyTransaction(tx).type === 'MakeYouRichTransaction') {
 			return await enableMakeMeRich(false)
 		} else {
-			return await sendPopupMessageToBackgroundPage({ method: 'popup_removeTransaction', options: tx.transaction.hash })
+			return await sendPopupMessageToBackgroundPage({ method: 'popup_removeTransaction', data: tx.transaction.hash })
 		}
 	}
 

--- a/app/ts/components/pages/InterceptorAccess.tsx
+++ b/app/ts/components/pages/InterceptorAccess.tsx
@@ -203,7 +203,7 @@ export function InterceptorAccess() {
 	async function approve() {
 		if (pendingAccessRequestArray.length === 0) throw Error('access request not loaded')
 		const accessRequest = pendingAccessRequestArray[0]
-		const options = {
+		const data = {
 			userReply: 'Approved' as const,
 			websiteOrigin: accessRequest.website.websiteOrigin,
 			requestAccessToAddress: accessRequest.requestAccessToAddress?.address,
@@ -213,13 +213,13 @@ export function InterceptorAccess() {
 		setPendingRequestAddedNotification(false)
 		setInformationUpdatedTimestamp(Date.now())
 		if (pendingAccessRequestArray.length === 1) await tryFocusingTab(accessRequest.socket.tabId)
-		await sendPopupMessageToBackgroundPage({ method: 'popup_interceptorAccess', options })
+		await sendPopupMessageToBackgroundPage({ method: 'popup_interceptorAccess', data })
 	}
 
 	async function reject() {
 		if (pendingAccessRequestArray.length === 0) throw Error('access request not loaded')
 		const accessRequest = pendingAccessRequestArray[0]
-		const options = {
+		const data = {
 			userReply: 'Rejected' as const,
 			websiteOrigin: accessRequest.website.websiteOrigin,
 			requestAccessToAddress: accessRequest.requestAccessToAddress?.address,
@@ -229,7 +229,7 @@ export function InterceptorAccess() {
 		setPendingRequestAddedNotification(false)
 		setInformationUpdatedTimestamp(Date.now())
 		if (pendingAccessRequestArray.length === 1) await tryFocusingTab(accessRequest.socket.tabId)
-		await sendPopupMessageToBackgroundPage({ method: 'popup_interceptorAccess', options })
+		await sendPopupMessageToBackgroundPage({ method: 'popup_interceptorAccess', data })
 	}
 
 	function renameAddressCallBack(entry: AddressBookEntry) {
@@ -248,7 +248,7 @@ export function InterceptorAccess() {
 	async function refreshActiveAddress() {
 		if (pendingAccessRequestArray.length === 0) throw Error('access request not loaded')
 		const accessRequest = pendingAccessRequestArray[0]
-		await sendPopupMessageToBackgroundPage({ method: 'popup_interceptorAccessRefresh', options: {
+		await sendPopupMessageToBackgroundPage({ method: 'popup_interceptorAccessRefresh', data: {
 			socket: accessRequest.socket,
 			website: accessRequest.website,
 			requestAccessToAddress: accessRequest.requestAccessToAddress?.address,
@@ -259,7 +259,7 @@ export function InterceptorAccess() {
 	async function setActiveAddressAndInformAboutIt(address: bigint | 'signer') {
 		if (pendingAccessRequestArray.length === 0) throw Error('access request not loaded')
 		const accessRequest = pendingAccessRequestArray[0]
-		await sendPopupMessageToBackgroundPage({ method: 'popup_interceptorAccessChangeAddress', options: {
+		await sendPopupMessageToBackgroundPage({ method: 'popup_interceptorAccessChangeAddress', data: {
 			socket: accessRequest.socket,
 			website: accessRequest.website,
 			requestAccessToAddress: accessRequest.requestAccessToAddress?.address,

--- a/app/ts/components/pages/InterceptorAccessList.tsx
+++ b/app/ts/components/pages/InterceptorAccessList.tsx
@@ -158,7 +158,7 @@ export function InterceptorAccessList(param: InterceptorAccessListParams) {
 				access: addr.access,
 			})),
 		}))
-		sendPopupMessageToBackgroundPage({ method: 'popup_changeInterceptorAccess', options: newEntries })
+		sendPopupMessageToBackgroundPage({ method: 'popup_changeInterceptorAccess', data: newEntries })
 		updateEditableAccessList(newEntries)
 		param.setWebsiteAccess(newEntries)
 		return goHome()

--- a/app/ts/components/pages/PersonalSign.tsx
+++ b/app/ts/components/pages/PersonalSign.tsx
@@ -407,14 +407,14 @@ export function PersonalSign() {
 	async function approve() {
 		if (personalSignRequestData === undefined) throw new Error('personalSignRequestData is missing')
 		await tryFocusingTab(personalSignRequestData.tabIdOpenedFrom)
-		await sendPopupMessageToBackgroundPage({ method: 'popup_personalSign', options: { requestId: personalSignRequestData.requestId, accept: true } })
+		await sendPopupMessageToBackgroundPage({ method: 'popup_personalSign', data: { requestId: personalSignRequestData.requestId, accept: true } })
 		globalThis.close()
 	}
 
 	async function reject() {
 		if (personalSignRequestData === undefined) throw new Error('personalSignRequestData is missing')
 		await tryFocusingTab(personalSignRequestData.tabIdOpenedFrom)
-		await sendPopupMessageToBackgroundPage({ method: 'popup_personalSign', options: { requestId: personalSignRequestData.requestId, accept: false } })
+		await sendPopupMessageToBackgroundPage({ method: 'popup_personalSign', data: { requestId: personalSignRequestData.requestId, accept: false } })
 		globalThis.close()
 	}
 

--- a/app/ts/simulation/services/EthereumSubscriptionService.ts
+++ b/app/ts/simulation/services/EthereumSubscriptionService.ts
@@ -41,7 +41,6 @@ export async function sendSubscriptionMessagesForNewBlock(blockNumber: bigint, e
 				const newBlock = await ethereumClientService.getBlock(blockNumber, false)
 
 				postMessageIfStillConnected(websiteTabConnections, subscription.subscriptionCreatorSocket, {
-					options: subscription.params,
 					method: 'newHeads' as const, 
 					result: { subscription: subscription.type, result: newBlock } as const,
 					subscription: subscription.subscriptionId,
@@ -51,7 +50,6 @@ export async function sendSubscriptionMessagesForNewBlock(blockNumber: bigint, e
 					const simulatedBlock = await getSimulatedBlock(ethereumClientService, simulationState, blockNumber + 1n, false)
 					// post our simulated block on top (reorg it)
 					postMessageIfStillConnected(websiteTabConnections, subscription.subscriptionCreatorSocket, {
-						options: subscription.params,
 						method: 'newHeads' as const, 
 						result: { subscription: subscription.type, result: simulatedBlock },
 						subscription: subscription.subscriptionId,

--- a/app/ts/simulation/services/EthereumSubscriptionService.ts
+++ b/app/ts/simulation/services/EthereumSubscriptionService.ts
@@ -1,4 +1,4 @@
-import { EthSubscribeParams, NewHeadsSubscriptionData } from '../../utils/wire-types.js'
+import { EthSubscribeParams } from '../../utils/wire-types.js'
 import { assertNever } from '../../utils/typescript.js'
 import { EthereumClientService } from './EthereumClientService.js'
 import { getEthereumSubscriptions, updateEthereumSubscriptions } from '../../background/storageVariables.js'
@@ -41,9 +41,9 @@ export async function sendSubscriptionMessagesForNewBlock(blockNumber: bigint, e
 				const newBlock = await ethereumClientService.getBlock(blockNumber, false)
 
 				postMessageIfStillConnected(websiteTabConnections, subscription.subscriptionCreatorSocket, {
-					interceptorApproved: true,
 					options: subscription.params,
-					result: NewHeadsSubscriptionData.serialize({ subscription: subscription.type, result: newBlock }),
+					method: 'newHeads' as const, 
+					result: { subscription: subscription.type, result: newBlock } as const,
 					subscription: subscription.subscriptionId,
 				})
 
@@ -51,9 +51,9 @@ export async function sendSubscriptionMessagesForNewBlock(blockNumber: bigint, e
 					const simulatedBlock = await getSimulatedBlock(ethereumClientService, simulationState, blockNumber + 1n, false)
 					// post our simulated block on top (reorg it)
 					postMessageIfStillConnected(websiteTabConnections, subscription.subscriptionCreatorSocket, {
-						interceptorApproved: true,
 						options: subscription.params,
-						result: NewHeadsSubscriptionData.serialize({ subscription: subscription.type, result: simulatedBlock }),
+						method: 'newHeads' as const, 
+						result: { subscription: subscription.type, result: simulatedBlock },
 						subscription: subscription.subscriptionId,
 					})
 				}

--- a/app/ts/simulation/services/SimulationModeEthereumClientService.ts
+++ b/app/ts/simulation/services/SimulationModeEthereumClientService.ts
@@ -636,10 +636,8 @@ export const getHashOfSimulatedBlock = () => {
 }
 
 export const simulatePersonalSign = async (params: PersonalSignParams | SignTypedDataParams | OldSignTypedDataParams) => {
-	if (params.method === 'personal_sign') {
-		return await new ethers.Wallet(bytes32String(MOCK_PRIVATE_KEY)).signMessage(params.params[0])
-	}
-	return 'NOT IMPLEMENTED'
+	if (params.method === 'personal_sign') return await new ethers.Wallet(bytes32String(MOCK_PRIVATE_KEY)).signMessage(params.params[0])
+	throw new Error(`Simulated signing not implemented for method ${ params.method }`)
 }
 
 const getSimulatedTokenBalances = async (ethereumClientService: EthereumClientService, transactionQueue: EthereumUnsignedTransaction[], balances: { token: bigint, owner: bigint }[], blockNumber: bigint): Promise<TokenBalancesAfter> => {

--- a/app/ts/simulation/services/SimulationModeEthereumClientService.ts
+++ b/app/ts/simulation/services/SimulationModeEthereumClientService.ts
@@ -611,7 +611,7 @@ export const simulatedCall = async (ethereumClientService: EthereumClientService
 	} as const
 
 	const multicallResult = blockTag === 'latest' || blockTag === 'pending' ?
-		await simulatedMulticall(ethereumClientService, simulationState, [transaction], await ethereumClientService.getBlockNumber() + 1n)
+		await simulatedMulticall(ethereumClientService, simulationState, [transaction], await ethereumClientService.getBlockNumber() + (simulationState === undefined ? 0n : 1n))
 		: await simulatedMulticall(ethereumClientService, simulationState, [transaction], blockTag)
 	const callResult = multicallResult[multicallResult.length - 1]
 	if (callResult.statusCode === 'failure') {

--- a/app/ts/simulation/services/SimulationModeEthereumClientService.ts
+++ b/app/ts/simulation/services/SimulationModeEthereumClientService.ts
@@ -54,7 +54,8 @@ export const transactionQueueTotalGasLimit = (simulationState: SimulationState) 
 	return simulationState.simulatedTransactions.reduce((a, b) => a + b.signedTransaction.gas, 0n)
 }
 
-export const simulationGasLeft = (simulationState: SimulationState, blockHeader: EthereumBlockHeader) => {
+export const simulationGasLeft = (simulationState: SimulationState | undefined, blockHeader: EthereumBlockHeader) => {
+	if (simulationState === undefined) return blockHeader.gasLimit * 1023n / 1024n
 	return max(blockHeader.gasLimit * 1023n / 1024n - transactionQueueTotalGasLimit(simulationState), 0n)
 }
 
@@ -217,7 +218,8 @@ export const setSimulationTransactions = async (ethereumClientService: EthereumC
 	}
 }
 
-export const getTransactionQueue = (simulationState: SimulationState) => {
+export const getTransactionQueue = (simulationState: SimulationState | undefined) => {
+	if (simulationState === undefined) return []
 	return simulationState.simulatedTransactions.map((x) => x.signedTransaction)
 }
 export const getPrependTransactionsQueue = (simulationState: SimulationState) => simulationState.prependTransactionsQueue
@@ -345,7 +347,7 @@ export const getSimulatedTransactionCount = async (ethereumClientService: Ethere
 	return (await ethereumClientService.getTransactionCount(address, blockTag)) + addedTransactions
 }
 
-export const getSimulatedTransactionReceipt = async (ethereumClientService: EthereumClientService, simulationState: SimulationState, hash: bigint): Promise<EthTransactionReceiptResponse> => {
+export const getSimulatedTransactionReceipt = async (ethereumClientService: EthereumClientService, simulationState: SimulationState | undefined, hash: bigint): Promise<EthTransactionReceiptResponse> => {
 	let cumGas = 0n
 	let currentLogIndex = 0
 	if (simulationState === undefined) { return await ethereumClientService.getTransactionReceipt(hash) }
@@ -387,8 +389,8 @@ export const getSimulatedTransactionReceipt = async (ethereumClientService: Ethe
 	return await ethereumClientService.getTransactionReceipt(hash)
 }
 
-export const getSimulatedBalance = async (ethereumClientService: EthereumClientService, simulationState: SimulationState, address: bigint, blockTag: EthereumBlockTag = 'latest'): Promise<bigint> => {
-	if (await canQueryNodeDirectly(ethereumClientService, simulationState, blockTag) || simulationState === undefined) return await ethereumClientService.getBalance(address, blockTag)
+export const getSimulatedBalance = async (ethereumClientService: EthereumClientService, simulationState: SimulationState | undefined, address: bigint, blockTag: EthereumBlockTag = 'latest'): Promise<bigint> => {
+	if (simulationState === undefined || await canQueryNodeDirectly(ethereumClientService, simulationState, blockTag)) return await ethereumClientService.getBalance(address, blockTag)
 	const balances = new Map<bigint, bigint>()
 	for (const transaction of simulationState.simulatedTransactions) {
 		if (transaction.multicallResponse.statusCode !== 'success') continue
@@ -403,8 +405,8 @@ export const getSimulatedBalance = async (ethereumClientService: EthereumClientS
 	return await ethereumClientService.getBalance(address, blockTag)
 }
 
-export const getSimulatedCode = async (ethereumClientService: EthereumClientService, simulationState: SimulationState, address: bigint, blockTag: EthereumBlockTag = 'latest') => {
-	if (await canQueryNodeDirectly(ethereumClientService, simulationState, blockTag)) {
+export const getSimulatedCode = async (ethereumClientService: EthereumClientService, simulationState: SimulationState | undefined, address: bigint, blockTag: EthereumBlockTag = 'latest') => {
+	if (simulationState === undefined || await canQueryNodeDirectly(ethereumClientService, simulationState, blockTag)) {
 		return {
 			statusCode: 'success',
 			getCodeReturn: await ethereumClientService.getCode(address, blockTag)
@@ -537,7 +539,8 @@ const getLogsOfSimulatedBlock = (simulationState: SimulationState, logFilter: Et
 	)
 }
 
-export const getSimulatedLogs = async (ethereumClientService: EthereumClientService, simulationState: SimulationState, logFilter: EthGetLogsRequest): Promise<EthGetLogsResponse> => {
+export const getSimulatedLogs = async (ethereumClientService: EthereumClientService, simulationState: SimulationState | undefined, logFilter: EthGetLogsRequest): Promise<EthGetLogsResponse> => {
+	if (simulationState === undefined) return await ethereumClientService.getLogs(logFilter)
 	const toBlock = 'toBlock' in logFilter && logFilter.toBlock !== undefined ? logFilter.toBlock : 'latest'
 	const fromBlock = 'fromBlock' in logFilter && logFilter.fromBlock !== undefined ? logFilter.fromBlock : 'latest'
 	if (toBlock === 'pending' || fromBlock === 'pending') return await ethereumClientService.getLogs(logFilter)
@@ -550,12 +553,12 @@ export const getSimulatedLogs = async (ethereumClientService: EthereumClientServ
 	return logs
 }
 
-export const getSimulatedBlockNumber = async (ethereumClientService: EthereumClientService, simulationState: SimulationState, ) => {
+export const getSimulatedBlockNumber = async (ethereumClientService: EthereumClientService, simulationState: SimulationState | undefined) => {
 	if (simulationState === undefined) return (await ethereumClientService.getBlockNumber()) + 1n
 	return await ethereumClientService.getBlockNumber()
 }
 
-export const getSimulatedTransactionByHash = async (ethereumClientService: EthereumClientService, simulationState: SimulationState, hash: bigint): Promise<EthereumSignedTransactionWithBlockData|undefined> => {
+export const getSimulatedTransactionByHash = async (ethereumClientService: EthereumClientService, simulationState: SimulationState | undefined, hash: bigint): Promise<EthereumSignedTransactionWithBlockData|undefined> => {
 	// try to see if the transaction is in our queue
 	if (simulationState === undefined) return await ethereumClientService.getTransactionByHash(hash)
 	for (const [index, simulatedTransaction] of simulationState.simulatedTransactions.entries()) {
@@ -598,7 +601,7 @@ export const getTokenDecimals = async (ethereumClientService: EthereumClientServ
 	return EthereumQuantity.parse(response)
 }
 
-export const simulatedCall = async (ethereumClientService: EthereumClientService, simulationState: SimulationState, params: Pick<IUnsignedTransaction1559, 'to' | 'from' | 'input' | 'value' | 'maxFeePerGas' | 'maxPriorityFeePerGas' | 'gasLimit'>, blockTag: EthereumBlockTag = 'latest') => {
+export const simulatedCall = async (ethereumClientService: EthereumClientService, simulationState: SimulationState | undefined, params: Pick<IUnsignedTransaction1559, 'to' | 'from' | 'input' | 'value' | 'maxFeePerGas' | 'maxPriorityFeePerGas' | 'gasLimit'>, blockTag: EthereumBlockTag = 'latest') => {
 	const transaction = {
 		...params,
 		type: '1559',
@@ -620,10 +623,10 @@ export const simulatedCall = async (ethereumClientService: EthereumClientService
 			}
 		}
 	}
-	return { result: EthereumData.serialize(callResult.returnValue) }
+	return { result: callResult.returnValue }
 }
 
-export const simulatedMulticall = async (ethereumClientService: EthereumClientService, simulationState: SimulationState, transactions: EthereumUnsignedTransaction[], blockNumber: bigint) => {
+export const simulatedMulticall = async (ethereumClientService: EthereumClientService, simulationState: SimulationState | undefined, transactions: EthereumUnsignedTransaction[], blockNumber: bigint) => {
 	const mergedTxs: EthereumUnsignedTransaction[] = getTransactionQueue(simulationState)
 	return await ethereumClientService.multicall(mergedTxs.concat(transactions), blockNumber)
 }

--- a/app/ts/utils/interceptor-messages.ts
+++ b/app/ts/utils/interceptor-messages.ts
@@ -47,6 +47,7 @@ export const InpageScriptCallBack = funtypes.Union(
 	funtypes.ReadonlyObject({ method: funtypes.Literal('request_signer_chainId'), result: funtypes.ReadonlyTuple() }),
 	funtypes.ReadonlyObject({ method: funtypes.Literal('request_signer_to_wallet_switchEthereumChain'), result: EthereumQuantity }),
 	funtypes.ReadonlyObject({ method: funtypes.Literal('request_signer_to_eth_requestAccounts'), result: funtypes.ReadonlyTuple() }),
+	funtypes.ReadonlyObject({ method: funtypes.Literal('request_signer_to_eth_accounts'), result: funtypes.ReadonlyTuple() }),
 	funtypes.ReadonlyObject({ method: funtypes.Literal('disconnect'), result: funtypes.ReadonlyTuple() }),
 	funtypes.ReadonlyObject({ method: funtypes.Literal('connect'), result: funtypes.ReadonlyTuple(EthereumQuantity) }),
 	funtypes.ReadonlyObject({ method: funtypes.Literal('accountsChanged'), result: funtypes.ReadonlyArray(EthereumAddress) }),

--- a/app/ts/utils/interceptor-messages.ts
+++ b/app/ts/utils/interceptor-messages.ts
@@ -53,12 +53,6 @@ export const InpageScriptCallBack = funtypes.Union(
 	funtypes.ReadonlyObject({ method: funtypes.Literal('accountsChanged'), result: funtypes.ReadonlyArray(EthereumAddress) }),
 	funtypes.ReadonlyObject({ method: funtypes.Literal('chainChanged'), result: EthereumQuantity }),
 )
-/*
-export type NonForwardingRPCRequestSuccessfullReturnValue = funtypes.Static<typeof NonForwardingRPCRequestSuccessfullReturnValue>
-export const NonForwardingRPCRequestSuccessfullReturnValue = funtypes.Union(
-funtypes.ReadonlyObject({ data: SendRawTransaction, result: EthereumBytes32 }),
-funtypes.ReadonlyObject({ data: SendTransactionParams, result: EthereumBytes32 })
-*/
 
 export type NonForwardingRPCRequestSuccessfullReturnValue = funtypes.Static<typeof NonForwardingRPCRequestSuccessfullReturnValue>
 export const NonForwardingRPCRequestSuccessfullReturnValue = funtypes.Union(
@@ -118,7 +112,7 @@ export const RPCReply = funtypes.Union(
 	funtypes.ReadonlyObject({ // forward directly to wallet
 		forward: funtypes.Literal(true),
 		method: funtypes.String,
-	}), //todo, add check here that we can only forward specific requets
+	}), // TODO, add check here that we can only forward specific requests (send transaction and signatures)
 )
 
 export type RPCReplyWithRequestId = funtypes.Static<typeof RPCReply>

--- a/app/ts/utils/interceptor-messages.ts
+++ b/app/ts/utils/interceptor-messages.ts
@@ -1,6 +1,6 @@
 import * as funtypes from 'funtypes'
 import { AddressBookEntries, AddressBookEntry, AddressInfo, AddressInfoEntry, ContactEntries, SignerName, Website, WebsiteSocket } from './user-interface-types.js'
-import { EthGetLogsResponse, EthTransactionReceiptResponse, EthereumAddress, EthereumBlockHeaderWithTransactionHashes, EthereumBytes32, EthereumData, EthereumQuantity, EthereumSignedTransactionWithBlockData, GetBlockReturn, GetSimulationStackReply, OldSignTypedDataParams, PersonalSignParams, SignTypedDataParams } from './wire-types.js'
+import { EstimateGasParams, EthBalanceParams, EthBlockByNumberParams, EthCallParams, EthGetLogsParams, EthGetLogsResponse, EthSubscribeParams, EthTransactionReceiptResponse, EthUnSubscribeParams, EthereumAddress, EthereumBlockHeaderWithTransactionHashes, EthereumBytes32, EthereumData, EthereumQuantity, EthereumSignedTransactionWithBlockData, GetBlockReturn, GetCode, GetSimulationStack, GetSimulationStackReply, GetTransactionCount, OldSignTypedDataParams, PersonalSignParams, SendRawTransaction, SendTransactionParams, SignTypedDataParams, SwitchEthereumChainParams, TransactionByHashParams, TransactionReceiptParams } from './wire-types.js'
 import { SimulationState, OptionalEthereumAddress, SimulatedAndVisualizedTransaction, SimResults, TokenPriceEstimate, WebsiteCreatedEthereumUnsignedTransaction } from './visualizer-types.js'
 import { ICON_ACCESS_DENIED, ICON_ACTIVE, ICON_NOT_ACTIVE, ICON_SIGNING, ICON_SIGNING_NOT_SUPPORTED, ICON_SIMULATING } from './constants.js'
 import { PersonalSignRequestData } from './personal-message-definitions.js'
@@ -14,6 +14,15 @@ export const MessageMethodAndParams = funtypes.Union(
 	funtypes.ReadonlyObject({ method: funtypes.String }).asReadonly()
 )
 
+export type WalletSwitchEthereumChainReply = funtypes.Static<typeof WalletSwitchEthereumChainReply>
+export const WalletSwitchEthereumChainReply = funtypes.ReadonlyObject({
+	method: funtypes.Literal('wallet_switchEthereumChain_reply'),
+	params: funtypes.Tuple(funtypes.ReadonlyObject({
+		accept: funtypes.Boolean,
+		chainId: EthereumQuantity,
+	}))
+}).asReadonly()
+
 export type InterceptedRequest = funtypes.Static<typeof InterceptedRequest>
 export const InterceptedRequest = funtypes.Intersect(
 	funtypes.ReadonlyObject({
@@ -25,89 +34,120 @@ export const InterceptedRequest = funtypes.Intersect(
 )
 export type ProviderMessage = InterceptedRequest
 
-export type InpageScriptRequestAndCallBacks = funtypes.Static<typeof InpageScriptRequestAndCallBacks>
-export const InpageScriptRequestAndCallBacks = funtypes.Union(
-	funtypes.ReadonlyObject({ method: funtypes.Literal('request_signer_chainId'), result: funtypes.ReadonlyTuple() }),
-	funtypes.ReadonlyObject({ method: funtypes.Literal('request_signer_to_eth_requestAccounts'), result: funtypes.ReadonlyTuple() }),
-	funtypes.ReadonlyObject({ method: funtypes.Literal('request_signer_to_wallet_switchEthereumChain'), result: EthereumQuantity }),
-	funtypes.ReadonlyObject({ method: funtypes.Literal('connect'), result: funtypes.ReadonlyTuple(EthereumQuantity) }),
-	funtypes.ReadonlyObject({ method: funtypes.Literal('accountsChanged'), result: funtypes.ReadonlyArray(EthereumAddress) }),
-	funtypes.ReadonlyObject({ method: funtypes.Literal('chainChanged'), result: EthereumQuantity }),
+export type InpageScriptRequest = funtypes.Static<typeof InpageScriptRequest>
+export const InpageScriptRequest = funtypes.Union(
+	funtypes.ReadonlyObject({ options: funtypes.ReadonlyObject({ method: funtypes.Literal('request_signer_chainId'), params: funtypes.ReadonlyTuple() }) }),
+	funtypes.ReadonlyObject({ options: funtypes.ReadonlyObject({ method: funtypes.Literal('request_signer_to_eth_requestAccounts'), params: funtypes.ReadonlyTuple() }) }),
+	funtypes.ReadonlyObject({ options: funtypes.ReadonlyObject({ method: funtypes.Literal('request_signer_to_wallet_switchEthereumChain'), params: EthereumQuantity }) }),
 )
 
-export type NonForwardingRPCRequestSuccessfullReturnValue = funtypes.Static<typeof NonForwardingRPCRequestSuccessfullReturnValue>
-export const NonForwardingRPCRequestSuccessfullReturnValue = funtypes.Union(
-	funtypes.ReadonlyObject({ method: funtypes.Literal('method!'), result: funtypes.ReadonlyTuple(EthereumAddress) }),
-	funtypes.ReadonlyObject({ method: funtypes.Literal('eth_getBlockByNumber'), result: GetBlockReturn }),
-	funtypes.ReadonlyObject({ method: funtypes.Literal('eth_getBalance'), result: EthereumQuantity }),
-	funtypes.ReadonlyObject({ method: funtypes.Literal('eth_estimateGas'), result: EthereumQuantity }),
-	funtypes.ReadonlyObject({ method: funtypes.Literal('eth_getTransactionByHash'), result: funtypes.Union(EthereumSignedTransactionWithBlockData, funtypes.Undefined) }),
-	funtypes.ReadonlyObject({ method: funtypes.Literal('eth_getTransactionReceipt'), result: EthTransactionReceiptResponse }),
-	funtypes.ReadonlyObject({ method: funtypes.Literal('eth_subscribe'), result: funtypes.String }),
-	funtypes.ReadonlyObject({ method: funtypes.Literal('eth_unsubscribe'), result: funtypes.Boolean }),
-	funtypes.ReadonlyObject({ method: funtypes.Literal('eth_chainId'), result: EthereumQuantity }),
-	funtypes.ReadonlyObject({ method: funtypes.Literal('net_version'), result: EthereumQuantity }),
-	funtypes.ReadonlyObject({ method: funtypes.Literal('eth_blockNumber'), result: EthereumQuantity }),
-	funtypes.ReadonlyObject({ method: funtypes.Literal('eth_getCode'), result: EthereumData }),
-	funtypes.ReadonlyObject({ method: funtypes.Literal('wallet_switchEthereumChain'), result: funtypes.Null }),
-	funtypes.ReadonlyObject({ method: funtypes.Literal('eth_accounts'), result: funtypes.ReadonlyArray(EthereumAddress) }),
-	funtypes.ReadonlyObject({ method: funtypes.Literal('wallet_getPermissions'), result: funtypes.ReadonlyTuple(funtypes.ReadonlyObject({ eth_accounts: funtypes.ReadonlyObject({}) })) }),
-	funtypes.ReadonlyObject({ method: funtypes.Literal('eth_gasPrice'), result: EthereumQuantity }),
-	funtypes.ReadonlyObject({ method: funtypes.Literal('eth_getTransactionCount'), result: EthereumQuantity }),
-	funtypes.ReadonlyObject({ method: funtypes.Literal('interceptor_getSimulationStack'), result: funtypes.ReadonlyObject({ version: funtypes.Literal('1.0.0'), payload: GetSimulationStackReply }) }),
-	funtypes.ReadonlyObject({ method: funtypes.Literal('eth_getLogs'), result: EthGetLogsResponse }),
-	funtypes.ReadonlyObject({ method: funtypes.Literal('eth_sendTransaction'), result: EthereumBytes32 }),
-	funtypes.ReadonlyObject({ method: funtypes.Literal('eth_sendRawTransaction'), result: EthereumBytes32 }),
-	funtypes.ReadonlyObject({ method: funtypes.Literal('eth_accounts_reply'), result: funtypes.Literal('0x') }),
-	funtypes.ReadonlyObject({ method: funtypes.Literal('signer_chainChanged'), result: funtypes.Literal('0x') }),
-	funtypes.ReadonlyObject({ method: funtypes.Literal('wallet_switchEthereumChain_reply'), result: funtypes.Literal('0x') }),
-	funtypes.ReadonlyObject({ method: funtypes.Literal('connected_to_signer'), result: funtypes.Literal('0x') }),
-	funtypes.ReadonlyObject({ method: funtypes.Literal('eth_call'), result: EthereumData }),
-	funtypes.ReadonlyObject({ method: funtypes.Union(
-		funtypes.Literal('personal_sign'),
-		funtypes.Literal('eth_signTypedData'),
-		funtypes.Literal('eth_signTypedData_v1'),
-		funtypes.Literal('eth_signTypedData_v2'),
-		funtypes.Literal('eth_signTypedData_v3'),
-		funtypes.Literal('eth_signTypedData_v4')
-	), result: funtypes.String }),
-	funtypes.ReadonlyObject({ method: funtypes.Literal('newHeads'), result: funtypes.ReadonlyObject({ subscription: funtypes.Literal('newHeads'), result: EthereumBlockHeaderWithTransactionHashes }) }),
-	InpageScriptRequestAndCallBacks,
+export type InpageScriptCallBack = funtypes.Static<typeof InpageScriptCallBack>
+export const InpageScriptCallBack = funtypes.Union(
+	funtypes.ReadonlyObject({ options: funtypes.ReadonlyObject({ method: funtypes.Literal('connect'), params: funtypes.ReadonlyTuple() }), result: funtypes.ReadonlyTuple(EthereumQuantity) }),
+	funtypes.ReadonlyObject({ options: funtypes.ReadonlyObject({ method: funtypes.Literal('accountsChanged'), params: funtypes.ReadonlyTuple() }), result: funtypes.ReadonlyArray(EthereumAddress) }),
+	funtypes.ReadonlyObject({ options: funtypes.ReadonlyObject({ method: funtypes.Literal('chainChanged'), params: funtypes.ReadonlyTuple() }), result: EthereumQuantity }),
+	funtypes.ReadonlyObject({ options: funtypes.ReadonlyObject({ method: funtypes.Literal('disconnect'), params: funtypes.ReadonlyTuple() }), result: funtypes.ReadonlyTuple() }),
+	funtypes.ReadonlyObject({ options: funtypes.ReadonlyObject({ method: funtypes.Literal('eth_accounts_reply'), params: funtypes.ReadonlyTuple() }), result: funtypes.Literal('0x') }),
+	funtypes.ReadonlyObject({ options: funtypes.ReadonlyObject({ method: funtypes.Literal('signer_chainChanged'), params: funtypes.ReadonlyTuple() }), result: funtypes.Literal('0x') }),
+	funtypes.ReadonlyObject({ options: WalletSwitchEthereumChainReply, result: funtypes.Literal('0x') }),
+	funtypes.ReadonlyObject({ options: funtypes.ReadonlyObject({ method: funtypes.Literal('connected_to_signer'), params: funtypes.ReadonlyTuple() }), result: funtypes.Literal('0x') }),
 )
+
+export type ErrorReturn = funtypes.Static<typeof ErrorReturn>
+export const ErrorReturn = funtypes.ReadonlyObject({
+	error: funtypes.Intersect(
+		funtypes.ReadonlyObject({
+			code: funtypes.Number,
+			message: funtypes.String,
+		}),
+		funtypes.ReadonlyPartial({
+			data: funtypes.String,
+		})
+	)
+})
+
 export type NonForwardingRPCRequestReturnValue = funtypes.Static<typeof NonForwardingRPCRequestReturnValue>
 export const NonForwardingRPCRequestReturnValue = funtypes.Union(
-	NonForwardingRPCRequestSuccessfullReturnValue,
-	funtypes.ReadonlyObject({
-		error: funtypes.Intersect(
-			funtypes.ReadonlyObject({
-				code: funtypes.Number,
-				message: funtypes.String,
-			}),
-			funtypes.ReadonlyPartial({
-				data: funtypes.String,
-			})
-		)
-	}),
+	funtypes.Intersect(funtypes.ReadonlyObject({ options: EthBlockByNumberParams}), funtypes.Union(funtypes.ReadonlyObject({ result: GetBlockReturn }), ErrorReturn)),
+	funtypes.Intersect(funtypes.ReadonlyObject({ options: EthBalanceParams}), funtypes.Union(funtypes.ReadonlyObject({ result: EthereumQuantity }), ErrorReturn)),
+	funtypes.Intersect(funtypes.ReadonlyObject({ options: EstimateGasParams}), funtypes.Union(funtypes.ReadonlyObject({ result: EthereumQuantity }), ErrorReturn)),
+	funtypes.Intersect(funtypes.ReadonlyObject({ options: TransactionByHashParams}), funtypes.Union(funtypes.ReadonlyObject({ result: funtypes.Union(EthereumSignedTransactionWithBlockData, funtypes.Undefined) }), ErrorReturn)),
+	funtypes.Intersect(funtypes.ReadonlyObject({ options: TransactionReceiptParams}), funtypes.Union(funtypes.ReadonlyObject({ result: EthTransactionReceiptResponse }), ErrorReturn)),
+	funtypes.Intersect(funtypes.ReadonlyObject({ options: EthSubscribeParams}), funtypes.Union(funtypes.ReadonlyObject({ result: funtypes.String }), ErrorReturn)),
+	funtypes.Intersect(funtypes.ReadonlyObject({ options: EthUnSubscribeParams}), funtypes.Union(funtypes.ReadonlyObject({ result: funtypes.Boolean }), ErrorReturn)),
+	funtypes.Intersect(funtypes.ReadonlyObject({ options: funtypes.ReadonlyObject({ method: funtypes.Literal('eth_chainId') })}), funtypes.Union(funtypes.ReadonlyObject({ result: EthereumQuantity }), ErrorReturn)),
+	funtypes.Intersect(funtypes.ReadonlyObject({ options: funtypes.ReadonlyObject({ method: funtypes.Literal('net_version') })}), funtypes.Union(funtypes.ReadonlyObject({ result: EthereumQuantity }), ErrorReturn)),
+	funtypes.Intersect(funtypes.ReadonlyObject({ options: funtypes.ReadonlyObject({ method: funtypes.Literal('eth_blockNumber') })}), funtypes.Union(funtypes.ReadonlyObject({ result: EthereumQuantity }), ErrorReturn)),
+	funtypes.Intersect(funtypes.ReadonlyObject({ options: GetCode}), funtypes.Union(funtypes.ReadonlyObject({ result: EthereumData }), ErrorReturn)),
+	funtypes.Intersect(funtypes.ReadonlyObject({ options: SwitchEthereumChainParams}), funtypes.Union(funtypes.ReadonlyObject({ result: funtypes.Null }), ErrorReturn)),
+	funtypes.Intersect(funtypes.ReadonlyObject({ options: funtypes.ReadonlyObject({ method: funtypes.Literal('eth_accounts') })}), funtypes.Union(funtypes.ReadonlyObject({ result: funtypes.ReadonlyArray(EthereumAddress) }), ErrorReturn)),
+	funtypes.Intersect(funtypes.ReadonlyObject({ options: funtypes.ReadonlyObject({ method: funtypes.Literal('wallet_getPermissions') })}), funtypes.Union(funtypes.ReadonlyObject({ result: funtypes.ReadonlyTuple(funtypes.ReadonlyObject({ eth_accounts: funtypes.ReadonlyObject({}) })) }), ErrorReturn)),
+	funtypes.Intersect(funtypes.ReadonlyObject({ options: funtypes.ReadonlyObject({ method: funtypes.Literal('eth_gasPrice') })}), funtypes.Union(funtypes.ReadonlyObject({ result: EthereumQuantity }), ErrorReturn)),
+	funtypes.Intersect(funtypes.ReadonlyObject({ options: GetTransactionCount }), funtypes.Union(funtypes.ReadonlyObject({ result: EthereumQuantity }), ErrorReturn)),
+	funtypes.Intersect(funtypes.ReadonlyObject({ options: GetSimulationStack }), funtypes.Union(funtypes.ReadonlyObject({ result: funtypes.ReadonlyObject({ version: funtypes.Literal('1.0.0'), payload: GetSimulationStackReply }) }), ErrorReturn)),
+	funtypes.Intersect(funtypes.ReadonlyObject({ options: EthGetLogsParams }), funtypes.Union(funtypes.ReadonlyObject({ result: EthGetLogsResponse }), ErrorReturn)),
+	funtypes.Intersect(funtypes.ReadonlyObject({ options: SendTransactionParams }), funtypes.Union(funtypes.ReadonlyObject({ result: EthereumBytes32 }), ErrorReturn)),
+	funtypes.Intersect(funtypes.ReadonlyObject({ options: SendRawTransaction }), funtypes.Union(funtypes.ReadonlyObject({ result: EthereumBytes32 }), ErrorReturn)),
+	funtypes.Intersect(funtypes.ReadonlyObject({ options: EthCallParams }), funtypes.Union(funtypes.ReadonlyObject({ result: EthereumData }), ErrorReturn)),
+	funtypes.Intersect(funtypes.ReadonlyObject({ options: funtypes.Union(PersonalSignParams, SignTypedDataParams, OldSignTypedDataParams) }), funtypes.Union(funtypes.ReadonlyObject({ result: funtypes.String }), ErrorReturn)),
 )
 
-export type HandleRPCRequestReturnValue = funtypes.Static<typeof HandleRPCRequestReturnValue>
-export const HandleRPCRequestReturnValue = funtypes.Union(
+export type SubscriptionReturnValue = funtypes.Static<typeof SubscriptionReturnValue>
+export const SubscriptionReturnValue = funtypes.ReadonlyObject({
+	method: funtypes.Literal('newHeads'),
+	result: funtypes.ReadonlyObject({
+		subscription: funtypes.Literal('newHeads'),
+		result: EthereumBlockHeaderWithTransactionHashes
+	})
+})
+
+export type RPCReply = funtypes.Static<typeof RPCReply>
+export const RPCReply = funtypes.Union(
 	NonForwardingRPCRequestReturnValue,
-	funtypes.ReadonlyObject({ forward: funtypes.Literal(true) }) //todo, add check here that we can only forward specific requets
+	funtypes.ReadonlyObject({ forward: funtypes.Literal(true) }), //todo, add check here that we can only forward specific requets
+)
+
+export type RPCReplyWithRequestId = funtypes.Static<typeof RPCReply>
+export const RPCReplyWithRequestId = funtypes.Intersect(
+	funtypes.ReadonlyObject({ requestId: funtypes.Number }),
+	RPCReply,
+)
+
+export type InpageMessage = funtypes.Static<typeof InpageMessage>
+export const InpageMessage = funtypes.Union(
+	InpageScriptCallBack,
+	RPCReplyWithRequestId,
+)
+
+export type InterceptorMessageToInpage = funtypes.Static<typeof InterceptorMessageToInpage>
+export const InterceptorMessageToInpage = funtypes.Intersect(
+	funtypes.ReadonlyObject({ interceptorApproved: funtypes.Literal(true) }),
+	funtypes.Union(RPCReply, InpageScriptCallBack)
 )
 
 export type InterceptedRequestForward = funtypes.Static<typeof InterceptedRequestForward>
-export const InterceptedRequestForward = funtypes.Intersect(
-	funtypes.ReadonlyObject({
-		interceptorApproved: funtypes.Literal(true),
-		options: MessageMethodAndParams,
-	}).asReadonly(),
-	funtypes.Union(NonForwardingRPCRequestReturnValue, funtypes.ReadonlyObject({})),
-	funtypes.Partial({
-		subscription: funtypes.String,
-		usingInterceptorWithoutSigner: funtypes.Boolean,
+export const InterceptedRequestForward =  funtypes.Union(
+	funtypes.ReadonlyObject({ // forward directly to wallet
+		forward: funtypes.Literal(true),
+		methodAndParams: MessageMethodAndParams,
 		requestId: funtypes.Number
-	}).asReadonly()
+	}).asReadonly(),
+	funtypes.Intersect( // respond with a result
+		funtypes.ReadonlyObject({
+			methodAndParams: MessageMethodAndParams,
+			requestId: funtypes.Number
+		}).asReadonly(),
+		NonForwardingRPCRequestReturnValue,
+	),
+	funtypes.Intersect( // subscriptions
+		funtypes.ReadonlyObject({
+			methodAndParams: MessageMethodAndParams,
+			subscription: funtypes.String,
+		}).asReadonly(),
+		SubscriptionReturnValue,
+	),
+	InpageScriptRequest, // request Interceptors inpage script for something
+	InpageScriptCallBack, // send callback
 )
 
 export type TransactionConfirmation = funtypes.Static<typeof TransactionConfirmation>
@@ -265,17 +305,11 @@ export const ChangeActiveChain = funtypes.ReadonlyObject({
 export type ChainChangeConfirmation = funtypes.Static<typeof ChainChangeConfirmation>
 export const ChainChangeConfirmation = funtypes.ReadonlyObject({
 	method: funtypes.Literal('popup_changeChainDialog'),
-	options: funtypes.Union(
-		funtypes.ReadonlyObject({
-			chainId: EthereumQuantity,
-			requestId: funtypes.Number,
-			accept: funtypes.Literal(true),
-		}),
-		funtypes.ReadonlyObject({
-			requestId: funtypes.Number,
-			accept: funtypes.Literal(false),
-		}),
-	)
+	options: funtypes.ReadonlyObject({
+		chainId: EthereumQuantity,
+		requestId: funtypes.Number,
+		accept: funtypes.Boolean,
+	}),	
 }).asReadonly()
 
 export type SignerChainChangeConfirmation = funtypes.Static<typeof SignerChainChangeConfirmation>
@@ -291,15 +325,6 @@ export type ConnectedToSigner = funtypes.Static<typeof ConnectedToSigner>
 export const ConnectedToSigner = funtypes.ReadonlyObject({
 	method: funtypes.Literal('connected_to_signer'),
 	params: funtypes.Tuple(SignerName),
-}).asReadonly()
-
-export type WalletSwitchEthereumChainReply = funtypes.Static<typeof WalletSwitchEthereumChainReply>
-export const WalletSwitchEthereumChainReply = funtypes.ReadonlyObject({
-	method: funtypes.Literal('wallet_switchEthereumChain_reply'),
-	params: funtypes.Tuple(funtypes.ReadonlyObject({
-		accept: funtypes.Boolean,
-		chainId: EthereumQuantity,
-	}))
 }).asReadonly()
 
 export type GetAddressBookDataFilter = funtypes.Static<typeof GetAddressBookDataFilter>

--- a/app/ts/utils/interceptor-messages.ts
+++ b/app/ts/utils/interceptor-messages.ts
@@ -1,6 +1,6 @@
 import * as funtypes from 'funtypes'
 import { AddressBookEntries, AddressBookEntry, AddressInfo, AddressInfoEntry, ContactEntries, SignerName, Website, WebsiteSocket } from './user-interface-types.js'
-import { EthTransactionReceiptResponse, EthereumAddress, EthereumData, EthereumQuantity, EthereumSignedTransactionWithBlockData, GetBlockReturn, OldSignTypedDataParams, PersonalSignParams, SignTypedDataParams } from './wire-types.js'
+import { EthGetLogsResponse, EthTransactionReceiptResponse, EthereumAddress, EthereumBlockHeaderWithTransactionHashes, EthereumBytes32, EthereumData, EthereumQuantity, EthereumSignedTransactionWithBlockData, GetBlockReturn, GetSimulationStackReply, OldSignTypedDataParams, PersonalSignParams, SignTypedDataParams } from './wire-types.js'
 import { SimulationState, OptionalEthereumAddress, SimulatedAndVisualizedTransaction, SimResults, TokenPriceEstimate, WebsiteCreatedEthereumUnsignedTransaction } from './visualizer-types.js'
 import { ICON_ACCESS_DENIED, ICON_ACTIVE, ICON_NOT_ACTIVE, ICON_SIGNING, ICON_SIGNING_NOT_SUPPORTED, ICON_SIMULATING } from './constants.js'
 import { PersonalSignRequestData } from './personal-message-definitions.js'
@@ -25,23 +25,58 @@ export const InterceptedRequest = funtypes.Intersect(
 )
 export type ProviderMessage = InterceptedRequest
 
+export type InpageScriptRequestAndCallBacks = funtypes.Static<typeof InpageScriptRequestAndCallBacks>
+export const InpageScriptRequestAndCallBacks = funtypes.Union(
+	funtypes.ReadonlyObject({ method: funtypes.Literal('request_signer_chainId'), result: funtypes.ReadonlyTuple() }),
+	funtypes.ReadonlyObject({ method: funtypes.Literal('request_signer_to_eth_requestAccounts'), result: funtypes.ReadonlyTuple() }),
+	funtypes.ReadonlyObject({ method: funtypes.Literal('request_signer_to_wallet_switchEthereumChain'), result: EthereumQuantity }),
+	funtypes.ReadonlyObject({ method: funtypes.Literal('connect'), result: funtypes.ReadonlyTuple(EthereumQuantity) }),
+	funtypes.ReadonlyObject({ method: funtypes.Literal('accountsChanged'), result: funtypes.ReadonlyArray(EthereumAddress) }),
+	funtypes.ReadonlyObject({ method: funtypes.Literal('chainChanged'), result: EthereumQuantity }),
+)
+
+export type NonForwardingRPCRequestSuccessfullReturnValue = funtypes.Static<typeof NonForwardingRPCRequestSuccessfullReturnValue>
+export const NonForwardingRPCRequestSuccessfullReturnValue = funtypes.Union(
+	funtypes.ReadonlyObject({ method: funtypes.Literal('method!'), result: funtypes.ReadonlyTuple(EthereumAddress) }),
+	funtypes.ReadonlyObject({ method: funtypes.Literal('eth_getBlockByNumber'), result: GetBlockReturn }),
+	funtypes.ReadonlyObject({ method: funtypes.Literal('eth_getBalance'), result: EthereumQuantity }),
+	funtypes.ReadonlyObject({ method: funtypes.Literal('eth_estimateGas'), result: EthereumQuantity }),
+	funtypes.ReadonlyObject({ method: funtypes.Literal('eth_getTransactionByHash'), result: funtypes.Union(EthereumSignedTransactionWithBlockData, funtypes.Undefined) }),
+	funtypes.ReadonlyObject({ method: funtypes.Literal('eth_getTransactionReceipt'), result: EthTransactionReceiptResponse }),
+	funtypes.ReadonlyObject({ method: funtypes.Literal('eth_subscribe'), result: funtypes.String }),
+	funtypes.ReadonlyObject({ method: funtypes.Literal('eth_unsubscribe'), result: funtypes.Boolean }),
+	funtypes.ReadonlyObject({ method: funtypes.Literal('eth_chainId'), result: EthereumQuantity }),
+	funtypes.ReadonlyObject({ method: funtypes.Literal('net_version'), result: EthereumQuantity }),
+	funtypes.ReadonlyObject({ method: funtypes.Literal('eth_blockNumber'), result: EthereumQuantity }),
+	funtypes.ReadonlyObject({ method: funtypes.Literal('eth_getCode'), result: EthereumData }),
+	funtypes.ReadonlyObject({ method: funtypes.Literal('wallet_switchEthereumChain'), result: funtypes.Null }),
+	funtypes.ReadonlyObject({ method: funtypes.Literal('eth_accounts'), result: funtypes.ReadonlyArray(EthereumAddress) }),
+	funtypes.ReadonlyObject({ method: funtypes.Literal('wallet_getPermissions'), result: funtypes.ReadonlyTuple(funtypes.ReadonlyObject({ eth_accounts: funtypes.ReadonlyObject({}) })) }),
+	funtypes.ReadonlyObject({ method: funtypes.Literal('eth_gasPrice'), result: EthereumQuantity }),
+	funtypes.ReadonlyObject({ method: funtypes.Literal('eth_getTransactionCount'), result: EthereumQuantity }),
+	funtypes.ReadonlyObject({ method: funtypes.Literal('interceptor_getSimulationStack'), result: funtypes.ReadonlyObject({ version: funtypes.Literal('1.0.0'), payload: GetSimulationStackReply }) }),
+	funtypes.ReadonlyObject({ method: funtypes.Literal('eth_getLogs'), result: EthGetLogsResponse }),
+	funtypes.ReadonlyObject({ method: funtypes.Literal('eth_sendTransaction'), result: EthereumBytes32 }),
+	funtypes.ReadonlyObject({ method: funtypes.Literal('eth_sendRawTransaction'), result: EthereumBytes32 }),
+	funtypes.ReadonlyObject({ method: funtypes.Literal('eth_accounts_reply'), result: funtypes.Literal('0x') }),
+	funtypes.ReadonlyObject({ method: funtypes.Literal('signer_chainChanged'), result: funtypes.Literal('0x') }),
+	funtypes.ReadonlyObject({ method: funtypes.Literal('wallet_switchEthereumChain_reply'), result: funtypes.Literal('0x') }),
+	funtypes.ReadonlyObject({ method: funtypes.Literal('connected_to_signer'), result: funtypes.Literal('0x') }),
+	funtypes.ReadonlyObject({ method: funtypes.Literal('eth_call'), result: EthereumData }),
+	funtypes.ReadonlyObject({ method: funtypes.Union(
+		funtypes.Literal('personal_sign'),
+		funtypes.Literal('eth_signTypedData'),
+		funtypes.Literal('eth_signTypedData_v1'),
+		funtypes.Literal('eth_signTypedData_v2'),
+		funtypes.Literal('eth_signTypedData_v3'),
+		funtypes.Literal('eth_signTypedData_v4')
+	), result: funtypes.String }),
+	funtypes.ReadonlyObject({ method: funtypes.Literal('newHeads'), result: funtypes.ReadonlyObject({ subscription: funtypes.Literal('newHeads'), result: EthereumBlockHeaderWithTransactionHashes }) }),
+	InpageScriptRequestAndCallBacks,
+)
 export type NonForwardingRPCRequestReturnValue = funtypes.Static<typeof NonForwardingRPCRequestReturnValue>
 export const NonForwardingRPCRequestReturnValue = funtypes.Union(
-	funtypes.Union(
-		funtypes.ReadonlyObject({ method: funtypes.Literal('method!'), result: funtypes.ReadonlyTuple(EthereumAddress) }),
-		funtypes.ReadonlyObject({ method: funtypes.Literal('eth_getBlockByNumber'), result: GetBlockReturn }),
-		funtypes.ReadonlyObject({ method: funtypes.Literal('eth_getBalance'), result: EthereumQuantity }),
-		funtypes.ReadonlyObject({ method: funtypes.Literal('eth_estimateGas'), result: EthereumQuantity }),
-		funtypes.ReadonlyObject({ method: funtypes.Literal('eth_getTransactionByHash'), result: funtypes.Union(EthereumSignedTransactionWithBlockData, funtypes.Undefined) }),
-		funtypes.ReadonlyObject({ method: funtypes.Literal('eth_getTransactionReceipt'), result: EthTransactionReceiptResponse }),
-		funtypes.ReadonlyObject({ method: funtypes.Literal('eth_subscribe'), result: funtypes.String }),
-		funtypes.ReadonlyObject({ method: funtypes.Literal('eth_unsubscribe'), result: funtypes.Boolean }),
-		funtypes.ReadonlyObject({ method: funtypes.Literal('eth_chainId'), result: EthereumQuantity }),
-		funtypes.ReadonlyObject({ method: funtypes.Literal('net_version'), result: EthereumQuantity }),
-		funtypes.ReadonlyObject({ method: funtypes.Literal('eth_blockNumber'), result: EthereumQuantity }),
-		funtypes.ReadonlyObject({ method: funtypes.Literal('eth_getCode'), result: EthereumData }),
-		funtypes.ReadonlyObject({ method: funtypes.Literal('wallet_switchEthereumChain'), result: funtypes.Null }),
-	),
+	NonForwardingRPCRequestSuccessfullReturnValue,
 	funtypes.ReadonlyObject({
 		error: funtypes.Intersect(
 			funtypes.ReadonlyObject({
@@ -64,7 +99,7 @@ export const HandleRPCRequestReturnValue = funtypes.Union(
 export type InterceptedRequestForward = funtypes.Static<typeof InterceptedRequestForward>
 export const InterceptedRequestForward = funtypes.Intersect(
 	funtypes.ReadonlyObject({
-		interceptorApproved: funtypes.Boolean,
+		interceptorApproved: funtypes.Literal(true),
 		options: MessageMethodAndParams,
 	}).asReadonly(),
 	funtypes.Union(NonForwardingRPCRequestReturnValue, funtypes.ReadonlyObject({})),

--- a/app/ts/utils/interceptor-messages.ts
+++ b/app/ts/utils/interceptor-messages.ts
@@ -1,18 +1,9 @@
 import * as funtypes from 'funtypes'
 import { AddressBookEntries, AddressBookEntry, AddressInfo, AddressInfoEntry, ContactEntries, SignerName, Website, WebsiteSocket } from './user-interface-types.js'
-import { EstimateGasParams, EthBalanceParams, EthBlockByNumberParams, EthCallParams, EthGetLogsParams, EthGetLogsResponse, EthSubscribeParams, EthTransactionReceiptResponse, EthUnSubscribeParams, EthereumAddress, EthereumBlockHeaderWithTransactionHashes, EthereumBytes32, EthereumData, EthereumQuantity, EthereumSignedTransactionWithBlockData, GetBlockReturn, GetCode, GetSimulationStack, GetSimulationStackReply, GetTransactionCount, OldSignTypedDataParams, PersonalSignParams, SendRawTransaction, SendTransactionParams, SignTypedDataParams, SwitchEthereumChainParams, TransactionByHashParams, TransactionReceiptParams } from './wire-types.js'
+import { EthGetLogsResponse, EthTransactionReceiptResponse, EthereumAddress, EthereumBlockHeaderWithTransactionHashes, EthereumBytes32, EthereumData, EthereumQuantity, EthereumSignedTransactionWithBlockData, GetBlockReturn, GetSimulationStackReply, OldSignTypedDataParams, PersonalSignParams, SendRawTransaction, SendTransactionParams, SignTypedDataParams } from './wire-types.js'
 import { SimulationState, OptionalEthereumAddress, SimulatedAndVisualizedTransaction, SimResults, TokenPriceEstimate, WebsiteCreatedEthereumUnsignedTransaction } from './visualizer-types.js'
 import { ICON_ACCESS_DENIED, ICON_ACTIVE, ICON_NOT_ACTIVE, ICON_SIGNING, ICON_SIGNING_NOT_SUPPORTED, ICON_SIMULATING } from './constants.js'
 import { PersonalSignRequestData } from './personal-message-definitions.js'
-
-export type MessageMethodAndParams = funtypes.Static<typeof MessageMethodAndParams>
-export const MessageMethodAndParams = funtypes.Union(
-	funtypes.ReadonlyObject({
-		method: funtypes.String,
-		params: funtypes.Union(funtypes.Array(funtypes.Unknown), funtypes.Undefined)
-	}).asReadonly(),
-	funtypes.ReadonlyObject({ method: funtypes.String }).asReadonly()
-)
 
 export type WalletSwitchEthereumChainReply = funtypes.Static<typeof WalletSwitchEthereumChainReply>
 export const WalletSwitchEthereumChainReply = funtypes.ReadonlyObject({
@@ -25,36 +16,78 @@ export const WalletSwitchEthereumChainReply = funtypes.ReadonlyObject({
 
 export type InterceptedRequest = funtypes.Static<typeof InterceptedRequest>
 export const InterceptedRequest = funtypes.Intersect(
+	funtypes.Union(
+		funtypes.ReadonlyObject({
+			method: funtypes.String,
+			params: funtypes.Union(funtypes.Array(funtypes.Unknown), funtypes.Undefined)
+		}).asReadonly(),
+		funtypes.ReadonlyObject({ method: funtypes.String }).asReadonly()
+	),
 	funtypes.ReadonlyObject({
 		interceptorRequest: funtypes.Boolean,
 		usingInterceptorWithoutSigner: funtypes.Boolean,
-		options: MessageMethodAndParams,
 		requestId: funtypes.Number,
-	}).asReadonly()
+	})
 )
 export type ProviderMessage = InterceptedRequest
 
 export type InpageScriptRequest = funtypes.Static<typeof InpageScriptRequest>
-export const InpageScriptRequest = funtypes.Union(
-	funtypes.ReadonlyObject({ options: funtypes.ReadonlyObject({ method: funtypes.Literal('request_signer_chainId'), params: funtypes.ReadonlyTuple() }) }),
-	funtypes.ReadonlyObject({ options: funtypes.ReadonlyObject({ method: funtypes.Literal('request_signer_to_eth_requestAccounts'), params: funtypes.ReadonlyTuple() }) }),
-	funtypes.ReadonlyObject({ options: funtypes.ReadonlyObject({ method: funtypes.Literal('request_signer_to_wallet_switchEthereumChain'), params: EthereumQuantity }) }),
+export const InpageScriptRequest = funtypes.Intersect(
+	funtypes.ReadonlyObject({ requestId: funtypes.Number }),
+	funtypes.Union(
+		funtypes.ReadonlyObject({ method: funtypes.Literal('eth_accounts_reply'), result: funtypes.Literal('0x') }),
+		funtypes.ReadonlyObject({ method: funtypes.Literal('signer_chainChanged'), result: funtypes.Literal('0x') }),
+		funtypes.ReadonlyObject({ method: funtypes.Literal('connected_to_signer'), result: funtypes.Literal('0x') }),
+		funtypes.ReadonlyObject({ method: funtypes.Literal('wallet_switchEthereumChain_reply'), result: funtypes.Literal('0x') }),
+	)
 )
 
 export type InpageScriptCallBack = funtypes.Static<typeof InpageScriptCallBack>
 export const InpageScriptCallBack = funtypes.Union(
-	funtypes.ReadonlyObject({ options: funtypes.ReadonlyObject({ method: funtypes.Literal('connect'), params: funtypes.ReadonlyTuple() }), result: funtypes.ReadonlyTuple(EthereumQuantity) }),
-	funtypes.ReadonlyObject({ options: funtypes.ReadonlyObject({ method: funtypes.Literal('accountsChanged'), params: funtypes.ReadonlyTuple() }), result: funtypes.ReadonlyArray(EthereumAddress) }),
-	funtypes.ReadonlyObject({ options: funtypes.ReadonlyObject({ method: funtypes.Literal('chainChanged'), params: funtypes.ReadonlyTuple() }), result: EthereumQuantity }),
-	funtypes.ReadonlyObject({ options: funtypes.ReadonlyObject({ method: funtypes.Literal('disconnect'), params: funtypes.ReadonlyTuple() }), result: funtypes.ReadonlyTuple() }),
-	funtypes.ReadonlyObject({ options: funtypes.ReadonlyObject({ method: funtypes.Literal('eth_accounts_reply'), params: funtypes.ReadonlyTuple() }), result: funtypes.Literal('0x') }),
-	funtypes.ReadonlyObject({ options: funtypes.ReadonlyObject({ method: funtypes.Literal('signer_chainChanged'), params: funtypes.ReadonlyTuple() }), result: funtypes.Literal('0x') }),
-	funtypes.ReadonlyObject({ options: WalletSwitchEthereumChainReply, result: funtypes.Literal('0x') }),
-	funtypes.ReadonlyObject({ options: funtypes.ReadonlyObject({ method: funtypes.Literal('connected_to_signer'), params: funtypes.ReadonlyTuple() }), result: funtypes.Literal('0x') }),
+	funtypes.ReadonlyObject({ method: funtypes.Literal('request_signer_chainId'), result: funtypes.ReadonlyTuple() }),
+	funtypes.ReadonlyObject({ method: funtypes.Literal('request_signer_to_wallet_switchEthereumChain'), result: EthereumQuantity }),
+	funtypes.ReadonlyObject({ method: funtypes.Literal('request_signer_to_eth_requestAccounts'), result: funtypes.ReadonlyTuple() }),
+	funtypes.ReadonlyObject({ method: funtypes.Literal('disconnect'), result: funtypes.ReadonlyTuple() }),
+	funtypes.ReadonlyObject({ method: funtypes.Literal('connect'), result: funtypes.ReadonlyTuple(EthereumQuantity) }),
+	funtypes.ReadonlyObject({ method: funtypes.Literal('accountsChanged'), result: funtypes.ReadonlyArray(EthereumAddress) }),
+	funtypes.ReadonlyObject({ method: funtypes.Literal('chainChanged'), result: EthereumQuantity }),
+)
+/*
+export type NonForwardingRPCRequestSuccessfullReturnValue = funtypes.Static<typeof NonForwardingRPCRequestSuccessfullReturnValue>
+export const NonForwardingRPCRequestSuccessfullReturnValue = funtypes.Union(
+funtypes.ReadonlyObject({ data: SendRawTransaction, result: EthereumBytes32 }),
+funtypes.ReadonlyObject({ data: SendTransactionParams, result: EthereumBytes32 })
+*/
+
+export type NonForwardingRPCRequestSuccessfullReturnValue = funtypes.Static<typeof NonForwardingRPCRequestSuccessfullReturnValue>
+export const NonForwardingRPCRequestSuccessfullReturnValue = funtypes.Union(
+	funtypes.ReadonlyObject({ method: funtypes.Literal('eth_getBlockByNumber'), result: GetBlockReturn }),
+	funtypes.ReadonlyObject({ method: funtypes.Literal('eth_getBalance'), result: EthereumQuantity }),
+	funtypes.ReadonlyObject({ method: funtypes.Literal('eth_estimateGas'), result: EthereumQuantity }),
+	funtypes.ReadonlyObject({ method: funtypes.Literal('eth_getTransactionByHash'), result: funtypes.Union(EthereumSignedTransactionWithBlockData, funtypes.Undefined) }),
+	funtypes.ReadonlyObject({ method: funtypes.Literal('eth_getTransactionReceipt'), result: EthTransactionReceiptResponse }),
+	funtypes.ReadonlyObject({ method: funtypes.Literal('eth_subscribe'), result: funtypes.String }),
+	funtypes.ReadonlyObject({ method: funtypes.Literal('eth_unsubscribe'), result: funtypes.Boolean }),
+	funtypes.ReadonlyObject({ method: funtypes.Literal('eth_chainId'), result: EthereumQuantity }),
+	funtypes.ReadonlyObject({ method: funtypes.Literal('net_version'), result: EthereumQuantity }),
+	funtypes.ReadonlyObject({ method: funtypes.Literal('eth_blockNumber'), result: EthereumQuantity }),
+	funtypes.ReadonlyObject({ method: funtypes.Literal('eth_getCode'), result: EthereumData }),
+	funtypes.ReadonlyObject({ method: funtypes.Literal('wallet_switchEthereumChain'), result: funtypes.Null }),
+	funtypes.ReadonlyObject({ method: funtypes.Literal('eth_accounts'), result: funtypes.ReadonlyArray(EthereumAddress) }),
+	funtypes.ReadonlyObject({ method: funtypes.Literal('wallet_getPermissions'), result: funtypes.ReadonlyTuple(funtypes.ReadonlyObject({ eth_accounts: funtypes.ReadonlyObject({}) })) }),
+	funtypes.ReadonlyObject({ method: funtypes.Literal('eth_gasPrice'), result: EthereumQuantity }),
+	funtypes.ReadonlyObject({ method: funtypes.Literal('eth_getTransactionCount'), result: EthereumQuantity }),
+	funtypes.ReadonlyObject({ method: funtypes.Literal('interceptor_getSimulationStack'), result: funtypes.ReadonlyObject({ version: funtypes.Literal('1.0.0'), payload: GetSimulationStackReply }) }),
+	funtypes.ReadonlyObject({ method: funtypes.Literal('eth_getLogs'), result: EthGetLogsResponse }),
+	funtypes.ReadonlyObject({ method: funtypes.Literal('eth_sendRawTransaction'), result: EthereumBytes32 }),
+	funtypes.ReadonlyObject({ method: funtypes.Literal('eth_sendTransaction'), result: EthereumBytes32 }),
+	funtypes.ReadonlyObject({ method: funtypes.Literal('eth_call'), result: EthereumData }),
+	funtypes.ReadonlyObject({ method: funtypes.Union(funtypes.Literal('personal_sign'), funtypes.Literal('eth_signTypedData_v1'), funtypes.Literal('eth_signTypedData_v2'), funtypes.Literal('eth_signTypedData_v3'), funtypes.Literal('eth_signTypedData_v4'), funtypes.Literal('eth_signTypedData')), result: funtypes.String }),
 )
 
 export type ErrorReturn = funtypes.Static<typeof ErrorReturn>
 export const ErrorReturn = funtypes.ReadonlyObject({
+	method: funtypes.String,
 	error: funtypes.Intersect(
 		funtypes.ReadonlyObject({
 			code: funtypes.Number,
@@ -66,32 +99,6 @@ export const ErrorReturn = funtypes.ReadonlyObject({
 	)
 })
 
-export type NonForwardingRPCRequestReturnValue = funtypes.Static<typeof NonForwardingRPCRequestReturnValue>
-export const NonForwardingRPCRequestReturnValue = funtypes.Union(
-	funtypes.Intersect(funtypes.ReadonlyObject({ options: EthBlockByNumberParams}), funtypes.Union(funtypes.ReadonlyObject({ result: GetBlockReturn }), ErrorReturn)),
-	funtypes.Intersect(funtypes.ReadonlyObject({ options: EthBalanceParams}), funtypes.Union(funtypes.ReadonlyObject({ result: EthereumQuantity }), ErrorReturn)),
-	funtypes.Intersect(funtypes.ReadonlyObject({ options: EstimateGasParams}), funtypes.Union(funtypes.ReadonlyObject({ result: EthereumQuantity }), ErrorReturn)),
-	funtypes.Intersect(funtypes.ReadonlyObject({ options: TransactionByHashParams}), funtypes.Union(funtypes.ReadonlyObject({ result: funtypes.Union(EthereumSignedTransactionWithBlockData, funtypes.Undefined) }), ErrorReturn)),
-	funtypes.Intersect(funtypes.ReadonlyObject({ options: TransactionReceiptParams}), funtypes.Union(funtypes.ReadonlyObject({ result: EthTransactionReceiptResponse }), ErrorReturn)),
-	funtypes.Intersect(funtypes.ReadonlyObject({ options: EthSubscribeParams}), funtypes.Union(funtypes.ReadonlyObject({ result: funtypes.String }), ErrorReturn)),
-	funtypes.Intersect(funtypes.ReadonlyObject({ options: EthUnSubscribeParams}), funtypes.Union(funtypes.ReadonlyObject({ result: funtypes.Boolean }), ErrorReturn)),
-	funtypes.Intersect(funtypes.ReadonlyObject({ options: funtypes.ReadonlyObject({ method: funtypes.Literal('eth_chainId') })}), funtypes.Union(funtypes.ReadonlyObject({ result: EthereumQuantity }), ErrorReturn)),
-	funtypes.Intersect(funtypes.ReadonlyObject({ options: funtypes.ReadonlyObject({ method: funtypes.Literal('net_version') })}), funtypes.Union(funtypes.ReadonlyObject({ result: EthereumQuantity }), ErrorReturn)),
-	funtypes.Intersect(funtypes.ReadonlyObject({ options: funtypes.ReadonlyObject({ method: funtypes.Literal('eth_blockNumber') })}), funtypes.Union(funtypes.ReadonlyObject({ result: EthereumQuantity }), ErrorReturn)),
-	funtypes.Intersect(funtypes.ReadonlyObject({ options: GetCode}), funtypes.Union(funtypes.ReadonlyObject({ result: EthereumData }), ErrorReturn)),
-	funtypes.Intersect(funtypes.ReadonlyObject({ options: SwitchEthereumChainParams}), funtypes.Union(funtypes.ReadonlyObject({ result: funtypes.Null }), ErrorReturn)),
-	funtypes.Intersect(funtypes.ReadonlyObject({ options: funtypes.ReadonlyObject({ method: funtypes.Literal('eth_accounts') })}), funtypes.Union(funtypes.ReadonlyObject({ result: funtypes.ReadonlyArray(EthereumAddress) }), ErrorReturn)),
-	funtypes.Intersect(funtypes.ReadonlyObject({ options: funtypes.ReadonlyObject({ method: funtypes.Literal('wallet_getPermissions') })}), funtypes.Union(funtypes.ReadonlyObject({ result: funtypes.ReadonlyTuple(funtypes.ReadonlyObject({ eth_accounts: funtypes.ReadonlyObject({}) })) }), ErrorReturn)),
-	funtypes.Intersect(funtypes.ReadonlyObject({ options: funtypes.ReadonlyObject({ method: funtypes.Literal('eth_gasPrice') })}), funtypes.Union(funtypes.ReadonlyObject({ result: EthereumQuantity }), ErrorReturn)),
-	funtypes.Intersect(funtypes.ReadonlyObject({ options: GetTransactionCount }), funtypes.Union(funtypes.ReadonlyObject({ result: EthereumQuantity }), ErrorReturn)),
-	funtypes.Intersect(funtypes.ReadonlyObject({ options: GetSimulationStack }), funtypes.Union(funtypes.ReadonlyObject({ result: funtypes.ReadonlyObject({ version: funtypes.Literal('1.0.0'), payload: GetSimulationStackReply }) }), ErrorReturn)),
-	funtypes.Intersect(funtypes.ReadonlyObject({ options: EthGetLogsParams }), funtypes.Union(funtypes.ReadonlyObject({ result: EthGetLogsResponse }), ErrorReturn)),
-	funtypes.Intersect(funtypes.ReadonlyObject({ options: SendTransactionParams }), funtypes.Union(funtypes.ReadonlyObject({ result: EthereumBytes32 }), ErrorReturn)),
-	funtypes.Intersect(funtypes.ReadonlyObject({ options: SendRawTransaction }), funtypes.Union(funtypes.ReadonlyObject({ result: EthereumBytes32 }), ErrorReturn)),
-	funtypes.Intersect(funtypes.ReadonlyObject({ options: EthCallParams }), funtypes.Union(funtypes.ReadonlyObject({ result: EthereumData }), ErrorReturn)),
-	funtypes.Intersect(funtypes.ReadonlyObject({ options: funtypes.Union(PersonalSignParams, SignTypedDataParams, OldSignTypedDataParams) }), funtypes.Union(funtypes.ReadonlyObject({ result: funtypes.String }), ErrorReturn)),
-)
-
 export type SubscriptionReturnValue = funtypes.Static<typeof SubscriptionReturnValue>
 export const SubscriptionReturnValue = funtypes.ReadonlyObject({
 	method: funtypes.Literal('newHeads'),
@@ -101,10 +108,16 @@ export const SubscriptionReturnValue = funtypes.ReadonlyObject({
 	})
 })
 
+export type NonForwardingRPCRequestReturnValue = funtypes.Static<typeof NonForwardingRPCRequestReturnValue>
+export const NonForwardingRPCRequestReturnValue = funtypes.Union(NonForwardingRPCRequestSuccessfullReturnValue, ErrorReturn)
+
 export type RPCReply = funtypes.Static<typeof RPCReply>
 export const RPCReply = funtypes.Union(
 	NonForwardingRPCRequestReturnValue,
-	funtypes.ReadonlyObject({ forward: funtypes.Literal(true) }), //todo, add check here that we can only forward specific requets
+	funtypes.ReadonlyObject({ // forward directly to wallet
+		forward: funtypes.Literal(true),
+		method: funtypes.String,
+	}), //todo, add check here that we can only forward specific requets
 )
 
 export type RPCReplyWithRequestId = funtypes.Static<typeof RPCReply>
@@ -113,47 +126,40 @@ export const RPCReplyWithRequestId = funtypes.Intersect(
 	RPCReply,
 )
 
-export type InpageMessage = funtypes.Static<typeof InpageMessage>
-export const InpageMessage = funtypes.Union(
-	InpageScriptCallBack,
-	RPCReplyWithRequestId,
+export type InterceptedRequestForward = funtypes.Static<typeof InterceptedRequestForward>
+export const InterceptedRequestForward = funtypes.Union(
+	funtypes.ReadonlyObject({ // forward directly to wallet
+		forward: funtypes.Literal(true),
+		method: funtypes.String,
+		requestId: funtypes.Number
+	}),
+	funtypes.Intersect( // respond with a result
+		funtypes.ReadonlyObject({
+			requestId: funtypes.Number
+		}),
+		NonForwardingRPCRequestReturnValue,
+	),
+	funtypes.Intersect( // subscriptions
+		funtypes.ReadonlyObject({
+			method: funtypes.String,
+			subscription: funtypes.String,
+		}),
+		SubscriptionReturnValue,
+	),
+	InpageScriptRequest,
+	InpageScriptCallBack, // send callback
 )
 
 export type InterceptorMessageToInpage = funtypes.Static<typeof InterceptorMessageToInpage>
 export const InterceptorMessageToInpage = funtypes.Intersect(
 	funtypes.ReadonlyObject({ interceptorApproved: funtypes.Literal(true) }),
-	funtypes.Union(RPCReply, InpageScriptCallBack)
-)
-
-export type InterceptedRequestForward = funtypes.Static<typeof InterceptedRequestForward>
-export const InterceptedRequestForward =  funtypes.Union(
-	funtypes.ReadonlyObject({ // forward directly to wallet
-		forward: funtypes.Literal(true),
-		methodAndParams: MessageMethodAndParams,
-		requestId: funtypes.Number
-	}).asReadonly(),
-	funtypes.Intersect( // respond with a result
-		funtypes.ReadonlyObject({
-			methodAndParams: MessageMethodAndParams,
-			requestId: funtypes.Number
-		}).asReadonly(),
-		NonForwardingRPCRequestReturnValue,
-	),
-	funtypes.Intersect( // subscriptions
-		funtypes.ReadonlyObject({
-			methodAndParams: MessageMethodAndParams,
-			subscription: funtypes.String,
-		}).asReadonly(),
-		SubscriptionReturnValue,
-	),
-	InpageScriptRequest, // request Interceptors inpage script for something
-	InpageScriptCallBack, // send callback
+	InterceptedRequestForward,
 )
 
 export type TransactionConfirmation = funtypes.Static<typeof TransactionConfirmation>
 export const TransactionConfirmation = funtypes.ReadonlyObject({
 	method: funtypes.Literal('popup_confirmDialog'),
-	options: funtypes.ReadonlyObject({
+	data: funtypes.ReadonlyObject({
 		requestId: funtypes.Number,
 		accept: funtypes.Boolean,
 		windowId: funtypes.Number,
@@ -163,7 +169,7 @@ export const TransactionConfirmation = funtypes.ReadonlyObject({
 export type PersonalSign = funtypes.Static<typeof PersonalSign>
 export const PersonalSign = funtypes.ReadonlyObject({
 	method: funtypes.Literal('popup_personalSign'),
-	options: funtypes.ReadonlyObject({
+	data: funtypes.ReadonlyObject({
 		requestId: funtypes.Number,
 		accept: funtypes.Boolean
 	})
@@ -172,7 +178,7 @@ export const PersonalSign = funtypes.ReadonlyObject({
 export type InterceptorAccessRefresh = funtypes.Static<typeof InterceptorAccessRefresh>
 export const InterceptorAccessRefresh = funtypes.ReadonlyObject({
 	method: funtypes.Literal('popup_interceptorAccessRefresh'),
-	options: funtypes.ReadonlyObject({
+	data: funtypes.ReadonlyObject({
 		socket: WebsiteSocket,
 		website: Website,
 		requestAccessToAddress: OptionalEthereumAddress,
@@ -186,7 +192,7 @@ export const RefreshInterceptorAccessMetadata = funtypes.ReadonlyObject({ method
 export type InterceptorAccessChangeAddress = funtypes.Static<typeof InterceptorAccessChangeAddress>
 export const InterceptorAccessChangeAddress = funtypes.ReadonlyObject({
 	method: funtypes.Literal('popup_interceptorAccessChangeAddress'),
-	options: funtypes.ReadonlyObject({
+	data: funtypes.ReadonlyObject({
 		socket: WebsiteSocket,
 		website: Website,
 		requestAccessToAddress: OptionalEthereumAddress,
@@ -198,7 +204,7 @@ export const InterceptorAccessChangeAddress = funtypes.ReadonlyObject({
 export type ChangeActiveAddress = funtypes.Static<typeof ChangeActiveAddress>
 export const ChangeActiveAddress = funtypes.ReadonlyObject({
 	method: funtypes.Literal('popup_changeActiveAddress'),
-	options: funtypes.ReadonlyObject({
+	data: funtypes.ReadonlyObject({
 		simulationMode: funtypes.Boolean,
 		activeAddress: funtypes.Union(EthereumAddress, funtypes.Literal('signer'))
 	})
@@ -207,7 +213,7 @@ export const ChangeActiveAddress = funtypes.ReadonlyObject({
 export type ChangeMakeMeRich = funtypes.Static<typeof ChangeMakeMeRich>
 export const ChangeMakeMeRich = funtypes.ReadonlyObject({
 	method: funtypes.Literal('popup_changeMakeMeRich'),
-	options: funtypes.Boolean
+	data: funtypes.Boolean
 }).asReadonly()
 
 export type AddressBookCategory = funtypes.Static<typeof AddressBookCategory>
@@ -222,7 +228,7 @@ export const AddressBookCategory = funtypes.Union(
 export type RemoveAddressBookEntry = funtypes.Static<typeof RemoveAddressBookEntry>
 export const RemoveAddressBookEntry = funtypes.ReadonlyObject({
 	method: funtypes.Literal('popup_removeAddressBookEntry'),
-	options: funtypes.ReadonlyObject({
+	data: funtypes.ReadonlyObject({
 		address: EthereumAddress,
 		addressBookCategory: AddressBookCategory,
 	})
@@ -231,7 +237,7 @@ export const RemoveAddressBookEntry = funtypes.ReadonlyObject({
 export type AddOrEditAddressBookEntry = funtypes.Static<typeof AddOrEditAddressBookEntry>
 export const AddOrEditAddressBookEntry = funtypes.ReadonlyObject({
 	method: funtypes.Literal('popup_addOrModifyAddressBookEntry'),
-	options: AddressBookEntry,
+	data: AddressBookEntry,
 }).asReadonly()
 
 export const pages = ['Home', 'AddNewAddress', 'ChangeActiveAddress', 'AccessList', 'ModifyAddress']
@@ -248,25 +254,25 @@ export const Page = funtypes.Union(
 export type ChangePage = funtypes.Static<typeof ChangePage>
 export const ChangePage = funtypes.ReadonlyObject({
 	method: funtypes.Literal('popup_changePage'),
-	options: Page,
+	data: Page,
 }).asReadonly()
 
 export type RequestAccountsFromSigner = funtypes.Static<typeof RequestAccountsFromSigner>
 export const RequestAccountsFromSigner = funtypes.ReadonlyObject({
 	method: funtypes.Literal('popup_requestAccountsFromSigner'),
-	options: funtypes.Boolean
+	data: funtypes.Boolean
 }).asReadonly()
 
 export type EnableSimulationMode = funtypes.Static<typeof EnableSimulationMode>
 export const EnableSimulationMode = funtypes.ReadonlyObject({
 	method: funtypes.Literal('popup_enableSimulationMode'),
-	options: funtypes.Boolean
+	data: funtypes.Boolean
 }).asReadonly()
 
 export type RemoveTransaction = funtypes.Static<typeof RemoveTransaction>
 export const RemoveTransaction = funtypes.ReadonlyObject({
 	method: funtypes.Literal('popup_removeTransaction'),
-	options: EthereumQuantity,
+	data: EthereumQuantity,
 }).asReadonly()
 
 export type ResetSimulation = funtypes.Static<typeof ResetSimulation>
@@ -282,7 +288,7 @@ export const RefreshSimulation = funtypes.ReadonlyObject({
 export type ChangeInterceptorAccess = funtypes.Static<typeof ChangeInterceptorAccess>
 export const ChangeInterceptorAccess = funtypes.ReadonlyObject({
 	method: funtypes.Literal('popup_changeInterceptorAccess'),
-	options: funtypes.ReadonlyArray(
+	data: funtypes.ReadonlyArray(
 		funtypes.ReadonlyObject({
 			website: Website,
 			access: funtypes.Boolean,
@@ -299,13 +305,13 @@ export const ChangeInterceptorAccess = funtypes.ReadonlyObject({
 export type ChangeActiveChain = funtypes.Static<typeof ChangeActiveChain>
 export const ChangeActiveChain = funtypes.ReadonlyObject({
 	method: funtypes.Literal('popup_changeActiveChain'),
-	options: EthereumQuantity,
+	data: EthereumQuantity,
 }).asReadonly()
 
 export type ChainChangeConfirmation = funtypes.Static<typeof ChainChangeConfirmation>
 export const ChainChangeConfirmation = funtypes.ReadonlyObject({
 	method: funtypes.Literal('popup_changeChainDialog'),
-	options: funtypes.ReadonlyObject({
+	data: funtypes.ReadonlyObject({
 		chainId: EthereumQuantity,
 		requestId: funtypes.Number,
 		accept: funtypes.Boolean,
@@ -315,7 +321,7 @@ export const ChainChangeConfirmation = funtypes.ReadonlyObject({
 export type SignerChainChangeConfirmation = funtypes.Static<typeof SignerChainChangeConfirmation>
 export const SignerChainChangeConfirmation = funtypes.ReadonlyObject({
 	method: funtypes.Literal('popup_signerChangeChainDialog'),
-	options: funtypes.ReadonlyObject({
+	data: funtypes.ReadonlyObject({
 		chainId: EthereumQuantity,
 		accept: funtypes.Boolean,
 	})
@@ -342,7 +348,7 @@ export const GetAddressBookDataFilter = funtypes.Intersect(
 export type GetAddressBookData = funtypes.Static<typeof GetAddressBookData>
 export const GetAddressBookData = funtypes.ReadonlyObject({
 	method: funtypes.Literal('popup_getAddressBookData'),
-	options: GetAddressBookDataFilter,
+	data: GetAddressBookDataFilter,
 }).asReadonly()
 
 export type OpenAddressBook = funtypes.Static<typeof OpenAddressBook>
@@ -352,7 +358,7 @@ export const OpenAddressBook = funtypes.ReadonlyObject({
 
 export type GetAddressBookDataReplyData = funtypes.Static<typeof GetAddressBookDataReplyData>
 export const GetAddressBookDataReplyData = funtypes.ReadonlyObject({
-	options: GetAddressBookDataFilter,
+	data: GetAddressBookDataFilter,
 	entries: AddressBookEntries,
 	maxDataLength: funtypes.Number,
 }).asReadonly()
@@ -563,7 +569,7 @@ export const InterceptorAccessReply = funtypes.ReadonlyObject({
 export type InterceptorAccess = funtypes.Static<typeof InterceptorAccess>
 export const InterceptorAccess = funtypes.ReadonlyObject({
 	method: funtypes.Literal('popup_interceptorAccess'),
-	options: InterceptorAccessReply,
+	data: InterceptorAccessReply,
 }).asReadonly()
 
 export type PendingAccessRequestArray = funtypes.Static<typeof PendingAccessRequestArray>
@@ -660,6 +666,7 @@ export const PendingTransaction = funtypes.ReadonlyObject({
 	dialogId: funtypes.Number,
 	socket: WebsiteSocket,
 	request: InterceptedRequest,
+	transactionParams: funtypes.Union(SendTransactionParams, SendRawTransaction),
 	transactionToSimulate: WebsiteCreatedEthereumUnsignedTransaction,
 	simulationMode: funtypes.Boolean,
 	activeAddress: EthereumAddress,

--- a/app/ts/utils/wire-types.ts
+++ b/app/ts/utils/wire-types.ts
@@ -399,11 +399,11 @@ const RevertErrorParser: funtypes.ParsedValue<funtypes.String, string>['config']
 }
 
 export type MulticallRequestParameters = funtypes.Static<typeof MulticallRequestParameters>
-export const MulticallRequestParameters = funtypes.Readonly(funtypes.Tuple(
+export const MulticallRequestParameters = funtypes.ReadonlyTuple(
 	EthereumQuantity, // block number
 	EthereumAddress, // miner
 	funtypes.ReadonlyArray(EthereumUnsignedTransaction),
-))
+)
 
 export type MulticallResponseEventLog = funtypes.Static<typeof MulticallResponseEventLog>
 export const MulticallResponseEventLog =  funtypes.ReadonlyObject({
@@ -528,8 +528,8 @@ export type ToWireType<T> =
 	: T extends funtypes.Record<infer U, infer V> ? Record<funtypes.Static<U>, ToWireType<V>>
 	: T extends funtypes.Partial<infer U, infer V> ? V extends true ? { readonly [K in keyof U]?: ToWireType<U[K]> } : { [K in keyof U]?: ToWireType<U[K]> }
 	: T extends funtypes.Object<infer U, infer V> ? V extends true ? { readonly [K in keyof U]: ToWireType<U[K]> } : { [K in keyof U]: ToWireType<U[K]> }
-	: T extends funtypes.Readonly<funtypes.Tuple<infer U>> ? { readonly [P in keyof U]: ToWireType<U[P]>}
-	: T extends funtypes.Tuple<infer U> ? { [P in keyof U]: ToWireType<U[P]>}
+	: T extends funtypes.Readonly<funtypes.ReadonlyTuple<infer U>> ? { readonly [P in keyof U]: ToWireType<U[P]>}
+	: T extends funtypes.ReadonlyTuple<infer U> ? { [P in keyof U]: ToWireType<U[P]>}
 	: T extends funtypes.ReadonlyArray<infer U> ? readonly ToWireType<U>[]
 	: T extends funtypes.Array<infer U> ? ToWireType<U>[]
 	: T extends funtypes.ParsedValue<infer U, infer _> ? ToWireType<U>
@@ -549,8 +549,9 @@ export const DappRequestTransaction = funtypes.Intersect(
 		maxFeePerGas: funtypes.Union(EthereumQuantity, funtypes.Null), // etherscan sets this field to null, remove this if etherscan fixes this
 	}),
 	funtypes.Union(
-		funtypes.ReadonlyPartial({ data: EthereumData }),
-		funtypes.ReadonlyPartial({ input: EthereumData })
+		funtypes.ReadonlyObject({ data: EthereumData }),
+		funtypes.ReadonlyObject({ input: EthereumData }),
+		funtypes.ReadonlyObject({}),
 	)
 )
 
@@ -644,19 +645,19 @@ export const JsonRpcMessage = funtypes.Union(JsonRpcResponse, JsonRpcNotificatio
 export type TransactionByHashParams = funtypes.Static<typeof TransactionByHashParams>
 export const TransactionByHashParams = funtypes.ReadonlyObject({
 	method: funtypes.Literal('eth_getTransactionByHash'),
-	params: funtypes.Tuple(EthereumBytes32)
+	params: funtypes.ReadonlyTuple(EthereumBytes32)
 })
 
 export type SendTransactionParams = funtypes.Static<typeof SendTransactionParams>
 export const SendTransactionParams = funtypes.ReadonlyObject({
 	method: funtypes.Literal('eth_sendTransaction'),
-	params: funtypes.Tuple(DappRequestTransaction)
+	params: funtypes.ReadonlyTuple(DappRequestTransaction)
 })
 
 export type SendRawTransaction = funtypes.Static<typeof SendRawTransaction>
 export const SendRawTransaction = funtypes.ReadonlyObject({
 	method: funtypes.Literal('eth_sendRawTransaction'),
-	params: funtypes.Tuple(EthereumData),
+	params: funtypes.ReadonlyTuple(EthereumData),
 }).asReadonly()
 
 export type EthereumAccountsReply = funtypes.Static<typeof EthereumAccountsReply>
@@ -668,19 +669,19 @@ export const EthereumChainReply = funtypes.ReadonlyArray(EthereumQuantity)
 export type TransactionReceiptParams = funtypes.Static<typeof TransactionReceiptParams>
 export const TransactionReceiptParams = funtypes.ReadonlyObject({
 	method: funtypes.Literal('eth_getTransactionReceipt'),
-	params: funtypes.Tuple(EthereumBytes32)
+	params: funtypes.ReadonlyTuple(EthereumBytes32)
 })
 
 export type EstimateGasParams = funtypes.Static<typeof EstimateGasParams>
 export const EstimateGasParams = funtypes.ReadonlyObject({
 	method: funtypes.Literal('eth_estimateGas'),
-	params: funtypes.Union(funtypes.Tuple(DappRequestTransaction), funtypes.Tuple(DappRequestTransaction, EthereumBlockTag))
+	params: funtypes.Union(funtypes.ReadonlyTuple(DappRequestTransaction), funtypes.ReadonlyTuple(DappRequestTransaction, EthereumBlockTag))
 })
 
 export type EthCallParams = funtypes.Static<typeof EthCallParams>
 export const EthCallParams = funtypes.ReadonlyObject({
 	method: funtypes.Literal('eth_call'),
-	params: funtypes.Tuple(
+	params: funtypes.ReadonlyTuple(
 		DappRequestTransaction,
 		EthereumBlockTag
 	)
@@ -689,37 +690,37 @@ export const EthCallParams = funtypes.ReadonlyObject({
 export type EthGetLogsParams = funtypes.Static<typeof EthGetLogsParams>
 export const EthGetLogsParams = funtypes.ReadonlyObject({
 	method: funtypes.Literal('eth_getLogs'),
-	params: funtypes.Tuple(EthGetLogsRequest)
+	params: funtypes.ReadonlyTuple(EthGetLogsRequest)
 }).asReadonly()
 
 export type EthBalanceParams = funtypes.Static<typeof EthBalanceParams>
 export const EthBalanceParams = funtypes.ReadonlyObject({
 	method: funtypes.Literal('eth_getBalance'),
-	params: funtypes.Tuple(EthereumAddress, EthereumBlockTag)
+	params: funtypes.ReadonlyTuple(EthereumAddress, EthereumBlockTag)
 })
 
 export type EthBlockByNumberParams = funtypes.Static<typeof EthBlockByNumberParams>
 export const EthBlockByNumberParams = funtypes.ReadonlyObject({
 	method: funtypes.Literal('eth_getBlockByNumber'),
-	params: funtypes.Tuple(EthereumBlockTag, funtypes.Boolean)
+	params: funtypes.ReadonlyTuple(EthereumBlockTag, funtypes.Boolean)
 })
 
 export type EthSubscribeParams = funtypes.Static<typeof EthSubscribeParams>
 export const EthSubscribeParams = funtypes.ReadonlyObject({
 	method: funtypes.Literal('eth_subscribe'),
-	params: funtypes.Tuple(funtypes.Union(funtypes.Literal('newHeads'), funtypes.Literal('logs'), funtypes.Literal('newPendingTransactions'), funtypes.Literal('syncing')))
+	params: funtypes.ReadonlyTuple(funtypes.Union(funtypes.Literal('newHeads'), funtypes.Literal('logs'), funtypes.Literal('newPendingTransactions'), funtypes.Literal('syncing')))
 })
 
 export type EthUnSubscribeParams = funtypes.Static<typeof EthUnSubscribeParams>
 export const EthUnSubscribeParams = funtypes.ReadonlyObject({
 	method: funtypes.Literal('eth_unsubscribe'),
-	params: funtypes.Tuple(funtypes.String)
+	params: funtypes.ReadonlyTuple(funtypes.String)
 })
 
 export type EthGetStorageAtParams = funtypes.Static<typeof EthGetStorageAtParams>
 export const EthGetStorageAtParams = funtypes.ReadonlyObject({
 	method: funtypes.Literal('eth_getStorageAt'),
-	params: funtypes.Tuple(EthereumAddress, EthereumQuantity, EthereumBlockTag)
+	params: funtypes.ReadonlyTuple(EthereumAddress, EthereumQuantity, EthereumBlockTag)
 })
 
 export const EthSubscriptionResponse = funtypes.String
@@ -729,8 +730,8 @@ export type PersonalSignParams = funtypes.Static<typeof PersonalSignParams>
 export const PersonalSignParams = funtypes.ReadonlyObject({
 	method: funtypes.Literal('personal_sign'),
 	params: funtypes.Union(
-		funtypes.Tuple(funtypes.String, EthereumAddress, funtypes.Union(funtypes.String, funtypes.Undefined, funtypes.Null)), // message, account, password
-		funtypes.Tuple(funtypes.String, EthereumAddress) // message, account
+		funtypes.ReadonlyTuple(funtypes.String, EthereumAddress, funtypes.Union(funtypes.String, funtypes.Undefined, funtypes.Null)), // message, account, password
+		funtypes.ReadonlyTuple(funtypes.String, EthereumAddress) // message, account
 	)
 })
 
@@ -791,7 +792,7 @@ export const EIP712Message = funtypes.String.withParser(EIP712MessageParser)
 export type OldSignTypedDataParams = funtypes.Static<typeof OldSignTypedDataParams>
 export const OldSignTypedDataParams = funtypes.ReadonlyObject({
 	method: funtypes.Literal('eth_signTypedData'),
-	params: funtypes.Tuple(funtypes.ReadonlyArray(
+	params: funtypes.ReadonlyTuple(funtypes.ReadonlyArray(
 		funtypes.ReadonlyObject({
 			name: funtypes.String,
 			type: funtypes.String,
@@ -807,38 +808,36 @@ export const SignTypedDataParams = funtypes.ReadonlyObject({
 		funtypes.Literal('eth_signTypedData_v3'),
 		funtypes.Literal('eth_signTypedData_v4'),
 	),
-	params: funtypes.Tuple(EthereumAddress, EIP712Message), // address that will sign the message, typed data
+	params: funtypes.ReadonlyTuple(EthereumAddress, EIP712Message), // address that will sign the message, typed data
 })
 export type SwitchEthereumChainParams = funtypes.Static<typeof SwitchEthereumChainParams>
 export const SwitchEthereumChainParams = funtypes.ReadonlyObject({
 	method: funtypes.Literal('wallet_switchEthereumChain'),
-	params: funtypes.Tuple(funtypes.ReadonlyObject({
-		chainId: EthereumQuantity
-	}).asReadonly()),
+	params: funtypes.ReadonlyTuple(EthereumQuantity),
 }).asReadonly()
 
 export type GetCode = funtypes.Static<typeof GetCode>
 export const GetCode = funtypes.ReadonlyObject({
 	method: funtypes.Literal('eth_getCode'),
-	params: funtypes.Tuple(EthereumAddress, EthereumBlockTag)
+	params: funtypes.ReadonlyTuple(EthereumAddress, EthereumBlockTag)
 }).asReadonly()
 
 export type RequestPermissions = funtypes.Static<typeof RequestPermissions>
 export const RequestPermissions = funtypes.ReadonlyObject({
 	method: funtypes.Literal('wallet_requestPermissions'),
-	params: funtypes.Tuple( funtypes.ReadonlyObject({ eth_accounts: funtypes.ReadonlyObject({ }) }) )
+	params: funtypes.ReadonlyTuple( funtypes.ReadonlyObject({ eth_accounts: funtypes.ReadonlyObject({ }) }) )
 }).asReadonly()
 
 export type GetTransactionCount = funtypes.Static<typeof GetTransactionCount>
 export const GetTransactionCount = funtypes.ReadonlyObject({
 	method: funtypes.Literal('eth_getTransactionCount'),
-	params: funtypes.Tuple(EthereumAddress, EthereumBlockTag)
+	params: funtypes.ReadonlyTuple(EthereumAddress, EthereumBlockTag)
 }).asReadonly()
 
 export type EthSign = funtypes.Static<typeof EthSign>
 export const EthSign = funtypes.ReadonlyObject({
 	method: funtypes.Literal('eth_sign'),
-	params: funtypes.Tuple(EthereumAddress, funtypes.String),
+	params: funtypes.ReadonlyTuple(EthereumAddress, funtypes.String),
 }).asReadonly()
 
 export type GetSimulationStackReply = funtypes.Static<typeof GetSimulationStackReply>
@@ -854,7 +853,7 @@ export const GetSimulationStackReply = funtypes.ReadonlyArray(funtypes.Intersect
 export type GetSimulationStack = funtypes.Static<typeof GetSimulationStack>
 export const GetSimulationStack = funtypes.ReadonlyObject({
 	method: funtypes.Literal('interceptor_getSimulationStack'),
-	params: funtypes.Tuple(funtypes.Literal('1.0.0')),
+	params: funtypes.ReadonlyTuple(funtypes.Literal('1.0.0')),
 }).asReadonly()
 
 export type EthereumJsonRpcRequest = funtypes.Static<typeof EthereumJsonRpcRequest>

--- a/app/ts/utils/wire-types.ts
+++ b/app/ts/utils/wire-types.ts
@@ -482,8 +482,8 @@ export type ToWireType<T> =
 	: T extends funtypes.Record<infer U, infer V> ? Record<funtypes.Static<U>, ToWireType<V>>
 	: T extends funtypes.Partial<infer U, infer V> ? V extends true ? { readonly [K in keyof U]?: ToWireType<U[K]> } : { [K in keyof U]?: ToWireType<U[K]> }
 	: T extends funtypes.Object<infer U, infer V> ? V extends true ? { readonly [K in keyof U]: ToWireType<U[K]> } : { [K in keyof U]: ToWireType<U[K]> }
-	: T extends funtypes.Readonly<funtypes.ReadonlyTuple<infer U>> ? { readonly [P in keyof U]: ToWireType<U[P]>}
-	: T extends funtypes.ReadonlyTuple<infer U> ? { [P in keyof U]: ToWireType<U[P]>}
+	: T extends funtypes.Readonly<funtypes.Tuple<infer U>> ? { readonly [P in keyof U]: ToWireType<U[P]>}
+	: T extends funtypes.Tuple<infer U> ? { [P in keyof U]: ToWireType<U[P]>}
 	: T extends funtypes.ReadonlyArray<infer U> ? readonly ToWireType<U>[]
 	: T extends funtypes.Array<infer U> ? ToWireType<U>[]
 	: T extends funtypes.ParsedValue<infer U, infer _> ? ToWireType<U>

--- a/app/ts/utils/wire-types.ts
+++ b/app/ts/utils/wire-types.ts
@@ -545,8 +545,8 @@ export const DappRequestTransaction = funtypes.Intersect(
 		value: EthereumQuantity,
 		to: funtypes.Union(EthereumAddress, funtypes.Null),
 		gasPrice: EthereumQuantity,
-		maxPriorityFeePerGas: EthereumQuantity,
-		maxFeePerGas: EthereumQuantity,
+		maxPriorityFeePerGas: funtypes.Union(EthereumQuantity, funtypes.Null), // etherscan sets this field to null, remove this if etherscan fixes this
+		maxFeePerGas: funtypes.Union(EthereumQuantity, funtypes.Null), // etherscan sets this field to null, remove this if etherscan fixes this
 	}),
 	funtypes.Union(
 		funtypes.ReadonlyPartial({ data: EthereumData }),

--- a/app/ts/utils/wire-types.ts
+++ b/app/ts/utils/wire-types.ts
@@ -767,7 +767,7 @@ export const SignTypedDataParams = funtypes.ReadonlyObject({
 export type SwitchEthereumChainParams = funtypes.Static<typeof SwitchEthereumChainParams>
 export const SwitchEthereumChainParams = funtypes.ReadonlyObject({
 	method: funtypes.Literal('wallet_switchEthereumChain'),
-	params: funtypes.ReadonlyTuple(EthereumQuantity),
+	params: funtypes.Tuple(funtypes.ReadonlyObject({ chainId: EthereumQuantity }).asReadonly()),
 }).asReadonly()
 
 export type GetCode = funtypes.Static<typeof GetCode>

--- a/app/ts/utils/wire-types.ts
+++ b/app/ts/utils/wire-types.ts
@@ -1,6 +1,5 @@
 import * as funtypes from 'funtypes'
-import { UnionToIntersection, assertNever } from './typescript.js'
-import { IUnsignedTransaction } from './ethereum.js'
+import { UnionToIntersection } from './typescript.js'
 
 const BigIntParser: funtypes.ParsedValue<funtypes.String, bigint>['config'] = {
 	parse: value => {
@@ -473,51 +472,6 @@ export const NFTDataResponse = funtypes.ReadonlyObject({
 // Helpers
 //
 
-export function serializeUnsignedTransactionToJson(transaction: IUnsignedTransaction): unknown {
-	switch (transaction.type) {
-		case 'legacy':
-			return {
-				type: '0x0',
-				from: serialize(EthereumAddress, transaction.from),
-				nonce: serialize(EthereumQuantity, transaction.nonce),
-				gasPrice: serialize(EthereumQuantity, transaction.gasPrice),
-				gas: serialize(EthereumQuantity, transaction.gasLimit),
-				to: transaction.to !== null ? serialize(EthereumAddress, transaction.to) : null,
-				value: serialize(EthereumQuantity, transaction.value),
-				data: serialize(EthereumData, transaction.input),
-				...'chainId' in transaction && transaction.chainId !== undefined ? { chainId: serialize(EthereumQuantity, transaction.chainId) } : {},
-			}
-		case '2930':
-			return {
-				type: '0x1',
-				from: serialize(EthereumAddress, transaction.from),
-				nonce: serialize(EthereumQuantity, transaction.nonce),
-				gasPrice: serialize(EthereumQuantity, transaction.gasPrice),
-				gas: serialize(EthereumQuantity, transaction.gasLimit),
-				to: transaction.to !== null ? serialize(EthereumAddress, transaction.to) : null,
-				value: serialize(EthereumQuantity, transaction.value),
-				data: serialize(EthereumData, transaction.input),
-				chainId: serialize(EthereumQuantity, transaction.chainId),
-				accessList: serialize(EthereumAccessList, transaction.accessList),
-			}
-		case '1559':
-			return {
-				type: '0x2',
-				from: serialize(EthereumAddress, transaction.from),
-				nonce: serialize(EthereumQuantity, transaction.nonce),
-				maxFeePerGas: serialize(EthereumQuantity, transaction.maxFeePerGas),
-				maxPriorityFeePerGas: serialize(EthereumQuantity, transaction.maxPriorityFeePerGas),
-				gas: serialize(EthereumQuantity, transaction.gasLimit),
-				to: transaction.to !== null ? serialize(EthereumAddress, transaction.to) : null,
-				value: serialize(EthereumQuantity, transaction.value),
-				data: serialize(EthereumData, transaction.input),
-				chainId: serialize(EthereumQuantity, transaction.chainId),
-				accessList: serialize(EthereumAccessList, transaction.accessList),
-			}
-		default: assertNever(transaction)
-	}
-}
-
 export function serialize<T, U extends funtypes.Codec<T>>(funtype: U, value: T) {
 	return funtype.serialize(value) as ToWireType<U>
 }
@@ -658,7 +612,7 @@ export type SendRawTransaction = funtypes.Static<typeof SendRawTransaction>
 export const SendRawTransaction = funtypes.ReadonlyObject({
 	method: funtypes.Literal('eth_sendRawTransaction'),
 	params: funtypes.ReadonlyTuple(EthereumData),
-}).asReadonly()
+})
 
 export type EthereumAccountsReply = funtypes.Static<typeof EthereumAccountsReply>
 export const EthereumAccountsReply = funtypes.ReadonlyArray(EthereumAddress)

--- a/app/ts/utils/wire-types.ts
+++ b/app/ts/utils/wire-types.ts
@@ -615,7 +615,7 @@ export const SendRawTransaction = funtypes.ReadonlyObject({
 })
 
 export type EthereumAccountsReply = funtypes.Static<typeof EthereumAccountsReply>
-export const EthereumAccountsReply = funtypes.ReadonlyArray(EthereumAddress)
+export const EthereumAccountsReply = funtypes.ReadonlyTuple(funtypes.ReadonlyArray(EthereumAddress), funtypes.Boolean)
 
 export type EthereumChainReply = funtypes.Static<typeof EthereumChainReply>
 export const EthereumChainReply = funtypes.ReadonlyArray(EthereumQuantity)


### PR DESCRIPTION
- fix https://github.com/DarkFlorist/TheInterceptor/issues/519
- refactor:
  - RPC return values are now type checked and serialized at the end
  - rename "options" field to "data", as they weren't really options
  - unify RPC handling of simulation and signing mode to one function instead of two (as we now pass almost everything via our node)
  - use readonly tuples instead of tuples