### PR TITLE
Retrieve ABI from etherscan

### DIFF
--- a/app/ts/AddressBook.tsx
+++ b/app/ts/AddressBook.tsx
@@ -208,7 +208,7 @@ export function AddressBook() {
 	const searchStringRef = useRef<string | undefined>(searchString)
 	const currentPageRef = useRef<number>(currentPage)
 
-	const [addingNewAddress, setAddingNewAddress] = useState<IncompleteAddressBookEntry>({ addingAddress: false, type: 'activeAddress', address: undefined, askForAddressAccess: false, name: undefined, symbol: undefined, decimals: undefined, logoUri: undefined, entrySource: 'FilledIn' })
+	const [addingNewAddress, setAddingNewAddress] = useState<IncompleteAddressBookEntry>({ addingAddress: false, type: 'activeAddress', address: undefined, askForAddressAccess: false, name: undefined, symbol: undefined, decimals: undefined, logoUri: undefined, entrySource: 'FilledIn', abi: undefined })
 
 	const scrollTimer = useRef<ReturnType<typeof setTimeout> | undefined>(undefined)
 
@@ -374,6 +374,7 @@ export function AddressBook() {
 			address: undefined,
 			askForAddressAccess: true,
 			entrySource: 'FilledIn',
+			abi: undefined,
 		})
 	}
 
@@ -391,6 +392,7 @@ export function AddressBook() {
 			decimals: undefined,
 			logoUri: undefined,
 			...entry,
+			abi: 'abi' in entry ? entry.abi : undefined,
 			address: checksummedAddress(entry.address)
 		})
 	}

--- a/app/ts/background/background.ts
+++ b/app/ts/background/background.ts
@@ -4,7 +4,7 @@ import { Simulator, runProtectorsForTransaction, visualizeTransaction } from '..
 import { getEthDonator, getSignerName, getSimulationResults, updateSimulationResults, updateSimulationResultsWithCallBack } from './storageVariables.js'
 import { changeSimulationMode, getSettings, getMakeMeRich } from './settings.js'
 import { blockNumber, call, chainId, estimateGas, gasPrice, getAccounts, getBalance, getBlockByNumber, getCode, getLogs, getPermissions, getSimulationStack, getTransactionByHash, getTransactionCount, getTransactionReceipt, netVersion, personalSign, sendTransaction, subscribe, switchEthereumChain, unsubscribe, web3ClientVersion, getBlockByHash } from './simulationModeHanders.js'
-import { changeActiveAddress, changeMakeMeRich, changePage, resetSimulation, confirmDialog, refreshSimulation, removeTransaction, requestAccountsFromSigner, refreshPopupConfirmTransactionSimulation, confirmPersonalSign, confirmRequestAccess, changeInterceptorAccess, changeChainDialog, popupChangeActiveRpc, enableSimulationMode, addOrModifyAddressBookEntry, getAddressBookData, removeAddressBookEntry, openAddressBook, homeOpened, interceptorAccessChangeAddressOrRefresh, refreshPopupConfirmTransactionMetadata, changeSettings, importSettings, exportSettings, setNewRpcList, popupIdentifyAddress, popupFindAddressBookEntryWithSymbolOrName, removeSignedMessage, simulateGovernanceContractExecutionOnPass } from './popupMessageHandlers.js'
+import { changeActiveAddress, changeMakeMeRich, changePage, resetSimulation, confirmDialog, refreshSimulation, removeTransaction, requestAccountsFromSigner, refreshPopupConfirmTransactionSimulation, confirmPersonalSign, confirmRequestAccess, changeInterceptorAccess, changeChainDialog, popupChangeActiveRpc, enableSimulationMode, addOrModifyAddressBookEntry, getAddressBookData, removeAddressBookEntry, openAddressBook, homeOpened, interceptorAccessChangeAddressOrRefresh, refreshPopupConfirmTransactionMetadata, changeSettings, importSettings, exportSettings, setNewRpcList, popupIdentifyAddress, popupFindAddressBookEntryWithSymbolOrName, removeSignedMessage, simulateGovernanceContractExecutionOnPass, fetchAbiAndNameFromEtherScan } from './popupMessageHandlers.js'
 import { ProtectorResults, SimulationState, VisualizedSimulatorState, VisualizerResult, WebsiteCreatedEthereumUnsignedTransaction } from '../types/visualizer-types.js'
 import { WebsiteTabConnections } from '../types/user-interface-types.js'
 import { interceptorAccessMetadataRefresh, requestAccessFromUser, updateInterceptorAccessViewWithPendingRequests } from './windows/interceptorAccess.js'
@@ -554,6 +554,7 @@ export async function popupMessageHandler(
 		case 'popup_identifyAddress': return await popupIdentifyAddress(simulator, parsedRequest, settings)
 		case 'popup_findAddressBookEntryWithSymbolOrName': return await popupFindAddressBookEntryWithSymbolOrName(parsedRequest, settings)
 		case 'popup_simulateGovernanceContractExecution': return await simulateGovernanceContractExecutionOnPass(simulator.ethereum)
+		case 'popup_fetchAbiAndNameFromEtherScan': return await fetchAbiAndNameFromEtherScan(parsedRequest)
 		default: assertUnreachable(parsedRequest)
 	}
 }

--- a/app/ts/background/popupMessageHandlers.ts
+++ b/app/ts/background/popupMessageHandlers.ts
@@ -2,7 +2,7 @@ import { changeActiveAddressAndChainAndResetSimulation, changeActiveRpc, getPrep
 import { getSettings, setUseTabsInsteadOfPopup, setMakeMeRich, setPage, setUseSignersAddressAsActiveAddress, updateActiveAddresses, updateContacts, updateWebsiteAccess, exportSettingsAndAddressBook, importSettingsAndAddressBook, getMakeMeRich, getUseTabsInsteadOfPopup, getMetamaskCompatibilityMode, setMetamaskCompatibilityMode } from './settings.js'
 import { getPendingTransactions, getCurrentTabId, getOpenedAddressBookTabId, getTabState, saveCurrentTabId, setOpenedAddressBookTabId, setRpcList, getRpcList, getPrimaryRpcForChain, getSignerName, getRpcConnectionStatus, updateUserAddressBookEntries, getSimulationResults } from './storageVariables.js'
 import { Simulator } from '../simulation/simulator.js'
-import { ChangeActiveAddress, ChangeMakeMeRich, ChangePage, RemoveTransaction, RequestAccountsFromSigner, TransactionConfirmation, InterceptorAccess, ChangeInterceptorAccess, ChainChangeConfirmation, EnableSimulationMode, ChangeActiveChain, AddOrEditAddressBookEntry, GetAddressBookData, RemoveAddressBookEntry, InterceptorAccessRefresh, InterceptorAccessChangeAddress, Settings, RefreshConfirmTransactionMetadata, RefreshInterceptorAccessMetadata, ChangeSettings, ImportSettings, SetRpcList, IdentifyAddress, FindAddressBookEntryWithSymbolOrName, PersonalSignApproval, UpdateHomePage, RemoveSignedMessage, SimulateGovernanceContractExecutionReply } from '../types/interceptor-messages.js'
+import { ChangeActiveAddress, ChangeMakeMeRich, ChangePage, RemoveTransaction, RequestAccountsFromSigner, TransactionConfirmation, InterceptorAccess, ChangeInterceptorAccess, ChainChangeConfirmation, EnableSimulationMode, ChangeActiveChain, AddOrEditAddressBookEntry, GetAddressBookData, RemoveAddressBookEntry, InterceptorAccessRefresh, InterceptorAccessChangeAddress, Settings, RefreshConfirmTransactionMetadata, RefreshInterceptorAccessMetadata, ChangeSettings, ImportSettings, SetRpcList, IdentifyAddress, FindAddressBookEntryWithSymbolOrName, PersonalSignApproval, UpdateHomePage, RemoveSignedMessage, SimulateGovernanceContractExecutionReply, FetchAbiAndNameFromEtherScan } from '../types/interceptor-messages.js'
 import { formEthSendTransaction, formSendRawTransaction, resolvePendingTransaction, updateConfirmTransactionViewWithPendingTransactionOrClose } from './windows/confirmTransaction.js'
 import { resolvePersonalSign } from './windows/personalSign.js'
 import { getAddressMetadataForAccess, requestAddressChange, resolveInterceptorAccess } from './windows/interceptorAccess.js'
@@ -22,6 +22,7 @@ import { ExportedSettings } from '../types/exportedSettingsTypes.js'
 import { isJSON } from '../utils/json.js'
 import { UserAddressBook } from '../types/addressBookTypes.js'
 import { serialize } from '../types/wire-types.js'
+import { fetchAbi } from '../simulation/services/EtherScanAbiFetcher.js'
 
 export async function confirmDialog(simulator: Simulator, websiteTabConnections: WebsiteTabConnections, confirmation: TransactionConfirmation) {
 	await resolvePendingTransaction(simulator, websiteTabConnections, confirmation)
@@ -420,3 +421,12 @@ export async function simulateGovernanceContractExecutionOnPass(ethereum: Ethere
 		data: governanceContractExecutionVisualisation,
 	}))
 }
+
+export async function fetchAbiAndNameFromEtherScan(parsedRequest: FetchAbiAndNameFromEtherScan) {
+	const abi = await fetchAbi(parsedRequest.data)
+	return await sendPopupMessageToOpenWindows({
+		method: 'popup_fetchAbiAndNameFromEtherScanReply' as const,
+		data: abi,
+	})
+}
+

--- a/app/ts/components/App.tsx
+++ b/app/ts/components/App.tsx
@@ -41,7 +41,7 @@ export function App() {
 	const [isSettingsLoaded, setIsSettingsLoaded] = useState<boolean>(false)
 	const [currentBlockNumber, setCurrentBlockNumber] = useState<bigint | undefined>(undefined)
 	const [signerName, setSignerName] = useState<SignerName>('NoSignerDetected')
-	const [addingNewAddress, setAddingNewAddress] = useState<IncompleteAddressBookEntry> ({ addingAddress: false, type: 'activeAddress', address: undefined, askForAddressAccess: false, name: undefined, symbol: undefined, decimals: undefined, logoUri: undefined, entrySource: 'FilledIn' })
+	const [addingNewAddress, setAddingNewAddress] = useState<IncompleteAddressBookEntry> ({ addingAddress: false, type: 'activeAddress', address: undefined, askForAddressAccess: false, name: undefined, symbol: undefined, decimals: undefined, logoUri: undefined, entrySource: 'FilledIn', abi: undefined })
 	const [rpcConnectionStatus, setRpcConnectionStatus] = useState<RpcConnectionStatus>(undefined)
 	const [useTabsInsteadOfPopup, setUseTabsInsteadOfPopup] = useState<boolean | undefined>(undefined)
 	const [metamaskCompatibilityMode, setMetamaskCompatibilityMode] = useState<boolean | undefined>(undefined)
@@ -211,6 +211,7 @@ export function App() {
 			address: checksummedAddress(bigIntReprentation),
 			askForAddressAccess: true,
 			entrySource: 'FilledIn',
+			abi: undefined,
 		} )
 	}
 
@@ -222,6 +223,7 @@ export function App() {
 			symbol: undefined,
 			decimals: undefined,
 			logoUri: undefined,
+			abi: undefined,
 			...entry,
 			address: checksummedAddress(entry.address)
 		})
@@ -239,6 +241,7 @@ export function App() {
 			address: undefined,
 			askForAddressAccess: true,
 			entrySource: 'FilledIn',
+			abi: undefined,
 		} )
 	}
 

--- a/app/ts/components/pages/ConfirmTransaction.tsx
+++ b/app/ts/components/pages/ConfirmTransaction.tsx
@@ -258,7 +258,8 @@ export function ConfirmTransaction() {
 			decimals: undefined,
 			logoUri: undefined,
 			...entry,
-			address: checksummedAddress(entry.address)
+			address: checksummedAddress(entry.address),
+			abi: 'abi' in entry ? entry.abi : undefined,
 		})
 	}
 

--- a/app/ts/components/pages/InterceptorAccess.tsx
+++ b/app/ts/components/pages/InterceptorAccess.tsx
@@ -172,7 +172,7 @@ const DISABLED_DELAY_MS = 3000
 
 export function InterceptorAccess() {
 	const [pendingAccessRequestArray, setAccessRequest] = useState<PendingAccessRequestArray>([])
-	const [addingNewAddress, setAddingNewAddress] = useState<IncompleteAddressBookEntry> ({ addingAddress: false, type: 'activeAddress', address: undefined, askForAddressAccess: false, name: undefined, symbol: undefined, decimals: undefined, logoUri: undefined, entrySource: 'FilledIn' })
+	const [addingNewAddress, setAddingNewAddress] = useState<IncompleteAddressBookEntry> ({ addingAddress: false, type: 'activeAddress', address: undefined, askForAddressAccess: false, name: undefined, symbol: undefined, decimals: undefined, logoUri: undefined, entrySource: 'FilledIn', abi: undefined })
 	const [appPage, setAppPage] = useState('Home')
 	const [informationUpdatedTimestamp, setInformationUpdatedTimestamp] = useState(0)
 	const [, setTimeSinceInformationUpdate] = useState(0)
@@ -242,7 +242,8 @@ export function InterceptorAccess() {
 			decimals: undefined,
 			logoUri: undefined,
 			...entry,
-			address: checksummedAddress(entry.address)
+			address: checksummedAddress(entry.address),
+			abi: 'abi' in entry ? entry.abi : undefined,
 		})
 	}
 
@@ -308,6 +309,7 @@ export function InterceptorAccess() {
 			address: undefined,
 			askForAddressAccess: true,
 			entrySource: 'FilledIn',
+			abi: undefined,
 		} )
 	}
 

--- a/app/ts/components/pages/PersonalSign.tsx
+++ b/app/ts/components/pages/PersonalSign.tsx
@@ -507,7 +507,8 @@ export function PersonalSign() {
 			decimals: undefined,
 			logoUri: undefined,
 			...entry,
-			address: checksummedAddress(entry.address)
+			address: checksummedAddress(entry.address),
+			abi: 'abi' in entry ? entry.abi : undefined,
 		})
 	}
 

--- a/app/ts/simulation/services/EtherScanAbiFetcher.ts
+++ b/app/ts/simulation/services/EtherScanAbiFetcher.ts
@@ -5,7 +5,9 @@ import { addressString } from '../../utils/bigint.js'
 const EtherScanABIKey = 'PSW8C433Q667DVEX5BCRMGNAH9FSGFZ7Q8'
 
 export async function fetchAbi(contractAddress: EthereumAddress) {
-	const parsedSourceCode = EtherscanSourceCodeResult.safeParse(await (await fetch(`https://api.etherscan.io/api?module=contract&action=getsourcecode&address=${ addressString(contractAddress) }&apiKey=${ EtherScanABIKey }`)).json())
+	const sourceCodeResponse= await fetch(`https://api.etherscan.io/api?module=contract&action=getsourcecode&address=${ addressString(contractAddress) }&apiKey=${ EtherScanABIKey }`)
+	const json = await sourceCodeResponse.json()
+	const parsedSourceCode = EtherscanSourceCodeResult.safeParse(json)
 
 	// Extract ABI from getSourceCode request if not proxy, otherwise attempt to fetch ABI of implementation
 	if (parsedSourceCode.success == false || parsedSourceCode.value.status !== 'success') return undefined

--- a/app/ts/simulation/services/EtherScanAbiFetcher.ts
+++ b/app/ts/simulation/services/EtherScanAbiFetcher.ts
@@ -1,0 +1,26 @@
+import { EtherscanGetABIResult, EtherscanSourceCodeResult } from '../../types/etherscan.js'
+import { EthereumAddress } from '../../types/wire-types.js'
+import { addressString } from '../../utils/bigint.js'
+
+const EtherScanABIKey = 'PSW8C433Q667DVEX5BCRMGNAH9FSGFZ7Q8'
+
+export async function fetchAbi(contractAddress: EthereumAddress) {
+	const parsedSourceCode = EtherscanSourceCodeResult.safeParse(await (await fetch(`https://api.etherscan.io/api?module=contract&action=getsourcecode&address=${ addressString(contractAddress) }&apiKey=${ EtherScanABIKey }`)).json())
+
+	// Extract ABI from getSourceCode request if not proxy, otherwise attempt to fetch ABI of implementation
+	if (parsedSourceCode.success == false || parsedSourceCode.value.status !== 'success') return undefined
+	
+	if (parsedSourceCode.value.result[0].Proxy === 'yes' && parsedSourceCode.value.result[0].Implementation !== '') {
+		const implReq = await fetch(`https://api.etherscan.io/api?module=contract&action=getabi&address=${ addressString(parsedSourceCode.value.result[0].Implementation) }&apiKey=${ EtherScanABIKey }`)
+		const implResult = EtherscanGetABIResult.safeParse(await implReq.json())
+		const implementationName = EtherscanSourceCodeResult.safeParse(await (await fetch(`https://api.etherscan.io/api?module=contract&action=getsourcecode&address=${ addressString(parsedSourceCode.value.result[0].Implementation) }&apiKey=${ EtherScanABIKey }`)).json())
+		if (!implResult.success || !implementationName.success) return undefined
+		return { address: contractAddress, abi: implResult.value.result, contractName: `Proxy: ${ implementationName.value.result[0].ContractName }` }
+	} else {
+		return {
+			abi: parsedSourceCode.value.result[0].ABI && parsedSourceCode.value.result[0].ABI !== 'Contract source code not verified' ? parsedSourceCode.value.result[0].ABI : undefined,
+			contractName: parsedSourceCode.value.result[0].ContractName,
+			address: contractAddress,
+		}
+	}
+}

--- a/app/ts/simulation/services/EtherScanAbiFetcher.ts
+++ b/app/ts/simulation/services/EtherScanAbiFetcher.ts
@@ -4,25 +4,29 @@ import { addressString } from '../../utils/bigint.js'
 
 const EtherScanABIKey = 'PSW8C433Q667DVEX5BCRMGNAH9FSGFZ7Q8'
 
+async function fetchJsonOrUndefined(url: string): Promise<string | undefined> {
+	const response = await fetch(url)
+	if (!response.ok) return undefined // TODO, here we might want to propagate the error of not being able to reach etherscan to user
+	return await response.json()
+}
+
 export async function fetchAbi(contractAddress: EthereumAddress) {
-	const sourceCodeResponse= await fetch(`https://api.etherscan.io/api?module=contract&action=getsourcecode&address=${ addressString(contractAddress) }&apiKey=${ EtherScanABIKey }`)
-	const json = await sourceCodeResponse.json()
+	const json = await fetchJsonOrUndefined(`https://api.etherscan.io/api?module=contract&action=getsourcecode&address=${ addressString(contractAddress) }&apiKey=${ EtherScanABIKey }`)
 	const parsedSourceCode = EtherscanSourceCodeResult.safeParse(json)
 
 	// Extract ABI from getSourceCode request if not proxy, otherwise attempt to fetch ABI of implementation
 	if (parsedSourceCode.success == false || parsedSourceCode.value.status !== 'success') return undefined
 	
 	if (parsedSourceCode.value.result[0].Proxy === 'yes' && parsedSourceCode.value.result[0].Implementation !== '') {
-		const implReq = await fetch(`https://api.etherscan.io/api?module=contract&action=getabi&address=${ addressString(parsedSourceCode.value.result[0].Implementation) }&apiKey=${ EtherScanABIKey }`)
-		const implResult = EtherscanGetABIResult.safeParse(await implReq.json())
-		const implementationName = EtherscanSourceCodeResult.safeParse(await (await fetch(`https://api.etherscan.io/api?module=contract&action=getsourcecode&address=${ addressString(parsedSourceCode.value.result[0].Implementation) }&apiKey=${ EtherScanABIKey }`)).json())
+		const implReq = await fetchJsonOrUndefined(`https://api.etherscan.io/api?module=contract&action=getabi&address=${ addressString(parsedSourceCode.value.result[0].Implementation) }&apiKey=${ EtherScanABIKey }`)
+		const implResult = EtherscanGetABIResult.safeParse(implReq)
+		const implementationName = EtherscanSourceCodeResult.safeParse(await fetchJsonOrUndefined(`https://api.etherscan.io/api?module=contract&action=getsourcecode&address=${ addressString(parsedSourceCode.value.result[0].Implementation) }&apiKey=${ EtherScanABIKey }`))
 		if (!implResult.success || !implementationName.success) return undefined
 		return { address: contractAddress, abi: implResult.value.result, contractName: `Proxy: ${ implementationName.value.result[0].ContractName }` }
-	} else {
-		return {
-			abi: parsedSourceCode.value.result[0].ABI && parsedSourceCode.value.result[0].ABI !== 'Contract source code not verified' ? parsedSourceCode.value.result[0].ABI : undefined,
-			contractName: parsedSourceCode.value.result[0].ContractName,
-			address: contractAddress,
-		}
+	}
+	return {
+		abi: parsedSourceCode.value.result[0].ABI && parsedSourceCode.value.result[0].ABI !== 'Contract source code not verified' ? parsedSourceCode.value.result[0].ABI : undefined,
+		contractName: parsedSourceCode.value.result[0].ContractName,
+		address: contractAddress,
 	}
 }

--- a/app/ts/types/addressBookTypes.ts
+++ b/app/ts/types/addressBookTypes.ts
@@ -39,6 +39,7 @@ export const Erc20TokenEntry = funtypes.ReadonlyObject({
 	entrySource: EntrySource,
 }).And(funtypes.Partial({
 	logoUri: funtypes.String,
+	abi: funtypes.String,
 }))
 
 export type Erc721Entry = funtypes.Static<typeof Erc721Entry>
@@ -51,6 +52,7 @@ export const Erc721Entry = funtypes.ReadonlyObject({
 }).And(funtypes.Partial({
 	protocol: funtypes.String,
 	logoUri: funtypes.String,
+	abi: funtypes.String,
 }))
 
 export type Erc1155Entry = funtypes.Static<typeof Erc1155Entry>
@@ -64,6 +66,7 @@ export const Erc1155Entry = funtypes.ReadonlyObject({
 }).And(funtypes.Partial({
 	protocol: funtypes.String,
 	logoUri: funtypes.String,
+	abi: funtypes.String,
 }))
 
 export type ContactEntry = funtypes.Static<typeof ContactEntry>
@@ -74,6 +77,7 @@ export const ContactEntry = funtypes.ReadonlyObject({
 	entrySource: funtypes.Union(EntrySource, funtypes.Literal(undefined).withParser(LiteralConverterParserFactory(undefined, 'User' as const))),
 }).And(funtypes.Partial({
 	logoUri: funtypes.String,
+	abi: funtypes.String,
 }))
 
 export type ContactEntries = funtypes.Static<typeof ContactEntries>
@@ -88,6 +92,7 @@ export const ContractEntry = funtypes.ReadonlyObject({
 }).And(funtypes.Partial({
 	protocol: funtypes.String,
 	logoUri: funtypes.String,
+	abi: funtypes.String,
 }))
 
 export type AddressBookEntryCategory = 'contact' | 'activeAddress' | 'ERC20' | 'ERC721' | 'contract' | 'ERC1155'
@@ -115,6 +120,7 @@ export type IncompleteAddressBookEntry = {
 	decimals: bigint | undefined
 	logoUri: string | undefined
 	entrySource: EntrySource
+	abi: string | undefined
 }
 
 export type UserAddressBook = funtypes.Static<typeof UserAddressBook>

--- a/app/ts/types/etherscan.ts
+++ b/app/ts/types/etherscan.ts
@@ -1,0 +1,23 @@
+import * as funtypes from 'funtypes'
+import { EthereumAddress, LiteralConverterParserFactory } from './wire-types.js'
+// Not full result definition, only entries that we consume
+// https://docs.etherscan.io/api-endpoints/contracts#get-contract-source-code-for-verified-contract-source-codes
+export type EtherscanSourceCodeResult = funtypes.Static<typeof EtherscanSourceCodeResult>
+export const EtherscanSourceCodeResult = funtypes.Object({
+	status: funtypes.Union(funtypes.Literal('1').withParser(LiteralConverterParserFactory('1', 'success' as const)), funtypes.Literal('0').withParser(LiteralConverterParserFactory('0', 'failure' as const))),
+	result: funtypes.ReadonlyTuple(funtypes.Object({
+		ContractName: funtypes.String,
+		ABI: funtypes.String,
+		Proxy: funtypes.Union(funtypes.Literal('1').withParser(LiteralConverterParserFactory('1', 'yes' as const)), funtypes.Literal('0').withParser(LiteralConverterParserFactory('0', 'no' as const))),
+		Implementation: funtypes.Union(funtypes.Literal(''), EthereumAddress)
+	}))
+}).asReadonly()
+
+
+// Not full result definition, only entries that we consume
+// https://docs.etherscan.io/api-endpoints/contracts#get-contract-abi-for-verified-contract-source-codes
+export type EtherscanGetABIResult = funtypes.Static<typeof EtherscanGetABIResult>
+export const EtherscanGetABIResult = funtypes.Object({
+	status: funtypes.Union(funtypes.Literal('1').withParser(LiteralConverterParserFactory('1', 'success' as const)), funtypes.Literal('0').withParser(LiteralConverterParserFactory('0', 'failure' as const))),
+	result: funtypes.String
+}).asReadonly()

--- a/app/ts/types/interceptor-messages.ts
+++ b/app/ts/types/interceptor-messages.ts
@@ -641,6 +641,25 @@ export const SimulateGovernanceContractExecutionReply = funtypes.ReadonlyObject(
 	)
 }).asReadonly()
 
+export type FetchAbiAndNameFromEtherScan = funtypes.Static<typeof FetchAbiAndNameFromEtherScan>
+export const FetchAbiAndNameFromEtherScan = funtypes.ReadonlyObject({
+	method: funtypes.Literal('popup_fetchAbiAndNameFromEtherScan'),
+	data: EthereumAddress,
+}).asReadonly()
+
+export type FetchAbiAndNameFromEtherScanReply = funtypes.Static<typeof FetchAbiAndNameFromEtherScanReply>
+export const FetchAbiAndNameFromEtherScanReply = funtypes.ReadonlyObject({
+	method: funtypes.Literal('popup_fetchAbiAndNameFromEtherScanReply'),
+	data: funtypes.Union(
+		funtypes.ReadonlyObject({
+			address: EthereumAddress,
+			abi: funtypes.Union(funtypes.String, funtypes.Undefined),
+			contractName: funtypes.String,
+		}),
+		funtypes.Undefined,
+	)
+}).asReadonly()
+
 export type PopupMessage = funtypes.Static<typeof PopupMessage>
 export const PopupMessage = funtypes.Union(
 	TransactionConfirmation,
@@ -681,6 +700,7 @@ export const PopupMessage = funtypes.Union(
 	SetRpcList,
 	IdentifyAddress,
 	FindAddressBookEntryWithSymbolOrName,
+	FetchAbiAndNameFromEtherScan,
 )
 
 export type MessageToPopup = funtypes.Static<typeof MessageToPopup>
@@ -704,6 +724,7 @@ export const MessageToPopup = funtypes.Union(
 	PartialUpdateHomePage,
 	PartiallyParsedPersonalSignRequest,
 	PartiallyParsedSimulateGovernanceContractExecutionReply,
+	FetchAbiAndNameFromEtherScanReply,
 )
 
 export type ExternalPopupMessage = funtypes.Static<typeof MessageToPopup>


### PR DESCRIPTION
Fixes  partially https://github.com/DarkFlorist/TheInterceptor/issues/706

- Adds button to import ABI from etherscan
- ABI is saved to addressbook

still missing that user could see the abi somewhere and that user could paste the abi themselves (we need verification for this), and user should be able to change eherscan api key

<img width="497" alt="image" src="https://github.com/DarkFlorist/TheInterceptor/assets/13102010/49fd033e-3d39-4126-86e7-6e81b6ef2137">
