### PR TITLE
fix wrong nonce on eth_call

### DIFF
--- a/app/ts/simulation/services/SimulationModeEthereumClientService.ts
+++ b/app/ts/simulation/services/SimulationModeEthereumClientService.ts
@@ -610,7 +610,7 @@ export const simulatedCall = async (ethereumClientService: EthereumClientService
 		...params,
 		type: '1559',
 		gas: params.gasLimit,
-		nonce: await getSimulatedTransactionCount(ethereumClientService, simulationStateToUse, params.from, blockNumToUse),
+		nonce: await getSimulatedTransactionCount(ethereumClientService, simulationStateToUse, params.from, blockTag),
 		chainId: ethereumClientService.getChainId(),
 	} as const
 	const multicallResult = await simulatedMulticall(ethereumClientService, simulationStateToUse, [transaction], blockNumToUse)


### PR DESCRIPTION
when calculating the nonce for multicall for `eth_call`, if eth_call's from field matched to some simulation stacks transation, that resulted in a nonce error as we are using wrong block tag. 