### PR TITLE
Change `log` to `event`.

### DIFF
--- a/app/ts/components/simulationExplaining/customExplainers/CatchAllVisualizer.tsx
+++ b/app/ts/components/simulationExplaining/customExplainers/CatchAllVisualizer.tsx
@@ -179,7 +179,7 @@ export function CatchAllVisualizer(param: TransactionImportanceBlockParams) {
 		&& receivingTokenResults.length === 0
 	) {
 		return <div class = 'notification transaction-importance-box'>
-			<p class = 'paragraph'> { param.simTx.events.length == 0 ? 'The transaction does no visible important changes to your accounts.' : `The transaction does no visible important changes to your accounts, HOWEVER, it produces ${ param.simTx.events.length == 1 ? '1 log' : `${ param.simTx.events.length } logs` }. `}</p>
+			<p class = 'paragraph'> { param.simTx.events.length == 0 ? 'The transaction does no visible important changes to your accounts.' : `The transaction does no visible important changes to your accounts, HOWEVER, it produces ${ param.simTx.events.length } event${ param.simTx.events.length === 1 '' : 's' }.`}</p>
 		</div>
 	}
 

--- a/app/ts/components/simulationExplaining/customExplainers/CatchAllVisualizer.tsx
+++ b/app/ts/components/simulationExplaining/customExplainers/CatchAllVisualizer.tsx
@@ -179,7 +179,7 @@ export function CatchAllVisualizer(param: TransactionImportanceBlockParams) {
 		&& receivingTokenResults.length === 0
 	) {
 		return <div class = 'notification transaction-importance-box'>
-			<p class = 'paragraph'> { param.simTx.events.length == 0 ? 'The transaction does no visible important changes to your accounts.' : `The transaction does no visible important changes to your accounts, HOWEVER, it produces ${ param.simTx.events.length } event${ param.simTx.events.length === 1 '' : 's' }.`}</p>
+			<p class = 'paragraph'> { param.simTx.events.length == 0 ? 'The transaction does no visible important changes to your accounts.' : `The transaction does no visible important changes to your accounts, HOWEVER, it produces ${ param.simTx.events.length } event${ param.simTx.events.length === 1 ? '' : 's' }.`}</p>
 		</div>
 	}
 


### PR DESCRIPTION
Also does a minor refactor for pluralization that I believe makes it a bit more readable.

The main purpose of this change is to fix `log => event`.  If you dislike the refactor I did, I don't mind backing it out.  I was confused when I first read the code due to the ternary, so I figured I would change it to what I *expected* to help the next reader.