### PR TITLE
use parent block for eth send transaction base fee, always show simulation clear button

### DIFF
--- a/app/ts/components/pages/Home.tsx
+++ b/app/ts/components/pages/Home.tsx
@@ -351,9 +351,22 @@ export function Home(param: HomeParams) {
 			</div>
 		: <></> }
 
-		{ simulationMode && currentBlockNumber === undefined ? <div style = 'padding: 10px'> <DinoSays text = { 'Not connected to a network' } /> </div> : <></> }
-		{ !simulationMode || activeSimulationAddress === undefined || currentBlockNumber === undefined || simulationAndVisualisationResults?.activeAddress !== activeSimulationAddress.address || simulationAndVisualisationResults.rpcNetwork.httpsRpc !== rpcNetwork.httpsRpc 
-			? <></>
+		{ !simulationMode || activeSimulationAddress === undefined || currentBlockNumber === undefined
+			? <div style = 'display: grid; grid-template-columns: auto auto; padding-left: 10px; padding-right: 10px' >
+				<div class = 'log-cell' style = 'justify-content: left;'>
+					{ simulationMode && currentBlockNumber === undefined ? <div style = 'padding: 10px'> <DinoSays text = { 'Not connected to a network' } /> </div> : <></> }
+				</div>
+				<div class = 'log-cell' style = 'justify-content: right;'>
+					<button className = 'button is-small is-danger' disabled = { false } onClick = { resetSimulation } >
+						<span class = 'icon'>
+							<img src = '../../img/broom.svg'/>
+						</span>
+						<span>
+							Clear
+						</span>
+					</button>
+				</div>
+			</div>
 			: <SimulationResults
 				simulationAndVisualisationResults = { simulationAndVisualisationResults }
 				removeTransaction = { removeTransaction }


### PR DESCRIPTION
- When sending a transaction, we should calculate the baseFeePerGas from current live block, not from the simulated block
- Always show simulation reset button (this is not visible if simulation is calculating, but it should)