### PR TITLE
Don't prompt access request again for the same request

### DIFF
--- a/app/ts/background/storageVariables.ts
+++ b/app/ts/background/storageVariables.ts
@@ -157,9 +157,10 @@ export async function updateTabState(tabId: number, updateFunc: (prevState: TabS
 const pendingAccessRequestsSemaphore = new Semaphore(1)
 export async function updatePendingAccessRequests(updateFunc: (prevState: PendingAccessRequestArray) => Promise<PendingAccessRequestArray>) {
 	return await pendingAccessRequestsSemaphore.execute(async () => {
-		const pendingAccessRequests = await updateFunc(PendingAccessRequestArray.parse(await browserStorageLocalSingleGetWithDefault('pendingInterceptorAccessRequests', [])))
+		const previous = PendingAccessRequestArray.parse(await browserStorageLocalSingleGetWithDefault('pendingInterceptorAccessRequests', []))
+		const pendingAccessRequests = await updateFunc(previous)
 		await browserStorageLocalSet('pendingInterceptorAccessRequests', PendingAccessRequestArray.serialize(pendingAccessRequests) as string)
-		return pendingAccessRequests
+		return { previous: previous, current: pendingAccessRequests }
 	})
 }
 export async function getPendingAccessRequests() {

--- a/app/ts/background/windows/changeChain.ts
+++ b/app/ts/background/windows/changeChain.ts
@@ -1,4 +1,4 @@
-import { PopupOrTab, addWindowTabListener, closePopupOrTab, openPopupOrTab, removeWindowTabListener } from '../../components/ui-utils.js'
+import { PopupOrTab, addWindowTabListener, browserTabsQueryById, closePopupOrTab, openPopupOrTab, removeWindowTabListener } from '../../components/ui-utils.js'
 import { METAMASK_ERROR_USER_REJECTED_REQUEST } from '../../utils/constants.js'
 import { Future } from '../../utils/future.js'
 import { ChainChangeConfirmation, SignerChainChangeConfirmation } from '../../utils/interceptor-messages.js'
@@ -80,7 +80,7 @@ export const openChangeChainDialog = async (
 	try {
 		const oldPromise = await getChainChangeConfirmationPromise()
 		if (oldPromise !== undefined) {
-			if ((await browser.tabs.query({ windowId: oldPromise.dialogId })).length > 0) {
+			if (await browserTabsQueryById(oldPromise.dialogId) !== undefined) {
 				return userDeniedChange
 			} else {
 				await setChainChangeConfirmationPromise(undefined)

--- a/app/ts/background/windows/personalSign.ts
+++ b/app/ts/background/windows/personalSign.ts
@@ -13,7 +13,7 @@ import { extractEIP712Message, validateEIP712Types } from '../../utils/eip712Par
 import { getAddressMetaData, getTokenMetadata } from '../metadataUtils.js'
 import { getPendingPersonalSignPromise, getRpcNetwork, getRpcNetworkForChain, getSignerName, setPendingPersonalSignPromise } from '../storageVariables.js'
 import { getSettings } from '../settings.js'
-import { PopupOrTab, addWindowTabListener, closePopupOrTab, openPopupOrTab, removeWindowTabListener } from '../../components/ui-utils.js'
+import { PopupOrTab, addWindowTabListener, browserTabsQueryById, closePopupOrTab, openPopupOrTab, removeWindowTabListener } from '../../components/ui-utils.js'
 import { simulatePersonalSign } from '../../simulation/services/SimulationModeEthereumClientService.js'
 import { InterceptedRequest, UniqueRequestIdentifier, doesUniqueRequestIdentifiersMatch } from '../../utils/requests.js'
 import { replyToInterceptedRequest } from '../messageSending.js'
@@ -255,7 +255,7 @@ export const openPersonalSignDialog = async (
 	try {
 		const oldPromise = await getPendingPersonalSignPromise()
 		if (oldPromise !== undefined) {
-			if ((await browser.tabs.query({ windowId: oldPromise.dialogId })).length > 0) {
+			if (await browserTabsQueryById(oldPromise.dialogId) !== undefined) {
 				return reject(signingParams)
 			} else {
 				await setPendingPersonalSignPromise(undefined)

--- a/app/ts/components/ui-utils.tsx
+++ b/app/ts/components/ui-utils.tsx
@@ -100,13 +100,17 @@ export async function openPopupOrTab(createData: browser.windows._CreateCreateDa
 	return { type: 'popup', windowOrTab: window }
 }
 
+export async function browserTabsQueryById(id: number) {
+	return (await browser.tabs.query({})).find((x) => x.id === id)
+}
+
 export async function getPopupOrTabById(popupOrTabId: PopupOrTabId) : Promise<PopupOrTab | undefined> {
 	switch (popupOrTabId.type) {
 		case 'tab': {
 			try {
-				const tabs = await browser.tabs.query({ windowId: popupOrTabId.id })
-				if (tabs.length === 0) return undefined
-				return { type: 'tab', windowOrTab: tabs[0] }
+				const tab = await browserTabsQueryById(popupOrTabId.id)
+				if (tab === undefined) return undefined
+				return { type: 'tab', windowOrTab: tab }
 			} catch(e) {
 				return undefined
 			}
@@ -126,8 +130,8 @@ export async function getPopupOrTabById(popupOrTabId: PopupOrTabId) : Promise<Po
 
 export async function getPopupOrTabOnlyById(id: number) : Promise<PopupOrTab | undefined> {
 	try {
-		const tabs = await browser.tabs.query({ windowId: id })
-		if (tabs.length !== 0) return { type: 'tab', windowOrTab: tabs[0] }
+		const tab = await browserTabsQueryById(id)
+		if (tab !== undefined) return { type: 'tab', windowOrTab: tab }
 	} catch(e) {}
 	try {
 		const window = await browser.windows.get(id)


### PR DESCRIPTION
The ens site is calling eth_requestAccounts in a loop all the time and this caused interceptor to behave badly. Now if dapp requests this account, we throw `Access request pending already` error. 

There was also another race condition bug caused by this, when you approve the request, it takes couple frames for access rights to propagate and during this time the dapp requested access again while the accesses were already.

And there's a third bug, I did not know tabs `id` and `windowId` are separate things, so now I am just using `id` to track things, instead of both mixed. 

fix https://github.com/DarkFlorist/TheInterceptor/issues/591