### PR TITLE
Fix blockie rendering gaps

### DIFF
--- a/app/ts/components/subcomponents/SVGBlockie.tsx
+++ b/app/ts/components/subcomponents/SVGBlockie.tsx
@@ -96,12 +96,12 @@ export function Blockie({ address, style }: SVGBlockieProps) {
 	const pixelDensity = 8
 	const { imageData, color, spotcolor, bgcolor } = useMemo(() => generateIdenticon({ address, size: pixelDensity }), [address])
 	return (
-		<svg width = '1em' height = '1em' viewBox = '0 0 64 64' xmlns = 'http://www.w3.org/2000/svg' { ...( style ? { style } : {}) }>
+		<svg width = '1em' height = '1em' viewBox = '0 0 64 64' xmlns = 'http://www.w3.org/2000/svg' { ...( style ? { style } : {}) } shape-rendering = 'crispEdges'>
 			{ imageData.map((data, index) => {
 				const fill = data === 0 ? bgcolor : data === 1 ? color : spotcolor
 				const pixelSize = 64 / pixelDensity
 
-				return <rect shapeRendering= 'crispedges' width = { pixelSize } height = { pixelSize } x = { ((index % pixelDensity) * 64) / pixelDensity } y = { Math.floor(index / pixelDensity) * pixelSize } fill = { fill } />
+				return <rect width = { pixelSize } height = { pixelSize } x = { ((index % pixelDensity) * 64) / pixelDensity } y = { Math.floor(index / pixelDensity) * pixelSize } fill = { fill } />
 			}) }
 		</svg>
 	)

--- a/app/ts/components/subcomponents/SVGBlockie.tsx
+++ b/app/ts/components/subcomponents/SVGBlockie.tsx
@@ -101,7 +101,7 @@ export function Blockie({ address, style }: SVGBlockieProps) {
 				const fill = data === 0 ? bgcolor : data === 1 ? color : spotcolor
 				const pixelSize = 64 / pixelDensity
 
-				return <rect width = { pixelSize } height = { pixelSize } x = { ((index % pixelDensity) * 64) / pixelDensity } y = { Math.floor(index / pixelDensity) * pixelSize } fill = { fill } />
+				return <rect shapeRendering= 'crispedges' width = { pixelSize } height = { pixelSize } x = { ((index % pixelDensity) * 64) / pixelDensity } y = { Math.floor(index / pixelDensity) * pixelSize } fill = { fill } />
 			}) }
 		</svg>
 	)

--- a/app/ts/components/subcomponents/SVGBlockie.tsx
+++ b/app/ts/components/subcomponents/SVGBlockie.tsx
@@ -96,12 +96,12 @@ export function Blockie({ address, style }: SVGBlockieProps) {
 	const pixelDensity = 8
 	const { imageData, color, spotcolor, bgcolor } = useMemo(() => generateIdenticon({ address, size: pixelDensity }), [address])
 	return (
-		<svg width = '1em' height = '1em' viewBox = '0 0 64 64' xmlns = 'http://www.w3.org/2000/svg' { ...( style ? { style } : {}) } shape-rendering = 'crispEdges'>
+		<svg width = '1em' height = '1em' viewBox = '0 0 64 64' xmlns = 'http://www.w3.org/2000/svg' { ...( style ? { style } : {}) }>
 			{ imageData.map((data, index) => {
 				const fill = data === 0 ? bgcolor : data === 1 ? color : spotcolor
 				const pixelSize = 64 / pixelDensity
 
-				return <rect width = { pixelSize } height = { pixelSize } x = { ((index % pixelDensity) * 64) / pixelDensity } y = { Math.floor(index / pixelDensity) * pixelSize } fill = { fill } />
+				return <rect width = { pixelSize } height = { pixelSize } x = { ((index % pixelDensity) * 64) / pixelDensity } y = { Math.floor(index / pixelDensity) * pixelSize } fill = { fill } shape-rendering = 'crispEdges' />
 			}) }
 		</svg>
 	)


### PR DESCRIPTION
Force renderer (browser) to display this SVG in crisp edges.

![image](https://github.com/DarkFlorist/TheInterceptor/assets/1169838/e9ee4c2a-695e-4b6c-acf3-041f12701864)

Update:

- preact doesn't actually transform the camelCase attribute so used dashes
