### PR TITLE
Confirm Dialouge crashes when trying to cast rpcNetwork object as string

### DIFF
--- a/app/ts/components/pages/ConfirmTransaction.tsx
+++ b/app/ts/components/pages/ConfirmTransaction.tsx
@@ -270,10 +270,10 @@ export function ConfirmTransaction() {
 				<div class = 'block popup-block'>
 					<div class = 'popup-block-scroll'>
 						<NetworkErrors rpcConnectionStatus = { rpcConnectionStatus }/>
-						
+
 						{ dialogState.data.transactionToSimulate.transactionSendingFormat === 'eth_sendRawTransaction'
 							? <DinoSaysNotification
-								text = { `This transaction is signed already. No extra signing required to forward it to ${ dialogState.data.simulationState.rpcNetwork }.` }
+								text = { `This transaction is signed already. No extra signing required to forward it to ${ dialogState.data.simulationState.rpcNetwork.name }.` }
 								close = { () => setPendingTransactionAddedNotification(false)}
 							/>
 							: <></>


### PR DESCRIPTION
Found this when trying to submit raw signed txs. I'm assuming network name is the best option to display to users? RPC URL would give potentially better insight for advanced users but different custom networks added should be named appropriately by users anyway.