### PR TITLE
Open confirm transaction view faster

### DIFF
--- a/app/ts/background/background.ts
+++ b/app/ts/background/background.ts
@@ -59,6 +59,7 @@ export const simulateGovernanceContractExecution = async (pendingTransaction: Pe
 	const returnError = (text: string) => ({ success: false as const, error: { type: 'Other' as const, message: text } })
 	try {
 		// identifies compound governane call and performs simulation if the vote passes
+		if (pendingTransaction.status !== 'Simulated') return returnError('Still simulating the voting transaction')
 		const pendingResults = pendingTransaction.simulationResults
 		if (pendingResults.statusCode !== 'success') return returnError('Voting transaction failed')
 		const fourByte = get4Byte(pendingTransaction.transactionToSimulate.transaction.input)
@@ -104,7 +105,7 @@ export const simulateGovernanceContractExecution = async (pendingTransaction: Pe
 				tokenBalancesAfter: tokenBalancesAfter[0],
 				website: pendingTransaction.transactionToSimulate.website,
 				created: new Date(),
-				originalRequestParameters: pendingTransaction.transactionToSimulate.originalRequestParameters,
+				originalRequestParameters: pendingTransaction.originalRequestParameters,
 			}],
 			blockNumber: parentBlock.number,
 			blockTimestamp: parentBlock.timestamp,

--- a/app/ts/background/popupMessageHandlers.ts
+++ b/app/ts/background/popupMessageHandlers.ts
@@ -198,7 +198,7 @@ export async function refreshPopupConfirmTransactionMetadata(ethereumClientServi
 	const first = promises[0]
 	const addressBookEntries = await addressBookEntriesPromise
 	const namedTokenIds = await namedTokenIdsPromise
-	if (first === undefined || first.simulationResults === undefined || first.simulationResults.statusCode !== 'success') return
+	if (first === undefined || first.status !== 'Simulated' || first.simulationResults === undefined || first.simulationResults.statusCode !== 'success') return
 	return await sendPopupMessageToOpenWindows({
 		method: 'popup_update_confirm_transaction_dialog',
 		data: [{
@@ -218,7 +218,8 @@ export async function refreshPopupConfirmTransactionMetadata(ethereumClientServi
 export async function refreshPopupConfirmTransactionSimulation(simulator: Simulator, ethereumClientService: EthereumClientService) {
 	const [firstTxn, ...remainingTxns] = await getPendingTransactions()
 	if (firstTxn === undefined) return await updateConfirmTransactionViewWithPendingTransactionOrClose()
-	const transactionToSimulate = firstTxn.request.method === 'eth_sendTransaction' ? await formEthSendTransaction(ethereumClientService, firstTxn.activeAddress, firstTxn.simulationMode, firstTxn.transactionToSimulate.website, firstTxn.request, firstTxn.created) : await formSendRawTransaction(ethereumClientService, firstTxn.request, firstTxn.transactionToSimulate.website, firstTxn.created)
+	if (firstTxn.status !== 'Simulated') return
+	const transactionToSimulate = firstTxn.originalRequestParameters.method === 'eth_sendTransaction' ? await formEthSendTransaction(ethereumClientService, firstTxn.activeAddress, firstTxn.simulationMode, firstTxn.transactionToSimulate.website, firstTxn.originalRequestParameters, firstTxn.created) : await formSendRawTransaction(ethereumClientService, firstTxn.originalRequestParameters, firstTxn.transactionToSimulate.website, firstTxn.created)
 	const refreshMessage = await refreshConfirmTransactionSimulation(simulator, ethereumClientService, firstTxn.activeAddress, firstTxn.simulationMode, firstTxn.uniqueRequestIdentifier, transactionToSimulate)
 	if ('error' in transactionToSimulate) {
 		return await sendPopupMessageToOpenWindows({

--- a/app/ts/background/storageVariables.ts
+++ b/app/ts/background/storageVariables.ts
@@ -9,6 +9,7 @@ import { AddressBookEntries } from '../types/addressBookTypes.js'
 import { SignerName } from '../types/signerTypes.js'
 import { PendingAccessRequest, PendingAccessRequestArray, PendingTransaction } from '../types/accessRequest.js'
 import { RpcEntries, RpcNetwork } from '../types/rpc.js'
+import { replaceElementInReadonlyArray } from '../utils/typed-arrays.js'
 
 export const getOpenedAddressBookTabId = async() => (await browserStorageLocalGet('addressbookTabId'))?.['addressbookTabId'] ?? undefined
 
@@ -28,13 +29,25 @@ export async function clearPendingTransactions() {
 		return await browserStorageLocalSet({ transactionsPendingForUserConfirmation: [] })
 	})
 }
-export async function appendPendingTransaction(promise: PendingTransaction) {
+export async function appendPendingTransaction(pendingTransaction: PendingTransaction) {
 	return await pendingTransactionsSemaphore.execute(async () => {
-		const promises = [...await getPendingTransactions(), promise]
-		await browserStorageLocalSet({ transactionsPendingForUserConfirmation: promises })
-		return promises
+		const pendingTransactions = [...await getPendingTransactions(), pendingTransaction]
+		await browserStorageLocalSet({ transactionsPendingForUserConfirmation: pendingTransactions })
+		return pendingTransactions
 	})
 }
+
+export async function replacePendingTransaction(pendingTransaction: PendingTransaction) {
+	return await pendingTransactionsSemaphore.execute(async () => {
+		const pendingTransactions = await getPendingTransactions()
+		const match = pendingTransactions.findIndex((pending) => doesUniqueRequestIdentifiersMatch(pending.uniqueRequestIdentifier, pendingTransaction.uniqueRequestIdentifier))
+		if (match < 0) return undefined
+		const replaced = replaceElementInReadonlyArray(pendingTransactions, match, pendingTransaction)
+		await browserStorageLocalSet({ transactionsPendingForUserConfirmation: replaced })
+		return pendingTransaction
+	})
+}
+
 export async function removePendingTransaction(uniqueRequestIdentifier: UniqueRequestIdentifier) {
 	return await pendingTransactionsSemaphore.execute(async () => {
 		const promises = await getPendingTransactions()

--- a/app/ts/components/pages/ConfirmTransaction.tsx
+++ b/app/ts/components/pages/ConfirmTransaction.tsx
@@ -29,6 +29,7 @@ function UnderTransactions(param: UnderTransactionsParams) {
 	return <div style = {`position: relative; top: ${ nTx * -HALF_HEADER_HEIGHT }px;`}>
 		{ param.pendingTransactions.map((pendingTransaction, index) => {
 			const style = `margin-bottom: 0px; scale: ${ Math.pow(0.95, nTx - index) }; position: relative; top: ${ (nTx - index) * HALF_HEADER_HEIGHT }px;`
+			if (pendingTransaction.status !== 'Simulated') return <p> Simulating... </p>
 			if (pendingTransaction.transactionToSimulate.error !== undefined) return <p>{ pendingTransaction.transactionToSimulate.error.message }</p>
 			if (pendingTransaction.simulationResults.statusCode === 'success') {
 				const simTx = pendingTransaction.simulationResults.data.simulatedAndVisualizedTransactions.at(-1)
@@ -155,7 +156,7 @@ export function ConfirmTransaction() {
 		const firstMessage = message.data[0]
 		if (firstMessage === undefined) throw new Error('message data was undefined')
 		setCurrentPendingTransaction(firstMessage)
-		if (firstMessage.simulationResults !== undefined && firstMessage.simulationResults.statusCode === 'success' && (currentBlockNumber === undefined || firstMessage.simulationResults.data.simulationState.blockNumber > currentBlockNumber)) {
+		if (firstMessage.status === 'Simulated' && firstMessage.simulationResults !== undefined && firstMessage.simulationResults.statusCode === 'success' && (currentBlockNumber === undefined || firstMessage.simulationResults.data.simulationState.blockNumber > currentBlockNumber)) {
 			setCurrentBlockNumber(firstMessage.simulationResults.data.simulationState.blockNumber)
 		}
 	}
@@ -214,6 +215,7 @@ export function ConfirmTransaction() {
 		if (pendingTransactions.length === 0) await tryFocusingTabOrWindow({ type: 'tab', id: currentPendingTransaction.uniqueRequestIdentifier.requestSocket.tabId })
 		
 		const getPossibleErrorString = () => {
+			if (currentPendingTransaction.status !== 'Simulated') return undefined
 			if (currentPendingTransaction.transactionToSimulate.error !== undefined) return currentPendingTransaction.transactionToSimulate.error.message
 			if (currentPendingTransaction.simulationResults.statusCode !== 'success' ) return undefined
 			const lastTx = currentPendingTransaction.simulationResults.data.simulatedAndVisualizedTransactions.at(-1)
@@ -230,7 +232,8 @@ export function ConfirmTransaction() {
 	}
 	const refreshMetadata = async () => {
 		// todo we should refresh metadata even if the resuls are failures
-		if (currentPendingTransaction === undefined || currentPendingTransaction.simulationResults === undefined || currentPendingTransaction.simulationResults.statusCode === 'failed') return
+		if (currentPendingTransaction === undefined ||  currentPendingTransaction.status !== 'Simulated') return
+		if (currentPendingTransaction.simulationResults === undefined || currentPendingTransaction.simulationResults.statusCode === 'failed') return
 		await sendPopupMessageToBackgroundPage({ method: 'popup_refreshConfirmTransactionMetadata', data: currentPendingTransaction.simulationResults.data })
 	}
 	const refreshSimulation = async () => {
@@ -240,7 +243,8 @@ export function ConfirmTransaction() {
 
 	function isConfirmDisabled() {
 		if (forceSend) return false
-		if (currentPendingTransaction === undefined) return false
+		if (currentPendingTransaction === undefined) return true
+		if (currentPendingTransaction.status !== 'Simulated') return true
 		if (currentPendingTransaction.simulationResults === undefined) return false
 		if (currentPendingTransaction.simulationResults.statusCode !== 'success' ) return false
 		const lastTx = currentPendingTransaction.simulationResults.data.simulatedAndVisualizedTransactions.at(-1)
@@ -264,12 +268,12 @@ export function ConfirmTransaction() {
 	}
 
 	function Buttons() {
-		const lastTx = currentPendingTransaction === undefined || currentPendingTransaction.simulationResults.statusCode !== 'success'
+		const lastTx = currentPendingTransaction === undefined || currentPendingTransaction.status !== 'Simulated' || currentPendingTransaction.simulationResults.statusCode !== 'success'
 			? undefined : currentPendingTransaction.simulationResults.data.simulatedAndVisualizedTransactions.at(-1)
-		if (lastTx === undefined || currentPendingTransaction === undefined || currentPendingTransaction.transactionToSimulate.error !== undefined) {
+		if (lastTx === undefined || currentPendingTransaction === undefined || currentPendingTransaction.status !== 'Simulated' || currentPendingTransaction.transactionToSimulate.error !== undefined) {
 			return <div style = 'display: flex; flex-direction: row;'>
 				<button className = 'button is-primary is-danger button-overflow dialog-button-left' onClick = { reject } >
-					{ 'Reject failing transaction' }
+					{ 'Reject' }
 				</button>
 			</div>
 		}
@@ -291,7 +295,9 @@ export function ConfirmTransaction() {
 		</div>
 	}
 
-	if (currentPendingTransaction === undefined) return <CenterToPageTextSpinner text = 'Simulating...'/>
+	if (currentPendingTransaction === undefined) return <CenterToPageTextSpinner text = 'Initializing...'/>
+	if (currentPendingTransaction.status === 'Crafting Transaction') return <CenterToPageTextSpinner text = 'Crafting Transaction...'/>
+	if (currentPendingTransaction === undefined || currentPendingTransaction.status === 'Simulating') return <CenterToPageTextSpinner text = 'Simulating Transaction...'/>
 	const simulationResults = currentPendingTransaction.simulationResults
 	if (simulationResults.statusCode === 'failed') return <CenterToPageTextSpinner text = 'Failed to simulate. Retrying...'/>
 
@@ -314,7 +320,7 @@ export function ConfirmTransaction() {
 					<div class = 'popup-block-scroll'>
 						<NetworkErrors rpcConnectionStatus = { rpcConnectionStatus }/>
 
-						{ currentPendingTransaction.transactionToSimulate.originalRequestParameters.method === 'eth_sendRawTransaction'
+						{ currentPendingTransaction.originalRequestParameters.method === 'eth_sendRawTransaction'
 							? <DinoSaysNotification
 								text = { `This transaction is signed already. No extra signing required to forward it to ${ simulationResults === undefined ? 'network' : simulationResults.data.simulationState.rpcNetwork.name }.` }
 								close = { () => setPendingTransactionAddedNotification(false)}

--- a/app/ts/types/JsonRpc-types.ts
+++ b/app/ts/types/JsonRpc-types.ts
@@ -416,3 +416,6 @@ export type SupportedEthereumJsonRpcRequestMethods = funtypes.Static<typeof Supp
 export const SupportedEthereumJsonRpcRequestMethods = funtypes.ReadonlyObject({
 	method: funtypes.Union(EthereumJsonRpcRequest.alternatives[0].fields.method, ...EthereumJsonRpcRequest.alternatives.map(x => x.fields.method)),
 })
+
+export type OriginalSendRequestParameters = funtypes.Static<typeof OriginalSendRequestParameters>
+export const OriginalSendRequestParameters = funtypes.Union(SendTransactionParams, SendRawTransactionParams)

--- a/app/ts/types/accessRequest.ts
+++ b/app/ts/types/accessRequest.ts
@@ -98,7 +98,6 @@ export const CraftingTransactionPendingTransaction = funtypes.Intersect(
 	funtypes.ReadonlyObject({ status: funtypes.Literal('Crafting Transaction') })
 )
 
-
 export type WaitingForSimulationPendingTransaction = funtypes.Static<typeof WaitingForSimulationPendingTransaction>
 export const WaitingForSimulationPendingTransaction = funtypes.Intersect(
 	SimulatedPendingTransactionBase,
@@ -107,7 +106,6 @@ export const WaitingForSimulationPendingTransaction = funtypes.Intersect(
 		status: funtypes.Literal('Simulating')
 	})
 )
-
 
 export type PendingTransaction = funtypes.Static<typeof PendingTransaction>
 export const PendingTransaction = funtypes.Union(CraftingTransactionPendingTransaction, WaitingForSimulationPendingTransaction, SimulatedPendingTransaction)

--- a/app/ts/types/visualizer-types.ts
+++ b/app/ts/types/visualizer-types.ts
@@ -3,7 +3,7 @@ import * as funtypes from 'funtypes'
 import { EthereumAddress, EthereumBytes32, EthereumData, EthereumInput, EthereumQuantity, EthereumSignedTransaction, EthereumTimestamp, EthereumUnsignedTransaction, OptionalEthereumAddress } from './wire-types.js'
 import { RenameAddressCallBack } from './user-interface-types.js'
 import { ERROR_INTERCEPTOR_GAS_ESTIMATION_FAILED } from '../utils/constants.js'
-import { EthBalanceChanges, EthSubscribeParams, SendRawTransactionParams, SendTransactionParams, SingleMulticallResponse } from './JsonRpc-types.js'
+import { EthBalanceChanges, EthSubscribeParams, OriginalSendRequestParameters, SendRawTransactionParams, SendTransactionParams, SingleMulticallResponse } from './JsonRpc-types.js'
 import { InterceptedRequest, WebsiteSocket } from '../utils/requests.js'
 import { AddressBookEntry, Erc721Entry, Erc20TokenEntry, Erc1155Entry } from './addressBookTypes.js'
 import { Website } from './websiteAccessTypes.js'
@@ -268,7 +268,7 @@ export type WebsiteCreatedEthereumUnsignedTransaction = funtypes.Static<typeof W
 export const WebsiteCreatedEthereumUnsignedTransaction = funtypes.ReadonlyObject({
 	website: Website,
 	created: EthereumTimestamp,
-	originalRequestParameters: funtypes.Union(SendTransactionParams, SendRawTransactionParams),
+	originalRequestParameters: OriginalSendRequestParameters,
 	transaction: EthereumUnsignedTransaction,
 	error: funtypes.Union(funtypes.Undefined, EstimateGasError.fields.error)
 })

--- a/app/ts/utils/typed-arrays.ts
+++ b/app/ts/utils/typed-arrays.ts
@@ -44,3 +44,10 @@ export function includesWithComparator<T>(array: readonly T[], searchElement: T,
 	}
 	return false
 }
+
+export function replaceElementInReadonlyArray<T>(originalArray: ReadonlyArray<T>, index: number, newValue: T): ReadonlyArray<T> {
+	if (index < 0 || index >= originalArray.length) throw new Error('Index is out of bounds')
+	const newArray = [...originalArray]
+	newArray[index] = newValue
+	return newArray
+}


### PR DESCRIPTION
Open Confirm transaction dialog faster by:
- Not waiting for nonce calculation
- Not waiting for gas limit calculation
- Not waiting for simulation to finish

Update these values after dialog has been opened afterwards