### PR TITLE
Separate startup script

### DIFF
--- a/app/html/background.html
+++ b/app/html/background.html
@@ -29,6 +29,6 @@
 		<main>Loading...</main>
 
 		<!-- a workaround for bug: https://bugzilla.mozilla.org/show_bug.cgi?id=1803984 -->
-		<script async type = 'module'>import '../js/background/background.js'</script>
+		<script async type = 'module'>import '../js/background/background-startup.js'</script>
 	</body>
 </html>

--- a/app/manifestV2.json
+++ b/app/manifestV2.json
@@ -31,7 +31,7 @@
 	// all hashes except the first one are from .html files `<script type = 'module'>import '../js/popup.js'</script>` part
 	// this was done to workaround bug: https://bugzilla.mozilla.org/show_bug.cgi?id=1803984
 	// the first hash is for importmaps: <script type = 'importmap'> ... </script>
-	"content_security_policy": "object-src 'self'; script-src 'self' 'sha256-UyyaCZUsudYpMz1pVcm+Zt52+oJyq+lsIZ258a7ufOM=' 'sha256-y2bC3XlnL3txBHGTwN4KRThAGFnM0R9B7x04C1zC5Sg=' 'sha256-Uit0MJakCHko/a4ufXGIQJssrw/9TvLamXN+6ltsoG8=' 'sha256-H3mVX1ZCLoCDyvKnpCmo127wWUkke4ADcFzg0RfP2ZM=' 'sha256-8HfgBeyLUz3lfmitlAsCqVcTegmlIKg2JkhG9r1SC3o=' 'sha256-0TgMBbiL41Lbex4DiXR11hCqokTcIKXw6/HJa+UJ7H4=' 'sha256-X9JOx19AgjNibvT805ows7My7i7Soq9cP0ELHgAiHKg=' 'sha256-gVIjW5dVlcD3TUPzJPpC1f6BIyZdWpfYxyJVWNRAlLg='",
+	"content_security_policy": "object-src 'self'; script-src 'self' 'sha256-UyyaCZUsudYpMz1pVcm+Zt52+oJyq+lsIZ258a7ufOM=' 'sha256-NKn9HNoZ5CU/EZeR4NUHWTM1SAsoy4LyW7lckzBnq+Y=' 'sha256-Uit0MJakCHko/a4ufXGIQJssrw/9TvLamXN+6ltsoG8=' 'sha256-H3mVX1ZCLoCDyvKnpCmo127wWUkke4ADcFzg0RfP2ZM=' 'sha256-8HfgBeyLUz3lfmitlAsCqVcTegmlIKg2JkhG9r1SC3o=' 'sha256-0TgMBbiL41Lbex4DiXR11hCqokTcIKXw6/HJa+UJ7H4=' 'sha256-X9JOx19AgjNibvT805ows7My7i7Soq9cP0ELHgAiHKg=' 'sha256-gVIjW5dVlcD3TUPzJPpC1f6BIyZdWpfYxyJVWNRAlLg='",
 	"content_scripts": [
 		{
 			"matches": ["file://*/*", "http://*/*", "https://*/*"],

--- a/app/ts/background/accessManagement.ts
+++ b/app/ts/background/accessManagement.ts
@@ -6,6 +6,7 @@ import { AddressInfoEntry, TabConnection, Website, WebsiteSocket, WebsiteTabConn
 import { InpageScriptCallBack, Settings, WebsiteAccessArray, WebsiteAddressAccess } from '../utils/interceptor-messages.js'
 import { updateWebsiteAccess } from './settings.js'
 import { sendSubscriptionReplyOrCallBack } from './messageSending.js'
+import { Simulator } from '../simulation/simulator.js'
 
 export function getConnectionDetails(websiteTabConnections: WebsiteTabConnections, socket: WebsiteSocket) {
 	const identifier = websiteSocketToString(socket)
@@ -201,15 +202,15 @@ export function getAssociatedAddresses(settings: Settings, websiteOrigin: string
 	return Array.from(new Set(all)).map(x => findAddressInfo(x, settings.userAddressBook.addressInfos))
 }
 
-async function askUserForAccessOnConnectionUpdate(websiteTabConnections: WebsiteTabConnections, socket: WebsiteSocket, websiteOrigin: string, activeAddress: AddressInfoEntry | undefined, settings: Settings) {
+async function askUserForAccessOnConnectionUpdate(simulator: Simulator | undefined, websiteTabConnections: WebsiteTabConnections, socket: WebsiteSocket, websiteOrigin: string, activeAddress: AddressInfoEntry | undefined, settings: Settings) {
 	const details = getConnectionDetails(websiteTabConnections, socket)
 	if (details === undefined) return
 
 	const website = await retrieveWebsiteDetails(details.port, websiteOrigin)
-	await requestAccessFromUser(websiteTabConnections, socket, website, undefined, activeAddress, settings, activeAddress?.address)
+	await requestAccessFromUser(simulator, websiteTabConnections, socket, website, undefined, activeAddress, settings, activeAddress?.address)
 }
 
-async function updateTabConnections(websiteTabConnections: WebsiteTabConnections, tabConnection: TabConnection, promptForAccessesIfNeeded: boolean, settings: Settings) {
+async function updateTabConnections(simulator: Simulator | undefined, websiteTabConnections: WebsiteTabConnections, tabConnection: TabConnection, promptForAccessesIfNeeded: boolean, settings: Settings) {
 	for (const key in tabConnection.connections) {
 		const connection = tabConnection.connections[key]
 		const activeAddress = await getActiveAddress(settings, connection.socket.tabId)
@@ -224,14 +225,14 @@ async function updateTabConnections(websiteTabConnections: WebsiteTabConnections
 
 		if (access === 'notFound' && connection.wantsToConnect && promptForAccessesIfNeeded) {
 			const addressInfo = activeAddress ? findAddressInfo(activeAddress, settings.userAddressBook.addressInfos) : undefined
-			askUserForAccessOnConnectionUpdate(websiteTabConnections, connection.socket, connection.websiteOrigin, addressInfo, settings)
+			askUserForAccessOnConnectionUpdate(simulator, websiteTabConnections, connection.socket, connection.websiteOrigin, addressInfo, settings)
 		}
 	}
 }
 
-export function updateWebsiteApprovalAccesses(websiteTabConnections: WebsiteTabConnections, promptForAccessesIfNeeded: boolean = true, settings: Settings) {
+export function updateWebsiteApprovalAccesses(simulator: Simulator | undefined, websiteTabConnections: WebsiteTabConnections, promptForAccessesIfNeeded: boolean = true, settings: Settings) {
 	// update port connections and disconnect from ports that should not have access anymore
 	for (const [_tab, tabConnection] of websiteTabConnections.entries() ) {
-		updateTabConnections(websiteTabConnections, tabConnection, promptForAccessesIfNeeded, settings)
+		updateTabConnections(simulator, websiteTabConnections, tabConnection, promptForAccessesIfNeeded, settings)
 	}
 }

--- a/app/ts/background/accessManagement.ts
+++ b/app/ts/background/accessManagement.ts
@@ -202,7 +202,7 @@ export function getAssociatedAddresses(settings: Settings, websiteOrigin: string
 	return Array.from(new Set(all)).map(x => findAddressInfo(x, settings.userAddressBook.addressInfos))
 }
 
-async function askUserForAccessOnConnectionUpdate(simulator: Simulator | undefined, websiteTabConnections: WebsiteTabConnections, socket: WebsiteSocket, websiteOrigin: string, activeAddress: AddressInfoEntry | undefined, settings: Settings) {
+async function askUserForAccessOnConnectionUpdate(simulator: Simulator, websiteTabConnections: WebsiteTabConnections, socket: WebsiteSocket, websiteOrigin: string, activeAddress: AddressInfoEntry | undefined, settings: Settings) {
 	const details = getConnectionDetails(websiteTabConnections, socket)
 	if (details === undefined) return
 
@@ -210,7 +210,7 @@ async function askUserForAccessOnConnectionUpdate(simulator: Simulator | undefin
 	await requestAccessFromUser(simulator, websiteTabConnections, socket, website, undefined, activeAddress, settings, activeAddress?.address)
 }
 
-async function updateTabConnections(simulator: Simulator | undefined, websiteTabConnections: WebsiteTabConnections, tabConnection: TabConnection, promptForAccessesIfNeeded: boolean, settings: Settings) {
+async function updateTabConnections(simulator: Simulator, websiteTabConnections: WebsiteTabConnections, tabConnection: TabConnection, promptForAccessesIfNeeded: boolean, settings: Settings) {
 	for (const key in tabConnection.connections) {
 		const connection = tabConnection.connections[key]
 		const activeAddress = await getActiveAddress(settings, connection.socket.tabId)
@@ -230,7 +230,7 @@ async function updateTabConnections(simulator: Simulator | undefined, websiteTab
 	}
 }
 
-export function updateWebsiteApprovalAccesses(simulator: Simulator | undefined, websiteTabConnections: WebsiteTabConnections, promptForAccessesIfNeeded: boolean = true, settings: Settings) {
+export function updateWebsiteApprovalAccesses(simulator: Simulator, websiteTabConnections: WebsiteTabConnections, promptForAccessesIfNeeded: boolean = true, settings: Settings) {
 	// update port connections and disconnect from ports that should not have access anymore
 	for (const [_tab, tabConnection] of websiteTabConnections.entries() ) {
 		updateTabConnections(simulator, websiteTabConnections, tabConnection, promptForAccessesIfNeeded, settings)

--- a/app/ts/background/background-startup.ts
+++ b/app/ts/background/background-startup.ts
@@ -1,0 +1,82 @@
+import 'webextension-polyfill'
+import { getMakeMeRich, getSettings } from './settings.js'
+import { getPrependTrasactions, onContentScriptConnected, popupMessageHandler, updateSimulationState } from './background.js'
+import { updateExtensionBadge } from './iconHandler.js'
+import { clearTabStates, getSimulationResults, removeTabState, setRpcConnectionStatus } from './storageVariables.js'
+import { setPrependTransactionsQueue } from '../simulation/services/SimulationModeEthereumClientService.js'
+import { Simulator } from '../simulation/simulator.js'
+import { TabConnection } from '../utils/user-interface-types.js'
+import { EthereumBlockHeader } from '../utils/wire-types.js'
+import { EthereumClientService } from '../simulation/services/EthereumClientService.js'
+import { sendPopupMessageToOpenWindows } from './backgroundUtils.js'
+import { sendSubscriptionMessagesForNewBlock } from '../simulation/services/EthereumSubscriptionService.js'
+import { refreshSimulation } from './popupMessageHandlers.js'
+import { isFailedToFetchError } from '../utils/errors.js'
+
+let simulator: Simulator | undefined = undefined
+
+const websiteTabConnections = new Map<number, TabConnection>()
+
+browser.runtime.onConnect.addListener(port => onContentScriptConnected(simulator, port, websiteTabConnections).catch(console.error))
+browser.tabs.onRemoved.addListener((tabId: number) => removeTabState(tabId))
+
+if (browser.runtime.getManifest().manifest_version === 2) {
+	clearTabStates()
+}
+
+async function newBlockAttemptCallback(blockheader: EthereumBlockHeader, ethereumClientService: EthereumClientService, isNewBlock: boolean) {
+	const rpcConnectionStatus = {
+		isConnected: true,
+		lastConnnectionAttempt: new Date(),
+		latestBlock: blockheader,
+		rpcNetwork: ethereumClientService.getRpcNetwork(),
+	}
+	await setRpcConnectionStatus(rpcConnectionStatus)
+	await updateExtensionBadge()
+	await sendPopupMessageToOpenWindows({ method: 'popup_new_block_arrived', data: { rpcConnectionStatus } })
+	if (isNewBlock) {
+		const settings = await getSettings()
+		await sendSubscriptionMessagesForNewBlock(blockheader.number, ethereumClientService, settings.simulationMode ? await refreshSimulation(simulator, ethereumClientService, settings) : undefined, websiteTabConnections)
+	}
+}
+
+async function onErrorBlockCallback(ethereumClientService: EthereumClientService, error: Error) {
+	if (isFailedToFetchError(error)) {
+		const rpcConnectionStatus = {
+			isConnected: false,
+			lastConnnectionAttempt: new Date(),
+			latestBlock: ethereumClientService.getLastKnownCachedBlockOrUndefined(),
+			rpcNetwork: ethereumClientService.getRpcNetwork(),
+		}
+		await setRpcConnectionStatus(rpcConnectionStatus)
+		await updateExtensionBadge()
+		return await sendPopupMessageToOpenWindows({ method: 'popup_failed_to_get_block', data: { rpcConnectionStatus } })
+	}
+	throw error
+}
+
+async function startup() {
+	const settings = await getSettings()
+	if (settings.rpcNetwork.httpsRpc !== undefined) {
+		simulator = new Simulator(settings.rpcNetwork, newBlockAttemptCallback, onErrorBlockCallback)
+	}
+	if (simulator === undefined) throw new Error('simulator not found')
+	browser.runtime.onMessage.addListener(async function (message: unknown) {
+		if (simulator === undefined) throw new Error('Interceptor not ready yet')
+		await popupMessageHandler(websiteTabConnections, simulator, message, await getSettings())
+	})
+
+	await updateExtensionBadge()
+
+	if (settings.simulationMode) {
+		// update prepend mode as our active address has changed, so we need to be sure the rich modes money is sent to right address
+		const ethereumClientService = simulator.ethereum
+		await updateSimulationState(simulator, async () => {
+			const simulationState = (await getSimulationResults()).simulationState
+			const prependQueue = await getPrependTrasactions(ethereumClientService, settings, await getMakeMeRich())
+			return await setPrependTransactionsQueue(ethereumClientService, simulationState, prependQueue)
+		}, settings.activeSimulationAddress, true)
+	}
+}
+
+startup()

--- a/app/ts/background/background-startup.ts
+++ b/app/ts/background/background-startup.ts
@@ -39,7 +39,7 @@ function getProviderHandler(method: string) {
 	}
 }
 
-export async function onContentScriptConnected(simulator: Simulator | undefined, port: browser.runtime.Port, websiteTabConnections: WebsiteTabConnections) {
+export async function onContentScriptConnected(simulator: Simulator, port: browser.runtime.Port, websiteTabConnections: WebsiteTabConnections) {
 	const socket = getSocketFromPort(port)
 	if (port?.sender?.url === undefined) return
 	const websiteOrigin = (new URL(port.sender.url)).hostname
@@ -171,9 +171,7 @@ async function startup() {
 	if (settings.rpcNetwork.httpsRpc === undefined) throw new Error('RPC not set')
 	const simulator = new Simulator(settings.rpcNetwork, newBlockAttemptCallback, onErrorBlockCallback)
 	browser.runtime.onConnect.addListener(port => onContentScriptConnected(simulator, port, websiteTabConnections).catch(console.error))
-	if (simulator === undefined) throw new Error('simulator not found')
 	browser.runtime.onMessage.addListener(async function (message: unknown) {
-		if (simulator === undefined) throw new Error('Interceptor not ready yet')
 		await popupMessageHandler(websiteTabConnections, simulator, message, await getSettings())
 	})
 

--- a/app/ts/background/background-startup.ts
+++ b/app/ts/background/background-startup.ts
@@ -1,30 +1,141 @@
 import 'webextension-polyfill'
 import { getMakeMeRich, getSettings } from './settings.js'
-import { getPrependTrasactions, onContentScriptConnected, popupMessageHandler, updateSimulationState } from './background.js'
-import { updateExtensionBadge } from './iconHandler.js'
-import { clearTabStates, getSimulationResults, removeTabState, setRpcConnectionStatus } from './storageVariables.js'
+import { gateKeepRequestBehindAccessDialog, getPrependTrasactions, handleContentScriptMessage, popupMessageHandler, refuseAccess, updateSimulationState } from './background.js'
+import { retrieveWebsiteDetails, updateExtensionBadge, updateExtensionIcon } from './iconHandler.js'
+import { clearTabStates, getSimulationResults, removeTabState, setRpcConnectionStatus, updateTabState } from './storageVariables.js'
 import { setPrependTransactionsQueue } from '../simulation/services/SimulationModeEthereumClientService.js'
 import { Simulator } from '../simulation/simulator.js'
-import { TabConnection } from '../utils/user-interface-types.js'
+import { TabConnection, WebsiteTabConnections } from '../utils/user-interface-types.js'
 import { EthereumBlockHeader } from '../utils/wire-types.js'
 import { EthereumClientService } from '../simulation/services/EthereumClientService.js'
-import { sendPopupMessageToOpenWindows } from './backgroundUtils.js'
+import { getActiveAddress, getSocketFromPort, sendPopupMessageToOpenWindows, websiteSocketToString } from './backgroundUtils.js'
 import { sendSubscriptionMessagesForNewBlock } from '../simulation/services/EthereumSubscriptionService.js'
 import { refreshSimulation } from './popupMessageHandlers.js'
 import { isFailedToFetchError } from '../utils/errors.js'
-
-let simulator: Simulator | undefined = undefined
+import { Semaphore } from '../utils/semaphore.js'
+import { RawInterceptedRequest } from '../utils/requests.js'
+import { verifyAccess } from './accessManagement.js'
+import { InpageScriptRequest, TabState } from '../utils/interceptor-messages.js'
+import { replyToInterceptedRequest } from './messageSending.js'
+import { assertNever } from '../utils/typescript.js'
+import { ICON_NOT_ACTIVE } from '../utils/constants.js'
+import { connectedToSigner, ethAccountsReply, signerChainChanged, walletSwitchEthereumChainReply } from './providerMessageHandlers.js'
 
 const websiteTabConnections = new Map<number, TabConnection>()
 
-browser.runtime.onConnect.addListener(port => onContentScriptConnected(simulator, port, websiteTabConnections).catch(console.error))
 browser.tabs.onRemoved.addListener((tabId: number) => removeTabState(tabId))
 
 if (browser.runtime.getManifest().manifest_version === 2) {
 	clearTabStates()
 }
 
-async function newBlockAttemptCallback(blockheader: EthereumBlockHeader, ethereumClientService: EthereumClientService, isNewBlock: boolean) {
+function getProviderHandler(method: string) {
+	switch (method) {
+		case 'eth_accounts_reply': return { method: 'eth_accounts_reply' as const, func: ethAccountsReply }
+		case 'signer_chainChanged': return { method: 'signer_chainChanged' as const, func: signerChainChanged }
+		case 'wallet_switchEthereumChain_reply': return { method: 'wallet_switchEthereumChain_reply' as const, func: walletSwitchEthereumChainReply }
+		case 'connected_to_signer': return { method: 'connected_to_signer' as const, func: connectedToSigner }
+		default: return { method: 'notProviderMethod' as const }
+	}
+}
+
+export async function onContentScriptConnected(simulator: Simulator | undefined, port: browser.runtime.Port, websiteTabConnections: WebsiteTabConnections) {
+	const socket = getSocketFromPort(port)
+	if (port?.sender?.url === undefined) return
+	const websiteOrigin = (new URL(port.sender.url)).hostname
+	const websitePromise = retrieveWebsiteDetails(port, websiteOrigin)
+	const identifier = websiteSocketToString(socket)
+
+	console.log(`content script connected ${ websiteOrigin }`)
+
+	const tabConnection = websiteTabConnections.get(socket.tabId)
+	const newConnection = {
+		port: port,
+		socket: socket,
+		websiteOrigin: websiteOrigin,
+		approved: false,
+		wantsToConnect: false,
+	}
+	port.onDisconnect.addListener(() => {
+		const tabConnection = websiteTabConnections.get(socket.tabId)
+		if (tabConnection === undefined) return
+		delete tabConnection.connections[websiteSocketToString(socket)]
+		if (Object.keys(tabConnection).length === 0) {
+			websiteTabConnections.delete(socket.tabId)
+		}
+	})
+
+	const pendingRequestLimiter = new Semaphore(20) // only allow 20 requests pending at the time for a port
+
+	port.onMessage.addListener(async (payload) => {
+		if (!(
+			'data' in payload
+			&& typeof payload.data === 'object'
+			&& payload.data !== null
+			&& 'interceptorRequest' in payload.data
+		)) return
+		await pendingRequestLimiter.execute(async () => {
+			const rawMessage = RawInterceptedRequest.parse(payload.data)
+			const request = {
+				method: rawMessage.method,
+				...'params' in rawMessage ? { params: rawMessage.params } : {},
+				interceptorRequest: rawMessage.interceptorRequest,
+				usingInterceptorWithoutSigner: rawMessage.usingInterceptorWithoutSigner,
+				uniqueRequestIdentifier: { requestId: rawMessage.requestId, requestSocket: socket },
+			}
+			const activeAddress = await getActiveAddress(await getSettings(), socket.tabId)
+			const access = verifyAccess(websiteTabConnections, socket, request.method === 'eth_requestAccounts', websiteOrigin, activeAddress, await getSettings())
+			const providerHandler = getProviderHandler(request.method)
+			const identifiedMethod = providerHandler.method
+			if (identifiedMethod !== 'notProviderMethod') {
+				await providerHandler.func(simulator, websiteTabConnections, port, request, access)
+				const message: InpageScriptRequest = {
+					uniqueRequestIdentifier: request.uniqueRequestIdentifier,
+					method: identifiedMethod,
+					result: '0x' as const,
+				}
+				return replyToInterceptedRequest(websiteTabConnections, message)
+			}
+			if (access === 'noAccess' || activeAddress === undefined) {
+				if (request.method === 'eth_accounts') {
+					return replyToInterceptedRequest(websiteTabConnections, { method: 'eth_accounts' as const, result: [], uniqueRequestIdentifier: request.uniqueRequestIdentifier })
+				}
+				// if user has not given access, assume we are on chain 1
+				if (request.method === 'eth_chainId' || request.method === 'net_version') {
+					return replyToInterceptedRequest(websiteTabConnections, { method: 'eth_chainId' as const, result: 1n, uniqueRequestIdentifier: request.uniqueRequestIdentifier })
+				}
+			}
+			if (activeAddress === undefined) return refuseAccess(websiteTabConnections, request)
+
+			switch (access) {
+				case 'noAccess': return refuseAccess(websiteTabConnections, request)
+				case 'askAccess': return await gateKeepRequestBehindAccessDialog(simulator, websiteTabConnections, socket, request, await websitePromise, activeAddress, await getSettings())
+				case 'hasAccess': return await handleContentScriptMessage(simulator, websiteTabConnections, request, await websitePromise, activeAddress)
+				default: assertNever(access)
+			}
+		})
+	})
+
+	if (tabConnection === undefined) {
+		websiteTabConnections.set(socket.tabId, {
+			connections: { [identifier]: newConnection },
+		})
+		await updateTabState(socket.tabId, (previousState: TabState) => {
+			return {
+				...previousState,
+				tabIconDetails: {
+					icon: ICON_NOT_ACTIVE,
+					iconReason: 'No active address selected.',
+				}
+			}
+		})
+		updateExtensionIcon(websiteTabConnections, socket, websiteOrigin)
+	} else {
+		tabConnection.connections[identifier] = newConnection
+	}
+}
+
+async function newBlockAttemptCallback(blockheader: EthereumBlockHeader, ethereumClientService: EthereumClientService, isNewBlock: boolean, simulator: Simulator) {
 	const rpcConnectionStatus = {
 		isConnected: true,
 		lastConnnectionAttempt: new Date(),
@@ -57,9 +168,9 @@ async function onErrorBlockCallback(ethereumClientService: EthereumClientService
 
 async function startup() {
 	const settings = await getSettings()
-	if (settings.rpcNetwork.httpsRpc !== undefined) {
-		simulator = new Simulator(settings.rpcNetwork, newBlockAttemptCallback, onErrorBlockCallback)
-	}
+	if (settings.rpcNetwork.httpsRpc === undefined) throw new Error('RPC not set')
+	const simulator = new Simulator(settings.rpcNetwork, newBlockAttemptCallback, onErrorBlockCallback)
+	browser.runtime.onConnect.addListener(port => onContentScriptConnected(simulator, port, websiteTabConnections).catch(console.error))
 	if (simulator === undefined) throw new Error('simulator not found')
 	browser.runtime.onMessage.addListener(async function (message: unknown) {
 		if (simulator === undefined) throw new Error('Interceptor not ready yet')

--- a/app/ts/background/background.ts
+++ b/app/ts/background/background.ts
@@ -1,44 +1,32 @@
 import { ConfirmTransactionTransactionSingleVisualization, InpageScriptRequest, PopupMessage, RPCReply, Settings, TabState } from '../utils/interceptor-messages.js'
 import 'webextension-polyfill'
 import { Simulator } from '../simulation/simulator.js'
-import { EthereumBlockHeader, EthereumJsonRpcRequest, SendRawTransaction, SendTransactionParams } from '../utils/wire-types.js'
-import { clearTabStates, getEthDonator, getSignerName, getSimulationResults, removeTabState, setRpcConnectionStatus, setSimulationUpdatingState, updateSimulationResults, updateTabState } from './storageVariables.js'
+import { EthereumJsonRpcRequest, SendRawTransaction, SendTransactionParams } from '../utils/wire-types.js'
+import { getEthDonator, getSignerName, getSimulationResults, updateSimulationResults, updateTabState } from './storageVariables.js'
 import { changeSimulationMode, getSettings, getMakeMeRich } from './settings.js'
 import { blockNumber, call, chainId, estimateGas, gasPrice, getAccounts, getBalance, getBlockByNumber, getCode, getLogs, getPermissions, getSimulationStack, getTransactionByHash, getTransactionCount, getTransactionReceipt, personalSign, sendRawTransaction, sendTransaction, subscribe, switchEthereumChain, unsubscribe } from './simulationModeHanders.js'
 import { changeActiveAddress, changeMakeMeRich, changePage, resetSimulation, confirmDialog, refreshSimulation, removeTransaction, requestAccountsFromSigner, refreshPopupConfirmTransactionSimulation, confirmPersonalSign, confirmRequestAccess, changeInterceptorAccess, changeChainDialog, popupChangeActiveRpc, enableSimulationMode, addOrModifyAddressInfo, getAddressBookData, removeAddressBookEntry, openAddressBook, homeOpened, interceptorAccessChangeAddressOrRefresh, refreshPopupConfirmTransactionMetadata, changeSettings, importSettings, exportSettings, setNewRpcList } from './popupMessageHandlers.js'
-import { WebsiteCreatedEthereumUnsignedTransaction, SimulationState, RpcEntry, RpcNetwork } from '../utils/visualizer-types.js'
-import { AddressBookEntry, Website, TabConnection, WebsiteSocket, WebsiteTabConnections } from '../utils/user-interface-types.js'
+import { WebsiteCreatedEthereumUnsignedTransaction, SimulationState, RpcNetwork } from '../utils/visualizer-types.js'
+import { AddressBookEntry, Website, WebsiteSocket, WebsiteTabConnections } from '../utils/user-interface-types.js'
 import { interceptorAccessMetadataRefresh, requestAccessFromUser, updateInterceptorAccessViewWithPendingRequests } from './windows/interceptorAccess.js'
 import { ICON_NOT_ACTIVE, MAKE_YOU_RICH_TRANSACTION, METAMASK_ERROR_FAILED_TO_PARSE_REQUEST, METAMASK_ERROR_NOT_AUTHORIZED, METAMASK_ERROR_NOT_CONNECTED_TO_CHAIN } from '../utils/constants.js'
 import { PriceEstimator } from '../simulation/priceEstimator.js'
 import { sendActiveAccountChangeToApprovedWebsitePorts, sendMessageToApprovedWebsitePorts, updateWebsiteApprovalAccesses, verifyAccess } from './accessManagement.js'
 import { findAddressInfo, getAddressBookEntriesForVisualiser } from './metadataUtils.js'
 import { getActiveAddress, getSocketFromPort, sendPopupMessageToOpenWindows, websiteSocketToString } from './backgroundUtils.js'
-import { retrieveWebsiteDetails, updateExtensionBadge, updateExtensionIcon } from './iconHandler.js'
+import { retrieveWebsiteDetails, updateExtensionIcon } from './iconHandler.js'
 import { connectedToSigner, ethAccountsReply, signerChainChanged, walletSwitchEthereumChainReply } from './providerMessageHandlers.js'
 import { assertNever, assertUnreachable } from '../utils/typescript.js'
 import { EthereumClientService } from '../simulation/services/EthereumClientService.js'
 import { appendTransaction, copySimulationState, getNonPrependedSimulatedTransactions, getNonceFixedSimulatedTransactions, getWebsiteCreatedEthereumUnsignedTransactions, setPrependTransactionsQueue, setSimulationTransactions } from '../simulation/services/SimulationModeEthereumClientService.js'
 import { Semaphore } from '../utils/semaphore.js'
 import { FetchResponseError, JsonRpcResponseError, isFailedToFetchError } from '../utils/errors.js'
-import { sendSubscriptionMessagesForNewBlock } from '../simulation/services/EthereumSubscriptionService.js'
 import { formSimulatedAndVisualizedTransaction } from '../components/formVisualizerResults.js'
 import { updateConfirmTransactionViewWithPendingTransaction } from './windows/confirmTransaction.js'
 import { updateChainChangeViewWithPendingRequest } from './windows/changeChain.js'
 import { updatePendingPersonalSignViewWithPendingRequests } from './windows/personalSign.js'
 import { InterceptedRequest, RawInterceptedRequest, UniqueRequestIdentifier } from '../utils/requests.js'
 import { replyToInterceptedRequest } from './messageSending.js'
-
-const websiteTabConnections = new Map<number, TabConnection>()
-
-browser.runtime.onConnect.addListener(port => onContentScriptConnected(port, websiteTabConnections).catch(console.error))
-browser.tabs.onRemoved.addListener((tabId: number) => removeTabState(tabId))
-
-if (browser.runtime.getManifest().manifest_version === 2) {
-	clearTabStates()
-}
-
-let simulator: Simulator | undefined = undefined
 
 async function visualizeSimulatorState(simulationState: SimulationState, simulator: Simulator) {
 	const priceEstimator = new PriceEstimator(simulator.ethereum)
@@ -66,51 +54,57 @@ async function visualizeSimulatorState(simulationState: SimulationState, simulat
 	}
 }
 
-export async function updateSimulationState(getUpdatedSimulationState: () => Promise<SimulationState | undefined>, activeAddress: bigint | undefined) {
-	if (simulator === undefined) return
-	const simulationId = (await getSimulationResults()).simulationId + 1
-	await setSimulationUpdatingState(simulationId, 'updating')
-	sendPopupMessageToOpenWindows({ method: 'popup_simulation_state_changed', data: { simulationId } })
-	try {
-		const updatedSimulationState = await getUpdatedSimulationState()
-		if (updatedSimulationState !== undefined) {
-			await updateSimulationResults({
-				simulationUpdatingState: 'done',
-				simulationId,
-				...await visualizeSimulatorState(updatedSimulationState, simulator),
-				activeAddress: activeAddress,
-			})
+const updateSimulationStateSemaphore = new Semaphore(1)
+export async function updateSimulationState(simulator: Simulator | undefined, getUpdatedSimulationState: (simulationState: SimulationState | undefined) => Promise<SimulationState | undefined>, activeAddress: bigint | undefined, invalidateOldState: boolean) {
+	if (simulator === undefined) return undefined
+	return await updateSimulationStateSemaphore.execute(async () => {
+		const simulationResults = await getSimulationResults()
+		const simulationId = simulationResults.simulationId + 1
+		if (invalidateOldState) {
+			await updateSimulationResults({ ...simulationResults, simulationId, simulationResultState: 'invalid', simulationUpdatingState: 'updating' })
 		} else {
-			await updateSimulationResults({
-				simulationUpdatingState: 'done',
-				simulationId,
-				addressBookEntries: [],
-				tokenPrices: [],
-				visualizerResults: [],
-				simulationState: updatedSimulationState,
-				activeAddress: activeAddress,
-			})
+			await updateSimulationResults({ ...simulationResults, simulationId, simulationUpdatingState: 'updating' })
 		}
-		sendPopupMessageToOpenWindows({ method: 'popup_simulation_state_changed', data: { simulationId } })
-		return updatedSimulationState
-	} catch (error) {
-		if (error instanceof Error) {
-			if (isFailedToFetchError(error)) {
-				await setSimulationUpdatingState(simulationId, 'failed')
-				await sendPopupMessageToOpenWindows({ method: 'popup_simulation_state_changed', data: { simulationId }  })
-				return undefined
+		await sendPopupMessageToOpenWindows({ method: 'popup_simulation_state_changed', data: { simulationId } })
+		try {
+			const updatedSimulationState = await getUpdatedSimulationState(simulationResults.simulationState)
+			if (updatedSimulationState !== undefined) {
+				await updateSimulationResults({
+					...await visualizeSimulatorState(updatedSimulationState, simulator),
+					simulationUpdatingState: 'done',		
+					simulationResultState: 'done',
+					simulationId,
+					activeAddress: activeAddress,
+				})
+			} else {
+				await updateSimulationResults({
+					simulationUpdatingState: 'done',
+					simulationResultState: 'done',
+					simulationId,
+					addressBookEntries: [],
+					tokenPrices: [],
+					visualizerResults: [],
+					simulationState: updatedSimulationState,
+					activeAddress: activeAddress,
+				})
 			}
+			await sendPopupMessageToOpenWindows({ method: 'popup_simulation_state_changed', data: { simulationId } })
+			return updatedSimulationState
+		} catch (error) {
+			if (error instanceof Error) {
+				if (isFailedToFetchError(error)) {
+					await updateSimulationResults({ ...simulationResults, simulationId, simulationUpdatingState: 'updating' })
+					await sendPopupMessageToOpenWindows({ method: 'popup_simulation_state_changed', data: { simulationId }  })
+					return undefined
+				}
+			}
+			throw error
 		}
-		throw error
-	}
-}
-
-export function setEthereumNodeBlockPolling(enabled: boolean) {
-	if (simulator === undefined) return
-	simulator.ethereum.setBlockPolling(enabled)
+	})
 }
 
 export async function refreshConfirmTransactionSimulation(
+	simulator: Simulator | undefined,
 	ethereumClientService: EthereumClientService,
 	activeAddress: bigint,
 	simulationMode: boolean,
@@ -190,6 +184,7 @@ export async function getPrependTrasactions(ethereumClientService: EthereumClien
 }
 
 async function handleRPCRequest(
+	simulator: Simulator | undefined,
 	simulationState: SimulationState | undefined,
 	websiteTabConnections: WebsiteTabConnections,
 	ethereumClientService: EthereumClientService,
@@ -237,7 +232,7 @@ async function handleRPCRequest(
 		case 'eth_signTypedData_v2':
 		case 'eth_signTypedData_v3':
 		case 'eth_signTypedData_v4': return await personalSign(ethereumClientService, websiteTabConnections, parsedRequest, request, settings.simulationMode, website, activeAddress)
-		case 'wallet_switchEthereumChain': return await switchEthereumChain(websiteTabConnections, ethereumClientService, parsedRequest, request, settings.simulationMode, website)
+		case 'wallet_switchEthereumChain': return await switchEthereumChain(simulator, websiteTabConnections, ethereumClientService, parsedRequest, request, settings.simulationMode, website)
 		case 'wallet_requestPermissions': return await getAccounts(activeAddress)
 		case 'wallet_getPermissions': return await getPermissions()
 		case 'eth_accounts': return await getAccounts(activeAddress)
@@ -251,13 +246,13 @@ async function handleRPCRequest(
 		case 'eth_sign': return { method: parsedRequest.method, error: { code: 10000, message: 'eth_sign is deprecated' } }
 		case 'eth_sendRawTransaction': {
 			if (forwardToSigner && settings.rpcNetwork.httpsRpc === undefined) return getForwardingMessage(parsedRequest)
-			const message = await sendRawTransaction(ethereumClientService, parsedRequest, request, !forwardToSigner, website, activeAddress)
+			const message = await sendRawTransaction(simulator, ethereumClientService, parsedRequest, request, !forwardToSigner, website, activeAddress)
 			if ('forward' in message) return getForwardingMessage(parsedRequest)
 			return message
 		}
 		case 'eth_sendTransaction': {
 			if (forwardToSigner && settings.rpcNetwork.httpsRpc === undefined) return getForwardingMessage(parsedRequest)
-			const message = await sendTransaction(websiteTabConnections, activeAddress, ethereumClientService, parsedRequest, request, !forwardToSigner, website)
+			const message = await sendTransaction(simulator, websiteTabConnections, activeAddress, ethereumClientService, parsedRequest, request, !forwardToSigner, website)
 			if ('forward' in message) return getForwardingMessage(parsedRequest)
 			return message
 		}
@@ -289,45 +284,9 @@ async function handleRPCRequest(
 	}
 }
 
-async function newBlockAttemptCallback(blockheader: EthereumBlockHeader, ethereumClientService: EthereumClientService, isNewBlock: boolean) {
-	const rpcConnectionStatus = {
-		isConnected: true,
-		lastConnnectionAttempt: new Date(),
-		latestBlock: blockheader,
-		rpcNetwork: ethereumClientService.getRpcNetwork(),
-	}
-	await setRpcConnectionStatus(rpcConnectionStatus)
-	await updateExtensionBadge()
-	await sendPopupMessageToOpenWindows({ method: 'popup_new_block_arrived', data: { rpcConnectionStatus } })
-	if (isNewBlock) {
-		const settings = await getSettings()
-		await sendSubscriptionMessagesForNewBlock(blockheader.number, ethereumClientService, settings.simulationMode ? await refreshSimulation(ethereumClientService, settings) : undefined, websiteTabConnections)
-	}
-}
-
-async function onErrorBlockCallback(ethereumClientService: EthereumClientService, error: Error) {
-	if (isFailedToFetchError(error)) {
-		const rpcConnectionStatus = {
-			isConnected: false,
-			lastConnnectionAttempt: new Date(),
-			latestBlock: ethereumClientService.getLastKnownCachedBlockOrUndefined(),
-			rpcNetwork: ethereumClientService.getRpcNetwork(),
-		}
-		await setRpcConnectionStatus(rpcConnectionStatus)
-		await updateExtensionBadge()
-		return await sendPopupMessageToOpenWindows({ method: 'popup_failed_to_get_block', data: { rpcConnectionStatus } })
-	}
-	throw error
-}
-
-
-export async function resetSimulator(entry: RpcEntry) {
-	if (simulator !== undefined) simulator.cleanup()
-	simulator = new Simulator(entry, newBlockAttemptCallback, onErrorBlockCallback)
-}
-
 const changeActiveAddressAndChainAndResetSimulationSemaphore = new Semaphore(1)
 export async function changeActiveAddressAndChainAndResetSimulation(
+	simulator: Simulator | undefined,
 	websiteTabConnections: WebsiteTabConnections,
 	change: {
 		simulationMode: boolean,
@@ -350,10 +309,10 @@ export async function changeActiveAddressAndChainAndResetSimulation(
 			})
 		}
 		const updatedSettings = await getSettings()
-		updateWebsiteApprovalAccesses(websiteTabConnections, undefined, updatedSettings)
+		updateWebsiteApprovalAccesses(simulator, websiteTabConnections, undefined, updatedSettings)
 		sendPopupMessageToOpenWindows({ method: 'popup_settingsUpdated', data: updatedSettings })
 		if (change.rpcNetwork !== undefined) {
-			if (change.rpcNetwork.httpsRpc !== undefined) await resetSimulator(change.rpcNetwork)
+			if (change.rpcNetwork.httpsRpc !== undefined) simulator.reset(change.rpcNetwork)
 			sendMessageToApprovedWebsitePorts(websiteTabConnections, { method: 'chainChanged' as const, result: change.rpcNetwork.chainId })
 			sendPopupMessageToOpenWindows({ method: 'popup_chain_update' })
 		}
@@ -363,19 +322,20 @@ export async function changeActiveAddressAndChainAndResetSimulation(
 		if (updatedSettings.simulationMode) {
 			// update prepend mode as our active address has changed, so we need to be sure the rich modes money is sent to right address
 			const ethereumClientService = simulator.ethereum
-			await updateSimulationState(async () => {
+			await updateSimulationState(simulator, async () => {
 				const simulationState = (await getSimulationResults()).simulationState
 				const prependQueue = await getPrependTrasactions(ethereumClientService, await getSettings(), await getMakeMeRich())
 				return await setPrependTransactionsQueue(ethereumClientService, simulationState, prependQueue)
-			}, updatedSettings.activeSimulationAddress)
+			}, updatedSettings.activeSimulationAddress, true)
 		}
 		// inform website about this only after we have updated simulation, as they often query the balance right after
 		sendActiveAccountChangeToApprovedWebsitePorts(websiteTabConnections, await getSettings())
 	})
 }
 
-export async function changeActiveRpc(websiteTabConnections: WebsiteTabConnections, rpcNetwork: RpcNetwork, simulationMode: boolean) {
-	if (simulationMode) return await changeActiveAddressAndChainAndResetSimulation(websiteTabConnections, {
+export async function changeActiveRpc(simulator: Simulator | undefined, websiteTabConnections: WebsiteTabConnections, rpcNetwork: RpcNetwork, simulationMode: boolean) {
+	
+	if (simulationMode) return await changeActiveAddressAndChainAndResetSimulation(simulator, websiteTabConnections, {
 		simulationMode: simulationMode,
 		rpcNetwork: rpcNetwork
 	})
@@ -383,17 +343,17 @@ export async function changeActiveRpc(websiteTabConnections: WebsiteTabConnectio
 	await sendPopupMessageToOpenWindows({ method: 'popup_settingsUpdated', data: await getSettings() })
 }
 
-export async function handleContentScriptMessage(websiteTabConnections: WebsiteTabConnections, request: InterceptedRequest, website: Website, activeAddress: bigint | undefined) {
+export async function handleContentScriptMessage(simulator: Simulator | undefined, websiteTabConnections: WebsiteTabConnections, request: InterceptedRequest, website: Website, activeAddress: bigint | undefined) {
 	try {
 		if (simulator === undefined) throw 'Interceptor not ready'
 		const settings = await getSettings()
 		if (settings.simulationMode) {
 			const simulationState = (await getSimulationResults()).simulationState
 			if (simulationState === undefined) throw new Error('no simulation state')
-			const resolved = await handleRPCRequest(simulationState, websiteTabConnections, simulator.ethereum, request.uniqueRequestIdentifier.requestSocket, website, request, settings, activeAddress)
+			const resolved = await handleRPCRequest(simulator, simulationState, websiteTabConnections, simulator.ethereum, request.uniqueRequestIdentifier.requestSocket, website, request, settings, activeAddress)
 			return replyToInterceptedRequest(websiteTabConnections, { ...request, ...resolved })
 		}
-		const resolved = await handleRPCRequest(undefined, websiteTabConnections, simulator.ethereum, request.uniqueRequestIdentifier.requestSocket, website, request, settings, activeAddress)
+		const resolved = await handleRPCRequest(simulator, undefined, websiteTabConnections, simulator.ethereum, request.uniqueRequestIdentifier.requestSocket, website, request, settings, activeAddress)
 		return replyToInterceptedRequest(websiteTabConnections, { ...request, ...resolved })
 	} catch (error) {
 		console.log(request)
@@ -437,9 +397,9 @@ export function refuseAccess(websiteTabConnections: WebsiteTabConnections, reque
 	})
 }
 
-export async function gateKeepRequestBehindAccessDialog(socket: WebsiteSocket, request: InterceptedRequest, website: Website, activeAddress: bigint | undefined, settings: Settings) {
+export async function gateKeepRequestBehindAccessDialog(simulator: Simulator | undefined, websiteTabConnections: WebsiteTabConnections, socket: WebsiteSocket, request: InterceptedRequest, website: Website, activeAddress: bigint | undefined, settings: Settings) {
 	const addressInfo = activeAddress !== undefined ? findAddressInfo(activeAddress, settings.userAddressBook.addressInfos) : undefined
-	return await requestAccessFromUser(websiteTabConnections, socket, website, request, addressInfo, settings, activeAddress)
+	return await requestAccessFromUser(simulator, websiteTabConnections, socket, website, request, addressInfo, settings, activeAddress)
 }
 
 function getProviderHandler(method: string) {
@@ -452,7 +412,7 @@ function getProviderHandler(method: string) {
 	}
 }
 
-async function onContentScriptConnected(port: browser.runtime.Port, websiteTabConnections: WebsiteTabConnections) {
+export async function onContentScriptConnected(simulator: Simulator | undefined, port: browser.runtime.Port, websiteTabConnections: WebsiteTabConnections) {
 	const socket = getSocketFromPort(port)
 	if (port?.sender?.url === undefined) return
 	const websiteOrigin = (new URL(port.sender.url)).hostname
@@ -501,7 +461,7 @@ async function onContentScriptConnected(port: browser.runtime.Port, websiteTabCo
 			const providerHandler = getProviderHandler(request.method)
 			const identifiedMethod = providerHandler.method
 			if (identifiedMethod !== 'notProviderMethod') {
-				await providerHandler.func(websiteTabConnections, port, request, access)
+				await providerHandler.func(simulator, websiteTabConnections, port, request, access)
 				const message: InpageScriptRequest = {
 					uniqueRequestIdentifier: request.uniqueRequestIdentifier,
 					method: identifiedMethod,
@@ -522,8 +482,8 @@ async function onContentScriptConnected(port: browser.runtime.Port, websiteTabCo
 
 			switch (access) {
 				case 'noAccess': return refuseAccess(websiteTabConnections, request)
-				case 'askAccess': return await gateKeepRequestBehindAccessDialog(socket, request, await websitePromise, activeAddress, await getSettings())
-				case 'hasAccess': return await handleContentScriptMessage(websiteTabConnections, request, await websitePromise, activeAddress)
+				case 'askAccess': return await gateKeepRequestBehindAccessDialog(simulator, websiteTabConnections, socket, request, await websitePromise, activeAddress, await getSettings())
+				case 'hasAccess': return await handleContentScriptMessage(simulator, websiteTabConnections, request, await websitePromise, activeAddress)
 				default: assertNever(access)
 			}
 		})
@@ -549,7 +509,7 @@ async function onContentScriptConnected(port: browser.runtime.Port, websiteTabCo
 
 }
 
-async function popupMessageHandler(
+export async function popupMessageHandler(
 	websiteTabConnections: WebsiteTabConnections,
 	simulator: Simulator,
 	request: unknown,
@@ -569,25 +529,25 @@ async function popupMessageHandler(
 	const parsedRequest = maybeParsedRequest.value
 
 	switch (parsedRequest.method) {
-		case 'popup_confirmDialog': return await confirmDialog(simulator.ethereum, websiteTabConnections, parsedRequest)
-		case 'popup_changeActiveAddress': return await changeActiveAddress(websiteTabConnections, parsedRequest)
-		case 'popup_changeMakeMeRich': return await changeMakeMeRich(simulator.ethereum, parsedRequest, settings)
+		case 'popup_confirmDialog': return await confirmDialog(simulator, simulator.ethereum, websiteTabConnections, parsedRequest)
+		case 'popup_changeActiveAddress': return await changeActiveAddress(simulator, websiteTabConnections, parsedRequest)
+		case 'popup_changeMakeMeRich': return await changeMakeMeRich(simulator, simulator.ethereum, parsedRequest, settings)
 		case 'popup_changePage': return await changePage(parsedRequest)
 		case 'popup_requestAccountsFromSigner': return await requestAccountsFromSigner(websiteTabConnections, parsedRequest)
-		case 'popup_resetSimulation': return await resetSimulation(simulator.ethereum, settings)
-		case 'popup_removeTransaction': return await removeTransaction(simulator.ethereum, parsedRequest, settings)
-		case 'popup_refreshSimulation': return await refreshSimulation(simulator.ethereum, settings)
-		case 'popup_refreshConfirmTransactionDialogSimulation': return await refreshPopupConfirmTransactionSimulation(simulator.ethereum, parsedRequest)
+		case 'popup_resetSimulation': return await resetSimulation(simulator, simulator.ethereum, settings)
+		case 'popup_removeTransaction': return await removeTransaction(simulator, simulator.ethereum, parsedRequest, settings)
+		case 'popup_refreshSimulation': return await refreshSimulation(simulator, simulator.ethereum, settings)
+		case 'popup_refreshConfirmTransactionDialogSimulation': return await refreshPopupConfirmTransactionSimulation(simulator, simulator.ethereum, parsedRequest)
 		case 'popup_refreshConfirmTransactionMetadata': return refreshPopupConfirmTransactionMetadata(simulator.ethereum, settings.userAddressBook, parsedRequest)
 		case 'popup_personalSign': return await confirmPersonalSign(websiteTabConnections, parsedRequest)
-		case 'popup_interceptorAccess': return await confirmRequestAccess(websiteTabConnections, parsedRequest)
-		case 'popup_changeInterceptorAccess': return await changeInterceptorAccess(websiteTabConnections, parsedRequest)
-		case 'popup_changeActiveRpc': return await popupChangeActiveRpc(websiteTabConnections, parsedRequest, settings)
-		case 'popup_changeChainDialog': return await changeChainDialog(websiteTabConnections, parsedRequest)
-		case 'popup_enableSimulationMode': return await enableSimulationMode(websiteTabConnections, parsedRequest)
-		case 'popup_addOrModifyAddressBookEntry': return await addOrModifyAddressInfo(websiteTabConnections, parsedRequest)
+		case 'popup_interceptorAccess': return await confirmRequestAccess(simulator, websiteTabConnections, parsedRequest)
+		case 'popup_changeInterceptorAccess': return await changeInterceptorAccess(simulator, websiteTabConnections, parsedRequest)
+		case 'popup_changeActiveRpc': return await popupChangeActiveRpc(simulator, websiteTabConnections, parsedRequest, settings)
+		case 'popup_changeChainDialog': return await changeChainDialog(simulator, websiteTabConnections, parsedRequest)
+		case 'popup_enableSimulationMode': return await enableSimulationMode(simulator, websiteTabConnections, parsedRequest)
+		case 'popup_addOrModifyAddressBookEntry': return await addOrModifyAddressInfo(simulator, websiteTabConnections, parsedRequest)
 		case 'popup_getAddressBookData': return await getAddressBookData(parsedRequest, settings.userAddressBook)
-		case 'popup_removeAddressBookEntry': return await removeAddressBookEntry(websiteTabConnections, parsedRequest)
+		case 'popup_removeAddressBookEntry': return await removeAddressBookEntry(simulator, websiteTabConnections, parsedRequest)
 		case 'popup_openAddressBook': return await openAddressBook()
 		case 'popup_personalSignReadyAndListening': return await updatePendingPersonalSignViewWithPendingRequests(simulator.ethereum)
 		case 'popup_changeChainReadyAndListening': return await updateChainChangeViewWithPendingRequest()
@@ -601,31 +561,7 @@ async function popupMessageHandler(
 		case 'popup_ChangeSettings': return await changeSettings(simulator, parsedRequest)
 		case 'popup_import_settings': return await importSettings(parsedRequest)
 		case 'popup_get_export_settings': return await exportSettings()
-		case 'popup_set_rpc_list': return await setNewRpcList(parsedRequest, settings)
+		case 'popup_set_rpc_list': return await setNewRpcList(simulator, parsedRequest, settings)
 		default: assertUnreachable(parsedRequest)
 	}
 }
-
-async function startup() {
-	const settings = await getSettings()
-	if (settings.rpcNetwork.httpsRpc !== undefined) await resetSimulator(settings.rpcNetwork)
-	if (simulator === undefined) throw new Error('simulator not found')
-	browser.runtime.onMessage.addListener(async function (message: unknown) {
-		if (simulator === undefined) throw new Error('Interceptor not ready yet')
-		await popupMessageHandler(websiteTabConnections, simulator, message, await getSettings())
-	})
-
-	await updateExtensionBadge()
-
-	if (settings.simulationMode) {
-		// update prepend mode as our active address has changed, so we need to be sure the rich modes money is sent to right address
-		const ethereumClientService = simulator.ethereum
-		await updateSimulationState(async () => {
-			const simulationState = (await getSimulationResults()).simulationState
-			const prependQueue = await getPrependTrasactions(ethereumClientService, settings, await getMakeMeRich())
-			return await setPrependTransactionsQueue(ethereumClientService, simulationState, prependQueue)
-		}, settings.activeSimulationAddress)
-	}
-}
-
-startup()

--- a/app/ts/background/popupMessageHandlers.ts
+++ b/app/ts/background/popupMessageHandlers.ts
@@ -1,6 +1,6 @@
-import { changeActiveAddressAndChainAndResetSimulation, changeActiveRpc, getPrependTrasactions, refreshConfirmTransactionSimulation, resetSimulator, updateSimulationState } from './background.js'
-import { getSettings, getMakeMeRich, getUseTabsInsteadOfPopup, setUseTabsInsteadOfPopup, setMakeMeRich, setPage, setUseSignersAddressAsActiveAddress, updateAddressInfos, updateContacts, updateWebsiteAccess, exportSettingsAndAddressBook, ExportedSettings, importSettingsAndAddressBook } from './settings.js'
-import { getPendingTransactions, getCurrentTabId, getOpenedAddressBookTabId, getSignerName, getSimulationResults, getTabState, saveCurrentTabId, setOpenedAddressBookTabId, setRpcList, getRpcList, getPrimaryRpcForChain, getRpcConnectionStatus, setRpcConnectionStatus } from './storageVariables.js'
+import { changeActiveAddressAndChainAndResetSimulation, changeActiveRpc, getPrependTrasactions, refreshConfirmTransactionSimulation, updateSimulationState } from './background.js'
+import { getSettings, setUseTabsInsteadOfPopup, setMakeMeRich, setPage, setUseSignersAddressAsActiveAddress, updateAddressInfos, updateContacts, updateWebsiteAccess, exportSettingsAndAddressBook, ExportedSettings, importSettingsAndAddressBook, getMakeMeRich, getUseTabsInsteadOfPopup } from './settings.js'
+import { getPendingTransactions, getCurrentTabId, getOpenedAddressBookTabId, getSimulationResults, getTabState, saveCurrentTabId, setOpenedAddressBookTabId, setRpcList, getRpcList, getPrimaryRpcForChain, setRpcConnectionStatus, getSignerName, getRpcConnectionStatus } from './storageVariables.js'
 import { Simulator } from '../simulation/simulator.js'
 import { ChangeActiveAddress, ChangeMakeMeRich, ChangePage, PersonalSign, RemoveTransaction, RequestAccountsFromSigner, TransactionConfirmation, InterceptorAccess, ChangeInterceptorAccess, ChainChangeConfirmation, EnableSimulationMode, ChangeActiveChain, AddOrEditAddressBookEntry, GetAddressBookData, RemoveAddressBookEntry, RefreshConfirmTransactionDialogSimulation, UserAddressBook, InterceptorAccessRefresh, InterceptorAccessChangeAddress, Settings, RefreshConfirmTransactionMetadata, RefreshInterceptorAccessMetadata, ChangeSettings, ImportSettings, SetRpcList } from '../utils/interceptor-messages.js'
 import { resolvePendingTransaction } from './windows/confirmTransaction.js'
@@ -16,21 +16,22 @@ import { assertUnreachable } from '../utils/typescript.js'
 import { WebsiteTabConnections } from '../utils/user-interface-types.js'
 import { EthereumClientService } from '../simulation/services/EthereumClientService.js'
 import { refreshSimulationState, removeTransactionAndUpdateTransactionNonces, resetSimulationState } from '../simulation/services/SimulationModeEthereumClientService.js'
-import { isFailedToFetchError } from '../utils/errors.js'
 import { formSimulatedAndVisualizedTransaction } from '../components/formVisualizerResults.js'
 import { isJSON } from '../utils/wire-types.js'
 import { doesUniqueRequestIdentifiersMatch } from '../utils/requests.js'
+import { SimulationState } from '../utils/visualizer-types.js'
+import { isFailedToFetchError } from '../utils/errors.js'
 
-export async function confirmDialog(ethereumClientService: EthereumClientService, websiteTabConnections: WebsiteTabConnections, confirmation: TransactionConfirmation) {
-	await resolvePendingTransaction(ethereumClientService, websiteTabConnections, confirmation)
+export async function confirmDialog(simulator: Simulator | undefined, ethereumClientService: EthereumClientService, websiteTabConnections: WebsiteTabConnections, confirmation: TransactionConfirmation) {
+	await resolvePendingTransaction(simulator, ethereumClientService, websiteTabConnections, confirmation)
 }
 
 export async function confirmPersonalSign(websiteTabConnections: WebsiteTabConnections, confirmation: PersonalSign) {
 	await resolvePersonalSign(websiteTabConnections, confirmation)
 }
 
-export async function confirmRequestAccess(websiteTabConnections: WebsiteTabConnections, confirmation: InterceptorAccess) {
-	await resolveInterceptorAccess(websiteTabConnections, confirmation.data)
+export async function confirmRequestAccess(simulator: Simulator | undefined, websiteTabConnections: WebsiteTabConnections, confirmation: InterceptorAccess) {
+	await resolveInterceptorAccess(simulator, websiteTabConnections, confirmation.data)
 }
 
 export async function getLastKnownCurrentTabId() {
@@ -51,7 +52,7 @@ export async function getSignerAccount() {
 	return signerAccounts !== undefined && signerAccounts.length > 0 ? signerAccounts[0] : undefined
 }
 
-export async function changeActiveAddress(websiteTabConnections: WebsiteTabConnections, addressChange: ChangeActiveAddress) {
+export async function changeActiveAddress(simulator: Simulator, websiteTabConnections: WebsiteTabConnections, addressChange: ChangeActiveAddress) {
 
 	// if using signers address, set the active address to signers address if available, otherwise we don't know active address and set it to be undefined
 	if (addressChange.data.activeAddress === 'signer') {
@@ -61,34 +62,33 @@ export async function changeActiveAddress(websiteTabConnections: WebsiteTabConne
 		sendMessageToApprovedWebsitePorts(websiteTabConnections, { method: 'request_signer_to_eth_accounts', result: [] })
 		sendMessageToApprovedWebsitePorts(websiteTabConnections, { method: 'request_signer_chainId', result: [] } )
 		
-		await changeActiveAddressAndChainAndResetSimulation(websiteTabConnections, {
+		await changeActiveAddressAndChainAndResetSimulation(simulator, websiteTabConnections, {
 			simulationMode: addressChange.data.simulationMode,
 			activeAddress: signerAccount,
 		})
 	} else {
 		await setUseSignersAddressAsActiveAddress(false)
-		await changeActiveAddressAndChainAndResetSimulation(websiteTabConnections, {
+		await changeActiveAddressAndChainAndResetSimulation(simulator, websiteTabConnections, {
 			simulationMode: addressChange.data.simulationMode,
 			activeAddress: addressChange.data.activeAddress,
 		})
 	}
 }
 
-export async function changeMakeMeRich(ethereumClientService: EthereumClientService, makeMeRichChange: ChangeMakeMeRich, settings: Settings) {
+export async function changeMakeMeRich(simulator: Simulator, ethereumClientService: EthereumClientService, makeMeRichChange: ChangeMakeMeRich, settings: Settings) {
 	await setMakeMeRich(makeMeRichChange.data)
-	await updateSimulationState(async () => {
-		const simulationState = (await getSimulationResults()).simulationState
+	await updateSimulationState(simulator, async (simulationState) => {
 		if (simulationState === undefined) return undefined
 		const prependQueue = await getPrependTrasactions(ethereumClientService, settings, makeMeRichChange.data)
 		return await resetSimulationState(ethereumClientService, { ...simulationState, prependTransactionsQueue: prependQueue })
-	}, settings.activeSimulationAddress)
+	}, settings.activeSimulationAddress, true)
 }
 
-export async function removeAddressBookEntry(websiteTabConnections: WebsiteTabConnections, removeAddressBookEntry: RemoveAddressBookEntry) {
+export async function removeAddressBookEntry(simulator: Simulator | undefined, websiteTabConnections: WebsiteTabConnections, removeAddressBookEntry: RemoveAddressBookEntry) {
 	switch(removeAddressBookEntry.data.addressBookCategory) {
 		case 'My Active Addresses': {
 			await updateAddressInfos((previousAddressInfos) => previousAddressInfos.filter((info) => info.address !== removeAddressBookEntry.data.address))
-			updateWebsiteApprovalAccesses(websiteTabConnections, undefined, await getSettings())
+			updateWebsiteApprovalAccesses(simulator, websiteTabConnections, undefined, await getSettings())
 			return await sendPopupMessageToOpenWindows({ method: 'popup_addressBookEntriesChanged' })
 		}
 		case 'My Contacts': {
@@ -102,7 +102,7 @@ export async function removeAddressBookEntry(websiteTabConnections: WebsiteTabCo
 	}
 }
 
-export async function addOrModifyAddressInfo(websiteTabConnections: WebsiteTabConnections, entry: AddOrEditAddressBookEntry) {
+export async function addOrModifyAddressInfo(simulator: Simulator | undefined, websiteTabConnections: WebsiteTabConnections, entry: AddOrEditAddressBookEntry) {
 	const newEntry = entry.data
 	switch (newEntry.type) {
 		case 'NFT':
@@ -116,7 +116,7 @@ export async function addOrModifyAddressInfo(websiteTabConnections: WebsiteTabCo
 					return previousAddressInfos.concat([newEntry])
 				}
 			})
-			updateWebsiteApprovalAccesses(websiteTabConnections, undefined, await getSettings())
+			updateWebsiteApprovalAccesses(simulator, websiteTabConnections, undefined, await getSettings())
 			return await sendPopupMessageToOpenWindows({ method: 'popup_addressBookEntriesChanged' })
 		}
 		case 'contact': {
@@ -133,9 +133,9 @@ export async function addOrModifyAddressInfo(websiteTabConnections: WebsiteTabCo
 	}
 }
 
-export async function changeInterceptorAccess(websiteTabConnections: WebsiteTabConnections, accessChange: ChangeInterceptorAccess) {
+export async function changeInterceptorAccess(simulator: Simulator | undefined, websiteTabConnections: WebsiteTabConnections, accessChange: ChangeInterceptorAccess) {
 	await updateWebsiteAccess(() => accessChange.data) // TODO: update 'popup_changeInterceptorAccess' to return list of changes instead of a new list
-	updateWebsiteApprovalAccesses(websiteTabConnections, undefined, await getSettings())
+	updateWebsiteApprovalAccesses(simulator, websiteTabConnections, undefined, await getSettings())
 	return await sendPopupMessageToOpenWindows({ method: 'popup_interceptor_access_changed' })
 }
 
@@ -150,28 +150,25 @@ export async function requestAccountsFromSigner(websiteTabConnections: WebsiteTa
 	}
 }
 
-export async function resetSimulation(ethereumClientService: EthereumClientService, settings: Settings) {
-	await updateSimulationState(async () => {
-		const simulationState = (await getSimulationResults()).simulationState
+export async function resetSimulation(simulator: Simulator, ethereumClientService: EthereumClientService, settings: Settings) {
+	await updateSimulationState(simulator, async (simulationState) => {
 		if (simulationState === undefined) return undefined
 		return await resetSimulationState(ethereumClientService, simulationState)
-	}, settings.activeSimulationAddress)
+	}, settings.activeSimulationAddress, true)
 }
 
-export async function removeTransaction(ethereumClientService: EthereumClientService, params: RemoveTransaction, settings: Settings) {
-	await updateSimulationState(async () => {
-		const simulationState = (await getSimulationResults()).simulationState
+export async function removeTransaction(simulator: Simulator, ethereumClientService: EthereumClientService, params: RemoveTransaction, settings: Settings) {
+	await updateSimulationState(simulator, async (simulationState) => {
 		if (simulationState === undefined) return
 		return await removeTransactionAndUpdateTransactionNonces(ethereumClientService, simulationState, params.data)
-	}, settings.activeSimulationAddress)
+	}, settings.activeSimulationAddress, true)
 }
 
-export async function refreshSimulation(ethereumClientService: EthereumClientService, settings: Settings) {
-	return await updateSimulationState(async() => {
-		const simulationState = (await getSimulationResults()).simulationState
+export async function refreshSimulation(simulator: Simulator | undefined, ethereumClientService: EthereumClientService, settings: Settings): Promise<SimulationState | undefined> {
+	return await updateSimulationState(simulator, async (simulationState) => {
 		if (simulationState === undefined) return
 		return await refreshSimulationState(ethereumClientService, simulationState)
-	}, settings.activeSimulationAddress)
+	}, settings.activeSimulationAddress, false)
 }
 
 export async function refreshPopupConfirmTransactionMetadata(ethereumClientService: EthereumClientService, userAddressBook: UserAddressBook, { data }: RefreshConfirmTransactionMetadata) {
@@ -193,8 +190,8 @@ export async function refreshPopupConfirmTransactionMetadata(ethereumClientServi
 	})
 }
 
-export async function refreshPopupConfirmTransactionSimulation(ethereumClientService: EthereumClientService, { data }: RefreshConfirmTransactionDialogSimulation) {
-	const refreshMessage = await refreshConfirmTransactionSimulation(ethereumClientService, data.activeAddress, data.simulationMode, data.uniqueRequestIdentifier, data.transactionToSimulate)
+export async function refreshPopupConfirmTransactionSimulation(simulator: Simulator | undefined, ethereumClientService: EthereumClientService, { data }: RefreshConfirmTransactionDialogSimulation) {
+	const refreshMessage = await refreshConfirmTransactionSimulation(simulator, ethereumClientService, data.activeAddress, data.simulationMode, data.uniqueRequestIdentifier, data.transactionToSimulate)
 	const promises = await getPendingTransactions()
 	if (promises.length === 0) return
 	const first = promises[0]
@@ -205,15 +202,15 @@ export async function refreshPopupConfirmTransactionSimulation(ethereumClientSer
 	})
 }
 
-export async function popupChangeActiveRpc(websiteTabConnections: WebsiteTabConnections, params: ChangeActiveChain, settings: Settings) {
-	return await changeActiveRpc(websiteTabConnections, params.data, settings.simulationMode)
+export async function popupChangeActiveRpc(simulator: Simulator | undefined, websiteTabConnections: WebsiteTabConnections, params: ChangeActiveChain, settings: Settings) {
+	return await changeActiveRpc(simulator, websiteTabConnections, params.data, settings.simulationMode)
 }
 
-export async function changeChainDialog(websiteTabConnections: WebsiteTabConnections, chainChange: ChainChangeConfirmation) {
-	await resolveChainChange(websiteTabConnections, chainChange)
+export async function changeChainDialog(simulator: Simulator | undefined, websiteTabConnections: WebsiteTabConnections, chainChange: ChainChangeConfirmation) {
+	await resolveChainChange(simulator, websiteTabConnections, chainChange)
 }
 
-export async function enableSimulationMode(websiteTabConnections: WebsiteTabConnections, params: EnableSimulationMode) {
+export async function enableSimulationMode(simulator: Simulator | undefined, websiteTabConnections: WebsiteTabConnections, params: EnableSimulationMode) {
 	const settings = await getSettings()
 	// if we are on unsupported chain, force change to a supported one
 	if (settings.useSignersAddressAsActiveAddress || params.data === false) {
@@ -222,14 +219,14 @@ export async function enableSimulationMode(websiteTabConnections: WebsiteTabConn
 		const tabId = await getLastKnownCurrentTabId()
 		const chainToSwitch = tabId === undefined ? undefined : (await getTabState(tabId)).signerChain
 		const networkToSwitch = chainToSwitch === undefined ? (await getRpcList())[0] : await getPrimaryRpcForChain(chainToSwitch)
-		await changeActiveAddressAndChainAndResetSimulation(websiteTabConnections, {
+		await changeActiveAddressAndChainAndResetSimulation(simulator, websiteTabConnections, {
 			simulationMode: params.data,
 			activeAddress: await getSignerAccount(),
 			...chainToSwitch === undefined ? {} :  { rpcNetwork: networkToSwitch },
 		})
 	} else {
 		const selectedNetworkToSwitch = settings.rpcNetwork.httpsRpc !== undefined ? settings.rpcNetwork : (await getRpcList())[0]
-		await changeActiveAddressAndChainAndResetSimulation(websiteTabConnections, {
+		await changeActiveAddressAndChainAndResetSimulation(simulator, websiteTabConnections, {
 			simulationMode: params.data,
 			...settings.rpcNetwork === selectedNetworkToSwitch ? {} : { rpcNetwork: selectedNetworkToSwitch }
 		})
@@ -293,7 +290,6 @@ export async function homeOpened(simulator: Simulator) {
 	}
 	const simResults = await getSimulationResults()
 	const simulatedAndVisualizedTransactions = simResults.simulationState === undefined || simResults.visualizerResults === undefined ? [] : formSimulatedAndVisualizedTransaction(simResults.simulationState, simResults.visualizerResults, simResults.addressBookEntries)
-
 	await sendPopupMessageToOpenWindows({
 		method: 'popup_UpdateHomePage',
 		data: {
@@ -361,12 +357,12 @@ export async function exportSettings() {
 	})
 }
 
-export async function setNewRpcList(request: SetRpcList, settings: Settings) {
+export async function setNewRpcList(simulator: Simulator | undefined, request: SetRpcList, settings: Settings) {
 	await setRpcList(request.data)
 	await sendPopupMessageToOpenWindows({ method: 'popup_update_rpc_list', data: request.data })
 	const primary = await getPrimaryRpcForChain(settings.rpcNetwork.chainId)
 	if (primary !== undefined) {
 		// reset to primary on update
-		await resetSimulator(primary)
+		simulator?.reset(primary)
 	}
 }

--- a/app/ts/background/popupMessageHandlers.ts
+++ b/app/ts/background/popupMessageHandlers.ts
@@ -22,7 +22,7 @@ import { doesUniqueRequestIdentifiersMatch } from '../utils/requests.js'
 import { SimulationState } from '../utils/visualizer-types.js'
 import { isFailedToFetchError } from '../utils/errors.js'
 
-export async function confirmDialog(simulator: Simulator | undefined, ethereumClientService: EthereumClientService, websiteTabConnections: WebsiteTabConnections, confirmation: TransactionConfirmation) {
+export async function confirmDialog(simulator: Simulator, ethereumClientService: EthereumClientService, websiteTabConnections: WebsiteTabConnections, confirmation: TransactionConfirmation) {
 	await resolvePendingTransaction(simulator, ethereumClientService, websiteTabConnections, confirmation)
 }
 
@@ -30,7 +30,7 @@ export async function confirmPersonalSign(websiteTabConnections: WebsiteTabConne
 	await resolvePersonalSign(websiteTabConnections, confirmation)
 }
 
-export async function confirmRequestAccess(simulator: Simulator | undefined, websiteTabConnections: WebsiteTabConnections, confirmation: InterceptorAccess) {
+export async function confirmRequestAccess(simulator: Simulator, websiteTabConnections: WebsiteTabConnections, confirmation: InterceptorAccess) {
 	await resolveInterceptorAccess(simulator, websiteTabConnections, confirmation.data)
 }
 
@@ -84,7 +84,7 @@ export async function changeMakeMeRich(simulator: Simulator, ethereumClientServi
 	}, settings.activeSimulationAddress, true)
 }
 
-export async function removeAddressBookEntry(simulator: Simulator | undefined, websiteTabConnections: WebsiteTabConnections, removeAddressBookEntry: RemoveAddressBookEntry) {
+export async function removeAddressBookEntry(simulator: Simulator, websiteTabConnections: WebsiteTabConnections, removeAddressBookEntry: RemoveAddressBookEntry) {
 	switch(removeAddressBookEntry.data.addressBookCategory) {
 		case 'My Active Addresses': {
 			await updateAddressInfos((previousAddressInfos) => previousAddressInfos.filter((info) => info.address !== removeAddressBookEntry.data.address))
@@ -102,7 +102,7 @@ export async function removeAddressBookEntry(simulator: Simulator | undefined, w
 	}
 }
 
-export async function addOrModifyAddressInfo(simulator: Simulator | undefined, websiteTabConnections: WebsiteTabConnections, entry: AddOrEditAddressBookEntry) {
+export async function addOrModifyAddressInfo(simulator: Simulator, websiteTabConnections: WebsiteTabConnections, entry: AddOrEditAddressBookEntry) {
 	const newEntry = entry.data
 	switch (newEntry.type) {
 		case 'NFT':
@@ -133,7 +133,7 @@ export async function addOrModifyAddressInfo(simulator: Simulator | undefined, w
 	}
 }
 
-export async function changeInterceptorAccess(simulator: Simulator | undefined, websiteTabConnections: WebsiteTabConnections, accessChange: ChangeInterceptorAccess) {
+export async function changeInterceptorAccess(simulator: Simulator, websiteTabConnections: WebsiteTabConnections, accessChange: ChangeInterceptorAccess) {
 	await updateWebsiteAccess(() => accessChange.data) // TODO: update 'popup_changeInterceptorAccess' to return list of changes instead of a new list
 	updateWebsiteApprovalAccesses(simulator, websiteTabConnections, undefined, await getSettings())
 	return await sendPopupMessageToOpenWindows({ method: 'popup_interceptor_access_changed' })
@@ -164,7 +164,7 @@ export async function removeTransaction(simulator: Simulator, ethereumClientServ
 	}, settings.activeSimulationAddress, true)
 }
 
-export async function refreshSimulation(simulator: Simulator | undefined, ethereumClientService: EthereumClientService, settings: Settings): Promise<SimulationState | undefined> {
+export async function refreshSimulation(simulator: Simulator, ethereumClientService: EthereumClientService, settings: Settings): Promise<SimulationState | undefined> {
 	return await updateSimulationState(simulator, async (simulationState) => {
 		if (simulationState === undefined) return
 		return await refreshSimulationState(ethereumClientService, simulationState)
@@ -190,7 +190,7 @@ export async function refreshPopupConfirmTransactionMetadata(ethereumClientServi
 	})
 }
 
-export async function refreshPopupConfirmTransactionSimulation(simulator: Simulator | undefined, ethereumClientService: EthereumClientService, { data }: RefreshConfirmTransactionDialogSimulation) {
+export async function refreshPopupConfirmTransactionSimulation(simulator: Simulator, ethereumClientService: EthereumClientService, { data }: RefreshConfirmTransactionDialogSimulation) {
 	const refreshMessage = await refreshConfirmTransactionSimulation(simulator, ethereumClientService, data.activeAddress, data.simulationMode, data.uniqueRequestIdentifier, data.transactionToSimulate)
 	const promises = await getPendingTransactions()
 	if (promises.length === 0) return
@@ -202,15 +202,15 @@ export async function refreshPopupConfirmTransactionSimulation(simulator: Simula
 	})
 }
 
-export async function popupChangeActiveRpc(simulator: Simulator | undefined, websiteTabConnections: WebsiteTabConnections, params: ChangeActiveChain, settings: Settings) {
+export async function popupChangeActiveRpc(simulator: Simulator, websiteTabConnections: WebsiteTabConnections, params: ChangeActiveChain, settings: Settings) {
 	return await changeActiveRpc(simulator, websiteTabConnections, params.data, settings.simulationMode)
 }
 
-export async function changeChainDialog(simulator: Simulator | undefined, websiteTabConnections: WebsiteTabConnections, chainChange: ChainChangeConfirmation) {
+export async function changeChainDialog(simulator: Simulator, websiteTabConnections: WebsiteTabConnections, chainChange: ChainChangeConfirmation) {
 	await resolveChainChange(simulator, websiteTabConnections, chainChange)
 }
 
-export async function enableSimulationMode(simulator: Simulator | undefined, websiteTabConnections: WebsiteTabConnections, params: EnableSimulationMode) {
+export async function enableSimulationMode(simulator: Simulator, websiteTabConnections: WebsiteTabConnections, params: EnableSimulationMode) {
 	const settings = await getSettings()
 	// if we are on unsupported chain, force change to a supported one
 	if (settings.useSignersAddressAsActiveAddress || params.data === false) {
@@ -357,7 +357,7 @@ export async function exportSettings() {
 	})
 }
 
-export async function setNewRpcList(simulator: Simulator | undefined, request: SetRpcList, settings: Settings) {
+export async function setNewRpcList(simulator: Simulator, request: SetRpcList, settings: Settings) {
 	await setRpcList(request.data)
 	await sendPopupMessageToOpenWindows({ method: 'popup_update_rpc_list', data: request.data })
 	const primary = await getPrimaryRpcForChain(settings.rpcNetwork.chainId)

--- a/app/ts/background/providerMessageHandlers.ts
+++ b/app/ts/background/providerMessageHandlers.ts
@@ -11,7 +11,7 @@ import { ProviderMessage } from '../utils/requests.js'
 import { sendSubscriptionReplyOrCallBackToPort } from './messageSending.js'
 import { Simulator } from '../simulation/simulator.js'
 
-export async function ethAccountsReply(simulator: Simulator | undefined, websiteTabConnections: WebsiteTabConnections, port: browser.runtime.Port, request: ProviderMessage, _connectInfoapproval: ApprovalState) {
+export async function ethAccountsReply(simulator: Simulator, websiteTabConnections: WebsiteTabConnections, port: browser.runtime.Port, request: ProviderMessage, _connectInfoapproval: ApprovalState) {
 	if (!('params' in request)) return
 	if (port.sender?.tab?.id === undefined) return
 
@@ -39,7 +39,7 @@ export async function ethAccountsReply(simulator: Simulator | undefined, website
 	}
 }
 
-async function changeSignerChain(simulator: Simulator | undefined, websiteTabConnections: WebsiteTabConnections, port: browser.runtime.Port, signerChain: bigint, approval: ApprovalState) {
+async function changeSignerChain(simulator: Simulator, websiteTabConnections: WebsiteTabConnections, port: browser.runtime.Port, signerChain: bigint, approval: ApprovalState) {
 	if (approval !== 'hasAccess') return
 	if (port.sender?.tab?.id === undefined) return
 	if ((await getTabState(port.sender.tab.id)).signerChain === signerChain) return
@@ -62,13 +62,13 @@ async function changeSignerChain(simulator: Simulator | undefined, websiteTabCon
 	sendPopupMessageToOpenWindows({ method: 'popup_chain_update' })
 }
 
-export async function signerChainChanged(simulator: Simulator | undefined, websiteTabConnections: WebsiteTabConnections, port: browser.runtime.Port, request: ProviderMessage, approval: ApprovalState) {
+export async function signerChainChanged(simulator: Simulator, websiteTabConnections: WebsiteTabConnections, port: browser.runtime.Port, request: ProviderMessage, approval: ApprovalState) {
 	if (!('params' in request)) return
 	const signerChain = EthereumChainReply.parse(request.params)[0]
 	await changeSignerChain(simulator, websiteTabConnections, port, signerChain, approval)
 }
 
-export async function walletSwitchEthereumChainReply(simulator: Simulator | undefined, websiteTabConnections: WebsiteTabConnections, port: browser.runtime.Port, request: ProviderMessage, approval: ApprovalState) {
+export async function walletSwitchEthereumChainReply(simulator: Simulator, websiteTabConnections: WebsiteTabConnections, port: browser.runtime.Port, request: ProviderMessage, approval: ApprovalState) {
 	if (approval !== 'hasAccess') return
 	const params = WalletSwitchEthereumChainReply.parse(request).params[0]
 	if (params.accept) await changeSignerChain(simulator, websiteTabConnections, port, params.chainId, approval)
@@ -81,7 +81,7 @@ export async function walletSwitchEthereumChainReply(simulator: Simulator | unde
 	})
 }
 
-export async function connectedToSigner(_simulator: Simulator | undefined, _websiteTabConnections: WebsiteTabConnections, port: browser.runtime.Port, request: ProviderMessage, approval: ApprovalState) {
+export async function connectedToSigner(_simulator: Simulator, _websiteTabConnections: WebsiteTabConnections, port: browser.runtime.Port, request: ProviderMessage, approval: ApprovalState) {
 	await setSignerName(ConnectedToSigner.parse(request).params[0])
 	await sendPopupMessageToOpenWindows({ method: 'popup_signer_name_changed' })
 	const settings = await getSettings()

--- a/app/ts/background/providerMessageHandlers.ts
+++ b/app/ts/background/providerMessageHandlers.ts
@@ -9,8 +9,9 @@ import { resolveSignerChainChange } from './windows/changeChain.js'
 import { ApprovalState } from './accessManagement.js'
 import { ProviderMessage } from '../utils/requests.js'
 import { sendSubscriptionReplyOrCallBackToPort } from './messageSending.js'
+import { Simulator } from '../simulation/simulator.js'
 
-export async function ethAccountsReply(websiteTabConnections: WebsiteTabConnections, port: browser.runtime.Port, request: ProviderMessage, _connectInfoapproval: ApprovalState) {
+export async function ethAccountsReply(simulator: Simulator | undefined, websiteTabConnections: WebsiteTabConnections, port: browser.runtime.Port, request: ProviderMessage, _connectInfoapproval: ApprovalState) {
 	if (!('params' in request)) return
 	if (port.sender?.tab?.id === undefined) return
 
@@ -28,9 +29,9 @@ export async function ethAccountsReply(websiteTabConnections: WebsiteTabConnecti
 	sendInternalWindowMessage({ method: 'window_signer_accounts_changed', data: { socket: getSocketFromPort(port) } })
 	// update active address if we are using signers address
 	const settings = await getSettings()
-	if ( (settings.useSignersAddressAsActiveAddress && settings.activeSimulationAddress !== signerAccounts[0])
+	if ((settings.useSignersAddressAsActiveAddress && settings.activeSimulationAddress !== signerAccounts[0])
 	|| (settings.simulationMode === false && tabStateChange.previousState.activeSigningAddress !== tabStateChange.newState.activeSigningAddress)) {
-		await changeActiveAddressAndChainAndResetSimulation(websiteTabConnections, {
+		await changeActiveAddressAndChainAndResetSimulation(simulator, websiteTabConnections, {
 			simulationMode: settings.simulationMode,
 			activeAddress: tabStateChange.newState.activeSigningAddress,
 		})
@@ -38,7 +39,7 @@ export async function ethAccountsReply(websiteTabConnections: WebsiteTabConnecti
 	}
 }
 
-async function changeSignerChain(websiteTabConnections: WebsiteTabConnections, port: browser.runtime.Port, signerChain: bigint, approval: ApprovalState) {
+async function changeSignerChain(simulator: Simulator | undefined, websiteTabConnections: WebsiteTabConnections, port: browser.runtime.Port, signerChain: bigint, approval: ApprovalState) {
 	if (approval !== 'hasAccess') return
 	if (port.sender?.tab?.id === undefined) return
 	if ((await getTabState(port.sender.tab.id)).signerChain === signerChain) return
@@ -53,7 +54,7 @@ async function changeSignerChain(websiteTabConnections: WebsiteTabConnections, p
 	// update active address if we are using signers address
 	const settings = await getSettings()
 	if ((settings.useSignersAddressAsActiveAddress || !settings.simulationMode) && settings.rpcNetwork.chainId !== signerChain) {
-		return changeActiveAddressAndChainAndResetSimulation(websiteTabConnections, {
+		return changeActiveAddressAndChainAndResetSimulation(simulator, websiteTabConnections, {
 			simulationMode: settings.simulationMode,
 			rpcNetwork: await getRpcNetworkForChain(signerChain),
 		})
@@ -61,16 +62,16 @@ async function changeSignerChain(websiteTabConnections: WebsiteTabConnections, p
 	sendPopupMessageToOpenWindows({ method: 'popup_chain_update' })
 }
 
-export async function signerChainChanged(websiteTabConnections: WebsiteTabConnections, port: browser.runtime.Port, request: ProviderMessage, approval: ApprovalState) {
+export async function signerChainChanged(simulator: Simulator | undefined, websiteTabConnections: WebsiteTabConnections, port: browser.runtime.Port, request: ProviderMessage, approval: ApprovalState) {
 	if (!('params' in request)) return
 	const signerChain = EthereumChainReply.parse(request.params)[0]
-	await changeSignerChain(websiteTabConnections, port, signerChain, approval)
+	await changeSignerChain(simulator, websiteTabConnections, port, signerChain, approval)
 }
 
-export async function walletSwitchEthereumChainReply(websiteTabConnections: WebsiteTabConnections, port: browser.runtime.Port, request: ProviderMessage, approval: ApprovalState) {
+export async function walletSwitchEthereumChainReply(simulator: Simulator | undefined, websiteTabConnections: WebsiteTabConnections, port: browser.runtime.Port, request: ProviderMessage, approval: ApprovalState) {
 	if (approval !== 'hasAccess') return
 	const params = WalletSwitchEthereumChainReply.parse(request).params[0]
-	if (params.accept) await changeSignerChain(websiteTabConnections, port, params.chainId, approval)
+	if (params.accept) await changeSignerChain(simulator, websiteTabConnections, port, params.chainId, approval)
 	await resolveSignerChainChange({
 		method: 'popup_signerChangeChainDialog',
 		data: {
@@ -80,7 +81,7 @@ export async function walletSwitchEthereumChainReply(websiteTabConnections: Webs
 	})
 }
 
-export async function connectedToSigner(_websiteTabConnections: WebsiteTabConnections, port: browser.runtime.Port, request: ProviderMessage, approval: ApprovalState) {
+export async function connectedToSigner(_simulator: Simulator | undefined, _websiteTabConnections: WebsiteTabConnections, port: browser.runtime.Port, request: ProviderMessage, approval: ApprovalState) {
 	await setSignerName(ConnectedToSigner.parse(request).params[0])
 	await sendPopupMessageToOpenWindows({ method: 'popup_signer_name_changed' })
 	const settings = await getSettings()

--- a/app/ts/background/simulationModeHanders.ts
+++ b/app/ts/background/simulationModeHanders.ts
@@ -46,7 +46,7 @@ function getFromField(websiteTabConnections: WebsiteTabConnections, simulationMo
 }
 
 export async function sendTransaction(
-	simulator: Simulator | undefined,
+	simulator: Simulator,
 	websiteTabConnections: WebsiteTabConnections,
 	activeAddress: bigint | undefined,
 	ethereumClientService: EthereumClientService,
@@ -108,7 +108,7 @@ export async function sendTransaction(
 }
 
 export async function sendRawTransaction(
-	simulator: Simulator | undefined,
+	simulator: Simulator,
 	ethereumClientService: EthereumClientService,
 	sendRawTransactionParams: SendRawTransaction,
 	request: InterceptedRequest,
@@ -243,7 +243,7 @@ export async function personalSign(ethereumClientService: EthereumClientService,
 	return await openPersonalSignDialog(ethereumClientService, websiteTabConnections, params, request, simulationMode, website, activeAddress)
 }
 
-export async function switchEthereumChain(simulator: Simulator | undefined, websiteTabConnections: WebsiteTabConnections, ethereumClientService: EthereumClientService, params: SwitchEthereumChainParams, request: InterceptedRequest, simulationMode: boolean, website: Website) {
+export async function switchEthereumChain(simulator: Simulator, websiteTabConnections: WebsiteTabConnections, ethereumClientService: EthereumClientService, params: SwitchEthereumChainParams, request: InterceptedRequest, simulationMode: boolean, website: Website) {
 	if (ethereumClientService.getChainId() === params.params[0].chainId) {
 		// we are already on the right chain
 		return { method: params.method, result: null }

--- a/app/ts/background/simulationModeHanders.ts
+++ b/app/ts/background/simulationModeHanders.ts
@@ -15,6 +15,7 @@ import { openConfirmTransactionDialog } from './windows/confirmTransaction.js'
 import { openPersonalSignDialog } from './windows/personalSign.js'
 import { assertNever } from '../utils/typescript.js'
 import { InterceptedRequest } from '../utils/requests.js'
+import { Simulator } from '../simulation/simulator.js'
 
 const defaultCallAddress = 0x1n
 
@@ -45,6 +46,7 @@ function getFromField(websiteTabConnections: WebsiteTabConnections, simulationMo
 }
 
 export async function sendTransaction(
+	simulator: Simulator | undefined,
 	websiteTabConnections: WebsiteTabConnections,
 	activeAddress: bigint | undefined,
 	ethereumClientService: EthereumClientService,
@@ -94,6 +96,7 @@ export async function sendTransaction(
 	return {
 		method: sendTransactionParams.method,
 		...await openConfirmTransactionDialog(
+			simulator,
 			ethereumClientService,
 			request,
 			sendTransactionParams,
@@ -105,6 +108,7 @@ export async function sendTransaction(
 }
 
 export async function sendRawTransaction(
+	simulator: Simulator | undefined,
 	ethereumClientService: EthereumClientService,
 	sendRawTransactionParams: SendRawTransaction,
 	request: InterceptedRequest,
@@ -153,6 +157,7 @@ export async function sendRawTransaction(
 	}
 	return { method: sendRawTransactionParams.method,
 		...await openConfirmTransactionDialog(
+			simulator,
 			ethereumClientService,
 			request,
 			sendRawTransactionParams,
@@ -238,12 +243,12 @@ export async function personalSign(ethereumClientService: EthereumClientService,
 	return await openPersonalSignDialog(ethereumClientService, websiteTabConnections, params, request, simulationMode, website, activeAddress)
 }
 
-export async function switchEthereumChain(websiteTabConnections: WebsiteTabConnections, ethereumClientService: EthereumClientService, params: SwitchEthereumChainParams, request: InterceptedRequest, simulationMode: boolean, website: Website) {
+export async function switchEthereumChain(simulator: Simulator | undefined, websiteTabConnections: WebsiteTabConnections, ethereumClientService: EthereumClientService, params: SwitchEthereumChainParams, request: InterceptedRequest, simulationMode: boolean, website: Website) {
 	if (ethereumClientService.getChainId() === params.params[0].chainId) {
 		// we are already on the right chain
 		return { method: params.method, result: null }
 	}
-	const change = await openChangeChainDialog(websiteTabConnections, request, simulationMode, website, params)
+	const change = await openChangeChainDialog(simulator, websiteTabConnections, request, simulationMode, website, params)
 	return { method: params.method, ...change }
 }
 

--- a/app/ts/background/storageVariables.ts
+++ b/app/ts/background/storageVariables.ts
@@ -3,7 +3,7 @@ import { PendingAccessRequestArray, PendingChainChangeConfirmationPromise, Pendi
 import { Semaphore } from '../utils/semaphore.js'
 import { browserStorageLocalSet, browserStorageLocalSingleGetWithDefault } from '../utils/storageUtils.js'
 import { SignerName } from '../utils/user-interface-types.js'
-import { EthereumSubscriptions, SimulationResults, RpcEntries, RpcNetwork, SimulationUpdatingState } from '../utils/visualizer-types.js'
+import { EthereumSubscriptions, SimulationResults, RpcEntries, RpcNetwork } from '../utils/visualizer-types.js'
 import * as funtypes from 'funtypes'
 import { defaultRpcs, getSettings } from './settings.js'
 import { UniqueRequestIdentifier, doesUniqueRequestIdentifiersMatch } from '../utils/requests.js'
@@ -77,6 +77,7 @@ export async function getSimulationResults() {
 	const results = await browserStorageLocalSingleGetWithDefault('simulationResults', undefined)
 	const emptyResults = {
 		simulationUpdatingState: 'done' as const,
+		simulationResultState: 'invalid' as const,
 		simulationId: 0,
 		simulationState: undefined,
 		visualizerResults: undefined,
@@ -101,14 +102,6 @@ export async function updateSimulationResults(newResults: SimulationResults) {
 		const oldResults = await getSimulationResults()
 		if (newResults.simulationId < oldResults.simulationId) return // do not update state with older state
 		return await browserStorageLocalSet('simulationResults', SimulationResults.serialize(newResults) as string)
-	})
-}
-
-export async function setSimulationUpdatingState(simulationId: number, simulationUpdatingState: SimulationUpdatingState) {
-	await simulationResultsSemaphore.execute(async () => {
-		const oldResults = await getSimulationResults()
-		if (simulationId < oldResults.simulationId) return // do not update state with older state
-		return await browserStorageLocalSet('simulationResults', SimulationResults.serialize({ ...oldResults, simulationId, simulationUpdatingState }) as string)
 	})
 }
 

--- a/app/ts/background/windows/changeChain.ts
+++ b/app/ts/background/windows/changeChain.ts
@@ -10,6 +10,7 @@ import { getChainChangeConfirmationPromise, getRpcNetworkForChain, setChainChang
 import { RpcNetwork } from '../../utils/visualizer-types.js'
 import { InterceptedRequest, UniqueRequestIdentifier, doesUniqueRequestIdentifiersMatch } from '../../utils/requests.js'
 import { replyToInterceptedRequest } from '../messageSending.js'
+import { Simulator } from '../../simulation/simulator.js'
 
 let pendForUserReply: Future<ChainChangeConfirmation> | undefined = undefined
 let pendForSignerReply: Future<SignerChainChangeConfirmation> | undefined = undefined
@@ -21,14 +22,14 @@ export async function updateChainChangeViewWithPendingRequest() {
 	if (promise) return sendPopupMessageToOpenWindows({ method: 'popup_ChangeChainRequest', data: promise })
 }
 
-export async function resolveChainChange(websiteTabConnections: WebsiteTabConnections, confirmation: ChainChangeConfirmation) {
+export async function resolveChainChange(simulator: Simulator | undefined, websiteTabConnections: WebsiteTabConnections, confirmation: ChainChangeConfirmation) {
 	if (pendForUserReply !== undefined) {
 		pendForUserReply.resolve(confirmation)
 		return
 	}
 	const data = await getChainChangeConfirmationPromise()
 	if (data === undefined || !doesUniqueRequestIdentifiersMatch(confirmation.data.uniqueRequestIdentifier, data.request.uniqueRequestIdentifier)) throw new Error('Unique request identifier mismatch in change chain')
-	const resolved = await resolve(websiteTabConnections, confirmation, data.simulationMode)
+	const resolved = await resolve(simulator, websiteTabConnections, confirmation, data.simulationMode)
 	replyToInterceptedRequest(websiteTabConnections, { method: 'wallet_switchEthereumChain' as const, ...resolved, uniqueRequestIdentifier: data.request.uniqueRequestIdentifier })
 	if (openedDialog) await closePopupOrTab(openedDialog)
 	openedDialog = undefined
@@ -58,6 +59,7 @@ const userDeniedChange = {
 } as const
 
 export const openChangeChainDialog = async (
+	simulator: Simulator | undefined,
 	websiteTabConnections: WebsiteTabConnections,
 	request: InterceptedRequest,
 	simulationMode: boolean,
@@ -72,7 +74,7 @@ export const openChangeChainDialog = async (
 		if (openedDialog === undefined || openedDialog.windowOrTab.id !== windowId) return
 		openedDialog = undefined
 		if (pendForUserReply === undefined) return
-		resolveChainChange(websiteTabConnections, rejectMessage(await getRpcNetworkForChain(params.params[0].chainId), request.uniqueRequestIdentifier))
+		resolveChainChange(simulator, websiteTabConnections, rejectMessage(await getRpcNetworkForChain(params.params[0].chainId), request.uniqueRequestIdentifier))
 	}
 
 	try {
@@ -104,14 +106,14 @@ export const openChangeChainDialog = async (
 			})
 			await updateChainChangeViewWithPendingRequest()
 		} else {
-			await resolveChainChange(websiteTabConnections, rejectMessage(await getRpcNetworkForChain(params.params[0].chainId), request.uniqueRequestIdentifier))
+			await resolveChainChange(simulator, websiteTabConnections, rejectMessage(await getRpcNetworkForChain(params.params[0].chainId), request.uniqueRequestIdentifier))
 		}
 		pendForSignerReply = undefined
 
 		const reply = await pendForUserReply
 
 		// forward message to content script
-		return resolve(websiteTabConnections, reply, simulationMode)
+		return resolve(simulator, websiteTabConnections, reply, simulationMode)
 	} finally {
 		removeWindowTabListener(onCloseWindow)
 		pendForUserReply = undefined
@@ -119,15 +121,15 @@ export const openChangeChainDialog = async (
 	}
 }
 
-async function resolve(websiteTabConnections: WebsiteTabConnections, reply: ChainChangeConfirmation, simulationMode: boolean) {
+async function resolve(simulator: Simulator | undefined, websiteTabConnections: WebsiteTabConnections, reply: ChainChangeConfirmation, simulationMode: boolean) {
 	await setChainChangeConfirmationPromise(undefined)
 	if (reply.data.accept) {
 		if (simulationMode) {
-			await changeActiveRpc(websiteTabConnections, reply.data.rpcNetwork, simulationMode)
+			await changeActiveRpc(simulator, websiteTabConnections, reply.data.rpcNetwork, simulationMode)
 			return { result: null }
 		}
 		pendForSignerReply = new Future<SignerChainChangeConfirmation>() // when not in simulation mode, we need to get reply from the signer too
-		await changeActiveRpc(websiteTabConnections, reply.data.rpcNetwork, simulationMode)
+		await changeActiveRpc(simulator, websiteTabConnections, reply.data.rpcNetwork, simulationMode)
 		const signerReply = await pendForSignerReply
 		if (signerReply.data.accept && signerReply.data.chainId === reply.data.rpcNetwork.chainId) {
 			return { result: null }

--- a/app/ts/background/windows/changeChain.ts
+++ b/app/ts/background/windows/changeChain.ts
@@ -22,7 +22,7 @@ export async function updateChainChangeViewWithPendingRequest() {
 	if (promise) return sendPopupMessageToOpenWindows({ method: 'popup_ChangeChainRequest', data: promise })
 }
 
-export async function resolveChainChange(simulator: Simulator | undefined, websiteTabConnections: WebsiteTabConnections, confirmation: ChainChangeConfirmation) {
+export async function resolveChainChange(simulator: Simulator, websiteTabConnections: WebsiteTabConnections, confirmation: ChainChangeConfirmation) {
 	if (pendForUserReply !== undefined) {
 		pendForUserReply.resolve(confirmation)
 		return
@@ -59,7 +59,7 @@ const userDeniedChange = {
 } as const
 
 export const openChangeChainDialog = async (
-	simulator: Simulator | undefined,
+	simulator: Simulator,
 	websiteTabConnections: WebsiteTabConnections,
 	request: InterceptedRequest,
 	simulationMode: boolean,
@@ -121,7 +121,7 @@ export const openChangeChainDialog = async (
 	}
 }
 
-async function resolve(simulator: Simulator | undefined, websiteTabConnections: WebsiteTabConnections, reply: ChainChangeConfirmation, simulationMode: boolean) {
+async function resolve(simulator: Simulator, websiteTabConnections: WebsiteTabConnections, reply: ChainChangeConfirmation, simulationMode: boolean) {
 	await setChainChangeConfirmationPromise(undefined)
 	if (reply.data.accept) {
 		if (simulationMode) {

--- a/app/ts/background/windows/confirmTransaction.ts
+++ b/app/ts/background/windows/confirmTransaction.ts
@@ -10,9 +10,10 @@ import { EstimateGasError, WebsiteCreatedEthereumUnsignedTransaction } from '../
 import { SendRawTransaction, SendTransactionParams } from '../../utils/wire-types.js'
 import { refreshConfirmTransactionSimulation, updateSimulationState } from '../background.js'
 import { getHtmlFile, sendPopupMessageToOpenWindows } from '../backgroundUtils.js'
-import { appendPendingTransaction, clearPendingTransactions, getPendingTransactions, getSimulationResults, removePendingTransaction } from '../storageVariables.js'
+import { appendPendingTransaction, clearPendingTransactions, getPendingTransactions, removePendingTransaction } from '../storageVariables.js'
 import { InterceptedRequest, getUniqueRequestIdentifierString } from '../../utils/requests.js'
 import { replyToInterceptedRequest } from '../messageSending.js'
+import { Simulator } from '../../simulation/simulator.js'
 
 export type Confirmation = 'Approved' | 'Rejected' | 'NoResponse'
 let openedDialog: PopupOrTab | undefined = undefined
@@ -37,7 +38,7 @@ async function updateConfirmTransactionViewWithPendingTransactionOrClose() {
 	openedDialog = undefined
 }
 
-export async function resolvePendingTransaction(ethereumClientService: EthereumClientService, websiteTabConnections: WebsiteTabConnections, confirmation: TransactionConfirmation) {
+export async function resolvePendingTransaction(simulator: Simulator | undefined, ethereumClientService: EthereumClientService, websiteTabConnections: WebsiteTabConnections, confirmation: TransactionConfirmation) {
 	const pending = pendingTransactions.get(getUniqueRequestIdentifierString(confirmation.data.uniqueRequestIdentifier))
 	const pendingTransaction = await removePendingTransaction(confirmation.data.uniqueRequestIdentifier)
 	if (pendingTransaction === undefined) throw new Error('Failed to find pending transaction')
@@ -46,7 +47,7 @@ export async function resolvePendingTransaction(ethereumClientService: EthereumC
 		return pending.resolve(confirmation.data.accept === true ? 'Approved' : 'Rejected')
 	} else {
 		// we have not been tracking this window, forward its message directly to content script (or signer)
-		const resolvedPromise = await resolve(ethereumClientService, pendingTransaction.simulationMode, pendingTransaction.activeAddress, pendingTransaction.transactionToSimulate, confirmation.data.accept)
+		const resolvedPromise = await resolve(simulator, ethereumClientService, pendingTransaction.simulationMode, pendingTransaction.activeAddress, pendingTransaction.transactionToSimulate, confirmation.data.accept)
 		replyToInterceptedRequest(websiteTabConnections, { ...pendingTransaction.transactionParams, ...resolvedPromise, uniqueRequestIdentifier: confirmation.data.uniqueRequestIdentifier })
 		openedDialog = await getPopupOrTabOnlyById(confirmation.data.windowId)
 	}
@@ -67,6 +68,7 @@ const rejectMessage = {
 }
 
 export async function openConfirmTransactionDialog(
+	simulator: Simulator | undefined,
 	ethereumClientService: EthereumClientService,
 	request: InterceptedRequest,
 	transactionParams: SendTransactionParams | SendRawTransaction,
@@ -96,7 +98,7 @@ export async function openConfirmTransactionDialog(
 					}
 				}
 			}
-			const refreshSimulationPromise = refreshConfirmTransactionSimulation(ethereumClientService, activeAddress, simulationMode, request.uniqueRequestIdentifier, transactionToSimulate)
+			const refreshSimulationPromise = refreshConfirmTransactionSimulation(simulator, ethereumClientService, activeAddress, simulationMode, request.uniqueRequestIdentifier, transactionToSimulate)
 
 			if (!justAddToPending) {
 				addWindowTabListener(onCloseWindow)
@@ -123,7 +125,7 @@ export async function openConfirmTransactionDialog(
 		})
 		if (addedPendingTransaction === false) return rejectMessage
 		const reply = await pendingTransaction
-		const resolvedPromise = await resolve(ethereumClientService, simulationMode, activeAddress, transactionToSimulate, reply === 'Approved' ? true : false)
+		const resolvedPromise = await resolve(simulator, ethereumClientService, simulationMode, activeAddress, transactionToSimulate, reply === 'Approved' ? true : false)
 		return resolvedPromise
 	} finally {
 		removeWindowTabListener(onCloseWindow)
@@ -132,14 +134,13 @@ export async function openConfirmTransactionDialog(
 	}
 }
 
-async function resolve(ethereumClientService: EthereumClientService, simulationMode: boolean, activeAddress: bigint, transactionToSimulate: WebsiteCreatedEthereumUnsignedTransaction, accept: boolean): Promise<{ forward: true } | { error: { code: number, message: string } } | { result: bigint }> {
+async function resolve(simulator: Simulator | undefined, ethereumClientService: EthereumClientService, simulationMode: boolean, activeAddress: bigint, transactionToSimulate: WebsiteCreatedEthereumUnsignedTransaction, accept: boolean): Promise<{ forward: true } | { error: { code: number, message: string } } | { result: bigint }> {
 	if (accept === false) return rejectMessage
 	if (!simulationMode) return { forward: true }
-	const newState = await updateSimulationState(async () => {
-		const simulationState = (await getSimulationResults()).simulationState
+	const newState = await updateSimulationState(simulator, async (simulationState) => {
 		if (simulationState === undefined) return undefined
 		return await appendTransaction(ethereumClientService, simulationState, transactionToSimulate)
-	}, activeAddress)
+	}, activeAddress, true)
 	if (newState === undefined || newState.simulatedTransactions === undefined || newState.simulatedTransactions.length === 0) {
 		return METAMASK_ERROR_NOT_CONNECTED_TO_CHAIN
 	}

--- a/app/ts/background/windows/confirmTransaction.ts
+++ b/app/ts/background/windows/confirmTransaction.ts
@@ -38,7 +38,7 @@ async function updateConfirmTransactionViewWithPendingTransactionOrClose() {
 	openedDialog = undefined
 }
 
-export async function resolvePendingTransaction(simulator: Simulator | undefined, ethereumClientService: EthereumClientService, websiteTabConnections: WebsiteTabConnections, confirmation: TransactionConfirmation) {
+export async function resolvePendingTransaction(simulator: Simulator, ethereumClientService: EthereumClientService, websiteTabConnections: WebsiteTabConnections, confirmation: TransactionConfirmation) {
 	const pending = pendingTransactions.get(getUniqueRequestIdentifierString(confirmation.data.uniqueRequestIdentifier))
 	const pendingTransaction = await removePendingTransaction(confirmation.data.uniqueRequestIdentifier)
 	if (pendingTransaction === undefined) throw new Error('Failed to find pending transaction')
@@ -68,7 +68,7 @@ const rejectMessage = {
 }
 
 export async function openConfirmTransactionDialog(
-	simulator: Simulator | undefined,
+	simulator: Simulator,
 	ethereumClientService: EthereumClientService,
 	request: InterceptedRequest,
 	transactionParams: SendTransactionParams | SendRawTransaction,
@@ -134,7 +134,7 @@ export async function openConfirmTransactionDialog(
 	}
 }
 
-async function resolve(simulator: Simulator | undefined, ethereumClientService: EthereumClientService, simulationMode: boolean, activeAddress: bigint, transactionToSimulate: WebsiteCreatedEthereumUnsignedTransaction, accept: boolean): Promise<{ forward: true } | { error: { code: number, message: string } } | { result: bigint }> {
+async function resolve(simulator: Simulator, ethereumClientService: EthereumClientService, simulationMode: boolean, activeAddress: bigint, transactionToSimulate: WebsiteCreatedEthereumUnsignedTransaction, accept: boolean): Promise<{ forward: true } | { error: { code: number, message: string } } | { result: bigint }> {
 	if (accept === false) return rejectMessage
 	if (!simulationMode) return { forward: true }
 	const newState = await updateSimulationState(simulator, async (simulationState) => {

--- a/app/ts/background/windows/interceptorAccess.ts
+++ b/app/ts/background/windows/interceptorAccess.ts
@@ -23,7 +23,7 @@ let openedDialog: OpenedDialogWithListeners = undefined
 
 const pendingInterceptorAccessSemaphore = new Semaphore(1)
 
-const onCloseWindow = async (simulator: Simulator | undefined, windowId: number, websiteTabConnections: WebsiteTabConnections) => { // check if user has closed the window on their own, if so, reject signature
+const onCloseWindow = async (simulator: Simulator, windowId: number, websiteTabConnections: WebsiteTabConnections) => { // check if user has closed the window on their own, if so, reject signature
 	if (openedDialog?.popupOrTab.windowOrTab.id !== windowId) return
 	removeWindowTabListener(openedDialog.onCloseWindow)
 
@@ -40,7 +40,7 @@ const onCloseWindow = async (simulator: Simulator | undefined, windowId: number,
 	}
 }
 
-export async function resolveInterceptorAccess(simulator: Simulator | undefined, websiteTabConnections: WebsiteTabConnections, reply: InterceptorAccessReply) {
+export async function resolveInterceptorAccess(simulator: Simulator, websiteTabConnections: WebsiteTabConnections, reply: InterceptorAccessReply) {
 	const promises = await getPendingAccessRequests()
 	const pendingRequest = promises.find((req) => req.accessRequestId === reply.accessRequestId)
 	if (pendingRequest === undefined) throw new Error('Access request missing!')
@@ -53,7 +53,7 @@ export function getAddressMetadataForAccess(websiteAccess: WebsiteAccessArray, a
 	return Array.from(addressSet).map((x) => findAddressInfo(x, addressInfos))
 }
 
-export async function changeAccess(simulator: Simulator | undefined, websiteTabConnections: WebsiteTabConnections, confirmation: InterceptorAccessReply, website: Website, promptForAccessesIfNeeded: boolean = true) {
+export async function changeAccess(simulator: Simulator, websiteTabConnections: WebsiteTabConnections, confirmation: InterceptorAccessReply, website: Website, promptForAccessesIfNeeded: boolean = true) {
 	if (confirmation.userReply === 'NoResponse') return
 	await setAccess(website, confirmation.userReply === 'Approved', confirmation.requestAccessToAddress)
 	updateWebsiteApprovalAccesses(simulator, websiteTabConnections, promptForAccessesIfNeeded, await getSettings())
@@ -86,7 +86,7 @@ async function askForSignerAccountsFromSignerIfNotAvailable(websiteTabConnection
 }
 
 export async function requestAccessFromUser(
-	simulator: Simulator | undefined,
+	simulator: Simulator,
 	websiteTabConnections: WebsiteTabConnections,
 	socket: WebsiteSocket,
 	website: Website,
@@ -195,7 +195,7 @@ async function updateViewOrClose() {
 	}
 }
 
-async function resolve(simulator: Simulator | undefined, websiteTabConnections: WebsiteTabConnections, accessReply: InterceptorAccessReply, request: InterceptedRequest | undefined, website: Website, activeAddress: bigint | undefined) {
+async function resolve(simulator: Simulator, websiteTabConnections: WebsiteTabConnections, accessReply: InterceptorAccessReply, request: InterceptedRequest | undefined, website: Website, activeAddress: bigint | undefined) {
 	await updatePendingAccessRequests(async (previousPendingAccessRequests) => {
 		return previousPendingAccessRequests.filter((x) => !(x.website.websiteOrigin === website.websiteOrigin && (x.requestAccessToAddress?.address === accessReply.requestAccessToAddress || x.requestAccessToAddress?.address === accessReply.originalRequestAccessToAddress)))
 	})

--- a/app/ts/backgroundServiceWorker.ts
+++ b/app/ts/backgroundServiceWorker.ts
@@ -1,4 +1,4 @@
-import './background/background.js'
+import './background/background-startup.js'
 import { getHtmlFile } from './background/backgroundUtils.js'
 import { clearTabStates } from './background/storageVariables.js'
 import { sleep } from './utils/sleep.js'

--- a/app/ts/components/App.tsx
+++ b/app/ts/components/App.tsx
@@ -1,6 +1,6 @@
 import { useState, useEffect } from 'preact/hooks'
 import { defaultAddresses } from '../background/settings.js'
-import { SimulatedAndVisualizedTransaction, SimulationAndVisualisationResults, SimulationState, TokenPriceEstimate, RpcEntry, RpcNetwork, RpcEntries, SimulationUpdatingState } from '../utils/visualizer-types.js'
+import { SimulatedAndVisualizedTransaction, SimulationAndVisualisationResults, SimulationState, TokenPriceEstimate, RpcEntry, RpcNetwork, RpcEntries, SimulationUpdatingState, SimulationResultState } from '../utils/visualizer-types.js'
 import { ChangeActiveAddress } from './pages/ChangeActiveAddress.js'
 import { Home } from './pages/Home.js'
 import { AddressInfo, AddressInfoEntry, AddressBookEntry, AddingNewAddressType, SignerName, AddressBookEntries } from '../utils/user-interface-types.js'
@@ -40,6 +40,7 @@ export function App() {
 	const [currentTabId, setCurrentTabId] = useState<number | undefined>(undefined)
 	const [rpcEntries, setRpcEntries] = useState<RpcEntries>([])
 	const [simulationUpdatingState, setSimulationUpdatingState] = useState<SimulationUpdatingState | undefined>(undefined)
+	const [simulationResultState, setSimulationResultState] = useState<SimulationResultState | undefined>(undefined)
 
 	async function setActiveAddressAndInformAboutIt(address: bigint | 'signer') {
 		setUseSignersAddressAsActiveAddress(address === 'signer')
@@ -116,6 +117,7 @@ export function App() {
 					data.simulation.activeAddress
 				)
 				setSimulationUpdatingState(data.simulation.simulationUpdatingState)
+				setSimulationResultState(data.simulation.simulationResultState)
 				setMakeMeRich(data.makeMeRich)
 				setSignerName(data.signerName)
 				setCurrentBlockNumber(data.currentBlockNumber)
@@ -149,7 +151,7 @@ export function App() {
 			if (message.method === 'popup_websiteIconChanged') return updateTabIcon(message)
 			if (message.method === 'popup_failed_to_get_block') return setRpcConnectionStatus(message.data.rpcConnectionStatus)
 			if (message.method === 'popup_update_rpc_list') return
-			if (message.method !== 'popup_UpdateHomePage') return await sendPopupMessageToBackgroundPage( { method: 'popup_requestNewHomeData' } )
+			if (message.method !== 'popup_UpdateHomePage') return await sendPopupMessageToBackgroundPage({ method: 'popup_requestNewHomeData' })
 			return updateHomePage(message)
 		}
 		browser.runtime.onMessage.addListener(popupMessageListener)
@@ -238,6 +240,7 @@ export function App() {
 							rpcConnectionStatus = { rpcConnectionStatus }
 							rpcEntries = { rpcEntries }
 							simulationUpdatingState = { simulationUpdatingState }
+							simulationResultState = { simulationResultState }
 						/>
 
 						<div class = { `modal ${ appPage !== 'Home' ? 'is-active' : ''}` }>

--- a/app/ts/components/pages/Home.tsx
+++ b/app/ts/components/pages/Home.tsx
@@ -1,6 +1,6 @@
 import { HomeParams, AddressInfo, FirstCardParams, SimulationStateParam, SignerName } from '../../utils/user-interface-types.js'
 import { useEffect, useState } from 'preact/hooks'
-import { SimulatedAndVisualizedTransaction, SimulationAndVisualisationResults, RpcEntry, RpcNetwork, RpcEntries, SimulationUpdatingState } from '../../utils/visualizer-types.js'
+import { SimulatedAndVisualizedTransaction, SimulationAndVisualisationResults, RpcEntry, RpcNetwork, RpcEntries, SimulationUpdatingState, SimulationResultState } from '../../utils/visualizer-types.js'
 import { ActiveAddress, findAddressInfo } from '../subcomponents/address.js'
 import { SimulationSummary } from '../simulationExplaining/SimulationSummary.js'
 import { ChainSelector } from '../subcomponents/ChainSelector.js'
@@ -177,7 +177,7 @@ function SimulationResults(param: SimulationStateParam) {
 			</div>
 		</p>
 
-		<div class = { param.simulationUpdatingState === 'updating' || param.simulationUpdatingState === 'failed' ? 'blur' : '' }>
+		<div class = { param.simulationResultState === 'invalid' || param.simulationUpdatingState === 'failed' ? 'blur' : '' }>
 			<Transactions
 				simulationAndVisualisationResults = { param.simulationAndVisualisationResults }
 				removeTransaction = { param.removeTransaction }
@@ -240,7 +240,8 @@ export function Home(param: HomeParams) {
 	const [rpcConnectionStatus, setRpcConnectionStatus] = useState<RpcConnectionStatus>(undefined)
 	const [rpcEntries, setRPCEntries] = useState<RpcEntries>([])
 	const [simulationUpdatingState, setSimulationUpdatingState] = useState<SimulationUpdatingState | undefined>(undefined)
-
+	const [simulationResultState, setSimulationResultState] = useState<SimulationResultState | undefined>(undefined)
+	
 	useEffect(() => {
 		setSimulationAndVisualisationResults(param.simVisResults)
 		setUseSignersAddressAsActiveAddress(param.useSignersAddressAsActiveAddress)
@@ -260,6 +261,7 @@ export function Home(param: HomeParams) {
 		setRpcConnectionStatus(param.rpcConnectionStatus)
 		setRPCEntries(param.rpcEntries)
 		setSimulationUpdatingState(param.simulationUpdatingState)
+		setSimulationResultState(param.simulationResultState)
 	}, [param.activeSigningAddress,
 		param.activeSimulationAddress,
 		param.signerAccounts,
@@ -274,6 +276,7 @@ export function Home(param: HomeParams) {
 		param.rpcConnectionStatus,
 		param.rpcEntries,
 		param.simulationUpdatingState,
+		param.simulationResultState,
 	])
 
 	function changeActiveAddress() {
@@ -350,6 +353,7 @@ export function Home(param: HomeParams) {
 				removeTransactionHashes = { removeTransactionHashes }
 				rpcConnectionStatus = { rpcConnectionStatus }
 				simulationUpdatingState = { simulationUpdatingState }
+				simulationResultState = { simulationResultState }
 			/>
 		}
 	</>

--- a/app/ts/simulation/services/EthereumClientService.ts
+++ b/app/ts/simulation/services/EthereumClientService.ts
@@ -23,6 +23,9 @@ export class EthereumClientService {
     }
 
 	public readonly getRpcNetwork = () => this.requestHandler.getRpcNetwork()
+	
+	public readonly getNewBlockAttemptCallback = () => this.newBlockAttemptCallback
+	public readonly getOnErrorBlockCallback = () => this.onErrorBlockCallback
 
 	public getLastKnownCachedBlockOrUndefined = () => this.cachedBlock
 
@@ -72,8 +75,8 @@ export class EthereumClientService {
 			if (this.cacheRefreshTimer === undefined) return
 			const newBlock = EthereumBlockHeader.parse(response)
 			console.log(`Current block number: ${ newBlock.number }`)
-			this.cachedBlock = newBlock
 			this.newBlockAttemptCallback(newBlock, this, this.cachedBlock?.number != newBlock.number)
+			this.cachedBlock = newBlock
 		} catch(error) {
 			if (error instanceof Error) {
 				return this.onErrorBlockCallback(this, error)

--- a/app/ts/simulation/simulator.ts
+++ b/app/ts/simulation/simulator.ts
@@ -36,14 +36,17 @@ const logHandler = new Map<string, Loghandler >([
 ])
 
 export class Simulator {
-	public readonly ethereum
+	public ethereum: EthereumClientService
 
 	public constructor(rpcNetwork: RpcNetwork, newBlockAttemptCallback: (blockHeader: EthereumBlockHeader, ethereumClientService: EthereumClientService, isNewBlock: boolean) => void, onErrorBlockCallback: (ethereumClientService: EthereumClientService, error: Error) => void) {
 		this.ethereum = new EthereumClientService(new EthereumJSONRpcRequestHandler(rpcNetwork), newBlockAttemptCallback, onErrorBlockCallback)
 	}
 
-	public cleanup = () => {
-		this.ethereum.cleanup()
+	public cleanup = () => this.ethereum.cleanup()
+
+	public reset = (rpcNetwork: RpcNetwork) => {
+		this.cleanup()
+		this.ethereum = new EthereumClientService(new EthereumJSONRpcRequestHandler(rpcNetwork), this.ethereum.getNewBlockAttemptCallback(), this.ethereum.getOnErrorBlockCallback())
 	}
 
 	public async visualizeTransactionChain(simulationState: SimulationState, transactions: WebsiteCreatedEthereumUnsignedTransaction[], blockNumber: bigint, multicallResults: MulticallResponse) {

--- a/app/ts/simulation/simulator.ts
+++ b/app/ts/simulation/simulator.ts
@@ -38,8 +38,12 @@ const logHandler = new Map<string, Loghandler >([
 export class Simulator {
 	public ethereum: EthereumClientService
 
-	public constructor(rpcNetwork: RpcNetwork, newBlockAttemptCallback: (blockHeader: EthereumBlockHeader, ethereumClientService: EthereumClientService, isNewBlock: boolean) => void, onErrorBlockCallback: (ethereumClientService: EthereumClientService, error: Error) => void) {
-		this.ethereum = new EthereumClientService(new EthereumJSONRpcRequestHandler(rpcNetwork), newBlockAttemptCallback, onErrorBlockCallback)
+	public constructor(rpcNetwork: RpcNetwork, newBlockAttemptCallback: (blockHeader: EthereumBlockHeader, ethereumClientService: EthereumClientService, isNewBlock: boolean, simulator: Simulator) => void, onErrorBlockCallback: (ethereumClientService: EthereumClientService, error: Error) => void) {
+		this.ethereum = new EthereumClientService(
+			new EthereumJSONRpcRequestHandler(rpcNetwork),
+			(blockHeader: EthereumBlockHeader, ethereumClientService: EthereumClientService, isNewBlock: boolean) => newBlockAttemptCallback(blockHeader, ethereumClientService, isNewBlock, this),
+			onErrorBlockCallback
+		)
 	}
 
 	public cleanup = () => this.ethereum.cleanup()

--- a/app/ts/utils/interceptor-messages.ts
+++ b/app/ts/utils/interceptor-messages.ts
@@ -1,7 +1,7 @@
 import * as funtypes from 'funtypes'
 import { AddressBookEntries, AddressBookEntry, AddressInfo, AddressInfoEntry, ContactEntries, SignerName, Website, WebsiteSocket } from './user-interface-types.js'
 import { EthGetLogsResponse, EthTransactionReceiptResponse, EthereumAddress, EthereumBlockHeader, EthereumBlockHeaderWithTransactionHashes, EthereumBytes32, EthereumData, EthereumQuantity, EthereumSignedTransactionWithBlockData, EthereumTimestamp, GetBlockReturn, GetSimulationStackReply, OldSignTypedDataParams, PersonalSignParams, SendRawTransaction, SendTransactionParams, SignTypedDataParams } from './wire-types.js'
-import { SimulationState, OptionalEthereumAddress, SimulatedAndVisualizedTransaction, SimResults, TokenPriceEstimate, WebsiteCreatedEthereumUnsignedTransaction, RpcNetwork, RpcEntries, RpcEntry, SimulationUpdatingState } from './visualizer-types.js'
+import { SimulationState, OptionalEthereumAddress, SimulatedAndVisualizedTransaction, SimResults, TokenPriceEstimate, WebsiteCreatedEthereumUnsignedTransaction, RpcNetwork, RpcEntries, RpcEntry, SimulationUpdatingState, SimulationResultState } from './visualizer-types.js'
 import { ICON_ACCESS_DENIED, ICON_ACTIVE, ICON_NOT_ACTIVE, ICON_SIGNING, ICON_SIGNING_NOT_SUPPORTED, ICON_SIMULATING } from './constants.js'
 import { PersonalSignRequestData } from './personal-message-definitions.js'
 import { InterceptedRequest, UniqueRequestIdentifier } from './requests.js'
@@ -567,6 +567,7 @@ export const UpdateHomePage = funtypes.ReadonlyObject({
 			activeAddress: OptionalEthereumAddress,
 			simulatedAndVisualizedTransactions: funtypes.ReadonlyArray(SimulatedAndVisualizedTransaction),
 			simulationUpdatingState: SimulationUpdatingState,
+			simulationResultState: SimulationResultState,
 		}),
 		websiteAccessAddressMetadata: funtypes.ReadonlyArray(AddressInfoEntry),
 		signerAccounts: funtypes.Union(funtypes.ReadonlyArray(EthereumAddress), funtypes.Undefined),

--- a/app/ts/utils/user-interface-types.ts
+++ b/app/ts/utils/user-interface-types.ts
@@ -1,7 +1,7 @@
 import { StateUpdater } from 'preact/hooks'
 import * as funtypes from 'funtypes'
 import { EthereumAddress, EthereumQuantity, LiteralConverterParserFactory } from './wire-types.js'
-import { SimulatedAndVisualizedTransaction, SimulationAndVisualisationResults, RpcEntry, RpcNetwork, RpcEntries, SimulationUpdatingState } from './visualizer-types.js'
+import { SimulatedAndVisualizedTransaction, SimulationAndVisualisationResults, RpcEntry, RpcNetwork, RpcEntries, SimulationUpdatingState, SimulationResultState } from './visualizer-types.js'
 import { IdentifiedSwapWithMetadata } from '../components/simulationExplaining/SwapTransactions.js'
 import { RpcConnectionStatus, Page, TabIconDetails, WebsiteAccessArray } from './interceptor-messages.js'
 
@@ -148,6 +148,7 @@ export type HomeParams = {
 	rpcConnectionStatus: RpcConnectionStatus,
 	rpcEntries: RpcEntries,
 	simulationUpdatingState: SimulationUpdatingState | undefined,
+	simulationResultState: SimulationResultState | undefined,
 }
 
 export type ChangeActiveAddressParam = {
@@ -191,6 +192,7 @@ export type SimulationStateParam = {
 	removeTransactionHashes: bigint[],
 	rpcConnectionStatus: RpcConnectionStatus,
 	simulationUpdatingState: SimulationUpdatingState | undefined,
+	simulationResultState: SimulationResultState | undefined,
 }
 
 export type LogAnalysisParams = {

--- a/app/ts/utils/visualizer-types.ts
+++ b/app/ts/utils/visualizer-types.ts
@@ -276,9 +276,13 @@ export type ERC721TokenApprovalChange = {
 export type SimulationUpdatingState = funtypes.Static<typeof SimulationUpdatingState>
 export const SimulationUpdatingState = funtypes.Union(funtypes.Literal('updating'), funtypes.Literal('done'), funtypes.Literal('failed'))
 
+export type SimulationResultState = funtypes.Static<typeof SimulationResultState>
+export const SimulationResultState = funtypes.Union(funtypes.Literal('done'), funtypes.Literal('invalid'))
+
 export type SimulationResults = funtypes.Static<typeof SimulationResults>
 export const SimulationResults = funtypes.ReadonlyObject({
 	simulationUpdatingState: SimulationUpdatingState, 
+	simulationResultState: SimulationResultState,
 	simulationId: funtypes.Number,
 	simulationState: funtypes.Union(SimulationState, funtypes.Undefined),
 	visualizerResults: funtypes.Union(funtypes.ReadonlyArray(SimResults), funtypes.Undefined),


### PR DESCRIPTION
- many popups were calling `background.js` which resulted `startup()` function being called for popups, which is a function that should only be called when interceptor starts. This resulted in us having multiple simulation states that sometimes got synced back together. I separated these startup functions to a separate file (background-startup.js) and made simulator variable a const that is moved around instead of being a global variable
- blur now only happens when the simulation state is clearly wrong (user has changed their active address, user has changed get rich mode or user has changed network)