### PR TITLE
remix fixes

### DIFF
--- a/app/ts/background/background.ts
+++ b/app/ts/background/background.ts
@@ -474,7 +474,7 @@ export const handleInterceptedRequest = async (port: browser.runtime.Port | unde
 	const identifiedMethod = providerHandler.method
 	if (identifiedMethod !== 'notProviderMethod') {
 		if (port === undefined) return
-		const providerHandlerReturn = await providerHandler.func(simulator, websiteTabConnections, port, request, access)
+		const providerHandlerReturn = await providerHandler.func(simulator, websiteTabConnections, port, request, access, activeAddress?.address)
 		if (providerHandlerReturn.type === 'doNotReply') return
 		const message: InpageScriptRequest = { uniqueRequestIdentifier: request.uniqueRequestIdentifier, ...providerHandlerReturn }
 		return replyToInterceptedRequest(websiteTabConnections, message)

--- a/app/ts/components/simulationExplaining/customExplainers/CatchAllVisualizer.tsx
+++ b/app/ts/components/simulationExplaining/customExplainers/CatchAllVisualizer.tsx
@@ -5,6 +5,8 @@ import { TokenSymbol, TokenAmount } from '../../subcomponents/coins.js'
 import { RenameAddressCallBack } from '../../../types/user-interface-types.js'
 import { SmallAddress } from '../../subcomponents/address.js'
 import { assertNever } from '../../../utils/typescript.js'
+import { getDeployedContractAddress } from '../../../simulation/services/SimulationModeEthereumClientService.js'
+import { addressString } from '../../../utils/bigint.js'
 
 type SendOrReceiveTokensImportanceBoxParams = {
 	sending: boolean,
@@ -119,7 +121,7 @@ export function CatchAllVisualizer(param: TransactionImportanceBlockParams) {
 			{ /* contract creation */}
 			{ param.simTx.transaction.to !== undefined ? <></> : <>
 				<div class = 'log-cell' style = 'justify-content: left; display: grid;'>
-					<p class = 'paragraph'> The transaction deploys a contract </p>
+					<p class = 'paragraph'> { `A contract is deployed to address ${ addressString(getDeployedContractAddress(param.simTx.transaction.from.address, param.simTx.transaction.nonce)) }` }</p>
 				</div>
 			</> }
 

--- a/app/ts/simulation/services/SimulationModeEthereumClientService.ts
+++ b/app/ts/simulation/services/SimulationModeEthereumClientService.ts
@@ -1,16 +1,17 @@
 import { EthereumClientService } from './EthereumClientService.js'
 import { EthereumUnsignedTransaction, EthereumSignedTransactionWithBlockData, EthereumBlockTag, EthereumAddress, EthereumBlockHeader, EthereumBlockHeaderWithTransactionHashes, EthereumSignedTransaction, EthereumData, EthereumQuantity, EthereumBytes32 } from '../../types/wire-types.js'
-import { addressString, bytes32String, calculateWeightedPercentile, dataStringWith0xStart, max, min, stringToUint8Array } from '../../utils/bigint.js'
+import { addressString, bigintToUint8Array, bytes32String, calculateWeightedPercentile, dataStringWith0xStart, max, min, stringToUint8Array } from '../../utils/bigint.js'
 import { CANNOT_SIMULATE_OFF_LEGACY_BLOCK, ERROR_INTERCEPTOR_GAS_ESTIMATION_FAILED, ETHEREUM_LOGS_LOGGER_ADDRESS, ETHEREUM_EIP1559_BASEFEECHANGEDENOMINATOR, ETHEREUM_EIP1559_ELASTICITY_MULTIPLIER, MOCK_ADDRESS, MULTICALL3, Multicall3ABI, DEFAULT_CALL_ADDRESS, GAS_PER_BLOB } from '../../utils/constants.js'
 import { Interface, TypedDataEncoder, ethers, hashMessage, keccak256, } from 'ethers'
 import { WebsiteCreatedEthereumUnsignedTransaction, SimulatedTransaction, SimulationState, TokenBalancesAfter, EstimateGasError, SignedMessageTransaction, WebsiteCreatedEthereumUnsignedTransactionOrFailed } from '../../types/visualizer-types.js'
-import { EthereumUnsignedTransactionToUnsignedTransaction, IUnsignedTransaction1559, serializeSignedTransactionToBytes } from '../../utils/ethereum.js'
+import { EthereumUnsignedTransactionToUnsignedTransaction, IUnsignedTransaction1559, rlpEncode, serializeSignedTransactionToBytes } from '../../utils/ethereum.js'
 import { EthGetLogsResponse, EthGetLogsRequest, EthTransactionReceiptResponse, DappRequestTransaction, EthGetFeeHistoryResponse, FeeHistory } from '../../types/JsonRpc-types.js'
 import { handleERC1155TransferBatch, handleERC1155TransferSingle } from '../logHandlers.js'
 import { assertNever } from '../../utils/typescript.js'
 import { SignMessageParams } from '../../types/jsonRpc-signing-types.js'
 import { EthSimulateV1CallResults, EthereumEvent, StateOverrides } from '../../types/multicall-types.js'
 import { getCodeByteCode } from '../../utils/ethereumByteCodes.js'
+import { stripLeadingZeros } from '../../utils/typed-arrays.js'
 
 const MOCK_PUBLIC_PRIVATE_KEY = 0x1n // key used to sign mock transactions
 const MOCK_SIMULATION_PRIVATE_KEY = 0x2n // key used to sign simulated transatons
@@ -425,6 +426,10 @@ export const getSimulatedTransactionCount = async (ethereumClientService: Ethere
 	return (await ethereumClientService.getTransactionCount(address, blockNumToUse)) + addedTransactions
 }
 
+export const getDeployedContractAddress = (from: EthereumAddress, nonce: EthereumQuantity): EthereumAddress => {
+	return BigInt(`0x${ keccak256(rlpEncode([stripLeadingZeros(bigintToUint8Array(from, 20)), stripLeadingZeros(bigintToUint8Array(nonce, 32))])).slice(26) }`)
+}
+
 export const getSimulatedTransactionReceipt = async (ethereumClientService: EthereumClientService, simulationState: SimulationState | undefined, hash: bigint): Promise<EthTransactionReceiptResponse> => {
 	let cumGas = 0n
 	let currentLogIndex = 0
@@ -445,7 +450,7 @@ export const getSimulatedTransactionReceipt = async (ethereumClientService: Ethe
 				blockNumber: blockNum,
 				transactionHash: simulatedTransaction.signedTransaction.hash,
 				transactionIndex: BigInt(index),
-				contractAddress: null, // this is not correct if we actually deploy contract, where to get right value?
+				contractAddress: simulatedTransaction.signedTransaction.to !== null ? null : getDeployedContractAddress(simulatedTransaction.signedTransaction.from, simulatedTransaction.signedTransaction.nonce),
 				cumulativeGasUsed: cumGas,
 				gasUsed: simulatedTransaction.ethSimulateV1CallResult.gasUsed,
 				effectiveGasPrice: 0x2n,

--- a/app/ts/types/JsonRpc-types.ts
+++ b/app/ts/types/JsonRpc-types.ts
@@ -82,7 +82,7 @@ export const DappRequestTransaction = funtypes.ReadonlyPartial({
 	} else if (x.maxPriorityFeePerGas !== undefined) {
 		return x.maxFeePerGas !== undefined && x.gasPrice === undefined
 	} else if (x.maxFeePerGas !== undefined) {
-		return x.maxPriorityFeePerGas !== undefined && x.gasPrice === undefined
+		return x.gasPrice === undefined /* && x.maxPriorityFeePerGas !== undefined*/ //Remix doesn't send "maxPriorityFeePerGas" with "maxFeePerGas"
 	} else {
 		return true
 	}

--- a/app/ts/types/interceptor-messages.ts
+++ b/app/ts/types/interceptor-messages.ts
@@ -29,7 +29,7 @@ export const InpageScriptRequestWithoutIdentifier = funtypes.Union(
 	funtypes.ReadonlyObject({ method: funtypes.Literal('signer_reply'), result: funtypes.Unknown }),
 	funtypes.ReadonlyObject({ method: funtypes.Literal('eth_accounts_reply'), result: funtypes.Literal('0x') }),
 	funtypes.ReadonlyObject({ method: funtypes.Literal('signer_chainChanged'), result: funtypes.Literal('0x') }),
-	funtypes.ReadonlyObject({ method: funtypes.Literal('connected_to_signer'), result: funtypes.ReadonlyObject({ metamaskCompatibilityMode: funtypes.Boolean }) }),
+	funtypes.ReadonlyObject({ method: funtypes.Literal('connected_to_signer'), result: funtypes.ReadonlyObject({ metamaskCompatibilityMode: funtypes.Boolean, activeAddress: funtypes.Union(EthereumAddress, funtypes.Undefined) }) }),
 	funtypes.ReadonlyObject({ method: funtypes.Literal('wallet_switchEthereumChain_reply'), result: funtypes.Literal('0x') }),
 )
 

--- a/app/ts/utils/ethereum.ts
+++ b/app/ts/utils/ethereum.ts
@@ -99,7 +99,7 @@ export function calculateV(transaction: DistributiveOmit<ITransactionSignatureLe
 }
 
 type RlpEncodeableData = Uint8Array | Array<RlpEncodeableData>
-function rlpEncode(data: RlpEncodeableData[]): Uint8Array {
+export function rlpEncode(data: RlpEncodeableData[]): Uint8Array {
 	function rlpEncodeArray(data: RlpEncodeableData): ethers.RlpStructuredData {
 		if (!Array.isArray(data)) return `0x${ dataString(data) }`
 		return data.map((x) => Array.isArray(x) ? rlpEncodeArray(x) : `0x${ dataString(x) }`)


### PR DESCRIPTION
- calculate contract deployment address and show it in UI
- add right contract deployment address to transaction receipt
<img width="580" alt="image" src="https://github.com/DarkFlorist/TheInterceptor/assets/13102010/c964415b-7041-4c01-81f8-5c1e1ec8ba74">

- don't require `maxPriorityFeePerGas` if `maxFeePerGas` is set