### PR TITLE
catch tab id errors and ignore them

### DIFF
--- a/app/ts/components/pages/ConfirmTransaction.tsx
+++ b/app/ts/components/pages/ConfirmTransaction.tsx
@@ -169,13 +169,18 @@ export function ConfirmTransaction() {
 			}
 			if (message.method === 'popup_confirm_transaction_dialog_pending_changed') {
 				updatePendingTransactions(message)
-				const currentWindowId = (await browser.windows.getCurrent()).id
-				const currentTabId = (await browser.tabs.getCurrent()).id
-				if (currentWindowId === undefined) throw new Error('could not get current window Id!')
-				if (currentTabId === undefined) throw new Error('could not get current tab Id!')
 				setPendingTransactionAddedNotification(true)
-				browser.windows.update(currentWindowId, { focused: true })
-				browser.tabs.update(currentTabId, { active: true })
+				try {
+					const currentWindowId = (await browser.windows.getCurrent()).id
+					const currentTabId = (await browser.tabs.getCurrent()).id
+					if (currentWindowId === undefined) throw new Error('could not get current window Id!')
+					if (currentTabId === undefined) throw new Error('could not get current tab Id!')
+					browser.windows.update(currentWindowId, { focused: true })
+					browser.tabs.update(currentTabId, { active: true })
+				} catch(e) {
+					console.warn('failed to focus window')
+					console.warn(e)
+				}
 				return
 			}
 			if (message.method !== 'popup_update_confirm_transaction_dialog') return

--- a/app/ts/components/pages/ConfirmTransaction.tsx
+++ b/app/ts/components/pages/ConfirmTransaction.tsx
@@ -172,8 +172,8 @@ export function ConfirmTransaction() {
 				setPendingTransactionAddedNotification(true)
 				try {
 					const currentWindowId = (await browser.windows.getCurrent()).id
-					const currentTabId = (await browser.tabs.getCurrent()).id
 					if (currentWindowId === undefined) throw new Error('could not get current window Id!')
+					const currentTabId = (await browser.tabs.getCurrent()).id
 					if (currentTabId === undefined) throw new Error('could not get current tab Id!')
 					browser.windows.update(currentWindowId, { focused: true })
 					browser.tabs.update(currentTabId, { active: true })

--- a/app/ts/components/pages/InterceptorAccess.tsx
+++ b/app/ts/components/pages/InterceptorAccess.tsx
@@ -189,10 +189,6 @@ export function InterceptorAccess() {
 					setPendingRequestAddedNotification(true)
 				}
 				setAccessRequest(message.data)
-				const currentWindowId = (await browser.windows.getCurrent()).id
-				const currentTabId = (await browser.tabs.getCurrent()).id
-				if (currentWindowId === undefined) throw new Error('could not get current window Id!')
-				if (currentTabId === undefined) throw new Error('could not get current tab Id!')
 				return
 			}
 		}


### PR DESCRIPTION
fix errors: "Unchecked runtime.lastError: No tab with id: 942650812." when we try to reach for tab id that has been closed