### PR TITLE
Add timeout to calls so they don't pend forever

### DIFF
--- a/app/ts/simulation/services/EthereumClientService.ts
+++ b/app/ts/simulation/services/EthereumClientService.ts
@@ -77,7 +77,7 @@ export class EthereumClientService {
 		if (this.retrievingBlock) return
 		try {
 			this.retrievingBlock = true
-			const response = await this.requestHandler.jsonRpcRequest({ method: 'eth_getBlockByNumber', params: ['latest', true] }, true)
+			const response = await this.requestHandler.jsonRpcRequest({ method: 'eth_getBlockByNumber', params: ['latest', true] }, true, 6000)
 			if (this.cacheRefreshTimer === undefined) return
 			const newBlock = EthereumBlockHeader.parse(response)
 			console.log(`Current block number: ${ newBlock.number }`)
@@ -86,6 +86,7 @@ export class EthereumClientService {
 			this.newBlockAttemptCallback(newBlock, this, gotNewBlock)
 			this.cachedBlock = newBlock
 		} catch(error) {
+			console.log(`Failed to get a block`)
 			console.warn(error)
 			return this.onErrorBlockCallback(this)
 		} finally {

--- a/app/ts/simulation/services/EthereumJSONRpcRequestHandler.ts
+++ b/app/ts/simulation/services/EthereumJSONRpcRequestHandler.ts
@@ -4,6 +4,7 @@ import { EthereumJsonRpcRequest, JsonRpcResponse } from '../../types/JsonRpc-typ
 import { FetchResponseError, JsonRpcResponseError } from '../../utils/errors.js'
 import { serialize } from '../../types/wire-types.js'
 import { keccak256, toUtf8Bytes } from 'ethers'
+import { fetchWithTimeout } from '../../utils/requests.js'
 
 export type IEthereumJSONRpcRequestHandler = Pick<EthereumJSONRpcRequestHandler, keyof EthereumJSONRpcRequestHandler>
 export class EthereumJSONRpcRequestHandler {
@@ -21,7 +22,7 @@ export class EthereumJSONRpcRequestHandler {
 
 	public readonly clearCache = () => { this.cache = new Map() }
 
-	private queryCached = async (request: EthereumJsonRpcRequest, requestId: number, bypassCache: boolean) => {
+	private queryCached = async (request: EthereumJsonRpcRequest, requestId: number, bypassCache: boolean, timeoutS: number = 60000) => {
 		const serialized = serialize(EthereumJsonRpcRequest, request)
 		assertIsObject(serialized)
 		const payload = {
@@ -37,15 +38,15 @@ export class EthereumJSONRpcRequestHandler {
 				if (cacheValue !== undefined) return cacheValue
 			}
 		}
-		const response = await fetch(this.rpcEntry.httpsRpc, payload)
+		const response = await fetchWithTimeout(this.rpcEntry.httpsRpc, payload, timeoutS)
 		const responseObject = response.ok ? { responseOk: true as const, responseString: await response.json() } : { responseOk: false as const, response }
 		if (this.caching) this.cache.set(hash, responseObject)
 		return responseObject
 	}
 
-	public readonly jsonRpcRequest = async (rpcRequest: EthereumJsonRpcRequest, bypassCache: boolean = false) => {
+	public readonly jsonRpcRequest = async (rpcRequest: EthereumJsonRpcRequest, bypassCache: boolean = false, timeoutS: number = 60000) => {
 		const requestId = ++this.nextRequestId
-		const responseObject = await this.queryCached(rpcRequest, requestId, bypassCache)
+		const responseObject = await this.queryCached(rpcRequest, requestId, bypassCache, timeoutS)
 		if (!responseObject.responseOk) {
 			console.log('req failed')
 			console.log(responseObject.response)
@@ -53,7 +54,12 @@ export class EthereumJSONRpcRequestHandler {
 			throw new FetchResponseError(responseObject.response, requestId)
 		}
 		const jsonRpcResponse = JsonRpcResponse.parse(responseObject.responseString)
-		if ('error' in jsonRpcResponse) throw new JsonRpcResponseError(jsonRpcResponse)
+		if ('error' in jsonRpcResponse) {
+			console.log('req failed')
+			console.log(responseObject)
+			console.log(rpcRequest)
+			throw new JsonRpcResponseError(jsonRpcResponse)
+		}
 		return jsonRpcResponse.result
 	}
 }

--- a/app/ts/simulation/services/EthereumJSONRpcRequestHandler.ts
+++ b/app/ts/simulation/services/EthereumJSONRpcRequestHandler.ts
@@ -22,7 +22,7 @@ export class EthereumJSONRpcRequestHandler {
 
 	public readonly clearCache = () => { this.cache = new Map() }
 
-	private queryCached = async (request: EthereumJsonRpcRequest, requestId: number, bypassCache: boolean, timeoutS: number = 60000) => {
+	private queryCached = async (request: EthereumJsonRpcRequest, requestId: number, bypassCache: boolean, timeoutMs: number = 60000) => {
 		const serialized = serialize(EthereumJsonRpcRequest, request)
 		assertIsObject(serialized)
 		const payload = {
@@ -38,15 +38,15 @@ export class EthereumJSONRpcRequestHandler {
 				if (cacheValue !== undefined) return cacheValue
 			}
 		}
-		const response = await fetchWithTimeout(this.rpcEntry.httpsRpc, payload, timeoutS)
+		const response = await fetchWithTimeout(this.rpcEntry.httpsRpc, payload, timeoutMs)
 		const responseObject = response.ok ? { responseOk: true as const, responseString: await response.json() } : { responseOk: false as const, response }
 		if (this.caching) this.cache.set(hash, responseObject)
 		return responseObject
 	}
 
-	public readonly jsonRpcRequest = async (rpcRequest: EthereumJsonRpcRequest, bypassCache: boolean = false, timeoutS: number = 60000) => {
+	public readonly jsonRpcRequest = async (rpcRequest: EthereumJsonRpcRequest, bypassCache: boolean = false, timeoutMs: number = 60000) => {
 		const requestId = ++this.nextRequestId
-		const responseObject = await this.queryCached(rpcRequest, requestId, bypassCache, timeoutS)
+		const responseObject = await this.queryCached(rpcRequest, requestId, bypassCache, timeoutMs)
 		if (!responseObject.responseOk) {
 			console.log('req failed')
 			console.log(responseObject.response)

--- a/app/ts/utils/requests.ts
+++ b/app/ts/utils/requests.ts
@@ -53,3 +53,11 @@ export const getUniqueRequestIdentifierString = (uniqueRequestIdentifier: Unique
 export const doesUniqueRequestIdentifiersMatch = (a: UniqueRequestIdentifier, b: UniqueRequestIdentifier) => {
 	return a.requestId == b.requestId && a.requestSocket.connectionName === b.requestSocket.connectionName && a.requestSocket.tabId === b.requestSocket.tabId
 }
+
+export async function fetchWithTimeout(resource: RequestInfo | URL, init?: RequestInit | undefined, timeoutS: number = 60000) {
+	const controller = new AbortController()
+	const id = setTimeout(() => controller.abort(), timeoutS)
+	const response = await fetch(resource, { ...init, signal: controller.signal })
+	clearTimeout(id)
+	return response
+}

--- a/app/ts/utils/requests.ts
+++ b/app/ts/utils/requests.ts
@@ -54,9 +54,9 @@ export const doesUniqueRequestIdentifiersMatch = (a: UniqueRequestIdentifier, b:
 	return a.requestId == b.requestId && a.requestSocket.connectionName === b.requestSocket.connectionName && a.requestSocket.tabId === b.requestSocket.tabId
 }
 
-export async function fetchWithTimeout(resource: RequestInfo | URL, init?: RequestInit | undefined, timeoutS: number = 60000) {
+export async function fetchWithTimeout(resource: RequestInfo | URL, init?: RequestInit | undefined, timeoutMs: number = 60000) {
 	const controller = new AbortController()
-	const id = setTimeout(() => controller.abort(), timeoutS)
+	const id = setTimeout(() => controller.abort(), timeoutMs)
 	const response = await fetch(resource, { ...init, signal: controller.signal })
 	clearTimeout(id)
 	return response


### PR DESCRIPTION
this is especially important for retrieving blocks, as interceptor gets stuck in trying to retrieve block while server does not respond

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Search functionality now includes a timeout feature to enhance performance and user experience.
  
- **Enhancements**
  - Improved error logging for failed block retrievals in the Ethereum simulation service.

- **Bug Fixes**
  - Implemented a new fetch request utility with timeout to prevent indefinite waiting during network calls.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->