### PR TITLE
Check if v#.#.# tag is being cut from head of release

### DIFF
--- a/.github/workflows/release-extension.yml
+++ b/.github/workflows/release-extension.yml
@@ -19,6 +19,15 @@ jobs:
           GIT_COMMIT_SHA="${{ github.sha }}"
           TAG=$(basename "${{ github.ref }}")
           VERSION=${TAG#v}
+
+          RELEASE_SHA=$(git rev-parse origin/release)
+          if [ "RELEASE_SHA" != "$GIT_COMMIT_SHA" ]; then
+            echo "Not cutting release from the release/ branch"
+            echo "origin/release: $RELEASE_SHA"
+            echo "tag: $GIT_COMMIT_SHA"
+            exit 1
+          fi
+
           echo "TAG=$TAG" >> $GITHUB_OUTPUT
           echo export const gitCommitSha = \"$GIT_COMMIT_SHA\" > $VERSION_FILE
           echo export const version = \"$VERSION\" >> $VERSION_FILE


### PR DESCRIPTION
The idea is that we protect `release` behind two approvals. then we cut releases off release, and if you try to tag anything other than HEAD of release, we bail.