### PR TITLE
Transaction sending rework

### DIFF
--- a/app/ts/background/background.ts
+++ b/app/ts/background/background.ts
@@ -3,9 +3,9 @@ import 'webextension-polyfill'
 import { Simulator } from '../simulation/simulator.js'
 import { getEthDonator, getSignerName, getSimulationResults, updateSimulationResults } from './storageVariables.js'
 import { changeSimulationMode, getSettings, getMakeMeRich } from './settings.js'
-import { blockNumber, call, chainId, estimateGas, gasPrice, getAccounts, getBalance, getBlockByNumber, getCode, getLogs, getPermissions, getSimulationStack, getTransactionByHash, getTransactionCount, getTransactionReceipt, personalSign, sendRawTransaction, sendTransaction, subscribe, switchEthereumChain, unsubscribe } from './simulationModeHanders.js'
+import { blockNumber, call, chainId, estimateGas, gasPrice, getAccounts, getBalance, getBlockByNumber, getCode, getLogs, getPermissions, getSimulationStack, getTransactionByHash, getTransactionCount, getTransactionReceipt, personalSign, sendTransaction, subscribe, switchEthereumChain, unsubscribe } from './simulationModeHanders.js'
 import { changeActiveAddress, changeMakeMeRich, changePage, resetSimulation, confirmDialog, refreshSimulation, removeTransaction, requestAccountsFromSigner, refreshPopupConfirmTransactionSimulation, confirmPersonalSign, confirmRequestAccess, changeInterceptorAccess, changeChainDialog, popupChangeActiveRpc, enableSimulationMode, addOrModifyAddressInfo, getAddressBookData, removeAddressBookEntry, openAddressBook, homeOpened, interceptorAccessChangeAddressOrRefresh, refreshPopupConfirmTransactionMetadata, changeSettings, importSettings, exportSettings, setNewRpcList } from './popupMessageHandlers.js'
-import { WebsiteCreatedEthereumUnsignedTransaction, SimulationState, RpcNetwork } from '../utils/visualizer-types.js'
+import { SimulationState, RpcNetwork, WebsiteCreatedEthereumUnsignedTransaction } from '../utils/visualizer-types.js'
 import { AddressBookEntry, Website, WebsiteSocket, WebsiteTabConnections } from '../utils/user-interface-types.js'
 import { interceptorAccessMetadataRefresh, requestAccessFromUser, updateInterceptorAccessViewWithPendingRequests } from './windows/interceptorAccess.js'
 import { MAKE_YOU_RICH_TRANSACTION, METAMASK_ERROR_FAILED_TO_PARSE_REQUEST, METAMASK_ERROR_NOT_AUTHORIZED, METAMASK_ERROR_NOT_CONNECTED_TO_CHAIN } from '../utils/constants.js'
@@ -24,7 +24,7 @@ import { updateChainChangeViewWithPendingRequest } from './windows/changeChain.j
 import { updatePendingPersonalSignViewWithPendingRequests } from './windows/personalSign.js'
 import { InterceptedRequest, UniqueRequestIdentifier } from '../utils/requests.js'
 import { replyToInterceptedRequest } from './messageSending.js'
-import { EthGetStorageAtParams, EthereumJsonRpcRequest, SendRawTransaction, SendTransactionParams, SupportedEthereumJsonRpcRequestMethods, WalletAddEthereumChain } from '../utils/JsonRpc-types.js'
+import { EthGetStorageAtParams, EthereumJsonRpcRequest, SendRawTransactionParams, SendTransactionParams, SupportedEthereumJsonRpcRequestMethods, WalletAddEthereumChain } from '../utils/JsonRpc-types.js'
 
 async function visualizeSimulatorState(simulationState: SimulationState, simulator: Simulator) {
 	const priceEstimator = new PriceEstimator(simulator.ethereum)
@@ -158,7 +158,7 @@ export async function refreshConfirmTransactionSimulation(
 }
 
 // returns true if simulation state was changed
-export async function getPrependTrasactions(ethereumClientService: EthereumClientService, settings: Settings, richMode: boolean) {
+export async function getPrependTrasactions(ethereumClientService: EthereumClientService, settings: Settings, richMode: boolean): Promise<WebsiteCreatedEthereumUnsignedTransaction[]> {
 	if (!settings.simulationMode || !richMode) return []
 	const activeAddress = settings.activeSimulationAddress
 	const chainId = settings.rpcNetwork.chainId
@@ -175,7 +175,8 @@ export async function getPrependTrasactions(ethereumClientService: EthereumClien
 		},
 		website: MAKE_YOU_RICH_TRANSACTION.website,
 		transactionCreated: new Date(),
-		transactionSendingFormat: MAKE_YOU_RICH_TRANSACTION.transactionSendingFormat,
+		originalTransactionRequestParameters: { method: MAKE_YOU_RICH_TRANSACTION.transactionSendingFormat, params: [{}] },
+		error: undefined,
 	}]
 }
 
@@ -192,7 +193,7 @@ async function handleRPCRequest(
 ): Promise<RPCReply> {
 	const maybeParsedRequest = EthereumJsonRpcRequest.safeParse(request)
 	const forwardToSigner = !settings.simulationMode && !request.usingInterceptorWithoutSigner
-	const getForwardingMessage = (request: SendRawTransaction | SendTransactionParams | WalletAddEthereumChain | EthGetStorageAtParams) => {
+	const getForwardingMessage = (request: SendRawTransactionParams | SendTransactionParams | WalletAddEthereumChain | EthGetStorageAtParams) => {
 		if (!forwardToSigner) throw new Error('Should not forward to signer')
 		return { forward: true as const, ...request }
 	}
@@ -253,15 +254,10 @@ async function handleRPCRequest(
 		}
 		case 'eth_getLogs': return await getLogs(ethereumClientService, simulationState, parsedRequest)
 		case 'eth_sign': return { method: parsedRequest.method, error: { code: 10000, message: 'eth_sign is deprecated' } }
-		case 'eth_sendRawTransaction': {
-			if (forwardToSigner && settings.rpcNetwork.httpsRpc === undefined) return getForwardingMessage(parsedRequest)
-			const message = await sendRawTransaction(simulator, ethereumClientService, parsedRequest, request, !forwardToSigner, website, activeAddress)
-			if ('forward' in message) return getForwardingMessage(parsedRequest)
-			return message
-		}
+		case 'eth_sendRawTransaction':
 		case 'eth_sendTransaction': {
 			if (forwardToSigner && settings.rpcNetwork.httpsRpc === undefined) return getForwardingMessage(parsedRequest)
-			const message = await sendTransaction(simulator, websiteTabConnections, activeAddress, ethereumClientService, parsedRequest, request, !forwardToSigner, website)
+			const message = await sendTransaction(simulator, activeAddress, ethereumClientService, parsedRequest, request, !forwardToSigner, website)
 			if ('forward' in message) return getForwardingMessage(parsedRequest)
 			return message
 		}

--- a/app/ts/background/simulationModeHanders.ts
+++ b/app/ts/background/simulationModeHanders.ts
@@ -1,21 +1,16 @@
-import { ethers } from 'ethers'
 import { EthereumClientService } from '../simulation/services/EthereumClientService.js'
 import { createEthereumSubscription, removeEthereumSubscription } from '../simulation/services/EthereumSubscriptionService.js'
 import { simulationGasLeft, getSimulatedBalance, getSimulatedBlock, getSimulatedBlockNumber, getSimulatedCode, getSimulatedLogs, getSimulatedStack, getSimulatedTransactionByHash, getSimulatedTransactionCount, getSimulatedTransactionReceipt, simulatedCall, simulateEstimateGas, getInputFieldFromDataOrInput } from '../simulation/services/SimulationModeEthereumClientService.js'
-import { dataStringWith0xStart, stringToUint8Array } from '../utils/bigint.js'
-import { CANNOT_SIMULATE_OFF_LEGACY_BLOCK, ERROR_INTERCEPTOR_GAS_ESTIMATION_FAILED, ERROR_INTERCEPTOR_GET_CODE_FAILED, KNOWN_CONTRACT_CALLER_ADDRESSES } from '../utils/constants.js'
+import { ERROR_INTERCEPTOR_GAS_ESTIMATION_FAILED, ERROR_INTERCEPTOR_GET_CODE_FAILED, KNOWN_CONTRACT_CALLER_ADDRESSES } from '../utils/constants.js'
 import { RPCReply } from '../utils/interceptor-messages.js'
 import { Website, WebsiteSocket, WebsiteTabConnections } from '../utils/user-interface-types.js'
 import { SimulationState } from '../utils/visualizer-types.js'
-import { EthereumAddress } from '../utils/wire-types.js'
-import { getConnectionDetails } from './accessManagement.js'
-import { getSimulationResults } from './storageVariables.js'
 import { openChangeChainDialog } from './windows/changeChain.js'
 import { openConfirmTransactionDialog } from './windows/confirmTransaction.js'
 import { openPersonalSignDialog } from './windows/personalSign.js'
 import { assertNever } from '../utils/typescript.js'
 import { InterceptedRequest } from '../utils/requests.js'
-import { EstimateGasParams, EthBalanceParams, EthBlockByNumberParams, EthCallParams, EthGetLogsParams, EthSubscribeParams, EthUnSubscribeParams, GetCode, GetSimulationStack, GetTransactionCount, OldSignTypedDataParams, PersonalSignParams, SendRawTransaction, SendTransactionParams, SignTypedDataParams, SwitchEthereumChainParams, TransactionByHashParams, TransactionReceiptParams } from '../utils/JsonRpc-types.js'
+import { EstimateGasParams, EthBalanceParams, EthBlockByNumberParams, EthCallParams, EthGetLogsParams, EthSubscribeParams, EthUnSubscribeParams, GetCode, GetSimulationStack, GetTransactionCount, OldSignTypedDataParams, PersonalSignParams, SendRawTransactionParams, SendTransactionParams, SignTypedDataParams, SwitchEthereumChainParams, TransactionByHashParams, TransactionReceiptParams } from '../utils/JsonRpc-types.js'
 import { Simulator } from '../simulation/simulator.js'
 
 const defaultCallAddress = 0x1n
@@ -35,139 +30,28 @@ export async function getTransactionReceipt(ethereumClientService: EthereumClien
 	return { method: request.method, result: await getSimulatedTransactionReceipt(ethereumClientService, simulationState, request.params[0]) }
 }
 
-function getFromField(websiteTabConnections: WebsiteTabConnections, simulationMode: boolean, transactionFrom: bigint | undefined, activeAddress: bigint | undefined, socket: WebsiteSocket) {
-	if (simulationMode && transactionFrom !== undefined) {
-		return transactionFrom // use `from` field directly from the dapp if we are in simulation mode and its available
-	} else {
-		const connection = getConnectionDetails(websiteTabConnections, socket)
-		if (connection === undefined) throw new Error('Not connected')
-		if (activeAddress === undefined) throw new Error('Access to active address is denied')
-		return activeAddress
-	}
-}
-
 export async function sendTransaction(
 	simulator: Simulator,
-	websiteTabConnections: WebsiteTabConnections,
 	activeAddress: bigint | undefined,
 	ethereumClientService: EthereumClientService,
-	sendTransactionParams: SendTransactionParams,
+	transactionParams: SendTransactionParams | SendRawTransactionParams,
 	request: InterceptedRequest,
 	simulationMode: boolean = true,
 	website: Website,
 ) {
-	const formTransaction = async() => {
-		const simulationState = simulationMode ? (await getSimulationResults()).simulationState : undefined
-		const block = getSimulatedBlock(ethereumClientService, simulationState)
-		const transactionDetails = sendTransactionParams.params[0]
-		const from = getFromField(websiteTabConnections, simulationMode, transactionDetails.from, activeAddress, request.uniqueRequestIdentifier.requestSocket)
-		const transactionCount = getSimulatedTransactionCount(ethereumClientService, simulationState, from)
-
-		const parentBlock = await block
-		if (parentBlock.baseFeePerGas === undefined) throw new Error(CANNOT_SIMULATE_OFF_LEGACY_BLOCK)
-		const transactionWithoutGas = {
-			type: '1559' as const,
-			from,
-			chainId: ethereumClientService.getChainId(),
-			nonce: await transactionCount,
-			maxFeePerGas: transactionDetails.maxFeePerGas !== undefined && transactionDetails.maxFeePerGas !== null ? transactionDetails.maxFeePerGas : parentBlock.baseFeePerGas * 2n,
-			maxPriorityFeePerGas: transactionDetails.maxPriorityFeePerGas !== undefined && transactionDetails.maxPriorityFeePerGas !== null ? transactionDetails.maxPriorityFeePerGas : 10n**8n, // 0.1 nanoEth/gas
-			to: transactionDetails.to === undefined ? null : transactionDetails.to,
-			value: transactionDetails.value != undefined  ? transactionDetails.value : 0n,
-			input: getInputFieldFromDataOrInput(transactionDetails),
-			accessList: [],
-		}
-		if (transactionDetails.gas === undefined) {
-			const estimateGas = await simulateEstimateGas(ethereumClientService, simulationState, transactionWithoutGas)
-			if ('error' in estimateGas) return estimateGas
-			return {
-				transaction: { ...transactionWithoutGas, gas: estimateGas.gas },
-				website: website,
-				transactionCreated: new Date(),
-				transactionSendingFormat: 'eth_sendTransaction' as const,
-			}
-		}
-		return {
-			transaction: { ...transactionWithoutGas, gas: transactionDetails.gas },
-			website: website,
-			transactionCreated: new Date(),
-			transactionSendingFormat: 'eth_sendTransaction' as const,
-		}
-	}
 	return {
-		method: sendTransactionParams.method,
+		method: transactionParams.method,
 		...await openConfirmTransactionDialog(
 			simulator,
 			ethereumClientService,
 			request,
-			sendTransactionParams,
+			transactionParams,
 			simulationMode,
-			formTransaction,
 			activeAddress,
+			website,
 		)
 	}
 }
-
-export async function sendRawTransaction(
-	simulator: Simulator,
-	ethereumClientService: EthereumClientService,
-	sendRawTransactionParams: SendRawTransaction,
-	request: InterceptedRequest,
-	simulationMode: boolean,
-	website: Website,
-	activeAddress: bigint | undefined,
-) {
-	const formTransaction = async() => {	
-		const ethersTransaction = ethers.Transaction.from(dataStringWith0xStart(sendRawTransactionParams.params[0]))
-		const transactionDetails = {
-			from: EthereumAddress.parse(ethersTransaction.from),
-			input: stringToUint8Array(ethersTransaction.data),
-			...ethersTransaction.gasLimit === null ? { gas: ethersTransaction.gasLimit } : {},
-			value: ethersTransaction.value,
-			...ethersTransaction.to === null ? {} : { to: EthereumAddress.parse(ethersTransaction.to) },
-			...ethersTransaction.gasPrice === null ? {} : { gasPrice: ethersTransaction.gasPrice },
-			...ethersTransaction.maxPriorityFeePerGas === null ? {} : { maxPriorityFeePerGas: ethersTransaction.maxPriorityFeePerGas },
-			...ethersTransaction.maxFeePerGas === null ? {} : { maxFeePerGas: ethersTransaction.maxFeePerGas },
-		}
-
-		const simulationState = (await getSimulationResults()).simulationState
-		const block = getSimulatedBlock(ethereumClientService, simulationState)
-		const parentBlock = await block
-		if (parentBlock.baseFeePerGas === undefined) throw new Error(CANNOT_SIMULATE_OFF_LEGACY_BLOCK)
-		const maxFeePerGas = parentBlock.baseFeePerGas * 2n
-		const transaction = {
-			type: '1559' as const,
-			from: transactionDetails.from,
-			chainId: ethereumClientService.getChainId(),
-			nonce: BigInt(ethersTransaction.nonce),
-			maxFeePerGas: transactionDetails.maxFeePerGas ? transactionDetails.maxFeePerGas : maxFeePerGas,
-			maxPriorityFeePerGas: transactionDetails.maxPriorityFeePerGas ? transactionDetails.maxPriorityFeePerGas : 1n,
-			to: transactionDetails.to === undefined ? null : transactionDetails.to,
-			value: transactionDetails.value ? transactionDetails.value : 0n,
-			input: transactionDetails.input,
-			accessList: [],
-			gas: ethersTransaction.gasLimit,
-		}
-		return {
-			transaction,
-			website: website,
-			transactionCreated: new Date(),
-			transactionSendingFormat: 'eth_sendRawTransaction' as const,
-		}
-	}
-	return { method: sendRawTransactionParams.method,
-		...await openConfirmTransactionDialog(
-			simulator,
-			ethereumClientService,
-			request,
-			sendRawTransactionParams,
-			simulationMode,
-			formTransaction,
-			activeAddress,
-		)
-	}
-}
-
 async function singleCallWithFromOverride(ethereumClientService: EthereumClientService, simulationState: SimulationState | undefined, request: EthCallParams, from: bigint) {
 	const callParams = request.params[0]
 	const blockTag = request.params.length > 1 ? request.params[1] : 'latest' as const

--- a/app/ts/background/windows/confirmTransaction.ts
+++ b/app/ts/background/windows/confirmTransaction.ts
@@ -1,19 +1,22 @@
 import { PopupOrTab, addWindowTabListener, closePopupOrTab, getPopupOrTabOnlyById, openPopupOrTab, removeWindowTabListener } from '../../components/ui-utils.js'
 import { EthereumClientService } from '../../simulation/services/EthereumClientService.js'
-import { appendTransaction } from '../../simulation/services/SimulationModeEthereumClientService.js'
-import { ERROR_INTERCEPTOR_NO_ACTIVE_ADDRESS, METAMASK_ERROR_NOT_CONNECTED_TO_CHAIN, METAMASK_ERROR_USER_REJECTED_REQUEST } from '../../utils/constants.js'
+import { appendTransaction, getInputFieldFromDataOrInput, getSimulatedBlock, getSimulatedTransactionCount, simulateEstimateGas } from '../../simulation/services/SimulationModeEthereumClientService.js'
+import { CANNOT_SIMULATE_OFF_LEGACY_BLOCK, ERROR_INTERCEPTOR_NO_ACTIVE_ADDRESS, METAMASK_ERROR_NOT_CONNECTED_TO_CHAIN, METAMASK_ERROR_USER_REJECTED_REQUEST } from '../../utils/constants.js'
 import { Future } from '../../utils/future.js'
 import { TransactionConfirmation } from '../../utils/interceptor-messages.js'
 import { Semaphore } from '../../utils/semaphore.js'
-import { WebsiteTabConnections } from '../../utils/user-interface-types.js'
-import { EstimateGasError, WebsiteCreatedEthereumUnsignedTransaction } from '../../utils/visualizer-types.js'
-import { SendRawTransaction, SendTransactionParams } from '../../utils/JsonRpc-types.js'
+import { Website, WebsiteTabConnections } from '../../utils/user-interface-types.js'
+import { WebsiteCreatedEthereumUnsignedTransaction } from '../../utils/visualizer-types.js'
+import { SendRawTransactionParams, SendTransactionParams } from '../../utils/JsonRpc-types.js'
 import { refreshConfirmTransactionSimulation, updateSimulationState } from '../background.js'
 import { getHtmlFile, sendPopupMessageToOpenWindows } from '../backgroundUtils.js'
-import { appendPendingTransaction, clearPendingTransactions, getPendingTransactions, removePendingTransaction } from '../storageVariables.js'
+import { appendPendingTransaction, clearPendingTransactions, getPendingTransactions, getSimulationResults, removePendingTransaction } from '../storageVariables.js'
 import { InterceptedRequest, getUniqueRequestIdentifierString } from '../../utils/requests.js'
 import { replyToInterceptedRequest } from '../messageSending.js'
 import { Simulator } from '../../simulation/simulator.js'
+import { ethers } from 'ethers'
+import { dataStringWith0xStart, stringToUint8Array } from '../../utils/bigint.js'
+import { EthereumAddress } from '../../utils/wire-types.js'
 
 type Confirmation = TransactionConfirmation | 'NoResponse'
 let openedDialog: PopupOrTab | undefined = undefined
@@ -23,10 +26,7 @@ const pendingConfirmationSemaphore = new Semaphore(1)
 export async function updateConfirmTransactionViewWithPendingTransaction() {
 	const promises = await getPendingTransactions()
 	if (promises.length >= 1) {
-		await sendPopupMessageToOpenWindows({
-			method: 'popup_update_confirm_transaction_dialog',
-			data: promises.map((p) => p.simulationResults),
-		})
+		await sendPopupMessageToOpenWindows({ method: 'popup_update_confirm_transaction_dialog', data: promises })
 		return true
 	}
 	return false
@@ -48,7 +48,7 @@ export async function resolvePendingTransaction(simulator: Simulator, ethereumCl
 	} else {
 		// we have not been tracking this window, forward its message directly to content script (or signer)
 		const resolvedPromise = await resolve(simulator, ethereumClientService, pendingTransaction.simulationMode, pendingTransaction.activeAddress, pendingTransaction.transactionToSimulate, confirmation)
-		replyToInterceptedRequest(websiteTabConnections, { ...pendingTransaction.transactionParams, ...resolvedPromise, uniqueRequestIdentifier: confirmation.data.uniqueRequestIdentifier })
+		replyToInterceptedRequest(websiteTabConnections, { ...pendingTransaction.transactionToSimulate.originalTransactionRequestParameters, ...resolvedPromise, uniqueRequestIdentifier: confirmation.data.uniqueRequestIdentifier })
 		openedDialog = await getPopupOrTabOnlyById(confirmation.data.windowId)
 	}
 }
@@ -69,14 +69,86 @@ const formRejectMessage = (errorString: undefined | string) => {
 	}
 }
 
+export const formSendRawTransaction = async(ethereumClientService: EthereumClientService, sendRawTransactionParams: SendRawTransactionParams, website: Website, transactionCreated: Date): Promise<WebsiteCreatedEthereumUnsignedTransaction> => {	
+	const ethersTransaction = ethers.Transaction.from(dataStringWith0xStart(sendRawTransactionParams.params[0]))
+	const transactionDetails = {
+		from: EthereumAddress.parse(ethersTransaction.from),
+		input: stringToUint8Array(ethersTransaction.data),
+		...ethersTransaction.gasLimit === null ? { gas: ethersTransaction.gasLimit } : {},
+		value: ethersTransaction.value,
+		...ethersTransaction.to === null ? {} : { to: EthereumAddress.parse(ethersTransaction.to) },
+		...ethersTransaction.gasPrice === null ? {} : { gasPrice: ethersTransaction.gasPrice },
+		...ethersTransaction.maxPriorityFeePerGas === null ? {} : { maxPriorityFeePerGas: ethersTransaction.maxPriorityFeePerGas },
+		...ethersTransaction.maxFeePerGas === null ? {} : { maxFeePerGas: ethersTransaction.maxFeePerGas },
+	}
+
+	if (transactionDetails.maxFeePerGas === undefined) throw new Error('No support for non-1559 transactions')
+
+	const transaction = {
+		type: '1559' as const,
+		from: transactionDetails.from,
+		chainId: ethereumClientService.getChainId(),
+		nonce: BigInt(ethersTransaction.nonce),
+		maxFeePerGas: transactionDetails.maxFeePerGas,
+		maxPriorityFeePerGas: transactionDetails.maxPriorityFeePerGas ? transactionDetails.maxPriorityFeePerGas : 0n,
+		to: transactionDetails.to === undefined ? null : transactionDetails.to,
+		value: transactionDetails.value ? transactionDetails.value : 0n,
+		input: transactionDetails.input,
+		accessList: [],
+		gas: ethersTransaction.gasLimit,
+	}
+	return {
+		transaction,
+		website,
+		transactionCreated,
+		originalTransactionRequestParameters: sendRawTransactionParams,
+		error: undefined,
+	}
+}
+
+export const formEthSendTransaction = async(ethereumClientService: EthereumClientService, activeAddress: bigint | undefined, simulationMode: boolean = true, website: Website, sendTransactionParams: SendTransactionParams, transactionCreated: Date): Promise<WebsiteCreatedEthereumUnsignedTransaction> => {
+	const simulationState = simulationMode ? (await getSimulationResults()).simulationState : undefined
+	const blockPromise = getSimulatedBlock(ethereumClientService, simulationState)
+	const transactionDetails = sendTransactionParams.params[0]
+	if (activeAddress === undefined) throw new Error('Access to active address is denied')
+	const from = simulationMode && transactionDetails.from !== undefined ? transactionDetails.from : activeAddress
+	const transactionCount = getSimulatedTransactionCount(ethereumClientService, simulationState, from)
+	const parentBlock = await blockPromise
+	if (parentBlock.baseFeePerGas === undefined) throw new Error(CANNOT_SIMULATE_OFF_LEGACY_BLOCK)
+	const transactionWithoutGas = {
+		type: '1559' as const,
+		from,
+		chainId: ethereumClientService.getChainId(),
+		nonce: await transactionCount,
+		maxFeePerGas: transactionDetails.maxFeePerGas !== undefined && transactionDetails.maxFeePerGas !== null ? transactionDetails.maxFeePerGas : parentBlock.baseFeePerGas * 2n,
+		maxPriorityFeePerGas: transactionDetails.maxPriorityFeePerGas !== undefined && transactionDetails.maxPriorityFeePerGas !== null ? transactionDetails.maxPriorityFeePerGas : 10n**8n, // 0.1 nanoEth/gas
+		to: transactionDetails.to === undefined ? null : transactionDetails.to,
+		value: transactionDetails.value != undefined  ? transactionDetails.value : 0n,
+		input: getInputFieldFromDataOrInput(transactionDetails),
+		accessList: [],
+	}
+	const extraParams = {
+		website,
+		transactionCreated,
+		originalTransactionRequestParameters: sendTransactionParams,
+		error: undefined,
+	}
+	if (transactionDetails.gas === undefined) {
+		const estimateGas = await simulateEstimateGas(ethereumClientService, simulationState, transactionWithoutGas)
+		if ('error' in estimateGas) return { ...extraParams, ...estimateGas, transaction: { ...transactionWithoutGas, gas: estimateGas.gas } }
+		return { transaction: { ...transactionWithoutGas, gas: estimateGas.gas }, ...extraParams }
+	}
+	return { transaction: { ...transactionWithoutGas, gas: transactionDetails.gas }, ...extraParams }
+}
+
 export async function openConfirmTransactionDialog(
 	simulator: Simulator,
 	ethereumClientService: EthereumClientService,
 	request: InterceptedRequest,
-	transactionParams: SendTransactionParams | SendRawTransaction,
+	transactionParams: SendTransactionParams | SendRawTransactionParams,
 	simulationMode: boolean,
-	transactionToSimulatePromise: () => Promise<WebsiteCreatedEthereumUnsignedTransaction | EstimateGasError>,
 	activeAddress: bigint | undefined,
+	website: Website
 ) {
 	let justAddToPending = false
 	if (pendingTransactions.size !== 0) justAddToPending = true
@@ -84,9 +156,9 @@ export async function openConfirmTransactionDialog(
 	const uniqueRequestIdentifier = getUniqueRequestIdentifierString(request.uniqueRequestIdentifier)
 	pendingTransactions.set(uniqueRequestIdentifier, pendingTransaction)
 	try {
+		const transactionCreated = new Date()
+		const transactionToSimulate = transactionParams.method === 'eth_sendTransaction' ? await formEthSendTransaction(ethereumClientService, activeAddress, simulationMode, website, transactionParams, transactionCreated) : await formSendRawTransaction(ethereumClientService, transactionParams, website, transactionCreated)
 		if (activeAddress === undefined) return ERROR_INTERCEPTOR_NO_ACTIVE_ADDRESS
-		const transactionToSimulate = await transactionToSimulatePromise()
-		if ('error' in transactionToSimulate) return transactionToSimulate
 
 		const addedPendingTransaction = await pendingConfirmationSemaphore.execute(async () => {
 			if (!justAddToPending) {
@@ -99,29 +171,40 @@ export async function openConfirmTransactionDialog(
 					}
 				}
 			}
-			const refreshSimulationPromise = refreshConfirmTransactionSimulation(simulator, ethereumClientService, activeAddress, simulationMode, request.uniqueRequestIdentifier, transactionToSimulate)
 
-			if (!justAddToPending) {
+			const openDialog = async () => {
 				addWindowTabListener(onCloseWindow)
-				openedDialog = await openPopupOrTab({
-					url: getHtmlFile('confirmTransaction'),
-					type: 'popup',
-					height: 800,
-					width: 600,
+				return await openPopupOrTab({ url: getHtmlFile('confirmTransaction'), type: 'popup', height: 800, width: 600 })
+			}
+			const refreshSimulationPromise = refreshConfirmTransactionSimulation(simulator, ethereumClientService, activeAddress, simulationMode, request.uniqueRequestIdentifier, transactionToSimulate)
+			if ('error' in transactionToSimulate) {
+				if (!justAddToPending) openedDialog = await openDialog()
+				if (openedDialog?.windowOrTab.id === undefined) return false
+				await appendPendingTransaction({
+					dialogId: openedDialog.windowOrTab.id,
+					request,
+					simulationMode,
+					activeAddress,
+					transactionToSimulate,
+					simulationResults: await refreshSimulationPromise,
+					transactionCreated,
+				})
+			} else {
+				if (!justAddToPending) openedDialog = await openDialog()
+				if (openedDialog?.windowOrTab.id === undefined) return false
+				await appendPendingTransaction({
+					dialogId: openedDialog.windowOrTab.id,
+					request,
+					simulationMode,
+					activeAddress,
+					transactionToSimulate,
+					simulationResults: await refreshSimulationPromise,
+					transactionCreated,
 				})
 			}
-			if (openedDialog?.windowOrTab.id === undefined) return false
-			await appendPendingTransaction({
-				dialogId: openedDialog.windowOrTab.id,
-				transactionParams: transactionParams,
-				request: request,
-				transactionToSimulate: transactionToSimulate,
-				simulationMode: simulationMode,
-				activeAddress: activeAddress,
-				simulationResults: await refreshSimulationPromise,
-			})
+
 			await updateConfirmTransactionViewWithPendingTransaction()
-			if (justAddToPending) await sendPopupMessageToOpenWindows({ method: 'popup_confirm_transaction_dialog_pending_changed', data: (await getPendingTransactions()).map((p) => p.simulationResults) })
+			if (justAddToPending) await sendPopupMessageToOpenWindows({ method: 'popup_confirm_transaction_dialog_pending_changed', data: await getPendingTransactions() })
 			return true
 		})
 		if (addedPendingTransaction === false) return formRejectMessage(undefined)
@@ -136,6 +219,7 @@ export async function openConfirmTransactionDialog(
 }
 
 async function resolve(simulator: Simulator, ethereumClientService: EthereumClientService, simulationMode: boolean, activeAddress: bigint, transactionToSimulate: WebsiteCreatedEthereumUnsignedTransaction, confirmation: Confirmation): Promise<{ forward: true } | { error: { code: number, message: string } } | { result: bigint }> {
+	if (transactionToSimulate.error !== undefined) return { error: transactionToSimulate.error }
 	if (confirmation === 'NoResponse') return formRejectMessage(undefined)
 	if (confirmation.data.accept === false) return formRejectMessage(confirmation.data.transactionErrorString)
 	if (!simulationMode) return { forward: true }

--- a/app/ts/background/windows/confirmTransaction.ts
+++ b/app/ts/background/windows/confirmTransaction.ts
@@ -177,31 +177,17 @@ export async function openConfirmTransactionDialog(
 				return await openPopupOrTab({ url: getHtmlFile('confirmTransaction'), type: 'popup', height: 800, width: 600 })
 			}
 			const refreshSimulationPromise = refreshConfirmTransactionSimulation(simulator, ethereumClientService, activeAddress, simulationMode, request.uniqueRequestIdentifier, transactionToSimulate)
-			if ('error' in transactionToSimulate) {
-				if (!justAddToPending) openedDialog = await openDialog()
-				if (openedDialog?.windowOrTab.id === undefined) return false
-				await appendPendingTransaction({
-					dialogId: openedDialog.windowOrTab.id,
-					request,
-					simulationMode,
-					activeAddress,
-					transactionToSimulate,
-					simulationResults: await refreshSimulationPromise,
-					transactionCreated,
-				})
-			} else {
-				if (!justAddToPending) openedDialog = await openDialog()
-				if (openedDialog?.windowOrTab.id === undefined) return false
-				await appendPendingTransaction({
-					dialogId: openedDialog.windowOrTab.id,
-					request,
-					simulationMode,
-					activeAddress,
-					transactionToSimulate,
-					simulationResults: await refreshSimulationPromise,
-					transactionCreated,
-				})
-			}
+			if (!justAddToPending) openedDialog = await openDialog()
+			if (openedDialog?.windowOrTab.id === undefined) return false
+			await appendPendingTransaction({
+				dialogId: openedDialog.windowOrTab.id,
+				request,
+				simulationMode,
+				activeAddress,
+				transactionToSimulate,
+				simulationResults: await refreshSimulationPromise,
+				transactionCreated,
+			})
 
 			await updateConfirmTransactionViewWithPendingTransaction()
 			if (justAddToPending) await sendPopupMessageToOpenWindows({ method: 'popup_confirm_transaction_dialog_pending_changed', data: await getPendingTransactions() })

--- a/app/ts/components/App.tsx
+++ b/app/ts/components/App.tsx
@@ -91,7 +91,7 @@ export function App() {
 				rpcNetwork: simState.rpcNetwork,
 				tokenPrices: tokenPrices,
 				activeAddress: activeSimulationAddress,
-				addressMetaData: addressBookEntries,
+				addressBookEntries: addressBookEntries,
 			})
 		}
 

--- a/app/ts/components/simulationExplaining/SimulationSummary.tsx
+++ b/app/ts/components/simulationExplaining/SimulationSummary.tsx
@@ -642,7 +642,7 @@ export function SimulationSummary(param: SimulationSummaryParams) {
 	if (param.simulationAndVisualisationResults === undefined) return <></>
 
 	const logSummarizer = new LogSummarizer(param.simulationAndVisualisationResults.simulatedAndVisualizedTransactions)
-	const addressMetaData = new Map(param.simulationAndVisualisationResults.addressMetaData.map((x) => [addressString(x.address), x]))
+	const addressMetaData = new Map(param.simulationAndVisualisationResults.addressBookEntries.map((x) => [addressString(x.address), x]))
 	const originalSummary = logSummarizer.getSummary(addressMetaData, param.simulationAndVisualisationResults.tokenPrices)
 	const [ownAddresses, notOwnAddresses] = splitToOwnAndNotOwnAndCleanSummary(param.simulationAndVisualisationResults.simulatedAndVisualizedTransactions.at(0), originalSummary, param.simulationAndVisualisationResults.activeAddress, param.simulationAndVisualisationResults.rpcNetwork)
 

--- a/app/ts/utils/JsonRpc-types.ts
+++ b/app/ts/utils/JsonRpc-types.ts
@@ -222,8 +222,8 @@ export const SendTransactionParams = funtypes.ReadonlyObject({
 	params: funtypes.ReadonlyTuple(DappRequestTransaction)
 })
 
-export type SendRawTransaction = funtypes.Static<typeof SendRawTransaction>
-export const SendRawTransaction = funtypes.ReadonlyObject({
+export type SendRawTransactionParams = funtypes.Static<typeof SendRawTransactionParams>
+export const SendRawTransactionParams = funtypes.ReadonlyObject({
 	method: funtypes.Literal('eth_sendRawTransaction'),
 	params: funtypes.ReadonlyTuple(EthereumData),
 })
@@ -453,7 +453,7 @@ export const EthereumJsonRpcRequest = funtypes.Union(
 	TransactionByHashParams,
 	TransactionReceiptParams,
 	SendTransactionParams,
-	SendRawTransaction,
+	SendRawTransactionParams,
 	EthCallParams,
 	EthSubscribeParams,
 	EthUnSubscribeParams,

--- a/app/ts/utils/interceptor-messages.ts
+++ b/app/ts/utils/interceptor-messages.ts
@@ -5,7 +5,7 @@ import { SimulationState, OptionalEthereumAddress, SimulatedAndVisualizedTransac
 import { ICON_ACCESS_DENIED, ICON_ACTIVE, ICON_NOT_ACTIVE, ICON_SIGNING, ICON_SIGNING_NOT_SUPPORTED, ICON_SIMULATING } from './constants.js'
 import { PersonalSignRequestData } from './personal-message-definitions.js'
 import { InterceptedRequest, UniqueRequestIdentifier } from './requests.js'
-import { EthGetLogsResponse, EthGetStorageAtParams, EthTransactionReceiptResponse, GetBlockReturn, GetSimulationStackReply, OldSignTypedDataParams, PersonalSignParams, SendRawTransaction, SendTransactionParams, SignTypedDataParams, WalletAddEthereumChain } from './JsonRpc-types.js'
+import { EthGetLogsResponse, EthGetStorageAtParams, EthTransactionReceiptResponse, GetBlockReturn, GetSimulationStackReply, OldSignTypedDataParams, PersonalSignParams, SendRawTransactionParams, SendTransactionParams, SignTypedDataParams, WalletAddEthereumChain } from './JsonRpc-types.js'
 
 export type WalletSwitchEthereumChainReply = funtypes.Static<typeof WalletSwitchEthereumChainReply>
 export const WalletSwitchEthereumChainReply = funtypes.ReadonlyObject({
@@ -97,7 +97,7 @@ export const NonForwardingRPCRequestReturnValue = funtypes.Union(NonForwardingRP
 export type ForwardToWallet = funtypes.Static<typeof ForwardToWallet>
 export const ForwardToWallet = 	funtypes.Intersect( // forward directly to wallet
 	funtypes.ReadonlyObject({ forward: funtypes.Literal(true) }),
-	funtypes.Union(SendRawTransaction, SendTransactionParams, PersonalSignParams, SignTypedDataParams, OldSignTypedDataParams, WalletAddEthereumChain, EthGetStorageAtParams),
+	funtypes.Union(SendRawTransactionParams, SendTransactionParams, PersonalSignParams, SignTypedDataParams, OldSignTypedDataParams, WalletAddEthereumChain, EthGetStorageAtParams),
 )
 
 export type UnknownMethodForward = funtypes.Static<typeof UnknownMethodForward>
@@ -354,17 +354,6 @@ export const GetAddressBookDataReply = funtypes.ReadonlyObject({
 	data: GetAddressBookDataReplyData,
 }).asReadonly()
 
-export type RefreshConfirmTransactionDialogSimulation = funtypes.Static<typeof RefreshConfirmTransactionDialogSimulation>
-export const RefreshConfirmTransactionDialogSimulation = funtypes.ReadonlyObject({
-	method: funtypes.Literal('popup_refreshConfirmTransactionDialogSimulation'),
-	data: funtypes.ReadonlyObject({
-		activeAddress: EthereumAddress,
-		simulationMode: funtypes.Boolean,
-		uniqueRequestIdentifier: UniqueRequestIdentifier,
-		transactionToSimulate: WebsiteCreatedEthereumUnsignedTransaction,
-	}),
-}).asReadonly()
-
 export type RpcConnectionStatus = funtypes.Static<typeof RpcConnectionStatus>
 export const RpcConnectionStatus = funtypes.Union(funtypes.Undefined, funtypes.ReadonlyObject({
 	isConnected: funtypes.Boolean,
@@ -472,19 +461,40 @@ export const ConfirmTransactionSimulationFailed = funtypes.ReadonlyObject({
 export type ConfirmTransactionTransactionSingleVisualization = funtypes.Static<typeof ConfirmTransactionTransactionSingleVisualization>
 export const ConfirmTransactionTransactionSingleVisualization = funtypes.Union(ConfirmTransactionSimulationFailed, ConfirmTransactionSimulationStateChanged)
 
-export type ConfirmTransactionTransactionSingleVisualizationArray = funtypes.Static<typeof ConfirmTransactionTransactionSingleVisualizationArray>
-export const ConfirmTransactionTransactionSingleVisualizationArray = funtypes.ReadonlyArray(ConfirmTransactionTransactionSingleVisualization)
+export type PendingTransaction = funtypes.Static<typeof PendingTransaction>
+export const PendingTransaction = funtypes.ReadonlyObject({
+	dialogId: funtypes.Number,
+	request: InterceptedRequest,
+	simulationMode: funtypes.Boolean,
+	activeAddress: EthereumAddress,
+	transactionCreated: EthereumTimestamp,
+	simulationResults: ConfirmTransactionTransactionSingleVisualization,
+	transactionToSimulate: WebsiteCreatedEthereumUnsignedTransaction,
+})
+
+export type RefreshConfirmTransactionDialogSimulation = funtypes.Static<typeof RefreshConfirmTransactionDialogSimulation>
+export const RefreshConfirmTransactionDialogSimulation = funtypes.ReadonlyObject({
+	method: funtypes.Literal('popup_refreshConfirmTransactionDialogSimulation'),
+	data: funtypes.ReadonlyObject({
+		uniqueRequestIdentifier: UniqueRequestIdentifier,
+		activeAddress: EthereumAddress,
+		simulationMode: funtypes.Boolean,
+		originalTransactionRequestParameters: funtypes.Union(SendTransactionParams, SendRawTransactionParams),
+		website: Website,
+		transactionCreated: EthereumTimestamp,
+	})
+}).asReadonly()
 
 export type UpdateConfirmTransactionDialog = funtypes.Static<typeof UpdateConfirmTransactionDialog>
 export const UpdateConfirmTransactionDialog = funtypes.ReadonlyObject({
 	method: funtypes.Literal('popup_update_confirm_transaction_dialog'),
-	data: ConfirmTransactionTransactionSingleVisualizationArray,
+	data: funtypes.ReadonlyArray(PendingTransaction),
 }).asReadonly()
 
 export type ConfirmTransactionDialogPendingChanged = funtypes.Static<typeof ConfirmTransactionDialogPendingChanged>
 export const ConfirmTransactionDialogPendingChanged = funtypes.ReadonlyObject({
 	method: funtypes.Literal('popup_confirm_transaction_dialog_pending_changed'),
-	data: ConfirmTransactionTransactionSingleVisualizationArray,
+	data: funtypes.ReadonlyArray(PendingTransaction),
 }).asReadonly()
 
 export type WebsiteAddressAccess = funtypes.Static<typeof WebsiteAddressAccess>
@@ -626,17 +636,6 @@ export const WindowMessageSignerAccountsChanged = funtypes.ReadonlyObject({
 
 export type WindowMessage = funtypes.Static<typeof WindowMessage>
 export const WindowMessage = WindowMessageSignerAccountsChanged
-
-export type PendingTransaction = funtypes.Static<typeof PendingTransaction>
-export const PendingTransaction = funtypes.ReadonlyObject({
-	dialogId: funtypes.Number,
-	request: InterceptedRequest,
-	transactionParams: funtypes.Union(SendTransactionParams, SendRawTransaction),
-	transactionToSimulate: WebsiteCreatedEthereumUnsignedTransaction,
-	simulationMode: funtypes.Boolean,
-	activeAddress: EthereumAddress,
-	simulationResults: ConfirmTransactionTransactionSingleVisualization
-})
 
 export type PendingChainChangeConfirmationPromise = funtypes.Static<typeof PendingChainChangeConfirmationPromise>
 export const PendingChainChangeConfirmationPromise = funtypes.ReadonlyObject({

--- a/app/ts/utils/visualizer-types.ts
+++ b/app/ts/utils/visualizer-types.ts
@@ -4,7 +4,7 @@ import * as funtypes from 'funtypes'
 import { QUARANTINE_CODE } from '../simulation/protectors/quarantine-codes.js'
 import { AddressBookEntry, Erc721Entry, RenameAddressCallBack, Erc20TokenEntry, Website, WebsiteSocket, Erc1155Entry } from './user-interface-types.js'
 import { ERROR_INTERCEPTOR_GAS_ESTIMATION_FAILED } from './constants.js'
-import { EthBalanceChanges, EthSubscribeParams, SingleMulticallResponse } from './JsonRpc-types.js'
+import { EthBalanceChanges, EthSubscribeParams, SendRawTransactionParams, SendTransactionParams, SingleMulticallResponse } from './JsonRpc-types.js'
 
 
 export type NetworkPrice = funtypes.Static<typeof NetworkPrice>
@@ -158,15 +158,7 @@ export const SimulatedTransaction = funtypes.ReadonlyObject({
 	website: Website,
 	transactionCreated: EthereumTimestamp,
 	tokenBalancesAfter: TokenBalancesAfter,
-	transactionSendingFormat: funtypes.Union(funtypes.Literal('eth_sendRawTransaction'), funtypes.Literal('eth_sendTransaction')),
-})
-
-export type WebsiteCreatedEthereumUnsignedTransaction = funtypes.Static<typeof WebsiteCreatedEthereumUnsignedTransaction>
-export const WebsiteCreatedEthereumUnsignedTransaction = funtypes.ReadonlyObject({
-	website: Website,
-	transactionCreated: EthereumTimestamp,
-	transaction: EthereumUnsignedTransaction,
-	transactionSendingFormat: funtypes.Union(funtypes.Literal('eth_sendRawTransaction'), funtypes.Literal('eth_sendTransaction')),
+	originalTransactionRequestParameters: funtypes.Union(SendTransactionParams, SendRawTransactionParams),
 })
 
 export type EstimateGasError = funtypes.Static<typeof EstimateGasError>
@@ -175,7 +167,17 @@ export const EstimateGasError = funtypes.ReadonlyObject({
 		code: funtypes.Literal(ERROR_INTERCEPTOR_GAS_ESTIMATION_FAILED),
 		message: funtypes.String,
 		data: funtypes.String
-	})
+	}),
+	gas: EthereumQuantity,
+})
+
+export type WebsiteCreatedEthereumUnsignedTransaction = funtypes.Static<typeof WebsiteCreatedEthereumUnsignedTransaction>
+export const WebsiteCreatedEthereumUnsignedTransaction = funtypes.ReadonlyObject({
+	website: Website,
+	transactionCreated: EthereumTimestamp,
+	originalTransactionRequestParameters: funtypes.Union(SendTransactionParams, SendRawTransactionParams),
+	transaction: EthereumUnsignedTransaction,
+	error: funtypes.Union(funtypes.Undefined, EstimateGasError.fields.error)
 })
 
 export type SimulationState = funtypes.Static<typeof SimulationState>
@@ -187,6 +189,7 @@ export const SimulationState = funtypes.ReadonlyObject({
 	rpcNetwork: RpcNetwork,
 	simulationConductedTimestamp: EthereumTimestamp,
 })
+
 export type EthBalanceChangesWithMetadata = funtypes.Static<typeof EthBalanceChangesWithMetadata>
 export const EthBalanceChangesWithMetadata = funtypes.ReadonlyObject({
 	address: AddressBookEntry,
@@ -251,7 +254,7 @@ export type SimulationAndVisualisationResults = {
 	blockNumber: bigint,
 	blockTimestamp: Date,
 	simulationConductedTimestamp: Date,
-	addressMetaData: readonly AddressBookEntry[],
+	addressBookEntries: readonly AddressBookEntry[],
 	simulatedAndVisualizedTransactions: readonly SimulatedAndVisualizedTransaction[],
 	rpcNetwork: RpcNetwork,
 	tokenPrices: readonly TokenPriceEstimate[],

--- a/test/tests/nethermindComparison.ts
+++ b/test/tests/nethermindComparison.ts
@@ -94,7 +94,13 @@ export async function main() {
 
 		should('adding transaction and getting the next block should include all the same fields as Nethermind', async () => {
 			const block = await getSimulatedBlock(ethereum, simulationState, blockNumber, true)
-			const newState = await appendTransaction(ethereum, simulationState, { transaction: exampleTransaction, website: { websiteOrigin: 'test', icon: undefined, title: undefined }, transactionCreated: new Date(), transactionSendingFormat: 'eth_sendTransaction' })
+			const newState = await appendTransaction(ethereum, simulationState, {
+				transaction: exampleTransaction,
+				website: { websiteOrigin: 'test', icon: undefined, title: undefined },
+				transactionCreated: new Date(),
+				originalTransactionRequestParameters: { method: 'eth_sendTransaction', params: [{}]},
+				error: undefined,
+			})
 			const nextBlock = await getSimulatedBlock(ethereum, newState, blockNumber + 1n, true)
 			assert.equal(JSON.stringify(Object.keys(nextBlock).sort()), JSON.stringify(Object.keys(block).sort()))
 


### PR DESCRIPTION
- partially fixes https://github.com/DarkFlorist/TheInterceptor/issues/602 in a way that if when a new block is confirmed, the nonce is checked. However, we are not still counting pending transactions, only confirmed ones
- makes sure that error's data object is propagated to the dapp if available
-fix https://github.com/DarkFlorist/TheInterceptor/issues/606 : 
![image](https://github.com/DarkFlorist/TheInterceptor/assets/13102010/628d5e3f-26c3-49ff-bbdf-f3c7eb235303)

