### PR TITLE
Parse exported settings only once

### DIFF
--- a/app/ts/background/settings.ts
+++ b/app/ts/background/settings.ts
@@ -2,7 +2,7 @@ import { MOCK_PRIVATE_KEYS_ADDRESS } from '../utils/constants.js'
 import { ExportedSettings, Page } from '../types/exportedSettingsTypes.js'
 import { Settings } from '../types/interceptor-messages.js'
 import { Semaphore } from '../utils/semaphore.js'
-import { browserStorageLocalGet, browserStorageLocalSet } from '../utils/storageUtils.js'
+import { browserStorageLocalGet, browserStorageLocalGetUnParsed, browserStorageLocalSet } from '../utils/storageUtils.js'
 import { NetworkPrice, RpcEntries, RpcNetwork } from '../types/visualizer-types.js'
 import { EthereumAddress } from '../types/wire-types.js'
 import { ActiveAddressArray, ContactEntries } from '../types/addressBookTypes.js'
@@ -188,7 +188,7 @@ export async function exportSettingsAndAddressBook() {
 		name: 'InterceptorSettingsAndAddressBook' as const,
 		version: '1.2' as const,
 		exportedDate: (new Date).toISOString().split('T')[0],
-		settings: await browserStorageLocalGet([
+		settings: await browserStorageLocalGetUnParsed([
 			'activeSimulationAddress',
 			'addressInfos',
 			'page',

--- a/app/ts/utils/storageUtils.ts
+++ b/app/ts/utils/storageUtils.ts
@@ -66,6 +66,9 @@ export const LocalStorageKey = funtypes.Union(
 export async function browserStorageLocalGet(keys: LocalStorageKey | LocalStorageKey[]): Promise<LocalStorageItems> {
 	return LocalStorageItems.parse(await browser.storage.local.get(Array.isArray(keys) ? keys : [keys]))
 }
+export async function browserStorageLocalGetUnParsed(keys: LocalStorageKey | LocalStorageKey[]): Promise<unknown> {
+	return await browser.storage.local.get(Array.isArray(keys) ? keys : [keys])
+}
 export async function browserStorageLocalRemove(keys: LocalStorageKey | LocalStorageKey[]) {
 	return await browser.storage.local.remove(Array.isArray(keys) ? keys : [keys])
 }


### PR DESCRIPTION
`exportSettingsAndAddressBook` was parsing settings from local storage twice and failing when trying to parse address twice as it gets converted to bigint