### PR TITLE
blockheader can be null

### DIFF
--- a/app/ts/types/wire-types.ts
+++ b/app/ts/types/wire-types.ts
@@ -425,10 +425,10 @@ const EthereumBlockHeaderWithoutTransactions = funtypes.Intersect(
 )
 
 export type EthereumBlockHeaderWithTransactionHashes = funtypes.Static<typeof EthereumBlockHeaderWithTransactionHashes>
-export const EthereumBlockHeaderWithTransactionHashes = funtypes.Intersect(
+export const EthereumBlockHeaderWithTransactionHashes = funtypes.Union(funtypes.Null, funtypes.Intersect(
 	EthereumBlockHeaderWithoutTransactions,
 	funtypes.ReadonlyObject({ transactions: funtypes.ReadonlyArray(EthereumBytes32) })
-)
+))
 
 export type EthereumBlockHeader = funtypes.Static<typeof EthereumBlockHeader>
 export const EthereumBlockHeader = funtypes.Intersect(

--- a/test/tests/nethermindComparison.ts
+++ b/test/tests/nethermindComparison.ts
@@ -101,6 +101,7 @@ export async function main() {
 
 		should('getBlock with false aligns with Nethermind', async () => {
 			const block = await getSimulatedBlock(ethereum, undefined, simulationState, blockNumber, false)
+			if (block === null) throw new Error('Block was null')
 			const serialized = GetBlockReturn.serialize(block)
 			const expected = parseRequest(eth_getBlockByNumber_goerli_8443561_false)
 			assertIsObject(expected)


### PR DESCRIPTION
the blockheader can be null if its missing: <https://www.quicknode.com/docs/ethereum/eth_getBlockByNumber>