### PR TITLE
keep window open when sending transaction on signing mode until its approved by signer

### DIFF
--- a/app/inpage/ts/inpage.ts
+++ b/app/inpage/ts/inpage.ts
@@ -531,8 +531,7 @@ class InterceptorMessageListener {
 		}
 		const signerReply = await sendToSignerWithCatchError()
 		try {
-			const interceptorReply = await this.sendMessageToBackgroundPage({ method: 'signer_reply', params: [ signerReply ] })
-			pendingRequest.resolve(interceptorReply)
+			await this.sendMessageToBackgroundPage({ method: 'signer_reply', params: [ signerReply ] })
 		} catch(error: unknown) {
 			if (error instanceof Error) return pendingRequest.reject(error)
 			if (typeof error === 'object' && error !== null

--- a/app/ts/background/popupMessageHandlers.ts
+++ b/app/ts/background/popupMessageHandlers.ts
@@ -1,6 +1,6 @@
 import { changeActiveAddressAndChainAndResetSimulation, changeActiveRpc, getPrependTransactions, refreshConfirmTransactionSimulation, updateSimulationState, updateSimulationMetadata, simulateGovernanceContractExecution } from './background.js'
 import { getSettings, setUseTabsInsteadOfPopup, setMakeMeRich, setPage, setUseSignersAddressAsActiveAddress, updateWebsiteAccess, exportSettingsAndAddressBook, importSettingsAndAddressBook, getMakeMeRich, getUseTabsInsteadOfPopup, getMetamaskCompatibilityMode, setMetamaskCompatibilityMode, getPage } from './settings.js'
-import { getPendingTransactions, getCurrentTabId, getTabState, saveCurrentTabId, setRpcList, getRpcList, getPrimaryRpcForChain, getRpcConnectionStatus, updateUserAddressBookEntries, getSimulationResults, setIdsOfOpenedTabs, getIdsOfOpenedTabs, replacePendingTransaction } from './storageVariables.js'
+import { getPendingTransactions, getCurrentTabId, getTabState, saveCurrentTabId, setRpcList, getRpcList, getPrimaryRpcForChain, getRpcConnectionStatus, updateUserAddressBookEntries, getSimulationResults, setIdsOfOpenedTabs, getIdsOfOpenedTabs, updatePendingTransaction } from './storageVariables.js'
 import { Simulator, parseEvents } from '../simulation/simulator.js'
 import { ChangeActiveAddress, ChangeMakeMeRich, ChangePage, RemoveTransaction, RequestAccountsFromSigner, TransactionConfirmation, InterceptorAccess, ChangeInterceptorAccess, ChainChangeConfirmation, EnableSimulationMode, ChangeActiveChain, AddOrEditAddressBookEntry, GetAddressBookData, RemoveAddressBookEntry, InterceptorAccessRefresh, InterceptorAccessChangeAddress, Settings, RefreshConfirmTransactionMetadata, RefreshInterceptorAccessMetadata, ChangeSettings, ImportSettings, SetRpcList, PersonalSignApproval, UpdateHomePage, RemoveSignedMessage, SimulateGovernanceContractExecutionReply, SimulateGovernanceContractExecution, ChangeAddOrModifyAddressWindowState, FetchAbiAndNameFromEtherscan, OpenWebPage, DisableInterceptor } from '../types/interceptor-messages.js'
 import { formEthSendTransaction, formSendRawTransaction, resolvePendingTransaction } from './windows/confirmTransaction.js'
@@ -170,7 +170,7 @@ export async function refreshPopupConfirmTransactionMetadata(ethereumClientServi
 	const first = promises[0]
 	const addressBookEntries = await addressBookEntriesPromise
 	const namedTokenIds = await namedTokenIdsPromise
-	if (first === undefined || first.status !== 'Simulated' || first.simulationResults === undefined || first.simulationResults.statusCode !== 'success') return
+	if (first === undefined || first.transactionCreationStatus !== 'Simulated' || first.simulationResults === undefined || first.simulationResults.statusCode !== 'success') return
 	return await sendPopupMessageToOpenWindows({
 		method: 'popup_update_confirm_transaction_dialog',
 		data: {
@@ -194,12 +194,12 @@ export async function refreshPopupConfirmTransactionMetadata(ethereumClientServi
 export async function refreshPopupConfirmTransactionSimulation(simulator: Simulator, ethereumClientService: EthereumClientService) {
 	const currentBlockNumberPromise = ethereumClientService.getBlockNumber()
 	const [firstTxn] = await getPendingTransactions()
-	if (firstTxn === undefined || firstTxn.status !== 'Simulated') return
+	if (firstTxn === undefined || firstTxn.transactionCreationStatus !== 'Simulated') return
 	const transactionToSimulate = firstTxn.originalRequestParameters.method === 'eth_sendTransaction' ? await formEthSendTransaction(ethereumClientService, firstTxn.activeAddress, firstTxn.simulationMode, firstTxn.transactionToSimulate.website, firstTxn.originalRequestParameters, firstTxn.created, firstTxn.transactionIdentifier) : await formSendRawTransaction(ethereumClientService, firstTxn.originalRequestParameters, firstTxn.transactionToSimulate.website, firstTxn.created, firstTxn.transactionIdentifier)
 	if (transactionToSimulate.success === false) return
 	const refreshMessage = await refreshConfirmTransactionSimulation(simulator, ethereumClientService, firstTxn.activeAddress, firstTxn.simulationMode, firstTxn.uniqueRequestIdentifier, transactionToSimulate)
 	
-	await replacePendingTransaction({...firstTxn, transactionToSimulate, simulationResults: refreshMessage })
+	await updatePendingTransaction(firstTxn.uniqueRequestIdentifier, async (transaction) => ({...transaction, simulationResults: refreshMessage }))
 	return await sendPopupMessageToOpenWindows({ method: 'popup_update_confirm_transaction_dialog', data: {
 		pendingTransactions: await getPendingTransactions(),
 		currentBlockNumber: await currentBlockNumberPromise,

--- a/app/ts/background/storageVariables.ts
+++ b/app/ts/background/storageVariables.ts
@@ -42,16 +42,11 @@ export async function updatePendingTransactions(update: (pendingTransactions: re
 
 export async function updatePendingTransaction(uniqueRequestIdentifier: UniqueRequestIdentifier, update: (pendingTransaction: PendingTransaction) => Promise<PendingTransaction>) {
 	return await updatePendingTransactions(async (pendingTransactions) => {
-		console.log('updatePendingTransaction')
 		const match = pendingTransactions.findIndex((pending) => doesUniqueRequestIdentifiersMatch(pending.uniqueRequestIdentifier, uniqueRequestIdentifier))
 		if (match < 0) return pendingTransactions
 		const foundTransaction = pendingTransactions[match]
 		if (foundTransaction === undefined) return pendingTransactions
-		console.log('old')
-		console.log(foundTransaction)
 		const pendingTransaction = await update(foundTransaction)
-		console.log('replacing')
-		console.log(pendingTransaction)
 		return replaceElementInReadonlyArray(pendingTransactions, match, pendingTransaction)
 	})
 }

--- a/app/ts/components/subcomponents/Spinner.tsx
+++ b/app/ts/components/subcomponents/Spinner.tsx
@@ -1,11 +1,11 @@
-export function Spinner({ height } : { height: string }) {
+export function Spinner({ height, color } : { height: string, color?: string }) {
 	return (
 		<svg
-			style = { { height, margin: 'auto'  } }
+			style = { { height, margin: 'auto'} }
 			class = 'spinner'
 			viewBox = '0 0 100 100'
 			xmlns = 'http://www.w3.org/2000/svg'>
-				<circle cx = '50' cy = '50' r = '45'/>
+				<circle cx = '50' cy = '50' r = '45' style = { { ...color !== undefined ? { stroke: color } : {}  } }/>
 		</svg>
 	)
 }

--- a/app/ts/types/accessRequest.ts
+++ b/app/ts/types/accessRequest.ts
@@ -71,6 +71,16 @@ export const ConfirmTransactionSimulationFailed = funtypes.ReadonlyObject({
 export type ConfirmTransactionTransactionSingleVisualization = funtypes.Static<typeof ConfirmTransactionTransactionSingleVisualization>
 export const ConfirmTransactionTransactionSingleVisualization = funtypes.Union(ConfirmTransactionSimulationFailed, ConfirmTransactionSimulationStateChanged)
 
+export type PendingTransactionApprovalStatus = funtypes.Static<typeof PendingTransactionApprovalStatus>
+export const PendingTransactionApprovalStatus = funtypes.Union(
+	funtypes.ReadonlyObject({ status: funtypes.Union(funtypes.Literal('WaitingForUser'), funtypes.Literal('WaitingForSigner')) }),
+	funtypes.ReadonlyObject({
+		status: funtypes.Union(funtypes.Literal('SignerError')),
+		code: funtypes.Number,
+		message: funtypes.String,
+	}),
+)
+
 export type SimulatedPendingTransactionBase = funtypes.Static<typeof SimulatedPendingTransactionBase>
 export const SimulatedPendingTransactionBase = funtypes.ReadonlyObject({
 	popupOrTabId: PopupOrTabId,
@@ -81,6 +91,7 @@ export const SimulatedPendingTransactionBase = funtypes.ReadonlyObject({
 	created: EthereumTimestamp,
 	transactionIdentifier: EthereumQuantity,
 	website: Website,
+	approvalStatus: PendingTransactionApprovalStatus,
 })
 
 export type SimulatedPendingTransaction = funtypes.Static<typeof SimulatedPendingTransaction>
@@ -89,11 +100,11 @@ export const SimulatedPendingTransaction = funtypes.Intersect(
 	funtypes.ReadonlyObject({ simulationResults: ConfirmTransactionTransactionSingleVisualization }),
 	funtypes.Union(
 		funtypes.ReadonlyObject({
-			status: funtypes.Literal('Simulated'),
+			transactionCreationStatus: funtypes.Literal('Simulated'),
 			transactionToSimulate: WebsiteCreatedEthereumUnsignedTransaction,
 		}),
 		funtypes.ReadonlyObject({
-			status: funtypes.Literal('FailedToSimulate'),
+			transactionCreationStatus: funtypes.Literal('FailedToSimulate'),
 			transactionToSimulate: FailedToCreateWebsiteCreatedEthereumUnsignedTransaction,
 		}),
 	)
@@ -102,7 +113,7 @@ export const SimulatedPendingTransaction = funtypes.Intersect(
 export type CraftingTransactionPendingTransaction = funtypes.Static<typeof CraftingTransactionPendingTransaction>
 export const CraftingTransactionPendingTransaction = funtypes.Intersect(
 	SimulatedPendingTransactionBase,
-	funtypes.ReadonlyObject({ status: funtypes.Literal('Crafting Transaction') })
+	funtypes.ReadonlyObject({ transactionCreationStatus: funtypes.Literal('Crafting Transaction') })
 )
 
 export type WaitingForSimulationPendingTransaction = funtypes.Static<typeof WaitingForSimulationPendingTransaction>
@@ -110,7 +121,7 @@ export const WaitingForSimulationPendingTransaction = funtypes.Intersect(
 	SimulatedPendingTransactionBase,
 	funtypes.ReadonlyObject({
 		transactionToSimulate: WebsiteCreatedEthereumUnsignedTransaction,
-		status: funtypes.Literal('Simulating')
+		transactionCreationStatus: funtypes.Literal('Simulating')
 	})
 )
 

--- a/app/ts/types/interceptor-messages.ts
+++ b/app/ts/types/interceptor-messages.ts
@@ -7,7 +7,7 @@ import { UniqueRequestIdentifier, WebsiteSocket } from '../utils/requests.js'
 import { EthGetFeeHistoryResponse, EthGetLogsResponse, EthGetStorageAtParams, EthTransactionReceiptResponse, GetBlockReturn, GetSimulationStackReply, SendRawTransactionParams, SendTransactionParams, WalletAddEthereumChain } from './JsonRpc-types.js'
 import { AddressBookEntries, AddressBookEntry, ActiveAddressEntry } from './addressBookTypes.js'
 import { Page } from './exportedSettingsTypes.js'
-import { PopupOrTabId, Website, WebsiteAccess, WebsiteAccessArray } from './websiteAccessTypes.js'
+import { Website, WebsiteAccess, WebsiteAccessArray } from './websiteAccessTypes.js'
 import { SignerName } from './signerTypes.js'
 import { ConfirmTransactionDialogState, PendingAccessRequests, PendingTransaction } from './accessRequest.js'
 import { CodeMessageError, RpcEntries, RpcEntry, RpcNetwork } from './rpc.js'
@@ -24,6 +24,7 @@ export const WalletSwitchEthereumChainReply = funtypes.ReadonlyObject({
 
 export type InpageScriptRequestWithoutIdentifier = funtypes.Static<typeof InpageScriptRequestWithoutIdentifier>
 export const InpageScriptRequestWithoutIdentifier = funtypes.Union(
+	funtypes.ReadonlyObject({ type: funtypes.Literal('doNotReply') }),
 	funtypes.ReadonlyObject({ method: funtypes.Literal('signer_reply'), result: funtypes.Unknown }),
 	funtypes.ReadonlyObject({ method: funtypes.Literal('eth_accounts_reply'), result: funtypes.Literal('0x') }),
 	funtypes.ReadonlyObject({ method: funtypes.Literal('signer_chainChanged'), result: funtypes.Literal('0x') }),
@@ -182,9 +183,12 @@ export const TransactionConfirmation = funtypes.ReadonlyObject({
 		funtypes.Intersect(
 			funtypes.ReadonlyObject({ 
 				uniqueRequestIdentifier: UniqueRequestIdentifier,
-				popupOrTabId: PopupOrTabId
 			}),
 			funtypes.Union(
+				funtypes.ReadonlyObject({
+					action: funtypes.Literal('signerIncluded'),
+					transactionHash: EthereumBytes32,
+				}),
 				funtypes.ReadonlyObject({
 					action: funtypes.Union(funtypes.Literal('accept'), funtypes.Literal('noResponse')),
 				}),
@@ -343,8 +347,7 @@ export const ConnectedToSigner = funtypes.ReadonlyObject({
 export type SignerReplyForwardRequest = funtypes.Static<typeof SignerReplyForwardRequest>
 export const SignerReplyForwardRequest = funtypes.Intersect(
 	funtypes.ReadonlyObject({ requestId: funtypes.Number }),
-	ForwardToWallet,
-	UnknownMethodForward,
+	funtypes.Union(ForwardToWallet, UnknownMethodForward)
 )
 
 export type SignerReply = funtypes.Static<typeof SignerReply>


### PR DESCRIPTION
when sending transaction on signing mode, don't close the window but go into pending mode and close the window only when signer has approved it. If signer throws error, show that error on the UI

<img width="696" alt="image" src="https://github.com/DarkFlorist/TheInterceptor/assets/13102010/d411d3d0-2825-4515-915f-0068f3489ac7">
