### PR TITLE
make sure there's always valid RPC set for simulator

### DIFF
--- a/app/ts/background/background-startup.ts
+++ b/app/ts/background/background-startup.ts
@@ -1,8 +1,8 @@
 import 'webextension-polyfill'
-import { getMakeMeRich, getSettings } from './settings.js'
+import { defaultRpcs, getMakeMeRich, getSettings } from './settings.js'
 import { getPrependTrasactions, handleInterceptedRequest, popupMessageHandler, updateSimulationState } from './background.js'
 import { retrieveWebsiteDetails, updateExtensionBadge, updateExtensionIcon } from './iconHandler.js'
-import { clearTabStates, getSimulationResults, removeTabState, setRpcConnectionStatus, updateTabState } from './storageVariables.js'
+import { clearTabStates, getPrimaryRpcForChain, getSimulationResults, removeTabState, setRpcConnectionStatus, updateTabState } from './storageVariables.js'
 import { setPrependTransactionsQueue } from '../simulation/services/SimulationModeEthereumClientService.js'
 import { Simulator } from '../simulation/simulator.js'
 import { TabConnection, TabState, WebsiteTabConnections } from '../types/user-interface-types.js'
@@ -127,8 +127,9 @@ async function onErrorBlockCallback(ethereumClientService: EthereumClientService
 
 async function startup() {
 	const settings = await getSettings()
-	if (settings.rpcNetwork.httpsRpc === undefined) throw new Error('RPC not set')
-	const simulator = new Simulator(settings.rpcNetwork, newBlockAttemptCallback, onErrorBlockCallback)
+	const userSpecifiedSimulatorNetwork = settings.rpcNetwork.httpsRpc === undefined ? await getPrimaryRpcForChain(1n) : settings.rpcNetwork
+	const simulatorNetwork = userSpecifiedSimulatorNetwork === undefined ? defaultRpcs[0] : userSpecifiedSimulatorNetwork
+	const simulator = new Simulator(simulatorNetwork, newBlockAttemptCallback, onErrorBlockCallback)
 	browser.runtime.onConnect.addListener(port => onContentScriptConnected(simulator, port, websiteTabConnections).catch(console.error))
 	browser.runtime.onMessage.addListener(async function (message: unknown) {
 		await popupMessageHandler(websiteTabConnections, simulator, message, await getSettings())

--- a/app/ts/background/settings.ts
+++ b/app/ts/background/settings.ts
@@ -5,7 +5,7 @@ import { Semaphore } from '../utils/semaphore.js'
 import { EthereumAddress } from '../types/wire-types.js'
 import { ActiveAddressArray, ContactEntries } from '../types/addressBookTypes.js'
 import { WebsiteAccessArray } from '../types/websiteAccessTypes.js'
-import { RpcEntries, RpcNetwork } from '../types/rpc.js'
+import { RpcNetwork } from '../types/rpc.js'
 import { NetworkPrice } from '../types/visualizer-types.js'
 import { browserStorageLocalGet, browserStorageLocalSet } from '../utils/storageUtils.js'
 
@@ -52,7 +52,7 @@ export const networkPriceSources: { [chainId: string]: NetworkPrice } = {
 	}
 } as const
 
-export const defaultRpcs: RpcEntries = [
+export const defaultRpcs = [
 	{
 		name: 'Ethereum Mainnet',
 		chainId: 1n,
@@ -103,7 +103,7 @@ export const defaultRpcs: RpcEntries = [
 		minimized: true,
 		weth: 0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2n,
 	},
-]
+] as const
 
 export async function getSettings() : Promise<Settings> {
 	const results = await browserStorageLocalGet([


### PR DESCRIPTION
If external wallet is in unsupported chain (eg, optimism), and you start interceptor, interceptor tries to use optimism for simulation, but it doesn't have RPC that we can connect. This defaults to mainnet in this situation

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
	- Improved the initialization process for the network simulator to enhance reliability and user experience.
	- Streamlined settings management by updating the data types and constants used for network configurations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->