### PR TITLE
fix asking access on non-signer connected sites

### DIFF
--- a/app/ts/background/background-startup.ts
+++ b/app/ts/background/background-startup.ts
@@ -105,12 +105,14 @@ export async function onContentScriptConnected(simulator: Simulator, port: brows
 					return replyToInterceptedRequest(websiteTabConnections, { method: 'eth_chainId' as const, result: 1n, uniqueRequestIdentifier: request.uniqueRequestIdentifier })
 				}
 			}
-			if (activeAddress === undefined) return refuseAccess(websiteTabConnections, request)
 
 			switch (access) {
-				case 'noAccess': return refuseAccess(websiteTabConnections, request)
 				case 'askAccess': return await gateKeepRequestBehindAccessDialog(simulator, websiteTabConnections, socket, request, await websitePromise, activeAddress, await getSettings())
-				case 'hasAccess': return await handleContentScriptMessage(simulator, websiteTabConnections, request, await websitePromise, activeAddress)
+				case 'noAccess': return refuseAccess(websiteTabConnections, request)
+				case 'hasAccess': {
+					if (activeAddress === undefined) return refuseAccess(websiteTabConnections, request)
+					return await handleContentScriptMessage(simulator, websiteTabConnections, request, await websitePromise, activeAddress)
+				}
 				default: assertNever(access)
 			}
 		})


### PR DESCRIPTION
with this change, if you run
```
await window.ethereum.request({
	"method":"eth_requestAccounts",
	"params":[{ }]
})
```
on console on this site (while in signing mode), we first request access to the site, then ask signer for the address and then request access with that address.

Before we just denied access to the site as metamask was not giving address to us