### PR TITLE
Support for unsupported methods

### DIFF
--- a/app/ts/background/background.ts
+++ b/app/ts/background/background.ts
@@ -201,18 +201,8 @@ async function handleRPCRequest(
 		console.log(request)
 		console.warn(maybeParsedRequest.fullError)
 		const maybePartiallyParsedRequest = SupportedEthereumJsonRpcRequestMethods.safeParse(request)
-		if (maybePartiallyParsedRequest.success === false) {
-			// the method is some method that we are not supporting, forward it to the wallet if signer is available
-			if (forwardToSigner) return { forward: true as const, unknownMethod: true, ...request }
-			return {
-				method: request.method,
-				error: {
-					message: `Failed to parse RPC request: ${ JSON.stringify(request) }`,
-					data: maybeParsedRequest.fullError === undefined ? 'Failed to parse RPC request' : maybeParsedRequest.fullError.toString(),
-					code: METAMASK_ERROR_FAILED_TO_PARSE_REQUEST,
-				}
-			}
-		}
+		// the method is some method that we are not supporting, forward it to the wallet if signer is available
+		if (maybePartiallyParsedRequest.success === false && forwardToSigner) return { forward: true as const, unknownMethod: true, ...request }
 		return {
 			method: request.method,
 			error: {

--- a/app/ts/utils/JsonRpc-types.ts
+++ b/app/ts/utils/JsonRpc-types.ts
@@ -424,6 +424,27 @@ export const GetSimulationStack = funtypes.ReadonlyObject({
 	params: funtypes.ReadonlyTuple(funtypes.Literal('1.0.0')),
 }).asReadonly()
 
+export type WalletAddEthereumChain = funtypes.Static<typeof WalletAddEthereumChain>
+export const WalletAddEthereumChain = funtypes.ReadonlyObject({
+	method: funtypes.Literal('wallet_addEthereumChain'),
+	params: funtypes.Intersect(
+		funtypes.ReadonlyObject({
+			chainId: EthereumQuantity,
+			chainName: funtypes.String,
+			nativeCurrency: funtypes.ReadonlyObject({
+				name: funtypes.String,
+				symbol: funtypes.String,
+				decimals: funtypes.Number,
+			}),
+			rpcUrls: funtypes.ReadonlyArray(EthereumAddress),
+		}),
+		funtypes.Partial({
+			blockExplorerUrls: funtypes.ReadonlyArray(funtypes.String),
+			iconUrls: funtypes.ReadonlyArray(funtypes.String),
+		}).asReadonly()
+	)
+})
+
 export type EthereumJsonRpcRequest = funtypes.Static<typeof EthereumJsonRpcRequest>
 export const EthereumJsonRpcRequest = funtypes.Union(
 	EthBlockByNumberParams,
@@ -456,4 +477,12 @@ export const EthereumJsonRpcRequest = funtypes.Union(
 	EthGetLogsParams,
 	EthSign,
 	ExecutionSpec383MultiCallParams,
+	WalletAddEthereumChain,
 )
+
+// should be same as the above list, except with `params: funtypes.Unknown`
+export type SupportedEthereumJsonRpcRequestMethods = funtypes.Static<typeof SupportedEthereumJsonRpcRequestMethods>
+export const SupportedEthereumJsonRpcRequestMethods = funtypes.ReadonlyObject({
+	method:  EthereumJsonRpcRequest.fields.methods,
+	params: funtypes.Unknown,
+})

--- a/app/ts/utils/JsonRpc-types.ts
+++ b/app/ts/utils/JsonRpc-types.ts
@@ -483,6 +483,6 @@ export const EthereumJsonRpcRequest = funtypes.Union(
 // should be same as the above list, except with `params: funtypes.Unknown`
 export type SupportedEthereumJsonRpcRequestMethods = funtypes.Static<typeof SupportedEthereumJsonRpcRequestMethods>
 export const SupportedEthereumJsonRpcRequestMethods = funtypes.ReadonlyObject({
-	method:  EthereumJsonRpcRequest.fields.methods,
+	method: funtypes.Union(EthereumJsonRpcRequest.alternatives[0].fields.method, ...EthereumJsonRpcRequest.alternatives.map(x => x.fields.method)),
 	params: funtypes.Unknown,
 })

--- a/app/ts/utils/JsonRpc-types.ts
+++ b/app/ts/utils/JsonRpc-types.ts
@@ -484,5 +484,4 @@ export const EthereumJsonRpcRequest = funtypes.Union(
 export type SupportedEthereumJsonRpcRequestMethods = funtypes.Static<typeof SupportedEthereumJsonRpcRequestMethods>
 export const SupportedEthereumJsonRpcRequestMethods = funtypes.ReadonlyObject({
 	method: funtypes.Union(EthereumJsonRpcRequest.alternatives[0].fields.method, ...EthereumJsonRpcRequest.alternatives.map(x => x.fields.method)),
-	params: funtypes.Unknown,
 })

--- a/app/ts/utils/interceptor-messages.ts
+++ b/app/ts/utils/interceptor-messages.ts
@@ -5,7 +5,7 @@ import { SimulationState, OptionalEthereumAddress, SimulatedAndVisualizedTransac
 import { ICON_ACCESS_DENIED, ICON_ACTIVE, ICON_NOT_ACTIVE, ICON_SIGNING, ICON_SIGNING_NOT_SUPPORTED, ICON_SIMULATING } from './constants.js'
 import { PersonalSignRequestData } from './personal-message-definitions.js'
 import { InterceptedRequest, UniqueRequestIdentifier } from './requests.js'
-import { EthGetLogsResponse, EthTransactionReceiptResponse, GetBlockReturn, GetSimulationStackReply, OldSignTypedDataParams, PersonalSignParams, SendRawTransaction, SendTransactionParams, SignTypedDataParams } from './JsonRpc-types.js'
+import { EthGetLogsResponse, EthGetStorageAtParams, EthTransactionReceiptResponse, GetBlockReturn, GetSimulationStackReply, OldSignTypedDataParams, PersonalSignParams, SendRawTransaction, SendTransactionParams, SignTypedDataParams, WalletAddEthereumChain } from './JsonRpc-types.js'
 
 export type WalletSwitchEthereumChainReply = funtypes.Static<typeof WalletSwitchEthereumChainReply>
 export const WalletSwitchEthereumChainReply = funtypes.ReadonlyObject({
@@ -97,7 +97,7 @@ export const NonForwardingRPCRequestReturnValue = funtypes.Union(NonForwardingRP
 export type ForwardToWallet = funtypes.Static<typeof ForwardToWallet>
 export const ForwardToWallet = 	funtypes.Intersect( // forward directly to wallet
 	funtypes.ReadonlyObject({ forward: funtypes.Literal(true) }),
-	funtypes.Union(SendRawTransaction, SendTransactionParams, PersonalSignParams, SignTypedDataParams, OldSignTypedDataParams),
+	funtypes.Union(SendRawTransaction, SendTransactionParams, PersonalSignParams, SignTypedDataParams, OldSignTypedDataParams, WalletAddEthereumChain, EthGetStorageAtParams),
 )
 
 export type UnknownMethodForward = funtypes.Static<typeof UnknownMethodForward>

--- a/app/ts/utils/interceptor-messages.ts
+++ b/app/ts/utils/interceptor-messages.ts
@@ -100,10 +100,23 @@ export const ForwardToWallet = 	funtypes.Intersect( // forward directly to walle
 	funtypes.Union(SendRawTransaction, SendTransactionParams, PersonalSignParams, SignTypedDataParams, OldSignTypedDataParams),
 )
 
+export type UnknownMethodForward = funtypes.Static<typeof UnknownMethodForward>
+export const UnknownMethodForward = funtypes.Intersect(
+	funtypes.ReadonlyObject({
+		forward: funtypes.Literal(true),
+		unknownMethod: funtypes.Literal(true),
+		method: funtypes.String,
+	}),
+	funtypes.Partial({
+		params: funtypes.Unknown,
+	})
+)
+
 export type RPCReply = funtypes.Static<typeof RPCReply>
 export const RPCReply = funtypes.Union(
 	NonForwardingRPCRequestReturnValue,
 	ForwardToWallet,
+	UnknownMethodForward,
 )
 
 export type SubscriptionReplyOrCallBack = funtypes.Static<typeof SubscriptionReplyOrCallBack>


### PR DESCRIPTION
- forward `wallet_addEthereumChain` to wallet
- forward all unknown json rpc methods to a wallet that we are not supporting. This is done so that we are checking that the method is not one we support, and only then forward. If the dapp is sending a request method that we support, but with invalid parameters, we will block it and throw error

fix https://github.com/DarkFlorist/TheInterceptor/issues/569