### PR TITLE
Move Interceptor sleeping logic away from node to more higher level

### DIFF
--- a/app/ts/background/background.ts
+++ b/app/ts/background/background.ts
@@ -4,7 +4,7 @@ import { Simulator, runProtectorsForTransaction, visualizeTransaction } from '..
 import { getEthDonator, getSimulationResults, getTabState, updateSimulationResults, updateSimulationResultsWithCallBack } from './storageVariables.js'
 import { changeSimulationMode, getSettings, getMakeMeRich } from './settings.js'
 import { blockNumber, call, chainId, estimateGas, gasPrice, getAccounts, getBalance, getBlockByNumber, getCode, getLogs, getPermissions, getSimulationStack, getTransactionByHash, getTransactionCount, getTransactionReceipt, netVersion, personalSign, sendTransaction, subscribe, switchEthereumChain, unsubscribe, web3ClientVersion, getBlockByHash, feeHistory, installNewFilter, uninstallNewFilter, getFilterChanges, getFilterLogs } from './simulationModeHanders.js'
-import { changeActiveAddress, changeMakeMeRich, changePage, resetSimulation, confirmDialog, refreshSimulation, removeTransaction, requestAccountsFromSigner, refreshPopupConfirmTransactionSimulation, confirmPersonalSign, confirmRequestAccess, changeInterceptorAccess, changeChainDialog, popupChangeActiveRpc, enableSimulationMode, addOrModifyAddressBookEntry, getAddressBookData, removeAddressBookEntry, homeOpened, interceptorAccessChangeAddressOrRefresh, refreshPopupConfirmTransactionMetadata, changeSettings, importSettings, exportSettings, setNewRpcList, removeSignedMessage, simulateGovernanceContractExecutionOnPass, openNewTab, settingsOpened, changeAddOrModifyAddressWindowState, popupFetchAbiAndNameFromEtherscan, openWebPage, disableInterceptor, requestNewHomeData } from './popupMessageHandlers.js'
+import { changeActiveAddress, changeMakeMeRich, changePage, resetSimulation, confirmDialog, refreshSimulation, removeTransaction, requestAccountsFromSigner, refreshPopupConfirmTransactionSimulation, confirmPersonalSign, confirmRequestAccess, changeInterceptorAccess, changeChainDialog, popupChangeActiveRpc, enableSimulationMode, addOrModifyAddressBookEntry, getAddressBookData, removeAddressBookEntry, refreshHomeData, interceptorAccessChangeAddressOrRefresh, refreshPopupConfirmTransactionMetadata, changeSettings, importSettings, exportSettings, setNewRpcList, removeSignedMessage, simulateGovernanceContractExecutionOnPass, openNewTab, settingsOpened, changeAddOrModifyAddressWindowState, popupFetchAbiAndNameFromEtherscan, openWebPage, disableInterceptor, requestNewHomeData } from './popupMessageHandlers.js'
 import { ProtectorResults, SimulationState, VisualizedSimulatorState, VisualizerResult, WebsiteCreatedEthereumUnsignedTransaction, WebsiteCreatedEthereumUnsignedTransactionOrFailed } from '../types/visualizer-types.js'
 import { WebsiteTabConnections } from '../types/user-interface-types.js'
 import { askForSignerAccountsFromSignerIfNotAvailable, interceptorAccessMetadataRefresh, requestAccessFromUser, updateInterceptorAccessViewWithPendingRequests } from './windows/interceptorAccess.js'
@@ -36,6 +36,7 @@ import { Interface } from 'ethers'
 import { CompoundGovernanceAbi } from '../utils/abi.js'
 import { dataStringWith0xStart } from '../utils/bigint.js'
 import { connectedToSigner, ethAccountsReply, signerChainChanged, walletSwitchEthereumChainReply } from './providerMessageHandlers.js'
+import { makeSureInterceptorIsNotSleeping } from './sleeping.js'
 
 async function updateMetadataForSimulation(simulationState: SimulationState, ethereum: EthereumClientService, visualizerResults: readonly VisualizerResult[], protectorResults: readonly ProtectorResults[]) {
 	const settingsPromise = getSettings()
@@ -163,7 +164,9 @@ export const updateSimulationMetadata = async (ethereum: EthereumClientService) 
 }
 
 const updateSimulationStateSemaphore = new Semaphore(1)
-export async function updateSimulationState(ethereum: EthereumClientService, getUpdatedSimulationState: (simulationState: SimulationState | undefined) => Promise<SimulationState | undefined>, activeAddress: bigint | undefined, invalidateOldState: boolean) {
+
+export async function updateSimulationState(ethereum: EthereumClientService, getUpdatedSimulationState: (simulationState: SimulationState | undefined) => Promise<SimulationState | undefined>, activeAddress: bigint | undefined, invalidateOldState: boolean, onlyIfNotAlreadyUpdating: boolean = false) {
+	if (onlyIfNotAlreadyUpdating && updateSimulationStateSemaphore.getPermits() == 0) return
 	return await updateSimulationStateSemaphore.execute(async () => {
 		const simulationResults = await getSimulationResults()
 		const simulationId = simulationResults.simulationId + 1
@@ -218,6 +221,7 @@ export async function refreshConfirmTransactionSimulation(
 	uniqueRequestIdentifier: UniqueRequestIdentifier,
 	transactionToSimulate: WebsiteCreatedEthereumUnsignedTransactionOrFailed,
 ): Promise<ConfirmTransactionTransactionSingleVisualization> {
+	makeSureInterceptorIsNotSleeping(ethereumClientService)
 	const info = {
 		uniqueRequestIdentifier,
 		transactionToSimulate,
@@ -294,7 +298,6 @@ export async function getPrependTransactions(ethereumClientService: EthereumClie
 		transactionIdentifier: 0n,
 	}]
 }
-
 async function handleRPCRequest(
 	simulator: Simulator,
 	simulationState: SimulationState | undefined,
@@ -329,6 +332,7 @@ async function handleRPCRequest(
 		}
 	}
 	const parsedRequest = maybeParsedRequest.value
+	makeSureInterceptorIsNotSleeping(ethereumClientService)
 	switch (parsedRequest.method) {
 		case 'eth_getBlockByHash': return await getBlockByHash(ethereumClientService, simulationState, parsedRequest)
 		case 'eth_getBlockByNumber': return await getBlockByNumber(ethereumClientService, simulationState, parsedRequest)
@@ -608,7 +612,7 @@ export async function popupMessageHandler(
 		case 'popup_resetSimulation': return await resetSimulation(simulator, settings)
 		case 'popup_removeTransaction': return await removeTransaction(simulator, simulator.ethereum, parsedRequest, settings)
 		case 'popup_removeSignedMessage': return await removeSignedMessage(simulator, simulator.ethereum, parsedRequest, settings)
-		case 'popup_refreshSimulation': return await refreshSimulation(simulator, settings)
+		case 'popup_refreshSimulation': return await refreshSimulation(simulator, settings, false)
 		case 'popup_refreshConfirmTransactionDialogSimulation': return await refreshPopupConfirmTransactionSimulation(simulator, simulator.ethereum)
 		case 'popup_refreshConfirmTransactionMetadata': return refreshPopupConfirmTransactionMetadata(simulator.ethereum, parsedRequest)
 		case 'popup_personalSignApproval': return await confirmPersonalSign(simulator, websiteTabConnections, parsedRequest)
@@ -624,9 +628,9 @@ export async function popupMessageHandler(
 		case 'popup_personalSignReadyAndListening': return await updatePendingPersonalSignViewWithPendingRequests(simulator.ethereum)
 		case 'popup_changeChainReadyAndListening': return await updateChainChangeViewWithPendingRequest()
 		case 'popup_interceptorAccessReadyAndListening': return await updateInterceptorAccessViewWithPendingRequests()
-		case 'popup_confirmTransactionReadyAndListening': return await updateConfirmTransactionViewWithPendingTransaction()
+		case 'popup_confirmTransactionReadyAndListening': return await updateConfirmTransactionViewWithPendingTransaction(simulator.ethereum)
 		case 'popup_requestNewHomeData': return await requestNewHomeData(simulator)
-		case 'popup_homeOpened': return await homeOpened(simulator)
+		case 'popup_refreshHomeData': return await refreshHomeData(simulator)
 		case 'popup_settingsOpened': return await settingsOpened()
 		case 'popup_refreshInterceptorAccessMetadata': return await interceptorAccessMetadataRefresh()
 		case 'popup_interceptorAccessChangeAddress': return await interceptorAccessChangeAddressOrRefresh(websiteTabConnections, parsedRequest)

--- a/app/ts/background/background.ts
+++ b/app/ts/background/background.ts
@@ -221,7 +221,6 @@ export async function refreshConfirmTransactionSimulation(
 	uniqueRequestIdentifier: UniqueRequestIdentifier,
 	transactionToSimulate: WebsiteCreatedEthereumUnsignedTransactionOrFailed,
 ): Promise<ConfirmTransactionTransactionSingleVisualization> {
-	makeSureInterceptorIsNotSleeping(ethereumClientService)
 	const info = {
 		uniqueRequestIdentifier,
 		transactionToSimulate,

--- a/app/ts/background/sleeping.ts
+++ b/app/ts/background/sleeping.ts
@@ -1,0 +1,19 @@
+import { EthereumClientService } from "../simulation/services/EthereumClientService.js"
+import { TIME_BETWEEN_BLOCKS } from "../utils/constants.js"
+import { getInterceptorStartSleepingTimestamp, setInterceptorStartSleepingTimestamp } from "./storageVariables.js"
+
+export const makeSureInterceptorIsNotSleeping = (ethereumClientService: EthereumClientService) => {
+	setInterceptorStartSleepingTimestamp(Date.now() + TIME_BETWEEN_BLOCKS * 2 * 1000)
+	if (!ethereumClientService.isBlockPolling()) {
+		console.log('The Interceptor woke up! ⏰')
+		ethereumClientService.setBlockPolling(true)
+	}
+}
+
+export const checkIfInterceptorShouldSleep = async (ethereumClientService: EthereumClientService) => {
+	const startSleping = await getInterceptorStartSleepingTimestamp()
+	if (startSleping < Date.now() && ethereumClientService.isBlockPolling()) {
+		console.log('The Interceptor started to sleep 😴')
+		ethereumClientService.setBlockPolling(false)
+	}
+}

--- a/app/ts/background/sleeping.ts
+++ b/app/ts/background/sleeping.ts
@@ -1,6 +1,7 @@
 import { EthereumClientService } from "../simulation/services/EthereumClientService.js"
 import { TIME_BETWEEN_BLOCKS } from "../utils/constants.js"
 import { getInterceptorStartSleepingTimestamp, setInterceptorStartSleepingTimestamp } from "./storageVariables.js"
+import { isConfirmTransactionFocused } from "./windows/confirmTransaction.js"
 
 export const makeSureInterceptorIsNotSleeping = (ethereumClientService: EthereumClientService) => {
 	setInterceptorStartSleepingTimestamp(Date.now() + TIME_BETWEEN_BLOCKS * 2 * 1000)
@@ -10,7 +11,12 @@ export const makeSureInterceptorIsNotSleeping = (ethereumClientService: Ethereum
 	}
 }
 
+const checkConfirmTransaction = async (ethereumClientService: EthereumClientService) => {
+	if (await isConfirmTransactionFocused()) makeSureInterceptorIsNotSleeping(ethereumClientService)
+}
+
 export const checkIfInterceptorShouldSleep = async (ethereumClientService: EthereumClientService) => {
+	checkConfirmTransaction(ethereumClientService)
 	const startSleping = await getInterceptorStartSleepingTimestamp()
 	if (startSleping < Date.now() && ethereumClientService.isBlockPolling()) {
 		console.log('The Interceptor started to sleep 😴')

--- a/app/ts/background/storageVariables.ts
+++ b/app/ts/background/storageVariables.ts
@@ -215,6 +215,10 @@ export async function getRpcList() {
 	}
 }
 
+export const setInterceptorStartSleepingTimestamp = async(interceptorStartSleepingTimestamp: number) => await browserStorageLocalSet({ interceptorStartSleepingTimestamp })
+
+export const getInterceptorStartSleepingTimestamp = async () => (await browserStorageLocalGet('interceptorStartSleepingTimestamp'))?.['interceptorStartSleepingTimestamp'] ?? 0
+
 export const getPrimaryRpcForChain = async (chainId: bigint) => {
 	const rpcs = await getRpcList()
 	return rpcs.find((rpc) => rpc.chainId === chainId && rpc.primary)

--- a/app/ts/background/windows/changeChain.ts
+++ b/app/ts/background/windows/changeChain.ts
@@ -33,7 +33,7 @@ export async function resolveChainChange(simulator: Simulator, websiteTabConnect
 	if (data === undefined || !doesUniqueRequestIdentifiersMatch(confirmation.data.uniqueRequestIdentifier, data.request.uniqueRequestIdentifier)) throw new Error('Unique request identifier mismatch in change chain')
 	const resolved = await resolve(simulator, websiteTabConnections, confirmation, data.simulationMode)
 	replyToInterceptedRequest(websiteTabConnections, { method: 'wallet_switchEthereumChain' as const, ...resolved, uniqueRequestIdentifier: data.request.uniqueRequestIdentifier })
-	if (openedDialog) await closePopupOrTabById(openedDialog.popupOrTab)
+	if (openedDialog) await closePopupOrTabById(openedDialog)
 	openedDialog = undefined
 }
 
@@ -73,7 +73,7 @@ export const openChangeChainDialog = async (
 	pendForUserReply = new Future<ChainChangeConfirmation>()
 
 	const onCloseWindowOrTab = async (popupOrTab: PopupOrTabId) => { // check if user has closed the window on their own, if so, reject signature
-		if (openedDialog === undefined || openedDialog.popupOrTab.id !== popupOrTab.id || openedDialog.popupOrTab.type !== popupOrTab.type) return
+		if (openedDialog === undefined || openedDialog.id !== popupOrTab.id || openedDialog.type !== popupOrTab.type) return
 		openedDialog = undefined
 		if (pendForUserReply === undefined) return
 		resolveChainChange(simulator, websiteTabConnections, rejectMessage(await getRpcNetworkForChain(params.params[0].chainId), request.uniqueRequestIdentifier))
@@ -103,7 +103,7 @@ export const openChangeChainDialog = async (
 
 			await setChainChangeConfirmationPromise({
 				website: website,
-				popupOrTabId: openedDialog.popupOrTab,
+				popupOrTabId: openedDialog,
 				request: request,
 				simulationMode: simulationMode,
 				rpcNetwork: await getRpcNetworkForChain(params.params[0].chainId),
@@ -121,7 +121,7 @@ export const openChangeChainDialog = async (
 	} finally {
 		removeWindowTabListeners(onCloseWindow, onCloseTab)
 		pendForUserReply = undefined
-		if (openedDialog) await closePopupOrTabById(openedDialog.popupOrTab)
+		if (openedDialog) await closePopupOrTabById(openedDialog)
 		openedDialog = undefined
 	}
 }

--- a/app/ts/background/windows/confirmTransaction.ts
+++ b/app/ts/background/windows/confirmTransaction.ts
@@ -41,6 +41,16 @@ export async function updateConfirmTransactionViewWithPendingTransactionOrClose(
 	openedDialog = undefined
 }
 
+export const isConfirmTransactionFocused = async () => {
+	if (openedDialog === undefined) return false
+	const pendingTransactions = await getPendingTransactions()
+	if (pendingTransactions[0] === undefined) return false
+	const popup = await getPopupOrTabOnlyById(pendingTransactions[0].popupOrTabId)
+	if (popup === undefined) return false
+	if (popup.type === 'popup') return popup.window.focused
+	return popup.tab.active
+}
+
 export async function resolvePendingTransaction(simulator: Simulator, websiteTabConnections: WebsiteTabConnections, confirmation: TransactionConfirmation) {
 	const pending = pendingTransactions.get(getUniqueRequestIdentifierString(confirmation.data.uniqueRequestIdentifier))
 	const pendingTransaction = await removePendingTransaction(confirmation.data.uniqueRequestIdentifier)

--- a/app/ts/background/windows/confirmTransaction.ts
+++ b/app/ts/background/windows/confirmTransaction.ts
@@ -25,25 +25,26 @@ let openedDialog: PopupOrTab | undefined = undefined
 let pendingTransactions = new Map<string, Future<Confirmation>>()
 const pendingConfirmationSemaphore = new Semaphore(1)
 
-export async function updateConfirmTransactionViewWithPendingTransaction() {
+export async function updateConfirmTransactionViewWithPendingTransaction(ethereumClientService: EthereumClientService) {
 	const promises = await getPendingTransactions()
 	if (promises.length > 0) {
-		await sendPopupMessageToOpenWindows({ method: 'popup_update_confirm_transaction_dialog', data: promises })
+		const currentBlockNumberPromise = ethereumClientService.getBlockNumber()
+		await sendPopupMessageToOpenWindows({ method: 'popup_update_confirm_transaction_dialog', data: { pendingTransactions: promises, currentBlockNumber: await currentBlockNumberPromise }})
 		return true
 	}
 	return false
 }
 
-export async function updateConfirmTransactionViewWithPendingTransactionOrClose() {
-	if (await updateConfirmTransactionViewWithPendingTransaction() === true) return
-	if (openedDialog) await closePopupOrTabById(openedDialog.popupOrTab)
+export async function updateConfirmTransactionViewWithPendingTransactionOrClose(ethereumClientService: EthereumClientService) {
+	if (await updateConfirmTransactionViewWithPendingTransaction(ethereumClientService) === true) return
+	if (openedDialog) await closePopupOrTabById(openedDialog)
 	openedDialog = undefined
 }
 
 export async function resolvePendingTransaction(simulator: Simulator, websiteTabConnections: WebsiteTabConnections, confirmation: TransactionConfirmation) {
 	const pending = pendingTransactions.get(getUniqueRequestIdentifierString(confirmation.data.uniqueRequestIdentifier))
 	const pendingTransaction = await removePendingTransaction(confirmation.data.uniqueRequestIdentifier)
-	await updateConfirmTransactionViewWithPendingTransactionOrClose()
+	await updateConfirmTransactionViewWithPendingTransactionOrClose(simulator.ethereum)
 	if (pendingTransaction === undefined) return
 	if (pending) {
 		return pending.resolve(confirmation)
@@ -56,7 +57,7 @@ export async function resolvePendingTransaction(simulator: Simulator, websiteTab
 }
 
 const onCloseWindowOrTab = async (popupOrTabs: PopupOrTabId) => { // check if user has closed the window on their own, if so, reject all signatures
-	if (openedDialog === undefined || openedDialog.popupOrTab.id !== popupOrTabs.id || openedDialog.popupOrTab.type !== popupOrTabs.type) return
+	if (openedDialog === undefined || openedDialog.id !== popupOrTabs.id || openedDialog.type !== popupOrTabs.type) return
 	openedDialog = undefined
 	await clearPendingTransactions()
 	pendingTransactions.forEach((pending) => pending.resolve('NoResponse'))
@@ -187,11 +188,11 @@ export async function openConfirmTransactionDialog(
 				return await openPopupOrTab({ url: getHtmlFile('confirmTransaction'), type: 'popup', height: 800, width: 600 })
 			}
 			if (!justAddToPending || openedDialog === undefined) openedDialog = await openDialog()
-			else { await tryFocusingTabOrWindow(openedDialog.popupOrTab) }
+			else { await tryFocusingTabOrWindow(openedDialog) }
 
 			if (openedDialog === undefined) return false
 			const pendingTransaction = {
-				popupOrTabId: openedDialog.popupOrTab,
+				popupOrTabId: openedDialog,
 				originalRequestParameters: transactionParams,
 				uniqueRequestIdentifier: request.uniqueRequestIdentifier,
 				simulationMode,
@@ -202,9 +203,9 @@ export async function openConfirmTransactionDialog(
 				website,
 			}
 			await appendPendingTransaction(pendingTransaction)
-			if (justAddToPending) await sendPopupMessageToOpenWindows({ method: 'popup_confirm_transaction_dialog_pending_changed', data: await getPendingTransactions() })
+			if (justAddToPending) await sendPopupMessageToOpenWindows({ method: 'popup_confirm_transaction_dialog_pending_changed', data: { pendingTransactions: await getPendingTransactions() } })
 				
-			await updateConfirmTransactionViewWithPendingTransaction()
+			await updateConfirmTransactionViewWithPendingTransaction(ethereumClientService)
 
 			const transactionToSimulate = await transactionToSimulatePromise
 			if (transactionToSimulate.success === false) {
@@ -214,11 +215,11 @@ export async function openConfirmTransactionDialog(
 					simulationResults: await refreshConfirmTransactionSimulation(simulator, ethereumClientService, activeAddress, simulationMode, request.uniqueRequestIdentifier, transactionToSimulate),
 					status: 'FailedToSimulate' as const,
 				})
-				await updateConfirmTransactionViewWithPendingTransaction()
+				await updateConfirmTransactionViewWithPendingTransaction(ethereumClientService)
 				return false
 			} else {
 				await replacePendingTransaction({ ...pendingTransaction, transactionToSimulate: transactionToSimulate, status: 'Simulating' as const })
-				await updateConfirmTransactionViewWithPendingTransaction()
+				await updateConfirmTransactionViewWithPendingTransaction(ethereumClientService)
 
 				const simulatedTx = await replacePendingTransaction({
 					...pendingTransaction,
@@ -226,7 +227,7 @@ export async function openConfirmTransactionDialog(
 					simulationResults: await refreshConfirmTransactionSimulation(simulator, ethereumClientService, activeAddress, simulationMode, request.uniqueRequestIdentifier, transactionToSimulate),
 					status: 'Simulated' as const,
 				})
-				await updateConfirmTransactionViewWithPendingTransaction()
+				await updateConfirmTransactionViewWithPendingTransaction(ethereumClientService)
 				return simulatedTx !== undefined
 			}
 		})
@@ -239,7 +240,7 @@ export async function openConfirmTransactionDialog(
 	} finally {
 		removeWindowTabListeners(onCloseWindow, onCloseTab)
 		pendingTransactions.delete(uniqueRequestIdentifier)
-		await updateConfirmTransactionViewWithPendingTransactionOrClose()
+		await updateConfirmTransactionViewWithPendingTransactionOrClose(ethereumClientService)
 	}
 }
 

--- a/app/ts/background/windows/interceptorAccess.ts
+++ b/app/ts/background/windows/interceptorAccess.ts
@@ -28,7 +28,7 @@ let openedDialog: OpenedDialogWithListeners = undefined
 const pendingInterceptorAccessSemaphore = new Semaphore(1)
 
 const onCloseWindowOrTab = async (simulator: Simulator, popupOrTabs: PopupOrTabId, websiteTabConnections: WebsiteTabConnections) => { // check if user has closed the window on their own, if so, reject signature
-	if (openedDialog === undefined || openedDialog.popupOrTab.popupOrTab.id !== popupOrTabs.id || openedDialog.popupOrTab.popupOrTab.type !== popupOrTabs.type) return
+	if (openedDialog === undefined || openedDialog.popupOrTab.id !== popupOrTabs.id || openedDialog.popupOrTab.type !== popupOrTabs.type) return
 	removeWindowTabListeners(openedDialog.onClosePopup, openedDialog.onCloseTab)
 
 	openedDialog = undefined
@@ -147,7 +147,7 @@ export async function requestAccessFromUser(
 			}
 			if (openedDialog) {
 				removeWindowTabListeners(onCloseWindowCallback, onCloseTabCallback)
-				await closePopupOrTabById(openedDialog.popupOrTab.popupOrTab)
+				await closePopupOrTabById(openedDialog.popupOrTab)
 			}
 			openedDialog = { popupOrTab, onClosePopup: onCloseWindowCallback, onCloseTab: onCloseTabCallback,  }
 		}
@@ -158,7 +158,7 @@ export async function requestAccessFromUser(
 		}
 		const accessRequestId =  `${ accessAddress?.address } || ${ website.websiteOrigin }`
 		const pendingRequest = {
-			popupOrTabId: openedDialog.popupOrTab.popupOrTab,
+			popupOrTabId: openedDialog.popupOrTab,
 			socket,
 			request,
 			accessRequestId,
@@ -208,7 +208,7 @@ export async function requestAccessFromUser(
 					pendingAccessRequests: pendingRequests.current,
 				}
 			})
-			if (openedDialog !== undefined) await tryFocusingTabOrWindow(openedDialog.popupOrTab.popupOrTab)
+			if (openedDialog !== undefined) await tryFocusingTabOrWindow(openedDialog.popupOrTab)
 			return 
 		}
 		pendingAccessRequests.resolve(pendingRequests.current)
@@ -244,7 +244,7 @@ async function resolve(simulator: Simulator, websiteTabConnections: WebsiteTabCo
 
 	if (openedDialog) {
 		removeWindowTabListeners(openedDialog.onClosePopup, openedDialog.onCloseTab)
-		await closePopupOrTabById(openedDialog.popupOrTab.popupOrTab)
+		await closePopupOrTabById(openedDialog.popupOrTab)
 		openedDialog = undefined
 	}
 	const affectedEntryWithPendingRequest = pendingRequests.previous.filter((pending): pending is PendingAccessRequest & { request: InterceptedRequest } => isAffectedEntry(pending) && pending.request !== undefined)

--- a/app/ts/background/windows/personalSign.ts
+++ b/app/ts/background/windows/personalSign.ts
@@ -37,7 +37,7 @@ export async function resolvePersonalSign(simulator: Simulator, websiteTabConnec
 		const resolved = await resolve(simulator, confirmation, data.signedMessageTransaction)
 		replyToInterceptedRequest(websiteTabConnections, { ...data.signedMessageTransaction.originalRequestParameters, ...resolved, uniqueRequestIdentifier: confirmation.data.uniqueRequestIdentifier })
 	}
-	if (openedDialog) await closePopupOrTabById(openedDialog.popupOrTab)
+	if (openedDialog) await closePopupOrTabById(openedDialog)
 	openedDialog = undefined
 }
 
@@ -226,7 +226,7 @@ export const openPersonalSignDialog = async (
 ) => {
 
 	const onCloseWindowOrTab = async (popupOrTabs: PopupOrTabId) => {
-		if (openedDialog === undefined || openedDialog.popupOrTab.id !== popupOrTabs.id || openedDialog.popupOrTab.type !== popupOrTabs.type) return
+		if (openedDialog === undefined || openedDialog.id !== popupOrTabs.id || openedDialog.type !== popupOrTabs.type) return
 		if (pendingPersonalSign === undefined) return
 		openedDialog = undefined
 		return await resolvePersonalSign(simulator, websiteTabConnections, rejectMessage(request.uniqueRequestIdentifier))
@@ -265,7 +265,7 @@ export const openPersonalSignDialog = async (
 			addWindowTabListeners(onCloseWindow, onCloseTab)
 
 			await setPendingPersonalSignPromise({
-				popupOrTabId: openedDialog.popupOrTab,
+				popupOrTabId: openedDialog,
 				signedMessageTransaction,
 			})
 			await updatePendingPersonalSignViewWithPendingRequests(simulator.ethereum)

--- a/app/ts/components/pages/ConfirmTransaction.tsx
+++ b/app/ts/components/pages/ConfirmTransaction.tsx
@@ -283,8 +283,8 @@ export function ConfirmTransaction() {
 	const [unexpectedError, setUnexpectedError] = useState<string | undefined>(undefined)
 
 	const updatePendingTransactions = (message: ConfirmTransactionDialogPendingChanged | UpdateConfirmTransactionDialog) => {
-		setPendingTransactions(message.data)
-		const firstMessage = message.data[0]
+		setPendingTransactions(message.data.pendingTransactions)
+		const firstMessage = message.data.pendingTransactions[0]
 		if (firstMessage === undefined) throw new Error('message data was undefined')
 		setCurrentPendingTransaction(firstMessage)
 		if (firstMessage.status === 'Simulated' && firstMessage.simulationResults !== undefined && firstMessage.simulationResults.statusCode === 'success' && (currentBlockNumber === undefined || firstMessage.simulationResults.data.simulationState.blockNumber > currentBlockNumber)) {
@@ -323,6 +323,7 @@ export function ConfirmTransaction() {
 				return
 			}
 			if (parsed.method !== 'popup_update_confirm_transaction_dialog') return
+			setCurrentBlockNumber(parsed.data.currentBlockNumber)
 			return updatePendingTransactions(parsed)
 		}
 		browser.runtime.onMessage.addListener(popupMessageListener)

--- a/app/ts/components/simulationExplaining/SimulationSummary.tsx
+++ b/app/ts/components/simulationExplaining/SimulationSummary.tsx
@@ -688,7 +688,7 @@ export function SimulatedInBlockNumber({ simulationBlockNumber, currentBlockNumb
 		<p style = 'color: var(--subtitle-text-color); text-align: right; display: inline'>
 			{ 'Simulated ' }
 			<span style = { `font-weight: bold; font-family: monospace; color: ${
-				simulationBlockNumber === currentBlockNumber && rpcConnectionStatus?.isConnected ? 'var(--positive-color)' :
+				simulationBlockNumber === currentBlockNumber && (rpcConnectionStatus?.isConnected || rpcConnectionStatus === undefined) ? 'var(--positive-color)' :
 				currentBlockNumber !== undefined && simulationBlockNumber + 1n === currentBlockNumber ? 'var(--warning-color)' : 'var(--negative-color)'
 			} ` }>
 				<SomeTimeAgo priorTimestamp = { simulationConductedTimestamp }/>

--- a/app/ts/components/ui-utils.tsx
+++ b/app/ts/components/ui-utils.tsx
@@ -82,22 +82,24 @@ export function humanReadableDateFromSeconds(timeInSeconds: bigint) {
 }
 
 export type PopupOrTab = {
-	browserObject: browser.windows.Window,
-	popupOrTab: { type: 'popup',  id: number }
+	window: browser.windows.Window,
+	type: 'popup'
+	id: number 
 } | {
-	browserObject: browser.tabs.Tab,
-	popupOrTab: { type: 'tab',  id: number }
+	tab: browser.tabs.Tab,
+	type: 'tab'
+	id: number
 }
 
 export async function openPopupOrTab(createData: browser.windows._CreateCreateData & { url: string }) : Promise<PopupOrTab | undefined> {
 	if (await getUseTabsInsteadOfPopup()) {
 		const tab = await browser.tabs.create({ url: createData.url })
 		if (tab === undefined || tab === null || tab.id === undefined) return undefined
-		return { popupOrTab: { type: 'tab', id: tab.id }, browserObject: tab }
+		return { type: 'tab', id: tab.id, tab }
 	}
 	const window = await browser.windows.create(createData)
 	if (window === undefined || window === null || window.id === undefined) return undefined
-	return { popupOrTab: { type: 'popup', id: window.id }, browserObject: window }
+	return { type: 'popup', id: window.id, window }
 }
 
 export async function browserTabsQueryById(id: number) {
@@ -110,7 +112,7 @@ export async function getPopupOrTabById(popupOrTabId: PopupOrTabId) : Promise<Po
 			try {
 				const tab = await browserTabsQueryById(popupOrTabId.id)
 				if (tab === undefined || tab.id === undefined) return undefined
-				return { popupOrTab: { type: 'tab', id: tab.id }, browserObject: tab }
+				return { type: 'tab', id: tab.id, tab }
 			} catch(e) {
 				return undefined
 			}
@@ -119,7 +121,7 @@ export async function getPopupOrTabById(popupOrTabId: PopupOrTabId) : Promise<Po
 			try {
 				const window = await browser.windows.get(popupOrTabId.id)
 				if (window === undefined || window === null || window.id === undefined) return undefined
-				return { popupOrTab: { type: 'popup', id: window.id }, browserObject: window }
+				return { type: 'popup', id: window.id, window }
 			} catch(e) {
 				return undefined
 			}
@@ -133,7 +135,7 @@ export async function getPopupOrTabOnlyById(popupOrTab: PopupOrTabId) : Promise<
 		case 'tab': {
 			try {
 				const tab = await browserTabsQueryById(popupOrTab.id)
-				if (tab !== undefined) return { popupOrTab: { type: 'tab', id: popupOrTab.id }, browserObject: tab }
+				if (tab !== undefined) return { type: 'tab', id: popupOrTab.id, tab }
 			} catch(e) {
 				console.log('Failed to focus tab:', popupOrTab.id)
 				console.warn(e)
@@ -144,7 +146,7 @@ export async function getPopupOrTabOnlyById(popupOrTab: PopupOrTabId) : Promise<
 			try {
 				const window = await browser.windows.get(popupOrTab.id)
 				if (window === undefined || window === null) return undefined
-				return { popupOrTab: { type: 'popup', id: popupOrTab.id }, browserObject: window }
+				return { type: 'popup', id: popupOrTab.id, window }
 			} catch(e) {
 				console.log('Failed to focus poup:', popupOrTab.id)
 				console.warn(e)

--- a/app/ts/types/interceptor-messages.ts
+++ b/app/ts/types/interceptor-messages.ts
@@ -432,13 +432,18 @@ export const RefreshConfirmTransactionDialogSimulation = funtypes.ReadonlyObject
 export type UpdateConfirmTransactionDialog = funtypes.Static<typeof UpdateConfirmTransactionDialog>
 export const UpdateConfirmTransactionDialog = funtypes.ReadonlyObject({
 	method: funtypes.Literal('popup_update_confirm_transaction_dialog'),
-	data: funtypes.ReadonlyArray(PendingTransaction),
+	data: funtypes.ReadonlyObject({
+		pendingTransactions: funtypes.ReadonlyArray(PendingTransaction),
+		currentBlockNumber: EthereumQuantity,
+	})
 }).asReadonly()
 
 export type ConfirmTransactionDialogPendingChanged = funtypes.Static<typeof ConfirmTransactionDialogPendingChanged>
 export const ConfirmTransactionDialogPendingChanged = funtypes.ReadonlyObject({
 	method: funtypes.Literal('popup_confirm_transaction_dialog_pending_changed'),
-	data: funtypes.ReadonlyArray(PendingTransaction),
+	data: funtypes.ReadonlyObject({
+		pendingTransactions: funtypes.ReadonlyArray(PendingTransaction),
+	})
 }).asReadonly()
 
 export type InterceptorAccessReply = funtypes.Static<typeof InterceptorAccessReply>
@@ -772,7 +777,7 @@ export const PopupMessage = funtypes.Union(
 	funtypes.ReadonlyObject({ method: funtypes.Literal('popup_interceptorAccessReadyAndListening') }),
 	funtypes.ReadonlyObject({ method: funtypes.Literal('popup_confirmTransactionReadyAndListening') }),
 	funtypes.ReadonlyObject({ method: funtypes.Literal('popup_requestNewHomeData') }),
-	funtypes.ReadonlyObject({ method: funtypes.Literal('popup_homeOpened') }),
+	funtypes.ReadonlyObject({ method: funtypes.Literal('popup_refreshHomeData') }),
 	funtypes.ReadonlyObject({ method: funtypes.Literal('popup_openSettings') }),
 	funtypes.ReadonlyObject({ method: funtypes.Literal('popup_import_settings'), data: funtypes.ReadonlyObject({ fileContents: funtypes.String }) }),
 	funtypes.ReadonlyObject({ method: funtypes.Literal('popup_get_export_settings') }),

--- a/app/ts/utils/storageUtils.ts
+++ b/app/ts/utils/storageUtils.ts
@@ -48,6 +48,7 @@ export const LocalStorageItems = funtypes.ReadonlyPartial({
 	userAddressBookEntries: AddressBookEntries,
 	idsOfOpenedTabs: IdsOfOpenedTabs,
 	interceptorDisabled: funtypes.Boolean,
+	interceptorStartSleepingTimestamp: funtypes.Number,
 })
 
 export type LocalStorageKey = funtypes.Static<typeof LocalStorageKey>
@@ -76,7 +77,7 @@ export const LocalStorageKey = funtypes.Union(
 	funtypes.Literal('metamaskCompatibilityMode'),
 	funtypes.Literal('userAddressBookEntries'),
 	funtypes.Literal('idsOfOpenedTabs'),
-	funtypes.Literal('interceptorDisabled'),
+	funtypes.Literal('interceptorStartSleepingTimestamp'),
 )
 
 export async function browserStorageLocalGet(keys: LocalStorageKey | LocalStorageKey[]): Promise<LocalStorageItems> {

--- a/test/tests/nethermindComparison.ts
+++ b/test/tests/nethermindComparison.ts
@@ -24,6 +24,7 @@ class MockEthereumJSONRpcRequestHandler {
 
 	public readonly jsonRpcRequest = async (rpcRequest: EthereumJsonRpcRequest) => {
 		switch (rpcRequest.method) {
+			case 'eth_blockNumber': return `0x${ 8443561n.toString(16) }`
 			case 'eth_getBlockByNumber': {
 				if (rpcRequest.params[0] !== 8443561n && rpcRequest.params[0] !== 'latest') throw new Error('Unsupported block number')
 				if (rpcRequest.params[1] === true) return parseRequest(eth_getBlockByNumber_goerli_8443561_true)
@@ -34,8 +35,9 @@ class MockEthereumJSONRpcRequestHandler {
 				if (rpcRequest.params[0] === 0xe10c2a85168046080235fff99e2e14ef1e90c8cf5e9d675f2ca214e49e555e0fn) {
 					return parseRequest(eth_transactionByhash0xe10c2a85168046080235fff99e2e14ef1e90c8cf5e9d675f2ca214e49e555e0f)
 				}
-				throw new Error(`unsupprted Hash`)
+				throw new Error(`unsupported Hash`)
 			}
+			default: new Error(`unsupported method ${ rpcRequest.method }`)
 		}
 		return
 	}


### PR DESCRIPTION
Now when dapp makes rpc request, we will start a timer that interceptor goes to sleep in 24 secs, unless again a new rpc query comes and again restart this timer.

Also keeping home page open refreshes the timer as well as confirm transaction view (if focused)