### PR TITLE
Refactor confirm transaction

### DIFF
--- a/app/ts/background/background-startup.ts
+++ b/app/ts/background/background-startup.ts
@@ -19,6 +19,8 @@ import { ActiveAddress, AddressBookEntries } from '../types/addressBookTypes.js'
 import { getUniqueItemsByProperties } from '../utils/typed-arrays.js'
 import { updateContentScriptInjectionStrategyManifestV2 } from '../utils/contentScriptsUpdating.js'
 import { checkIfInterceptorShouldSleep } from './sleeping.js'
+import { addWindowTabListeners } from '../components/ui-utils.js'
+import { onCloseWindowOrTab } from './windows/confirmTransaction.js'
 
 const websiteTabConnections = new Map<number, TabConnection>()
 
@@ -189,6 +191,10 @@ async function startup() {
 	setInterval(async () => checkIfInterceptorShouldSleep(simulator.ethereum), 1000 )
 
 	await updateExtensionBadge()
+
+	const onCloseWindow = (id: number) => onCloseWindowOrTab({ type: 'popup' as const, id }, simulator, websiteTabConnections)
+	const onCloseTab = (id: number) => onCloseWindowOrTab({ type: 'tab' as const, id }, simulator, websiteTabConnections)
+	addWindowTabListeners(onCloseWindow, onCloseTab)
 }
 
 startup()

--- a/app/ts/background/background.ts
+++ b/app/ts/background/background.ts
@@ -376,7 +376,7 @@ async function handleRPCRequest(
 		case 'eth_sendRawTransaction':
 		case 'eth_sendTransaction': {
 			if (forwardToSigner && settings.currentRpcNetwork.httpsRpc === undefined) return getForwardingMessage(parsedRequest)
-			return await sendTransaction(simulator, activeAddress, ethereumClientService, parsedRequest, request, !forwardToSigner, website)
+			return await sendTransaction(simulator, activeAddress, ethereumClientService, parsedRequest, request, !forwardToSigner, website, websiteTabConnections)
 		}
 		case 'web3_clientVersion': return await web3ClientVersion(ethereumClientService)
 		case 'eth_feeHistory': return await feeHistory(ethereumClientService, parsedRequest)

--- a/app/ts/background/background.ts
+++ b/app/ts/background/background.ts
@@ -35,7 +35,7 @@ import { simulateCompoundGovernanceExecution } from '../simulation/compoundGover
 import { Interface } from 'ethers'
 import { CompoundGovernanceAbi } from '../utils/abi.js'
 import { dataStringWith0xStart } from '../utils/bigint.js'
-import { connectedToSigner, ethAccountsReply, signerChainChanged, walletSwitchEthereumChainReply } from './providerMessageHandlers.js'
+import { connectedToSigner, ethAccountsReply, signerChainChanged, signerReply, walletSwitchEthereumChainReply } from './providerMessageHandlers.js'
 import { makeSureInterceptorIsNotSleeping } from './sleeping.js'
 
 async function updateMetadataForSimulation(simulationState: SimulationState, ethereum: EthereumClientService, visualizerResults: readonly VisualizerResult[], protectorResults: readonly ProtectorResults[]) {
@@ -312,7 +312,7 @@ async function handleRPCRequest(
 	const forwardToSigner = !settings.simulationMode && !request.usingInterceptorWithoutSigner
 	const getForwardingMessage = (request: SendRawTransactionParams | SendTransactionParams | WalletAddEthereumChain | EthGetStorageAtParams) => {
 		if (!forwardToSigner) throw new Error('Should not forward to signer')
-		return { forward: true as const, ...request }
+		return { type: 'forwardToSigner' as const, ...request }
 	}
 
 	if (maybeParsedRequest.success === false) {
@@ -320,8 +320,9 @@ async function handleRPCRequest(
 		console.warn(maybeParsedRequest.fullError)
 		const maybePartiallyParsedRequest = SupportedEthereumJsonRpcRequestMethods.safeParse(request)
 		// the method is some method that we are not supporting, forward it to the wallet if signer is available
-		if (maybePartiallyParsedRequest.success === false && forwardToSigner) return { forward: true as const, unknownMethod: true, ...request }
+		if (maybePartiallyParsedRequest.success === false && forwardToSigner) return { type: 'forwardToSigner' as const, unknownMethod: true, ...request }
 		return {
+			type: 'result' as const,
 			method: request.method,
 			error: {
 				message: `Failed to parse RPC request: ${ serialize(InterceptedRequest, request) }`,
@@ -360,24 +361,22 @@ async function handleRPCRequest(
 		case 'eth_gasPrice': return await gasPrice(ethereumClientService)
 		case 'eth_getTransactionCount': return await getTransactionCount(ethereumClientService, simulationState, parsedRequest)
 		case 'interceptor_getSimulationStack': return await getSimulationStack(simulationState, parsedRequest)
-		case 'eth_multicall': return { method: parsedRequest.method, error: { code: 10000, message: 'Cannot call eth_multicall directly' } }
-		case 'eth_simulateV1': return { method: parsedRequest.method, error: { code: 10000, message: 'Cannot call eth_simulateV1 directly' } }
+		case 'eth_multicall': return { type: 'result', method: parsedRequest.method, error: { code: 10000, message: 'Cannot call eth_multicall directly' } }
+		case 'eth_simulateV1': return { type: 'result', method: parsedRequest.method, error: { code: 10000, message: 'Cannot call eth_simulateV1 directly' } }
 		case 'wallet_addEthereumChain': {
 			if (forwardToSigner) return getForwardingMessage(parsedRequest)
-			return { method: parsedRequest.method, error: { code: 10000, message: 'wallet_addEthereumChain not implemented' } }
+			return { type: 'result' as const, method: parsedRequest.method, error: { code: 10000, message: 'wallet_addEthereumChain not implemented' } }
 		}
 		case 'eth_getStorageAt': {
 			if (forwardToSigner) return getForwardingMessage(parsedRequest)
-			return { method: parsedRequest.method, error: { code: 10000, message: 'eth_getStorageAt not implemented' } }
+			return { type: 'result' as const,method: parsedRequest.method, error: { code: 10000, message: 'eth_getStorageAt not implemented' } }
 		}
 		case 'eth_getLogs': return await getLogs(ethereumClientService, simulationState, parsedRequest)
-		case 'eth_sign': return { method: parsedRequest.method, error: { code: 10000, message: 'eth_sign is deprecated' } }
+		case 'eth_sign': return { type: 'result' as const,method: parsedRequest.method, error: { code: 10000, message: 'eth_sign is deprecated' } }
 		case 'eth_sendRawTransaction':
 		case 'eth_sendTransaction': {
 			if (forwardToSigner && settings.currentRpcNetwork.httpsRpc === undefined) return getForwardingMessage(parsedRequest)
-			const message = await sendTransaction(simulator, activeAddress, ethereumClientService, parsedRequest, request, !forwardToSigner, website)
-			if ('forward' in message) return getForwardingMessage(parsedRequest)
-			return message
+			return await sendTransaction(simulator, activeAddress, ethereumClientService, parsedRequest, request, !forwardToSigner, website)
 		}
 		case 'web3_clientVersion': return await web3ClientVersion(ethereumClientService)
 		case 'eth_feeHistory': return await feeHistory(ethereumClientService, parsedRequest)
@@ -466,6 +465,7 @@ export async function changeActiveRpc(simulator: Simulator, websiteTabConnection
 
 function getProviderHandler(method: string) {
 	switch (method) {
+		case 'signer_reply': return { method: 'signer_reply' as const, func: signerReply }
 		case 'eth_accounts_reply': return { method: 'eth_accounts_reply' as const, func: ethAccountsReply }
 		case 'signer_chainChanged': return { method: 'signer_chainChanged' as const, func: signerChainChanged }
 		case 'wallet_switchEthereumChain_reply': return { method: 'wallet_switchEthereumChain_reply' as const, func: walletSwitchEthereumChainReply }
@@ -477,13 +477,14 @@ function getProviderHandler(method: string) {
 export const handleInterceptedRequest = async (port: browser.runtime.Port | undefined, websiteOrigin: string, websitePromise: Promise<Website> | Website, simulator: Simulator, socket: WebsiteSocket, request: InterceptedRequest, websiteTabConnections: WebsiteTabConnections): Promise<unknown> => {
 	const activeAddress = await getActiveAddress(await getSettings(), socket.tabId)
 	const access = verifyAccess(websiteTabConnections, socket, request.method === 'eth_requestAccounts' || request.method === 'eth_call', websiteOrigin, activeAddress, await getSettings())
-	if (access === 'interceptorDisabled') return replyToInterceptedRequest(websiteTabConnections, { ...request, ...ERROR_INTERCEPTOR_DISABLED })
+	if (access === 'interceptorDisabled') return replyToInterceptedRequest(websiteTabConnections, { type: 'result', ...request, ...ERROR_INTERCEPTOR_DISABLED })
 	const providerHandler = getProviderHandler(request.method)
 	const identifiedMethod = providerHandler.method
 	if (identifiedMethod !== 'notProviderMethod') {
 		if (port === undefined) return
 		const providerHandlerReturn = await providerHandler.func(simulator, websiteTabConnections, port, request, access)
 		const message: InpageScriptRequest = {
+			type: 'result' as const,
 			uniqueRequestIdentifier: request.uniqueRequestIdentifier,
 			...providerHandlerReturn,
 		}
@@ -499,10 +500,10 @@ export const handleInterceptedRequest = async (port: browser.runtime.Port | unde
 
 	if (access === 'noAccess' || activeAddress === undefined) {
 		switch (request.method) {
-			case 'eth_accounts': return replyToInterceptedRequest(websiteTabConnections, { method: 'eth_accounts' as const, result: [], uniqueRequestIdentifier: request.uniqueRequestIdentifier })
+			case 'eth_accounts': return replyToInterceptedRequest(websiteTabConnections, { type: 'result', method: 'eth_accounts' as const, result: [], uniqueRequestIdentifier: request.uniqueRequestIdentifier })
 			// if user has not given access, assume we are on chain 1
-			case 'eth_chainId': return replyToInterceptedRequest(websiteTabConnections, { method: request.method, result: 1n, uniqueRequestIdentifier: request.uniqueRequestIdentifier })
-			case 'net_version': return replyToInterceptedRequest(websiteTabConnections, { method: request.method, result: 1n, uniqueRequestIdentifier: request.uniqueRequestIdentifier })
+			case 'eth_chainId': return replyToInterceptedRequest(websiteTabConnections, { type: 'result', method: request.method, result: 1n, uniqueRequestIdentifier: request.uniqueRequestIdentifier })
+			case 'net_version': return replyToInterceptedRequest(websiteTabConnections, { type: 'result', method: request.method, result: 1n, uniqueRequestIdentifier: request.uniqueRequestIdentifier })
 			default: break
 		}
 	}
@@ -521,18 +522,15 @@ export const handleInterceptedRequest = async (port: browser.runtime.Port | unde
 export async function handleContentScriptMessage(simulator: Simulator, websiteTabConnections: WebsiteTabConnections, request: InterceptedRequest, website: Website, activeAddress: bigint | undefined) {
 	try {
 		const settings = await getSettings()
-		if (settings.simulationMode) {
-			const simulationState = (await getSimulationResults()).simulationState
-			const resolved = await handleRPCRequest(simulator, simulationState, websiteTabConnections, simulator.ethereum, request.uniqueRequestIdentifier.requestSocket, website, request, settings, activeAddress)
-			return replyToInterceptedRequest(websiteTabConnections, { ...request, ...resolved })
-		}
-		const resolved = await handleRPCRequest(simulator, undefined, websiteTabConnections, simulator.ethereum, request.uniqueRequestIdentifier.requestSocket, website, request, settings, activeAddress)
+		const simulationState = settings.simulationMode ? (await getSimulationResults()).simulationState : undefined
+		const resolved = await handleRPCRequest(simulator, simulationState, websiteTabConnections, simulator.ethereum, request.uniqueRequestIdentifier.requestSocket, website, request, settings, activeAddress)
 		return replyToInterceptedRequest(websiteTabConnections, { ...request, ...resolved })
 	} catch (error) {
 		console.log(request)
 		handleUnexpectedError(error)
 		if (error instanceof JsonRpcResponseError || error instanceof FetchResponseError) {
 			return replyToInterceptedRequest(websiteTabConnections, {
+				type: 'result', 
 				...request,
 				error: {
 					code: error.code,
@@ -544,12 +542,14 @@ export async function handleContentScriptMessage(simulator: Simulator, websiteTa
 		if (error instanceof Error) {
 			if (isFailedToFetchError(error)) {
 				return replyToInterceptedRequest(websiteTabConnections, {
+					type: 'result', 
 					...request,
 					...METAMASK_ERROR_NOT_CONNECTED_TO_CHAIN,
 				})
 			}
 			if (error.message.includes('Fetch request timed out')) {
 				return replyToInterceptedRequest(websiteTabConnections, {
+					type: 'result', 
 					...request,
 					error: {
 						code: 408,
@@ -559,6 +559,7 @@ export async function handleContentScriptMessage(simulator: Simulator, websiteTa
 			}
 		}
 		return replyToInterceptedRequest(websiteTabConnections, {
+			type: 'result', 
 			...request,
 			error: {
 				code: 123456,
@@ -570,6 +571,7 @@ export async function handleContentScriptMessage(simulator: Simulator, websiteTa
 
 export function refuseAccess(websiteTabConnections: WebsiteTabConnections, request: InterceptedRequest) {
 	return replyToInterceptedRequest(websiteTabConnections, {
+		type: 'result', 
 		...request,
 		error: {
 			code: METAMASK_ERROR_NOT_AUTHORIZED,

--- a/app/ts/background/messageSending.ts
+++ b/app/ts/background/messageSending.ts
@@ -33,6 +33,7 @@ export function postMessageIfStillConnected(websiteTabConnections: WebsiteTabCon
 }
 
 export function replyToInterceptedRequest(websiteTabConnections: WebsiteTabConnections, message: InterceptedRequestForward) {
+	if (message.type === 'doNotReply') return
 	const tabConnection = websiteTabConnections.get(message.uniqueRequestIdentifier.requestSocket.tabId)
 	const identifier = websiteSocketToString(message.uniqueRequestIdentifier.requestSocket)
 	if (tabConnection === undefined) return false

--- a/app/ts/background/popupMessageHandlers.ts
+++ b/app/ts/background/popupMessageHandlers.ts
@@ -42,10 +42,11 @@ export async function confirmRequestAccess(simulator: Simulator, websiteTabConne
 }
 
 export async function getLastKnownCurrentTabId() {
-	const tabId = getCurrentTabId()
+	const tabIdPromise = getCurrentTabId()
 	const tabs = await browser.tabs.query({ active: true, lastFocusedWindow: true })
-	if (tabs[0]?.id === undefined) return await tabId
-	if (await tabId !== tabs[0].id) saveCurrentTabId(tabs[0].id)
+	const tabId = await tabIdPromise
+	if (tabs[0]?.id === undefined) return tabId
+	if (tabId !== tabs[0].id) saveCurrentTabId(tabs[0].id)
 	return tabs[0].id
 }
 

--- a/app/ts/background/providerMessageHandlers.ts
+++ b/app/ts/background/providerMessageHandlers.ts
@@ -91,11 +91,11 @@ export async function connectedToSigner(_simulator: Simulator, _websiteTabConnec
 	const settings = await getSettings()
 	if (!settings.simulationMode || settings.useSignersAddressAsActiveAddress) {
 		if (approval === 'hasAccess') {
-			sendSubscriptionReplyOrCallBackToPort(port, { method: 'request_signer_to_eth_requestAccounts' as const, result: [] })
+			sendSubscriptionReplyOrCallBackToPort(port, { type: 'result' as const, method: 'request_signer_to_eth_requestAccounts' as const, result: [] })
 		} else {
-			sendSubscriptionReplyOrCallBackToPort(port, { method: 'request_signer_to_eth_accounts' as const, result: [] })
+			sendSubscriptionReplyOrCallBackToPort(port, { type: 'result' as const, method: 'request_signer_to_eth_accounts' as const, result: [] })
 		}
-		sendSubscriptionReplyOrCallBackToPort(port, { method: 'request_signer_chainId' as const, result: [] })
+		sendSubscriptionReplyOrCallBackToPort(port, { type: 'result' as const, method: 'request_signer_chainId' as const, result: [] })
 	}
 	return { method: 'connected_to_signer' as const, result: { metamaskCompatibilityMode: await getMetamaskCompatibilityMode() } }
 }

--- a/app/ts/background/providerMessageHandlers.ts
+++ b/app/ts/background/providerMessageHandlers.ts
@@ -1,4 +1,4 @@
-import { ConnectedToSigner, WalletSwitchEthereumChainReply } from '../types/interceptor-messages.js'
+import { ConnectedToSigner, SignerReply, WalletSwitchEthereumChainReply } from '../types/interceptor-messages.js'
 import { TabState, WebsiteTabConnections } from '../types/user-interface-types.js'
 import { EthereumAccountsReply, EthereumChainReply } from '../types/JsonRpc-types.js'
 import { changeActiveAddressAndChainAndResetSimulation } from './background.js'
@@ -10,6 +10,7 @@ import { ApprovalState } from './accessManagement.js'
 import { ProviderMessage } from '../utils/requests.js'
 import { sendSubscriptionReplyOrCallBackToPort } from './messageSending.js'
 import { Simulator } from '../simulation/simulator.js'
+import { METAMASK_ERROR_NOT_AUTHORIZED } from '../utils/constants.js'
 
 export async function ethAccountsReply(simulator: Simulator, websiteTabConnections: WebsiteTabConnections, port: browser.runtime.Port, request: ProviderMessage, _connectInfoapproval: ApprovalState) {
 	const returnValue = { method: 'eth_accounts_reply' as const, result: '0x' as const }
@@ -25,14 +26,7 @@ export async function ethAccountsReply(simulator: Simulator, websiteTabConnectio
 	}
 	const signerAccounts = signerAccountsReply.accounts
 	const activeSigningAddress = signerAccounts.length > 0 ? signerAccounts[0] : undefined
-	const tabStateChange = await updateTabState(port.sender.tab.id, (previousState: TabState) => {
-		return {
-			...previousState,
-			...signerAccounts.length > 0 ? { signerAccountError: undefined } : {},
-			signerAccounts: signerAccounts,
-			activeSigningAddress: activeSigningAddress,
-		}
-	})
+	const tabStateChange = await updateTabState(port.sender.tab.id, (previousState: TabState) => ({ ...previousState, ...signerAccounts.length > 0 ? { signerAccountError: undefined } : {}, signerAccounts, activeSigningAddress }))
 	sendPopupMessageToOpenWindows({ method: 'popup_activeSigningAddressChanged', data: { tabId: port.sender.tab.id, activeSigningAddress } })
 	sendInternalWindowMessage({ method: 'window_signer_accounts_changed', data: { socket: getSocketFromPort(port) } })
 	// update active address if we are using signers address
@@ -52,13 +46,7 @@ async function changeSignerChain(simulator: Simulator, websiteTabConnections: We
 	if (approval !== 'hasAccess') return
 	if (port.sender?.tab?.id === undefined) return
 	if ((await getTabState(port.sender.tab.id)).signerChain === signerChain) return
-
-	await updateTabState(port.sender.tab.id, (previousState: TabState) => {
-		return {
-			...previousState,
-			signerChain: signerChain,
-		}
-	})
+	await updateTabState(port.sender.tab.id, (previousState: TabState) => ({ ...previousState, signerChain }))
 
 	// update active address if we are using signers address
 	const settings = await getSettings()
@@ -110,4 +98,19 @@ export async function connectedToSigner(_simulator: Simulator, _websiteTabConnec
 		sendSubscriptionReplyOrCallBackToPort(port, { method: 'request_signer_chainId' as const, result: [] })
 	}
 	return { method: 'connected_to_signer' as const, result: { metamaskCompatibilityMode: await getMetamaskCompatibilityMode() } }
+}
+
+export async function signerReply(_simulator: Simulator, _websiteTabConnections: WebsiteTabConnections, _port: browser.runtime.Port, request: ProviderMessage, _approval: ApprovalState) {
+	console.log('signerReply')
+	console.log(request)
+	const signerReply = SignerReply.parse(request)
+	const params = signerReply.params[0]
+	if (params.success) return { method: 'signer_reply' as const, result: params.reply }
+	switch(params.forwardRequest.method) {
+		case 'eth_sendTransaction': {
+			if (params.error.code === METAMASK_ERROR_NOT_AUTHORIZED) console.log('we are not authorized!')
+			return { method: 'signer_reply' as const, error: params.error }
+		}
+	}
+	return { method: 'signer_reply' as const, error: params.error }
 }

--- a/app/ts/background/simulationModeHanders.ts
+++ b/app/ts/background/simulationModeHanders.ts
@@ -42,8 +42,9 @@ export async function sendTransaction(
 	request: InterceptedRequest,
 	simulationMode: boolean = true,
 	website: Website,
+	websiteTabConnections: WebsiteTabConnections,
 ) {
-	const action = await openConfirmTransactionDialog(simulator, ethereumClientService, request, transactionParams, simulationMode, activeAddress, website)
+	const action = await openConfirmTransactionDialog(simulator, ethereumClientService, request, transactionParams, simulationMode, activeAddress, website, websiteTabConnections)
 	if (action.type === 'doNotReply') return action
 	return { method: transactionParams.method, ...action }
 }

--- a/app/ts/background/simulationModeHanders.ts
+++ b/app/ts/background/simulationModeHanders.ts
@@ -17,21 +17,21 @@ import { SignMessageParams } from '../types/jsonRpc-signing-types.js'
 import { METAMASK_ERROR_BLANKET_ERROR } from '../utils/constants.js'
 
 export async function getBlockByHash(ethereumClientService: EthereumClientService, simulationState: SimulationState | undefined, request: EthBlockByHashParams) {
-	return { method: request.method, result: await getSimulatedBlockByHash(ethereumClientService, simulationState, request.params[0], request.params[1]) }
+	return { type: 'result' as const, method: request.method, result: await getSimulatedBlockByHash(ethereumClientService, simulationState, request.params[0], request.params[1]) }
 }
 export async function getBlockByNumber(ethereumClientService: EthereumClientService, simulationState: SimulationState | undefined, request: EthBlockByNumberParams) {
-	return { method: request.method, result: await getSimulatedBlock(ethereumClientService, simulationState, request.params[0], request.params[1]) }
+	return { type: 'result' as const, method: request.method, result: await getSimulatedBlock(ethereumClientService, simulationState, request.params[0], request.params[1]) }
 }
 export async function getBalance(ethereumClientService: EthereumClientService, simulationState: SimulationState | undefined, request: EthBalanceParams) {
-	return { method: request.method, result: await getSimulatedBalance(ethereumClientService, simulationState, request.params[0]) }
+	return { type: 'result' as const, method: request.method, result: await getSimulatedBalance(ethereumClientService, simulationState, request.params[0]) }
 }
 export async function getTransactionByHash(ethereumClientService: EthereumClientService, simulationState: SimulationState | undefined, request: TransactionByHashParams) {
 	const result = await getSimulatedTransactionByHash(ethereumClientService, simulationState, request.params[0])
-	if (result === undefined) return { method: request.method, result: undefined }
-	return { method: request.method, result: result }
+	if (result === undefined) return { type: 'result' as const, method: request.method, result: undefined }
+	return { type: 'result' as const, method: request.method, result: result }
 }
 export async function getTransactionReceipt(ethereumClientService: EthereumClientService, simulationState: SimulationState | undefined, request: TransactionReceiptParams) {
-	return { method: request.method, result: await getSimulatedTransactionReceipt(ethereumClientService, simulationState, request.params[0]) }
+	return { type: 'result' as const, method: request.method, result: await getSimulatedTransactionReceipt(ethereumClientService, simulationState, request.params[0]) }
 }
 
 export async function sendTransaction(
@@ -43,18 +43,9 @@ export async function sendTransaction(
 	simulationMode: boolean = true,
 	website: Website,
 ) {
-	return {
-		method: transactionParams.method,
-		...await openConfirmTransactionDialog(
-			simulator,
-			ethereumClientService,
-			request,
-			transactionParams,
-			simulationMode,
-			activeAddress,
-			website,
-		)
-	}
+	const action = await openConfirmTransactionDialog(simulator, ethereumClientService, request, transactionParams, simulationMode, activeAddress, website)
+	if (action.type === 'doNotReply') return action
+	return { method: transactionParams.method, ...action }
 }
 async function singleCallWithFromOverride(ethereumClientService: EthereumClientService, simulationState: SimulationState | undefined, request: EthCallParams, from: bigint) {
 	const callParams = request.params[0]
@@ -83,50 +74,50 @@ export async function call(ethereumClientService: EthereumClientService, simulat
 	const from = callParams.from !== undefined && !KNOWN_CONTRACT_CALLER_ADDRESSES.includes(callParams.from) ? callParams.from : DEFAULT_CALL_ADDRESS
 	const callResult = await singleCallWithFromOverride(ethereumClientService, simulationState, request, from)
 
-	if (callResult.error !== undefined && callResult.error.code === ERROR_INTERCEPTOR_GAS_ESTIMATION_FAILED ) return { method: request.method, ...callResult }
+	if (callResult.error !== undefined && callResult.error.code === ERROR_INTERCEPTOR_GAS_ESTIMATION_FAILED ) return { type: 'result' as const, method: request.method, ...callResult }
 
 	// if we fail our call because we are calling from a contract, retry and change address to our default calling address
 	// TODO: Remove this logic and KNOWN_CONTRACT_CALLER_ADDRESSES when multicall supports calling from contracts
 	if (callResult.error !== undefined && 'data' in callResult.error && callResult.error.data === 'sender has deployed code' && from !== DEFAULT_CALL_ADDRESS) {
 		const callerChangeResult = await singleCallWithFromOverride(ethereumClientService, simulationState, request, DEFAULT_CALL_ADDRESS)
-		return { method: request.method, ...callerChangeResult }
+		return { type: 'result' as const, method: request.method, ...callerChangeResult }
 	}
-	return { method: request.method, ...callResult }
+	return { type: 'result' as const, method: request.method, ...callResult }
 }
 
 export async function blockNumber(ethereumClientService: EthereumClientService, simulationState: SimulationState | undefined) {
-	return { method: 'eth_blockNumber' as const, result: await getSimulatedBlockNumber(ethereumClientService, simulationState) }
+	return { type: 'result' as const, method: 'eth_blockNumber' as const, result: await getSimulatedBlockNumber(ethereumClientService, simulationState) }
 }
 
 export async function estimateGas(ethereumClientService: EthereumClientService, simulationState: SimulationState | undefined, request: EstimateGasParams){
 	const estimatedGas = await simulateEstimateGas(ethereumClientService, simulationState, request.params[0])
-	if ('error' in estimatedGas) return { method: request.method, ...estimatedGas }
-	return { method: request.method, result: estimatedGas.gas }
+	if ('error' in estimatedGas) return { type: 'result' as const, method: request.method, ...estimatedGas }
+	return { type: 'result' as const, method: request.method, result: estimatedGas.gas }
 }
 
 export async function subscribe(socket: WebsiteSocket, request: EthSubscribeParams) {
-	return { method: request.method, result: await createEthereumSubscription(request, socket) }
+	return { type: 'result' as const, method: request.method, result: await createEthereumSubscription(request, socket) }
 }
 
 export async function unsubscribe(socket: WebsiteSocket, request: EthUnSubscribeParams) {
-	return { method: request.method, result: await removeEthereumSubscription(socket, request.params[0]) }
+	return { type: 'result' as const, method: request.method, result: await removeEthereumSubscription(socket, request.params[0]) }
 }
 
 export async function getAccounts(activeAddress: bigint | undefined) {
-	if (activeAddress === undefined) return { method: 'eth_accounts' as const, result: [] }
-	return { method: 'eth_accounts' as const, result: [activeAddress] }
+	if (activeAddress === undefined) return { type: 'result' as const, method: 'eth_accounts' as const, result: [] }
+	return { type: 'result' as const, method: 'eth_accounts' as const, result: [activeAddress] }
 }
 
 export async function chainId(ethereumClientService: EthereumClientService) {
-	return { method: 'eth_chainId' as const, result: ethereumClientService.getChainId() }
+	return { type: 'result' as const, method: 'eth_chainId' as const, result: ethereumClientService.getChainId() }
 }
 
 export async function netVersion(ethereumClientService: EthereumClientService) {
-	return { method: 'net_version' as const, result: (await chainId(ethereumClientService)).result }
+	return { type: 'result' as const, method: 'net_version' as const, result: (await chainId(ethereumClientService)).result }
 }
 
 export async function gasPrice(ethereumClientService: EthereumClientService) {
-	return { method: 'eth_gasPrice' as const, result: await ethereumClientService.getGasPrice() }
+	return { type: 'result' as const, method: 'eth_gasPrice' as const, result: await ethereumClientService.getGasPrice() }
 }
 
 export async function personalSign(simulator: Simulator, websiteTabConnections: WebsiteTabConnections, params: SignMessageParams, request: InterceptedRequest, simulationMode: boolean, website: Website, activeAddress: bigint | undefined): Promise<RPCReply> {
@@ -136,29 +127,30 @@ export async function personalSign(simulator: Simulator, websiteTabConnections: 
 export async function switchEthereumChain(simulator: Simulator, websiteTabConnections: WebsiteTabConnections, ethereumClientService: EthereumClientService, params: SwitchEthereumChainParams, request: InterceptedRequest, simulationMode: boolean, website: Website) {
 	if (ethereumClientService.getChainId() === params.params[0].chainId) {
 		// we are already on the right chain
-		return { method: params.method, result: null }
+		return { type: 'result' as const, method: params.method, result: null }
 	}
 	const change = await openChangeChainDialog(simulator, websiteTabConnections, request, simulationMode, website, params)
-	return { method: params.method, ...change }
+	return { type: 'result' as const, method: params.method, ...change }
 }
 
 export async function getCode(ethereumClientService: EthereumClientService, simulationState: SimulationState | undefined, request: GetCode) {
 	const code = await getSimulatedCode(ethereumClientService, simulationState, request.params[0], request.params[1])
-	if (code.statusCode === 'failure') return { method: request.method, ...ERROR_INTERCEPTOR_GET_CODE_FAILED }
-	return { method: request.method, result: code.getCodeReturn }
+	if (code.statusCode === 'failure') return { type: 'result' as const, method: request.method, ...ERROR_INTERCEPTOR_GET_CODE_FAILED }
+	return { type: 'result' as const, method: request.method, result: code.getCodeReturn }
 }
 
 export async function getPermissions() {
-	return { method: 'wallet_getPermissions', params: [], result: [ { "eth_accounts": {} } ] } as const
+	return { type: 'result' as const, method: 'wallet_getPermissions', params: [], result: [ { "eth_accounts": {} } ] } as const
 }
 
 export async function getTransactionCount(ethereumClientService: EthereumClientService, simulationState: SimulationState | undefined, request: GetTransactionCount) {
-	return { method: request.method, result: await getSimulatedTransactionCount(ethereumClientService, simulationState, request.params[0], request.params[1]) }
+	return { type: 'result' as const, method: request.method, result: await getSimulatedTransactionCount(ethereumClientService, simulationState, request.params[0], request.params[1]) }
 }
 
 export async function getSimulationStack(simulationState: SimulationState | undefined, request: GetSimulationStack) {
 	switch (request.params[0]) {
 		case '1.0.0': return {
+			type: 'result' as const,
 			method: request.method,
 			result: {
 				version: '1.0.0',
@@ -170,34 +162,34 @@ export async function getSimulationStack(simulationState: SimulationState | unde
 }
 
 export async function getLogs(ethereumClientService: EthereumClientService, simulationState: SimulationState | undefined, request: EthGetLogsParams) {
-	return { method: request.method, result: await getSimulatedLogs(ethereumClientService, simulationState, request.params[0]) }
+	return { type: 'result' as const, method: request.method, result: await getSimulatedLogs(ethereumClientService, simulationState, request.params[0]) }
 }
 
 export async function web3ClientVersion(ethereumClientService: EthereumClientService) {
-	return { method: 'web3_clientVersion' as const, result: await ethereumClientService.web3ClientVersion() }
+	return { type: 'result' as const, method: 'web3_clientVersion' as const, result: await ethereumClientService.web3ClientVersion() }
 }
 
 export async function feeHistory(ethereumClientService: EthereumClientService, request: FeeHistory) {
-	return { method: 'eth_feeHistory' as const, result: await getSimulatedFeeHistory(ethereumClientService, request) }
+	return { type: 'result' as const, method: 'eth_feeHistory' as const, result: await getSimulatedFeeHistory(ethereumClientService, request) }
 }
 
 export async function installNewFilter(socket: WebsiteSocket, request: EthNewFilter, ethereumClientService: EthereumClientService, simulationState: SimulationState | undefined) {
-	return { method: request.method, result: await createNewFilter(request, socket, ethereumClientService, simulationState) }
+	return { type: 'result' as const, method: request.method, result: await createNewFilter(request, socket, ethereumClientService, simulationState) }
 }
 
 export async function uninstallNewFilter(socket: WebsiteSocket, request: UninstallFilter) {
-	return { method: request.method, result: await removeEthereumSubscription(socket, request.params[0]) }
+	return { type: 'result' as const, method: request.method, result: await removeEthereumSubscription(socket, request.params[0]) }
 }
 
 export async function getFilterChanges(request: GetFilterChanges, ethereumClientService: EthereumClientService, simulationState: SimulationState | undefined) {
 	const result = await getEthFilterChanges(request.params[0], ethereumClientService, simulationState)
-	if (result === undefined) return { method: request.method, error: { code: METAMASK_ERROR_BLANKET_ERROR, message: 'No filter found for identifier' } }
+	if (result === undefined) return { type: 'result' as const, method: request.method, error: { code: METAMASK_ERROR_BLANKET_ERROR, message: 'No filter found for identifier' } }
 
-	return { method: request.method, result }
+	return { type: 'result' as const, method: request.method, result }
 }
 
 export async function getFilterLogs(request: GetFilterLogs, ethereumClientService: EthereumClientService, simulationState: SimulationState | undefined) {
 	const result = await getEthFilterLogs(request.params[0], ethereumClientService, simulationState)
-	if (result === undefined) return { method: request.method, error: { code: METAMASK_ERROR_BLANKET_ERROR, message: 'No filter found for identifier' } }
-	return { method: request.method, result }
+	if (result === undefined) return { type: 'result' as const, method: request.method, error: { code: METAMASK_ERROR_BLANKET_ERROR, message: 'No filter found for identifier' } }
+	return { type: 'result' as const, method: request.method, result }
 }

--- a/app/ts/background/windows/changeChain.ts
+++ b/app/ts/background/windows/changeChain.ts
@@ -32,7 +32,7 @@ export async function resolveChainChange(simulator: Simulator, websiteTabConnect
 	const data = await getChainChangeConfirmationPromise()
 	if (data === undefined || !doesUniqueRequestIdentifiersMatch(confirmation.data.uniqueRequestIdentifier, data.request.uniqueRequestIdentifier)) throw new Error('Unique request identifier mismatch in change chain')
 	const resolved = await resolve(simulator, websiteTabConnections, confirmation, data.simulationMode)
-	replyToInterceptedRequest(websiteTabConnections, { method: 'wallet_switchEthereumChain' as const, ...resolved, uniqueRequestIdentifier: data.request.uniqueRequestIdentifier })
+	replyToInterceptedRequest(websiteTabConnections, { type: 'result', method: 'wallet_switchEthereumChain' as const, ...resolved, uniqueRequestIdentifier: data.request.uniqueRequestIdentifier })
 	if (openedDialog) await closePopupOrTabById(openedDialog)
 	openedDialog = undefined
 }

--- a/app/ts/background/windows/confirmTransaction.ts
+++ b/app/ts/background/windows/confirmTransaction.ts
@@ -1,8 +1,7 @@
-import { PopupOrTab, addWindowTabListeners, closePopupOrTabById, getPopupOrTabOnlyById, openPopupOrTab, removeWindowTabListeners, tryFocusingTabOrWindow } from '../../components/ui-utils.js'
+import { closePopupOrTabById, getPopupOrTabOnlyById, openPopupOrTab, tryFocusingTabOrWindow } from '../../components/ui-utils.js'
 import { EthereumClientService } from '../../simulation/services/EthereumClientService.js'
 import { appendTransaction, getInputFieldFromDataOrInput, getSimulatedTransactionCount, simulateEstimateGas } from '../../simulation/services/SimulationModeEthereumClientService.js'
 import { CANNOT_SIMULATE_OFF_LEGACY_BLOCK, ERROR_INTERCEPTOR_NO_ACTIVE_ADDRESS, METAMASK_ERROR_NOT_CONNECTED_TO_CHAIN, METAMASK_ERROR_USER_REJECTED_REQUEST } from '../../utils/constants.js'
-import { Future } from '../../utils/future.js'
 import { TransactionConfirmation } from '../../types/interceptor-messages.js'
 import { Semaphore } from '../../utils/semaphore.js'
 import { WebsiteTabConnections } from '../../types/user-interface-types.js'
@@ -18,31 +17,18 @@ import { ethers, keccak256, toUtf8Bytes } from 'ethers'
 import { dataStringWith0xStart, stringToUint8Array } from '../../utils/bigint.js'
 import { EthereumAddress, EthereumQuantity } from '../../types/wire-types.js'
 import { PopupOrTabId, Website } from '../../types/websiteAccessTypes.js'
-import { PendingTransaction } from '../../types/accessRequest.js'
 
-type Confirmation = TransactionConfirmation | 'NoResponse'
-let openedDialog: PopupOrTab | undefined = undefined
-let pendingTransactions = new Map<string, Future<Confirmation>>()
 const pendingConfirmationSemaphore = new Semaphore(1)
 
 export async function updateConfirmTransactionViewWithPendingTransaction(ethereumClientService: EthereumClientService) {
 	const promises = await getPendingTransactions()
-	if (promises.length > 0) {
-		const currentBlockNumberPromise = ethereumClientService.getBlockNumber()
-		await sendPopupMessageToOpenWindows({ method: 'popup_update_confirm_transaction_dialog', data: { pendingTransactions: promises, currentBlockNumber: await currentBlockNumberPromise }})
-		return true
-	}
-	return false
-}
-
-export async function updateConfirmTransactionViewWithPendingTransactionOrClose(ethereumClientService: EthereumClientService) {
-	if (await updateConfirmTransactionViewWithPendingTransaction(ethereumClientService) === true) return
-	if (openedDialog) await closePopupOrTabById(openedDialog)
-	openedDialog = undefined
+	if (promises.length === 0) return false
+	const currentBlockNumberPromise = ethereumClientService.getBlockNumber()
+	await sendPopupMessageToOpenWindows({ method: 'popup_update_confirm_transaction_dialog', data: { pendingTransactions: promises, currentBlockNumber: await currentBlockNumberPromise }})
+	return true
 }
 
 export const isConfirmTransactionFocused = async () => {
-	if (openedDialog === undefined) return false
 	const pendingTransactions = await getPendingTransactions()
 	if (pendingTransactions[0] === undefined) return false
 	const popup = await getPopupOrTabOnlyById(pendingTransactions[0].popupOrTabId)
@@ -52,32 +38,36 @@ export const isConfirmTransactionFocused = async () => {
 }
 
 export async function resolvePendingTransaction(simulator: Simulator, websiteTabConnections: WebsiteTabConnections, confirmation: TransactionConfirmation) {
-	const pending = pendingTransactions.get(getUniqueRequestIdentifierString(confirmation.data.uniqueRequestIdentifier))
 	const pendingTransaction = await removePendingTransaction(confirmation.data.uniqueRequestIdentifier)
-	await updateConfirmTransactionViewWithPendingTransactionOrClose(simulator.ethereum)
-	if (pendingTransaction === undefined) return
-	if (pending) {
-		return pending.resolve(confirmation)
-	} else {
-		// we have not been tracking this window, forward its message directly to content script (or signer)
-		const resolvedPromise = await resolve(simulator, pendingTransaction.simulationMode, pendingTransaction.activeAddress, confirmation, pendingTransaction)
-		replyToInterceptedRequest(websiteTabConnections, { ...pendingTransaction.originalRequestParameters, ...resolvedPromise, uniqueRequestIdentifier: confirmation.data.uniqueRequestIdentifier })
-		openedDialog = await getPopupOrTabOnlyById(confirmation.data.popupOrTabId)
+	if (pendingTransaction === undefined) throw new Error('Tried to resolve pending transaction that did not exist anymore')
+	if (!(await updateConfirmTransactionViewWithPendingTransaction(simulator.ethereum))) await closePopupOrTabById(pendingTransaction.popupOrTabId)
+	
+	const reply = (message: { type: 'forwardToSigner' } | { type: 'result', error: { code: number, message: string } } | { type: 'result', result: bigint }) => {
+		replyToInterceptedRequest(websiteTabConnections, { ...pendingTransaction.originalRequestParameters, ...message, uniqueRequestIdentifier: confirmation.data.uniqueRequestIdentifier })
 	}
+	
+	if (confirmation.data.action === 'noResponse') return reply(formRejectMessage(undefined))
+	if (pendingTransaction === undefined || pendingTransaction.status !== 'Simulated') return reply(formRejectMessage(undefined))
+	if (confirmation.data.action === 'reject') return reply(formRejectMessage(confirmation.data.transactionErrorString))
+	if (!pendingTransaction.simulationMode) return reply({ type: 'forwardToSigner' })
+	const newState = await updateSimulationState(simulator.ethereum, async (simulationState) => await appendTransaction(simulator.ethereum, simulationState, pendingTransaction.transactionToSimulate), pendingTransaction.activeAddress, true)
+	if (newState === undefined || newState.simulatedTransactions === undefined || newState.simulatedTransactions.length === 0) return reply({ type: 'result', ...METAMASK_ERROR_NOT_CONNECTED_TO_CHAIN })
+	const lastTransaction = newState.simulatedTransactions[newState.simulatedTransactions.length - 1]
+	if (lastTransaction === undefined) throw new Error('missing last transaction')
+	return reply({ type: 'result', result: lastTransaction.signedTransaction.hash })
 }
 
-const onCloseWindowOrTab = async (popupOrTabs: PopupOrTabId) => { // check if user has closed the window on their own, if so, reject all signatures
-	if (openedDialog === undefined || openedDialog.id !== popupOrTabs.id || openedDialog.type !== popupOrTabs.type) return
-	openedDialog = undefined
+export const onCloseWindowOrTab = async (popupOrTabs: PopupOrTabId, simulator: Simulator, websiteTabConnections: WebsiteTabConnections) => { // check if user has closed the window on their own, if so, reject all signatures
+	const transactions = await getPendingTransactions()
+	const [firstTransaction] = transactions
+	if (firstTransaction?.popupOrTabId.id !== popupOrTabs.id) return
 	await clearPendingTransactions()
-	pendingTransactions.forEach((pending) => pending.resolve('NoResponse'))
-	pendingTransactions.clear()
+	await Promise.all(transactions.map( async (transaction) => resolvePendingTransaction(simulator, websiteTabConnections, { method: 'popup_confirmDialog', data: { uniqueRequestIdentifier: transaction.uniqueRequestIdentifier, action: 'noResponse', popupOrTabId: transaction.popupOrTabId } })))
 }
-const onCloseWindow = async (id: number) => onCloseWindowOrTab({ type: 'popup' as const, id })
-const onCloseTab = async (id: number) => onCloseWindowOrTab({ type: 'tab' as const, id })
 
 const formRejectMessage = (errorString: undefined | string) => {
 	return {
+		type: 'result' as const,
 		error: {
 			code: METAMASK_ERROR_USER_REJECTED_REQUEST,
 			message: errorString === undefined ? 'Interceptor Tx Signature: User denied transaction signature.' : `Interceptor Tx Signature: User denied reverting transaction: ${ errorString }.`
@@ -166,106 +156,69 @@ export async function openConfirmTransactionDialog(
 	transactionParams: SendTransactionParams | SendRawTransactionParams,
 	simulationMode: boolean,
 	activeAddress: bigint | undefined,
-	website: Website
+	website: Website,
 ) {
-	let justAddToPending = false
-	if (pendingTransactions.size !== 0) justAddToPending = true
-	const pendingTransaction = new Future<Confirmation>()
 	const uniqueRequestIdentifier = getUniqueRequestIdentifierString(request.uniqueRequestIdentifier)
-	pendingTransactions.set(uniqueRequestIdentifier, pendingTransaction)
 	const transactionIdentifier = EthereumQuantity.parse(keccak256(toUtf8Bytes(uniqueRequestIdentifier)))
-	try {
-		const created = new Date()
-		const transactionToSimulatePromise = transactionParams.method === 'eth_sendTransaction' ? formEthSendTransaction(ethereumClientService, activeAddress, simulationMode, website, transactionParams, created, transactionIdentifier) : formSendRawTransaction(ethereumClientService, transactionParams, website, created, transactionIdentifier)
-		if (activeAddress === undefined) return ERROR_INTERCEPTOR_NO_ACTIVE_ADDRESS
+	const created = new Date()
+	const transactionToSimulatePromise = transactionParams.method === 'eth_sendTransaction' ? formEthSendTransaction(ethereumClientService, activeAddress, simulationMode, website, transactionParams, created, transactionIdentifier) : formSendRawTransaction(ethereumClientService, transactionParams, website, created, transactionIdentifier)
+	if (activeAddress === undefined) return { type: 'result' as const, ...ERROR_INTERCEPTOR_NO_ACTIVE_ADDRESS }
 
-		const addedPendingTransaction = await pendingConfirmationSemaphore.execute(async () => {
-			if (!justAddToPending) {
-				const pendingTransactions = await getPendingTransactions()
-				if (pendingTransactions.length !== 0) {
-					const pendingTransaction = pendingTransactions[0]
-					if (pendingTransaction === undefined) throw new Error('pending transaction was undefined')
-					if (await getPopupOrTabOnlyById(pendingTransaction.popupOrTabId) !== undefined) {
-						justAddToPending = true
-					} else {
-						await clearPendingTransactions()
-					}
-				}
+	const addedPendingTransaction = await pendingConfirmationSemaphore.execute(async () => {
+		const getPendingTransactionWindow = async () => {
+			const [firstPendingTransaction] = await getPendingTransactions()
+			if (firstPendingTransaction !== undefined) {
+				const alreadyOpenWindow = await getPopupOrTabOnlyById(firstPendingTransaction.popupOrTabId)
+				if (alreadyOpenWindow) return alreadyOpenWindow
+				await clearPendingTransactions()
 			}
+			return await openPopupOrTab({ url: getHtmlFile('confirmTransaction'), type: 'popup', height: 800, width: 600 })
+		}
+		const openedDialog = await getPendingTransactionWindow()
+		if (openedDialog === undefined) return false //todo add better error here, somehow we failed to create window
+		const pendingTransaction = {
+			popupOrTabId: openedDialog,
+			originalRequestParameters: transactionParams,
+			uniqueRequestIdentifier: request.uniqueRequestIdentifier,
+			simulationMode,
+			activeAddress,
+			created,
+			status: 'Crafting Transaction' as const,
+			transactionIdentifier,
+			website,
+		}
+		const currentPendingTranasctions = await appendPendingTransaction(pendingTransaction)
+		if (currentPendingTranasctions.length > 1) await sendPopupMessageToOpenWindows({ method: 'popup_confirm_transaction_dialog_pending_changed', data: { pendingTransactions: await getPendingTransactions() } })
+			
+		await updateConfirmTransactionViewWithPendingTransaction(ethereumClientService)
 
-			const openDialog = async () => {
-				addWindowTabListeners(onCloseWindow, onCloseTab)
-				return await openPopupOrTab({ url: getHtmlFile('confirmTransaction'), type: 'popup', height: 800, width: 600 })
-			}
-			if (!justAddToPending || openedDialog === undefined) openedDialog = await openDialog()
-			else { await tryFocusingTabOrWindow(openedDialog) }
-
-			if (openedDialog === undefined) return false
-			const pendingTransaction = {
-				popupOrTabId: openedDialog,
-				originalRequestParameters: transactionParams,
-				uniqueRequestIdentifier: request.uniqueRequestIdentifier,
-				simulationMode,
-				activeAddress,
-				created,
-				status: 'Crafting Transaction' as const,
-				transactionIdentifier,
-				website,
-			}
-			await appendPendingTransaction(pendingTransaction)
-			if (justAddToPending) await sendPopupMessageToOpenWindows({ method: 'popup_confirm_transaction_dialog_pending_changed', data: { pendingTransactions: await getPendingTransactions() } })
-				
+		const transactionToSimulate = await transactionToSimulatePromise
+		if (transactionToSimulate.success === false) {
+			await replacePendingTransaction({
+				...pendingTransaction,
+				transactionToSimulate,
+				simulationResults: await refreshConfirmTransactionSimulation(simulator, ethereumClientService, activeAddress, simulationMode, request.uniqueRequestIdentifier, transactionToSimulate),
+				status: 'FailedToSimulate' as const,
+			})
+			await updateConfirmTransactionViewWithPendingTransaction(ethereumClientService)
+			return false
+		} else {
+			await replacePendingTransaction({ ...pendingTransaction, transactionToSimulate: transactionToSimulate, status: 'Simulating' as const })
 			await updateConfirmTransactionViewWithPendingTransaction(ethereumClientService)
 
-			const transactionToSimulate = await transactionToSimulatePromise
-			if (transactionToSimulate.success === false) {
-				await replacePendingTransaction({
-					...pendingTransaction,
-					transactionToSimulate,
-					simulationResults: await refreshConfirmTransactionSimulation(simulator, ethereumClientService, activeAddress, simulationMode, request.uniqueRequestIdentifier, transactionToSimulate),
-					status: 'FailedToSimulate' as const,
-				})
-				await updateConfirmTransactionViewWithPendingTransaction(ethereumClientService)
-				return false
-			} else {
-				await replacePendingTransaction({ ...pendingTransaction, transactionToSimulate: transactionToSimulate, status: 'Simulating' as const })
-				await updateConfirmTransactionViewWithPendingTransaction(ethereumClientService)
-
-				const simulatedTx = await replacePendingTransaction({
-					...pendingTransaction,
-					transactionToSimulate,
-					simulationResults: await refreshConfirmTransactionSimulation(simulator, ethereumClientService, activeAddress, simulationMode, request.uniqueRequestIdentifier, transactionToSimulate),
-					status: 'Simulated' as const,
-				})
-				await updateConfirmTransactionViewWithPendingTransaction(ethereumClientService)
-				return simulatedTx !== undefined
-			}
-		})
-		if (addedPendingTransaction === false) return formRejectMessage(undefined)
-		const pendingTransactionData = (await getPendingTransactions()).find((tx) => tx.transactionIdentifier === transactionIdentifier)
-		if (pendingTransactionData === undefined) return formRejectMessage(undefined)
-		const reply = await pendingTransaction
-		const resolvedPromise = await resolve(simulator, simulationMode, activeAddress, reply, pendingTransactionData)
-		return resolvedPromise
-	} finally {
-		removeWindowTabListeners(onCloseWindow, onCloseTab)
-		pendingTransactions.delete(uniqueRequestIdentifier)
-		await updateConfirmTransactionViewWithPendingTransactionOrClose(ethereumClientService)
-	}
-}
-
-async function resolve(simulator: Simulator, simulationMode: boolean, activeAddress: bigint, confirmation: Confirmation, pendingTransaction: PendingTransaction): Promise<{ forward: true } | { error: { code: number, message: string } } | { result: bigint }> {
-	if (confirmation === 'NoResponse') return formRejectMessage(undefined)
-	if (pendingTransaction === undefined || pendingTransaction.status !== 'Simulated') return formRejectMessage(undefined)
-	if (confirmation.data.accept === false) return formRejectMessage(confirmation.data.transactionErrorString)
-	if (!simulationMode) return { forward: true }
-	const newState = await updateSimulationState(simulator.ethereum, async (simulationState) => {
-		return await appendTransaction(simulator.ethereum, simulationState, pendingTransaction.transactionToSimulate)
-	}, activeAddress, true)
-	if (newState === undefined || newState.simulatedTransactions === undefined || newState.simulatedTransactions.length === 0) {
-		return METAMASK_ERROR_NOT_CONNECTED_TO_CHAIN
-	}
-	const lastTransaction = newState.simulatedTransactions[newState.simulatedTransactions.length - 1]
-	if (lastTransaction === undefined) throw new Error('missing last transaction')
-	return { result: lastTransaction.signedTransaction.hash }
+			const simulatedTx = await replacePendingTransaction({
+				...pendingTransaction,
+				transactionToSimulate,
+				simulationResults: await refreshConfirmTransactionSimulation(simulator, ethereumClientService, activeAddress, simulationMode, request.uniqueRequestIdentifier, transactionToSimulate),
+				status: 'Simulated' as const,
+			})
+			await updateConfirmTransactionViewWithPendingTransaction(ethereumClientService)
+			await tryFocusingTabOrWindow(openedDialog)
+			return simulatedTx !== undefined
+		}
+	})
+	if (addedPendingTransaction === false) return formRejectMessage(undefined)
+	const pendingTransactionData = (await getPendingTransactions()).find((tx) => tx.transactionIdentifier === transactionIdentifier)
+	if (pendingTransactionData === undefined) return formRejectMessage(undefined)
+	return { type: 'doNotReply' as const }
 }

--- a/app/ts/background/windows/interceptorAccess.ts
+++ b/app/ts/background/windows/interceptorAccess.ts
@@ -83,7 +83,7 @@ export async function askForSignerAccountsFromSignerIfNotAvailable(websiteTabCon
 	const channel = new BroadcastChannel(INTERNAL_CHANNEL_NAME)
 	try {
 		channel.addEventListener('message', listener)
-		const messageSent = sendSubscriptionReplyOrCallBack(websiteTabConnections, socket, { method: 'request_signer_to_eth_requestAccounts' as const, result: [] })
+		const messageSent = sendSubscriptionReplyOrCallBack(websiteTabConnections, socket, { type: 'result' as const, method: 'request_signer_to_eth_requestAccounts' as const, result: [] })
 		if (messageSent) await future
 	} finally {
 		channel.removeEventListener('message', listener)

--- a/app/ts/background/windows/interceptorAccess.ts
+++ b/app/ts/background/windows/interceptorAccess.ts
@@ -38,7 +38,7 @@ const onCloseWindowOrTab = async (simulator: Simulator, popupOrTabs: PopupOrTabI
 			originalRequestAccessToAddress: pendingRequest.originalRequestAccessToAddress?.address,
 			requestAccessToAddress: pendingRequest.requestAccessToAddress?.address,
 			accessRequestId: pendingRequest.accessRequestId,
-			userReply: 'NoResponse' as const
+			userReply: 'noResponse' as const
 		}
 		await resolve(simulator, websiteTabConnections, reply, pendingRequest.request, pendingRequest.website)
 	}
@@ -58,7 +58,7 @@ export async function getAddressMetadataForAccess(websiteAccess: WebsiteAccessAr
 }
 
 export async function changeAccess(simulator: Simulator, websiteTabConnections: WebsiteTabConnections, confirmation: InterceptorAccessReply, website: Website, promptForAccessesIfNeeded: boolean = true) {
-	if (confirmation.userReply === 'NoResponse') return
+	if (confirmation.userReply === 'noResponse') return
 	await setAccess(website, confirmation.userReply === 'Approved', confirmation.requestAccessToAddress)
 	updateWebsiteApprovalAccesses(simulator, websiteTabConnections, promptForAccessesIfNeeded, await getSettings())
 	await sendPopupMessageToOpenWindows({ method: 'popup_websiteAccess_changed' })
@@ -187,6 +187,7 @@ export async function requestAccessFromUser(
 		if (pendingRequests.previous.find((x) => x.accessRequestId === accessRequestId) !== undefined) {
 			if (request !== undefined) {
 				replyToInterceptedRequest(websiteTabConnections, {
+					type: 'result',
 					uniqueRequestIdentifier: request.uniqueRequestIdentifier,
 					method: request.method,
 					error: METAMASK_ERROR_ALREADY_PENDING.error,
@@ -216,7 +217,7 @@ export async function requestAccessFromUser(
 }
 
 async function resolve(simulator: Simulator, websiteTabConnections: WebsiteTabConnections, accessReply: InterceptorAccessReply, request: InterceptedRequest | undefined, website: Website) {
-	if (accessReply.userReply === 'NoResponse') {
+	if (accessReply.userReply === 'noResponse') {
 		if (request !== undefined) refuseAccess(websiteTabConnections, request)
 	} else {
 		const userRequestedAddressChange = accessReply.requestAccessToAddress !== accessReply.originalRequestAccessToAddress

--- a/app/ts/background/windows/personalSign.ts
+++ b/app/ts/background/windows/personalSign.ts
@@ -53,6 +53,7 @@ export async function updatePendingPersonalSignViewWithPendingRequests(ethereumC
 
 function rejectMessage(uniqueRequestIdentifier: UniqueRequestIdentifier) {
 	return {
+		type: 'result' as const,
 		method: 'popup_personalSignApproval',
 		data: {
 			uniqueRequestIdentifier,
@@ -63,6 +64,7 @@ function rejectMessage(uniqueRequestIdentifier: UniqueRequestIdentifier) {
 
 function reject(signingParams: SignMessageParams) {
 	return {
+		type: 'result' as const,
 		method: signingParams.method,
 		error: {
 			code: METAMASK_ERROR_USER_REJECTED_REQUEST,
@@ -291,9 +293,9 @@ async function resolve(simulator: Simulator, reply: PersonalSignApproval, signed
 				return await appendSignedMessage(simulator.ethereum, simulationState, signedMessageTransaction)
 			}, signedMessageTransaction.fakeSignedFor, true)
 			const signedMessage = (await simulatePersonalSign(signedMessageTransaction.originalRequestParameters, signedMessageTransaction.fakeSignedFor)).signature
-			return { result: signedMessage, method: signedMessageTransaction.originalRequestParameters.method }
+			return { type: 'result' as const, result: signedMessage, method: signedMessageTransaction.originalRequestParameters.method }
 		}
-		return { forward: true, ...signedMessageTransaction.originalRequestParameters } as const
+		return { type: 'forwardToSigner' as const, ...signedMessageTransaction.originalRequestParameters } as const
 	}
 	return reject(signedMessageTransaction.originalRequestParameters)
 }

--- a/app/ts/components/pages/ConfirmTransaction.tsx
+++ b/app/ts/components/pages/ConfirmTransaction.tsx
@@ -340,7 +340,7 @@ export function ConfirmTransaction() {
 		if (currentWindow.id === undefined) throw new Error('could not get our own Id!')
 		if (pendingTransactions.length === 1) await tryFocusingTabOrWindow({ type: 'tab', id: currentPendingTransaction.uniqueRequestIdentifier.requestSocket.tabId })
 		try {
-			await sendPopupMessageToBackgroundPage({ method: 'popup_confirmDialog', data: { uniqueRequestIdentifier: currentPendingTransaction.uniqueRequestIdentifier, accept: true, popupOrTabId: currentPendingTransaction.popupOrTabId } })
+			await sendPopupMessageToBackgroundPage({ method: 'popup_confirmDialog', data: { uniqueRequestIdentifier: currentPendingTransaction.uniqueRequestIdentifier, action: 'accept', popupOrTabId: currentPendingTransaction.popupOrTabId } })
 		} catch(e) {
 			console.log('eerrr')
 			console.log(e)
@@ -364,7 +364,7 @@ export function ConfirmTransaction() {
 		
 		await sendPopupMessageToBackgroundPage({ method: 'popup_confirmDialog', data: {
 			uniqueRequestIdentifier: currentPendingTransaction.uniqueRequestIdentifier,
-			accept: false,
+			action: 'reject',
 			popupOrTabId: currentPendingTransaction.popupOrTabId,
 			transactionErrorString: getPossibleErrorString(),
 		} })

--- a/app/ts/simulation/services/EthereumSubscriptionService.ts
+++ b/app/ts/simulation/services/EthereumSubscriptionService.ts
@@ -43,6 +43,7 @@ export async function sendSubscriptionMessagesForNewBlock(blockNumber: bigint, e
 				const newBlock = await ethereumClientService.getBlock(blockNumber, false)
 
 				sendSubscriptionReplyOrCallBack(websiteTabConnections, subscriptionOrFilter.subscriptionCreatorSocket, {
+					type: 'result',
 					method: 'newHeads' as const, 
 					result: { subscription: subscriptionOrFilter.type, result: newBlock } as const,
 					subscription: subscriptionOrFilter.subscriptionOrFilterId,
@@ -52,6 +53,7 @@ export async function sendSubscriptionMessagesForNewBlock(blockNumber: bigint, e
 					const simulatedBlock = await getSimulatedBlock(ethereumClientService, simulationState, blockNumber + 1n, false)
 					// post our simulated block on top (reorg it)
 					sendSubscriptionReplyOrCallBack(websiteTabConnections, subscriptionOrFilter.subscriptionCreatorSocket, {
+						type: 'result',
 						method: 'newHeads' as const, 
 						result: { subscription: subscriptionOrFilter.type, result: simulatedBlock },
 						subscription: subscriptionOrFilter.subscriptionOrFilterId,

--- a/app/ts/types/interceptor-messages.ts
+++ b/app/ts/types/interceptor-messages.ts
@@ -24,20 +24,28 @@ export const WalletSwitchEthereumChainReply = funtypes.ReadonlyObject({
 
 export type InpageScriptRequestWithoutIdentifier = funtypes.Static<typeof InpageScriptRequestWithoutIdentifier>
 export const InpageScriptRequestWithoutIdentifier = funtypes.Union(
+	funtypes.ReadonlyObject({ method: funtypes.Literal('signer_reply'), result: funtypes.Unknown }),
 	funtypes.ReadonlyObject({ method: funtypes.Literal('eth_accounts_reply'), result: funtypes.Literal('0x') }),
 	funtypes.ReadonlyObject({ method: funtypes.Literal('signer_chainChanged'), result: funtypes.Literal('0x') }),
-	funtypes.ReadonlyObject({ method: funtypes.Literal('connected_to_signer'), result: funtypes.ReadonlyObject({ metamaskCompatibilityMode: funtypes.Boolean}) }),
+	funtypes.ReadonlyObject({ method: funtypes.Literal('connected_to_signer'), result: funtypes.ReadonlyObject({ metamaskCompatibilityMode: funtypes.Boolean }) }),
 	funtypes.ReadonlyObject({ method: funtypes.Literal('wallet_switchEthereumChain_reply'), result: funtypes.Literal('0x') }),
 )
 
 export type InpageScriptRequest = funtypes.Static<typeof InpageScriptRequest>
 export const InpageScriptRequest = funtypes.Intersect(
-	funtypes.ReadonlyObject({ uniqueRequestIdentifier: UniqueRequestIdentifier }),
+	funtypes.ReadonlyObject({ uniqueRequestIdentifier: UniqueRequestIdentifier, type: funtypes.Literal('result') }),
 	InpageScriptRequestWithoutIdentifier,
 )
 
+export type ErrorReturn = funtypes.Static<typeof ErrorReturn>
+export const ErrorReturn = funtypes.ReadonlyObject({
+	method: funtypes.String,
+	error: funtypes.Intersect(CodeMessageError, funtypes.ReadonlyPartial({ data: funtypes.String }))
+})
+
 export type InpageScriptCallBack = funtypes.Static<typeof InpageScriptCallBack>
 export const InpageScriptCallBack = funtypes.Union(
+	ErrorReturn,
 	funtypes.ReadonlyObject({ method: funtypes.Literal('request_signer_chainId'), result: funtypes.ReadonlyTuple() }),
 	funtypes.ReadonlyObject({ method: funtypes.Literal('request_signer_to_wallet_switchEthereumChain'), result: EthereumQuantity }),
 	funtypes.ReadonlyObject({ method: funtypes.Literal('request_signer_to_eth_requestAccounts'), result: funtypes.ReadonlyTuple() }),
@@ -81,17 +89,6 @@ export const NonForwardingRPCRequestSuccessfullReturnValue = funtypes.Union(
 	funtypes.ReadonlyObject({ method: funtypes.Literal('eth_getFilterLogs'), result: EthGetLogsResponse }),
 )
 
-export type ErrorReturn = funtypes.Static<typeof ErrorReturn>
-export const ErrorReturn = funtypes.ReadonlyObject({
-	method: funtypes.String,
-	error: funtypes.Intersect(
-		CodeMessageError,
-		funtypes.ReadonlyPartial({
-			data: funtypes.String,
-		})
-	)
-})
-
 export type SubscriptionReturnValue = funtypes.Static<typeof SubscriptionReturnValue>
 export const SubscriptionReturnValue = funtypes.ReadonlyObject({
 	method: funtypes.Literal('newHeads'),
@@ -102,18 +99,21 @@ export const SubscriptionReturnValue = funtypes.ReadonlyObject({
 })
 
 export type NonForwardingRPCRequestReturnValue = funtypes.Static<typeof NonForwardingRPCRequestReturnValue>
-export const NonForwardingRPCRequestReturnValue = funtypes.Union(NonForwardingRPCRequestSuccessfullReturnValue, ErrorReturn)
+export const NonForwardingRPCRequestReturnValue = funtypes.Intersect(
+	funtypes.ReadonlyObject({ type: funtypes.Literal('result') }),
+	funtypes.Union(NonForwardingRPCRequestSuccessfullReturnValue, ErrorReturn)
+)
 
 export type ForwardToWallet = funtypes.Static<typeof ForwardToWallet>
 export const ForwardToWallet = 	funtypes.Intersect( // forward directly to wallet
-	funtypes.ReadonlyObject({ forward: funtypes.Literal(true) }),
+	funtypes.ReadonlyObject({ type: funtypes.Literal('forwardToSigner') }),
 	funtypes.Union(SendRawTransactionParams, SendTransactionParams, PersonalSignParams, SignTypedDataParams, OldSignTypedDataParams, WalletAddEthereumChain, EthGetStorageAtParams),
 )
 
 export type UnknownMethodForward = funtypes.Static<typeof UnknownMethodForward>
 export const UnknownMethodForward = funtypes.Intersect(
 	funtypes.ReadonlyObject({
-		forward: funtypes.Literal(true),
+		type: funtypes.Literal('forwardToSigner'),
 		unknownMethod: funtypes.Literal(true),
 		method: funtypes.String,
 	}),
@@ -127,6 +127,7 @@ export const RPCReply = funtypes.Union(
 	NonForwardingRPCRequestReturnValue,
 	ForwardToWallet,
 	UnknownMethodForward,
+	funtypes.ReadonlyObject({ type: funtypes.Literal('doNotReply') }),
 )
 
 export type SubscriptionReplyOrCallBack = funtypes.Static<typeof SubscriptionReplyOrCallBack>
@@ -134,6 +135,7 @@ export const SubscriptionReplyOrCallBack = funtypes.Union(
 	InpageScriptCallBack,
 	funtypes.Intersect(
 		funtypes.ReadonlyObject({
+			type: funtypes.Literal('result'),
 			method: funtypes.String,
 			subscription: funtypes.String,
 		}),
@@ -144,13 +146,13 @@ export const SubscriptionReplyOrCallBack = funtypes.Union(
 export type InterceptedRequestForwardWithRequestId = funtypes.Static<typeof InterceptedRequestForwardWithRequestId>
 export const InterceptedRequestForwardWithRequestId = funtypes.Intersect(
 	funtypes.ReadonlyObject({ requestId: funtypes.Number }),
-	funtypes.Union(RPCReply, InpageScriptRequestWithoutIdentifier),
+	funtypes.Union(RPCReply, funtypes.Intersect(funtypes.ReadonlyObject({ type: funtypes.Literal('result') }), InpageScriptRequestWithoutIdentifier)),
 )
 
 export type InterceptedRequestForward = funtypes.Static<typeof InterceptedRequestForward>
 export const InterceptedRequestForward = funtypes.Intersect(
 	funtypes.ReadonlyObject({ uniqueRequestIdentifier: UniqueRequestIdentifier }),
-	funtypes.Union(RPCReply, InpageScriptRequestWithoutIdentifier),
+	funtypes.Union(RPCReply, funtypes.Intersect(funtypes.ReadonlyObject({ type: funtypes.Literal('result') }), InpageScriptRequestWithoutIdentifier)),
 )
 
 export type InterceptorMessageToInpage = funtypes.Static<typeof InterceptorMessageToInpage>
@@ -175,19 +177,23 @@ export type TransactionConfirmation = funtypes.Static<typeof TransactionConfirma
 export const TransactionConfirmation = funtypes.ReadonlyObject({
 	method: funtypes.Literal('popup_confirmDialog'),
 	data: funtypes.Union(
-		funtypes.ReadonlyObject({
-			uniqueRequestIdentifier: UniqueRequestIdentifier,
-			accept: funtypes.Literal(true),
-			popupOrTabId: PopupOrTabId,
-		}),
-		funtypes.ReadonlyObject({
-			uniqueRequestIdentifier: UniqueRequestIdentifier,
-			accept: funtypes.Literal(false),
-			popupOrTabId: PopupOrTabId,
-			transactionErrorString: funtypes.Union(funtypes.String, funtypes.Undefined),
-		})
+		funtypes.Intersect(
+			funtypes.ReadonlyObject({ 
+				uniqueRequestIdentifier: UniqueRequestIdentifier,
+				popupOrTabId: PopupOrTabId
+			}),
+			funtypes.Union(
+				funtypes.ReadonlyObject({
+					action: funtypes.Union(funtypes.Literal('accept'), funtypes.Literal('noResponse')),
+				}),
+				funtypes.ReadonlyObject({
+					action: funtypes.Literal('reject'),
+					transactionErrorString: funtypes.Union(funtypes.String, funtypes.Undefined),
+				}),
+			)
+		)
 	)
-}).asReadonly()
+})
 
 export type PersonalSignApproval = funtypes.Static<typeof PersonalSignApproval>
 export const PersonalSignApproval = funtypes.ReadonlyObject({
@@ -331,6 +337,35 @@ export const ConnectedToSigner = funtypes.ReadonlyObject({
 	params: funtypes.Tuple(SignerName),
 }).asReadonly()
 
+
+export type SignerReplyForwardRequest = funtypes.Static<typeof SignerReplyForwardRequest>
+export const SignerReplyForwardRequest = funtypes.Intersect(
+	funtypes.ReadonlyObject({ requestId: funtypes.Number }),
+	ForwardToWallet,
+	UnknownMethodForward,
+)
+
+export type SignerReply = funtypes.Static<typeof SignerReply>
+export const SignerReply = funtypes.ReadonlyObject({
+	method: funtypes.Literal('signer_reply'),
+	params: funtypes.Tuple(funtypes.Union(
+		funtypes.ReadonlyObject({
+			success: funtypes.Literal(true),
+			forwardRequest: SignerReplyForwardRequest,
+			reply: funtypes.Unknown,
+		}),
+		funtypes.ReadonlyObject({
+			success: funtypes.Literal(false),
+			forwardRequest: SignerReplyForwardRequest,
+			error: funtypes.Intersect(
+				CodeMessageError,
+				funtypes.ReadonlyPartial({ data: funtypes.String })
+			)
+		})
+
+	)),
+}).asReadonly()
+
 export type GetAddressBookDataFilter = funtypes.Static<typeof GetAddressBookDataFilter>
 export const GetAddressBookDataFilter = funtypes.Intersect(
 	funtypes.ReadonlyObject({
@@ -451,7 +486,7 @@ export const InterceptorAccessReply = funtypes.ReadonlyObject({
 	accessRequestId: funtypes.String,
 	originalRequestAccessToAddress: OptionalEthereumAddress,
 	requestAccessToAddress: OptionalEthereumAddress,
-	userReply: funtypes.Union(funtypes.Literal('Approved'), funtypes.Literal('Rejected'), funtypes.Literal('NoResponse') ),
+	userReply: funtypes.Union(funtypes.Literal('Approved'), funtypes.Literal('Rejected'), funtypes.Literal('noResponse') ),
 })
 
 export type InterceptorAccess = funtypes.Static<typeof InterceptorAccess>

--- a/app/ts/types/interceptor-messages.ts
+++ b/app/ts/types/interceptor-messages.ts
@@ -131,16 +131,18 @@ export const RPCReply = funtypes.Union(
 )
 
 export type SubscriptionReplyOrCallBack = funtypes.Static<typeof SubscriptionReplyOrCallBack>
-export const SubscriptionReplyOrCallBack = funtypes.Union(
-	InpageScriptCallBack,
-	funtypes.Intersect(
-		funtypes.ReadonlyObject({
-			type: funtypes.Literal('result'),
-			method: funtypes.String,
-			subscription: funtypes.String,
-		}),
-		SubscriptionReturnValue,
-	),
+export const SubscriptionReplyOrCallBack = funtypes.Intersect(
+	funtypes.ReadonlyObject({ type: funtypes.Literal('result') }),
+	funtypes.Union(
+		InpageScriptCallBack,
+		funtypes.Intersect(
+			funtypes.ReadonlyObject({
+				method: funtypes.String,
+				subscription: funtypes.String,
+			}),
+			SubscriptionReturnValue,
+		)
+	)
 )
 
 export type InterceptedRequestForwardWithRequestId = funtypes.Static<typeof InterceptedRequestForwardWithRequestId>


### PR DESCRIPTION
- Refactor confirm transaction so that we do not wait for a promise anymore, but resolve the transactions from the local storage always
- When forward to signer request is sent to a signer, get the signers reply back to the interceptor and then return it only after that (currently we just log that this happened, but we don't do any modifications to it)
- Add `type` variable to forwarding messages to make it more clear what kind of message it is. Before there was quite confusing way to recognize it

work towards https://github.com/DarkFlorist/TheInterceptor/issues/810