### PR TITLE
show recipient on token transfer and when pending transactions are corrupt clear them

### DIFF
--- a/app/ts/background/storageVariables.ts
+++ b/app/ts/background/storageVariables.ts
@@ -14,7 +14,13 @@ export async function getOpenedAddressBookTabId() {
 
 export async function getPendingTransactions(): Promise<readonly PendingTransaction[]> {
 	const results = await browserStorageLocalSingleGetWithDefault('transactionsPendingForUserConfirmation', [])
-	return funtypes.ReadonlyArray(PendingTransaction).parse(results)
+	try {
+		return funtypes.ReadonlyArray(PendingTransaction).parse(results)
+	} catch(e) {
+		console.warn('Pending transactions were corrupt:')
+		console.warn(e)
+		return []
+	}
 }
 
 const pendingTransactionsSemaphore = new Semaphore(1)
@@ -81,6 +87,7 @@ export async function getSimulationResults() {
 		if (parsed === undefined) return emptyResults
 		return parsed
 	} catch (error) {
+		console.warn('Simulation results were corrupt:')
 		console.warn(error)
 		return emptyResults
 	}

--- a/app/ts/components/simulationExplaining/customExplainers/CatchAllVisualizer.tsx
+++ b/app/ts/components/simulationExplaining/customExplainers/CatchAllVisualizer.tsx
@@ -3,6 +3,7 @@ import { Erc20ApprovalChanges, ERC721OperatorChange, ERC721OperatorChanges, ERC7
 import { ERC721TokenApprovalChange, TokenApprovalChange, TokenVisualizerERC20Event, TokenVisualizerERC721AllApprovalEvent, TokenVisualizerERC721Event, TokenVisualizerResultWithMetadata, RpcNetwork } from '../../../utils/visualizer-types.js'
 import { EtherSymbol, TokenSymbol, TokenAmount, EtherAmount, ERC721TokenNumber } from '../../subcomponents/coins.js'
 import { RenameAddressCallBack } from '../../../utils/user-interface-types.js'
+import { SmallAddress } from '../../subcomponents/address.js'
 
 type EtherTransferEventParams = {
 	valueSent: bigint,
@@ -104,6 +105,17 @@ function SendOrReceiveTokensImportanceBox(param: SendOrReceiveTokensImportanceBo
 								{ ...tokenEvent.token }
 								textColor = { param.textColor }
 								useFullTokenName = { false }
+							/>
+						</div>
+						<div class = 'log-cell'>
+							<p class = 'ellipsis' style = { `color: ${ param.textColor }; margin-bottom: 0px; display: inline-block` }>
+								{ param.sending ? 'To' : 'From' }&nbsp;
+							</p>
+						</div>
+						<div class = 'log-cell'>
+							<SmallAddress 
+								addressBookEntry = { param.sending ? tokenEvent.to : tokenEvent.from }
+								renameAddressCallBack = { param.renameAddressCallBack }
 							/>
 						</div>
 					</table>

--- a/app/ts/components/simulationExplaining/customExplainers/CatchAllVisualizer.tsx
+++ b/app/ts/components/simulationExplaining/customExplainers/CatchAllVisualizer.tsx
@@ -109,7 +109,7 @@ function SendOrReceiveTokensImportanceBox(param: SendOrReceiveTokensImportanceBo
 						</div>
 						<div class = 'log-cell'>
 							<p class = 'ellipsis' style = { `color: ${ param.textColor }; margin-bottom: 0px; display: inline-block` }>
-								{ param.sending ? 'To' : 'From' }&nbsp;
+								{ param.sending ? 'to' : 'from' }&nbsp;
 							</p>
 						</div>
 						<div class = 'log-cell'>

--- a/app/ts/components/simulationExplaining/identifyTransaction.tsx
+++ b/app/ts/components/simulationExplaining/identifyTransaction.tsx
@@ -133,11 +133,11 @@ export const SimulatedAndVisualizedSimpleTokenTransferTransaction = funtypes.Int
 )
 
 export function isSimpleTokenTransfer(transaction: SimulatedAndVisualizedTransaction): transaction is SimulatedAndVisualizedSimpleTokenTransferTransaction {
-	if ( transaction.transaction.value === 0n
+	if (transaction.transaction.value === 0n
 		&& transaction.tokenResults.length === 1
 		&& transaction.tokenResults[0].isApproval == false
 		&& transaction.tokenResults[0].from.address !== transaction.tokenResults[0].to.address
-		&& transaction.tokenResults[0].from === transaction.transaction.from) return true
+		&& transaction.tokenResults[0].from.address === transaction.transaction.from.address) return true
 	return false
 }
 const getSimpleTokenTransferOrUndefined = createGuard<SimulatedAndVisualizedTransaction, SimulatedAndVisualizedSimpleTokenTransferTransaction>((simTx) => isSimpleTokenTransfer(simTx) ? simTx : undefined)


### PR DESCRIPTION
There was a bug in identifying a simple transfer. This is what the view should look like:
![image](https://github.com/DarkFlorist/TheInterceptor/assets/13102010/73254644-dfc0-434b-993e-79359e34d164)

When a transfer is identified but it's not a simple transfer, we fallback to show the transfer anyway, I added recipient to this as well:
![image](https://github.com/DarkFlorist/TheInterceptor/assets/13102010/1e21239d-cb0c-4b06-9972-5ef730adb41a)

Previous storage changes also break the old storage, so I made it so that those storage variables are just cleared (it clears pending transactions if they exist) if parsin fails and issues a warning.


Fix https://github.com/DarkFlorist/TheInterceptor/issues/482
