### PR TITLE
reverse resolution hashes

### DIFF
--- a/app/ts/background/background.ts
+++ b/app/ts/background/background.ts
@@ -43,11 +43,11 @@ async function updateMetadataForSimulation(simulationState: SimulationState, eth
 	const settingsPromise = getSettings()
 	const settings = await settingsPromise
 	const allEvents = eventsForEachTransaction.flat()
-	const ensLabelHashesPromise = retrieveEnsLabelHashes(allEvents)
-	const ensNameHashesPromise = retrieveEnsNodeHashes(ethereum, allEvents)
 	const addressBookEntryPromises = getAddressBookEntriesForVisualiser(ethereum, requestAbortController, allEvents, simulationState)
 	const namedTokenIdPromises = nameTokenIds(ethereum, allEvents)
 	const addressBookEntries = await addressBookEntryPromises
+	const ensNameHashesPromise = retrieveEnsNodeHashes(ethereum, allEvents, addressBookEntries)
+	const ensLabelHashesPromise = retrieveEnsLabelHashes(allEvents, addressBookEntries)
 	const namedTokenIds = await namedTokenIdPromises
 	const simulatedAndVisualizedTransactions = formSimulatedAndVisualizedTransaction(simulationState, eventsForEachTransaction, protectorResults, addressBookEntries, namedTokenIds, { ensNameHashes: await ensNameHashesPromise, ensLabelHashes: await ensLabelHashesPromise })
 	const VisualizedPersonalSignRequest = simulationState.signedMessages.map((signedMessage) => craftPersonalSignPopupMessage(ethereum, requestAbortController, signedMessage, settings.currentRpcNetwork))

--- a/app/ts/background/metadataUtils.ts
+++ b/app/ts/background/metadataUtils.ts
@@ -224,7 +224,7 @@ export async function retrieveEnsLabelHashes(events: EnrichedEthereumEvents, add
 }
 
 const addNewEnsNameEntry = async (name: string) => {
-	const [label, _] = name.split('.')
+	const [label] = name.split('.')
 	if (label !== undefined) await addEnsLabelHash(label)
 	await addEnsNodeHash(name)
 }

--- a/app/ts/background/popupMessageHandlers.ts
+++ b/app/ts/background/popupMessageHandlers.ts
@@ -176,10 +176,10 @@ export async function refreshPopupConfirmTransactionMetadata(ethereumClientServi
 	const allEvents = eventsForEachTransaction.flat()
 	const addressBookEntriesPromise = getAddressBookEntriesForVisualiser(ethereumClientService, requestAbortController, allEvents, data.simulationState)
 	const namedTokenIdsPromise = nameTokenIds(ethereumClientService, allEvents)
-	const ensNameHashesPromise = retrieveEnsNodeHashes(ethereumClientService, allEvents)
-	const ensLabelHashesPromise = retrieveEnsLabelHashes(allEvents)
 	const addressBookEntries = await addressBookEntriesPromise
+	const ensNameHashesPromise = retrieveEnsNodeHashes(ethereumClientService, allEvents, addressBookEntries)
 	const namedTokenIds = await namedTokenIdsPromise
+	const ensLabelHashesPromise = retrieveEnsLabelHashes(allEvents, addressBookEntries)
 	if (first === undefined || (first.transactionOrMessageCreationStatus !== 'Simulated' && first.transactionOrMessageCreationStatus !== 'FailedToSimulate') || first.simulationResults === undefined || first.simulationResults.statusCode !== 'success') return
 	return await sendPopupMessageToOpenWindows({
 		method: 'popup_update_confirm_transaction_dialog',

--- a/app/ts/components/formVisualizerResults.ts
+++ b/app/ts/components/formVisualizerResults.ts
@@ -48,6 +48,8 @@ export function formSimulatedAndVisualizedTransaction(simState: SimulationState,
 					const node = ens.ensNameHashes.find((nameHash) => nameHash.nameHash === event.logInformation.node) ?? { nameHash: event.logInformation.node, name: undefined }
 					return { ...event, logInformation: { ...event.logInformation, node } }
 				}
+				case 'ENSReverseClaimed':
+				case 'ENSNameChanged':
 				case 'ENSNameUnwrapped':
 				case 'ENSNewResolver':
 				case 'ENSTransfer':

--- a/app/ts/simulation/logHandlers.ts
+++ b/app/ts/simulation/logHandlers.ts
@@ -205,3 +205,18 @@ export function handleEnsNameUnWrapped(eventLog: ParsedEvent) {
 	if (eventLog.args[0]?.typeValue.type !== 'fixedBytes' || eventLog.args[1]?.typeValue.type !== 'address') throw new Error('Malformed ENS Name Unwrapped Event')
 	return { node: EthereumBytes32.parse(dataStringWith0xStart(eventLog.args[0].typeValue.value)) }
 }
+
+// event NameChanged(bytes32 indexed node, string name); // 0x231b0Ee14048e9dCcD1d247744d114a4EB5E8E63
+export function handleEnsNameChanged(eventLog: ParsedEvent) {
+	if (eventLog.args[0]?.typeValue.type !== 'fixedBytes' || eventLog.args[1]?.typeValue.type !== 'string') throw new Error('Malformed ENS Name Unwrapped Event')
+	return { node: EthereumBytes32.parse(dataStringWith0xStart(eventLog.args[0].typeValue.value)) }
+}
+
+// event ReverseClaimed(address indexed addr, bytes32 indexed node) // 0xa58E81fe9b61B5c3fE2AFD33CF304c454AbFc7Cb
+export function handleEnsReverseClaimed(eventLog: ParsedEvent) {
+	if (eventLog.args[0]?.typeValue.type !== 'address' || eventLog.args[1]?.typeValue.type !== 'fixedBytes') throw new Error('Malformed ENS Name Unwrapped Event')
+	return {
+		addr: eventLog.args[0]?.typeValue.value,
+		node: EthereumBytes32.parse(dataStringWith0xStart(eventLog.args[1].typeValue.value))
+	}
+}

--- a/app/ts/simulation/simulator.ts
+++ b/app/ts/simulation/simulator.ts
@@ -9,8 +9,8 @@ import { eoaCalldata } from './protectors/eoaCalldata.js'
 import { tokenToContract } from './protectors/tokenToContract.js'
 import { WebsiteCreatedEthereumUnsignedTransaction, SimulationState, TokenVisualizerResult, EnrichedEthereumEvent, ParsedEvent, ParsedEnsEvent } from '../types/visualizer-types.js'
 import { EthereumJSONRpcRequestHandler } from './services/EthereumJSONRpcRequestHandler.js'
-import { APPROVAL_LOG, DEPOSIT_LOG, ENS_ADDRESS_CHANGED, ENS_ADDR_CHANGED, ENS_CONTENT_HASH_CHANGED, ENS_ETHEREUM_NAME_SERVICE, ENS_ETH_REGISTRAR_CONTROLLER, ENS_FUSES_SET, ENS_NAME_RENEWED, ENS_NAME_UNWRAPPED, ENS_NEW_OWNER, ENS_NEW_RESOLVER, ENS_PUBLIC_RESOLVER, ENS_PUBLIC_RESOLVER_2, ENS_REGISTRAR_NAME_RENEWED, ENS_REGISTRY_WITH_FALLBACK, ENS_TEXT_CHANGED, ENS_TEXT_CHANGED_KEY_VALUE, ENS_TOKEN_WRAPPER, ENS_TRANSFER, ERC1155_TRANSFERBATCH_LOG, ERC1155_TRANSFERSINGLE_LOG, ERC721_APPROVAL_FOR_ALL_LOG, TRANSFER_LOG, WITHDRAWAL_LOG } from '../utils/constants.js'
-import { handleApprovalLog, handleDepositLog, handleERC1155TransferBatch, handleERC1155TransferSingle, handleERC20TransferLog, handleEnsAddrChanged, handleEnsAddressChanged, handleEnsContentHashChanged, handleEnsFusesSet, handleEnsNameUnWrapped, handleEnsNewOwner, handleEnsNewResolver, handleEnsRegistrarNameRenewed, handleEnsTextChanged, handleEnsTextChangedKeyValue, handleEnsTransfer, handleErc721ApprovalForAllLog, handleNameRenewed, handleWithdrawalLog } from './logHandlers.js'
+import { APPROVAL_LOG, DEPOSIT_LOG, ENS_ADDRESS_CHANGED, ENS_ADDR_CHANGED, ENS_CONTENT_HASH_CHANGED, ENS_ETHEREUM_NAME_SERVICE, ENS_ETH_REGISTRAR_CONTROLLER, ENS_FUSES_SET, ENS_NAME_CHANGED, ENS_NAME_RENEWED, ENS_NAME_UNWRAPPED, ENS_NEW_OWNER, ENS_NEW_RESOLVER, ENS_PUBLIC_RESOLVER, ENS_PUBLIC_RESOLVER_2, ENS_REGISTRAR_NAME_RENEWED, ENS_REGISTRY_WITH_FALLBACK, ENS_REVERSE_CLAIMED, ENS_REVERSE_REGISTRAR, ENS_TEXT_CHANGED, ENS_TEXT_CHANGED_KEY_VALUE, ENS_TOKEN_WRAPPER, ENS_TRANSFER, ERC1155_TRANSFERBATCH_LOG, ERC1155_TRANSFERSINGLE_LOG, ERC721_APPROVAL_FOR_ALL_LOG, TRANSFER_LOG, WITHDRAWAL_LOG } from '../utils/constants.js'
+import { handleApprovalLog, handleDepositLog, handleERC1155TransferBatch, handleERC1155TransferSingle, handleERC20TransferLog, handleEnsAddrChanged, handleEnsAddressChanged, handleEnsContentHashChanged, handleEnsFusesSet, handleEnsNameChanged, handleEnsNameUnWrapped, handleEnsNewOwner, handleEnsNewResolver, handleEnsRegistrarNameRenewed, handleEnsReverseClaimed, handleEnsTextChanged, handleEnsTextChangedKeyValue, handleEnsTransfer, handleErc721ApprovalForAllLog, handleNameRenewed, handleWithdrawalLog } from './logHandlers.js'
 import { RpcEntry } from '../types/rpc.js'
 import { AddressBookEntryCategory } from '../types/addressBookTypes.js'
 import { parseEventIfPossible } from './services/SimulationModeEthereumClientService.js'
@@ -75,6 +75,8 @@ const ensEventHandler = (parsedEvent: ParsedEvent): ParsedEnsEvent | undefined =
 			if (logSignature === ENS_TEXT_CHANGED) return { logInformation: handleEnsTextChanged(parsedEvent), type: 'ENSTextChanged' as const }
 			if (logSignature === ENS_TEXT_CHANGED_KEY_VALUE) return { logInformation: handleEnsTextChangedKeyValue(parsedEvent), type: 'ENSTextChangedKeyValue' as const }
 			if (logSignature === ENS_CONTENT_HASH_CHANGED) return { logInformation: handleEnsContentHashChanged(parsedEvent), type: 'ENSContentHashChanged' as const }
+			if (logSignature === ENS_NAME_CHANGED) return { logInformation: handleEnsNameChanged(parsedEvent), type: 'ENSNameChanged' as const }
+
 		}
 		if (parsedEvent.loggersAddressBookEntry.address === ENS_TOKEN_WRAPPER) {
 			if (logSignature === ENS_FUSES_SET) return { logInformation: handleEnsFusesSet(parsedEvent), type: 'ENSFusesSet' as const }
@@ -90,6 +92,9 @@ const ensEventHandler = (parsedEvent: ParsedEvent): ParsedEnsEvent | undefined =
 			if (logSignature === ENS_TRANSFER) return { logInformation: handleEnsTransfer(parsedEvent), type: 'ENSTransfer' as const }
 			if (logSignature === ENS_NEW_OWNER) return { logInformation: handleEnsNewOwner(parsedEvent), type: 'ENSNewOwner' as const }
 			if (logSignature === ENS_NEW_RESOLVER) return { logInformation: handleEnsNewResolver(parsedEvent), type: 'ENSNewResolver' as const }
+		}
+		else if(parsedEvent.loggersAddressBookEntry.address === ENS_REVERSE_REGISTRAR) {
+			if (logSignature === ENS_REVERSE_CLAIMED) return { logInformation: handleEnsReverseClaimed(parsedEvent), type: 'ENSReverseClaimed' as const }
 		}
 	}
 	return undefined

--- a/app/ts/types/visualizer-types.ts
+++ b/app/ts/types/visualizer-types.ts
@@ -115,6 +115,8 @@ export const ParsedEnsEvent = funtypes.Union(
 			funtypes.Literal('ENSTextChangedKeyValue'),
 			funtypes.Literal('ENSContentHashChanged'),
 			funtypes.Literal('ENSNameUnwrapped'),
+			funtypes.Literal('ENSNameChanged'),
+			funtypes.Literal('ENSReverseClaimed'),
 		),
 		logInformation: funtypes.ReadonlyObject({
 			node: EthereumBytes32,
@@ -281,6 +283,8 @@ export const EnrichedEthereumEventWithMetadata = funtypes.Union(
 					funtypes.Literal('ENSTextChangedKeyValue'),
 					funtypes.Literal('ENSContentHashChanged'),
 					funtypes.Literal('ENSNameUnwrapped'),
+					funtypes.Literal('ENSNameChanged'),
+					funtypes.Literal('ENSReverseClaimed'),
 				),
 				logInformation: funtypes.ReadonlyObject({
 					node: MaybeENSNameHash,

--- a/app/ts/utils/bigint.ts
+++ b/app/ts/utils/bigint.ts
@@ -60,9 +60,8 @@ export function nanoString(value: bigint): string {
 	return bigintToDecimalString(value, 9n)
 }
 
-export function addressString(address: bigint) {
-	return `0x${address.toString(16).padStart(40, '0')}`
-}
+export const addressString = (address: bigint) => `0x${ address.toString(16).padStart(40, '0') }`
+export const addressStringWithout0x = (address: bigint) => address.toString(16).padStart(40, '0')
 
 export function checksummedAddress(address: bigint) {
 	return ethers.getAddress(addressString(address))

--- a/app/ts/utils/constants.ts
+++ b/app/ts/utils/constants.ts
@@ -1,4 +1,4 @@
-import { ethers } from 'ethers'
+import { ethers, namehash } from 'ethers'
 import { CHAIN_NAMES } from './chainNames.js'
 
 // common contract addresses
@@ -44,6 +44,8 @@ export const ENS_TEXT_CHANGED_KEY_VALUE = ethers.keccak256(ethers.toUtf8Bytes('T
 export const ENS_CONTENT_HASH_CHANGED = ethers.keccak256(ethers.toUtf8Bytes('ContenthashChanged(bytes32,bytes)'))
 export const ENS_FUSES_SET = ethers.keccak256(ethers.toUtf8Bytes('FusesSet(bytes32,uint32)'))
 export const ENS_NAME_UNWRAPPED = ethers.keccak256(ethers.toUtf8Bytes('NameUnwrapped(bytes32,address)'))
+export const ENS_NAME_CHANGED = ethers.keccak256(ethers.toUtf8Bytes('NameChanged(bytes32,string)'))
+export const ENS_REVERSE_CLAIMED = ethers.keccak256(ethers.toUtf8Bytes('ReverseClaimed(address,bytes32)'))
 
 // Other
 export const MOCK_ADDRESS = 0xdeadbeefdeadbeefdeadbeefdeadbeefdeadbeefn
@@ -53,6 +55,10 @@ export const ENS_ETH_REGISTRAR_CONTROLLER = 0x253553366Da8546fC250F225fe3d25d0C7
 export const ENS_ETHEREUM_NAME_SERVICE = 0x57f1887a8BF19b14fC0dF6Fd9B2acc9Af147eA85n
 export const ENS_PUBLIC_RESOLVER_2 = 0x4976fb03C32e5B8cfe2b6cCB31c09Ba78EBaBa41n
 export const ENS_REGISTRY_WITH_FALLBACK = 0x00000000000C2E074eC69A0dFb2997BA6C7d2e1en
+export const ENS_REVERSE_REGISTRAR = 0xa58E81fe9b61B5c3fE2AFD33CF304c454AbFc7Cbn
+
+// ENS Nodes
+export const ENS_ADDR_REVERSE_NODE = { name: 'addr.reverse', nameHash: BigInt(namehash('addr.reverse')) }
 
 // ENS Fuses
 export const CANNOT_UNWRAP = 1n

--- a/app/ts/utils/ethereumNameService.ts
+++ b/app/ts/utils/ethereumNameService.ts
@@ -1,7 +1,8 @@
-import { ethers } from 'ethers'
+import { ethers, namehash } from 'ethers'
 import { EthereumClientService } from '../simulation/services/EthereumClientService.js'
-import { bytes32String, stringToUint8Array } from './bigint.js'
+import { addressStringWithout0x, bytes32String, stringToUint8Array } from './bigint.js'
 import { CANNOT_APPROVE, CANNOT_BURN_FUSES, CANNOT_CREATE_SUBDOMAIN, CANNOT_SET_RESOLVER, CANNOT_SET_TTL, CANNOT_TRANSFER, CANNOT_UNWRAP, CAN_DO_EVERYTHING, CAN_EXTEND_EXPIRY, ENS_TOKEN_WRAPPER, IS_DOT_ETH, MOCK_ADDRESS, PARENT_CANNOT_CONTROL } from './constants.js'
+import { EthereumAddress } from '../types/wire-types.js'
 
 // parses ens string, eg vitalik.eth from the wrapped ens names() return value
 function encodeEthereumNameServiceString(data: string): string | undefined {
@@ -84,4 +85,9 @@ export const extractENSFuses = (uint: bigint): readonly EnsFuseName[] => {
 		}
 	}
 	return result
+}
+
+export const getEnsReverseNodeHash = (address: EthereumAddress) => {
+	const name = `${ addressStringWithout0x(address) }.addr.reverse`
+	return { nameHash: BigInt(namehash(name)), name }
 }


### PR DESCRIPTION
- when doing ENS name resolutions, add all addresses in the stack and calculate reverse hashes and check if any nodes matches to those. If a math is found cache is for future use

<img width="825" alt="image" src="https://github.com/DarkFlorist/TheInterceptor/assets/13102010/edfd39a6-9fc0-44c9-8e23-d280f93dc35f">

- name changed event
- reverse claimed event
