### PR TITLE
Re-layout Raw Transaction Information

### DIFF
--- a/app/css/bulma.css
+++ b/app/css/bulma.css
@@ -414,24 +414,6 @@ fieldset {
   border: none;
 }
 
-pre {
-  -webkit-overflow-scrolling: touch;
-  background-color: whitesmoke;
-  color: #4a4a4a;
-  font-size: 0.875em;
-  overflow-x: auto;
-  padding: 1.25rem 1.5rem;
-  white-space: pre;
-  word-wrap: normal;
-}
-
-pre code {
-  background-color: transparent;
-  color: currentColor;
-  font-size: 1em;
-  padding: 0;
-}
-
 table td,
 table th {
   vertical-align: top;

--- a/app/css/interceptor.css
+++ b/app/css/interceptor.css
@@ -1165,3 +1165,45 @@ summary:where(details[open] > *) {
 	text-overflow: ellipsis;
 	overflow: hidden;
 }
+
+.columnar {
+	--grid-cols: minmax(min-content,max-content) minmax(50%,1fr);
+	--gap-x: 1rem;
+	--gap-y: 0.5rem;
+	font-size: 0.875rem;
+	line-height: 1.2;
+	width: fit-content;
+	margin: 0 auto;
+}
+
+.columnar > * {
+	max-width: 100%;
+	min-width: 0;
+}
+
+.columnar dt {
+	justify-self: end;
+	text-align: right;
+	color: var(--subtitle-text-color);
+}
+
+.columnar dd {
+	justify-self: start;
+	text-align: left;
+	color: white;
+}
+
+pre {
+	display: inline-block;
+	font: inherit;
+	font-family: 'Atkinson';
+	font-size: 0.875rem;
+	line-height: 1.2;
+	padding: 0.15rem 0.5rem;
+	border-radius: 4px;
+	background-color: var(--alpha-005);
+	color: var(--subtitle-text-color);
+	word-break: break-all;
+	white-space: pre-wrap;
+}
+

--- a/app/css/interceptor.css
+++ b/app/css/interceptor.css
@@ -1167,7 +1167,7 @@ summary:where(details[open] > *) {
 }
 
 .columnar {
-	--grid-cols: minmax(min-content,max-content) minmax(50%,1fr);
+	--grid-cols: minmax(min-content, max-content) minmax(50%, 1fr);
 	--gap-x: 1rem;
 	--gap-y: 0.5rem;
 	font-size: 0.875rem;

--- a/app/css/interceptor.css
+++ b/app/css/interceptor.css
@@ -1166,7 +1166,7 @@ summary:where(details[open] > *) {
 	overflow: hidden;
 }
 
-.columnar {
+.key-value-pair {
 	--grid-cols: minmax(min-content, max-content) minmax(50%, 1fr);
 	--gap-x: 1rem;
 	--gap-y: 0.5rem;
@@ -1176,18 +1176,18 @@ summary:where(details[open] > *) {
 	margin: 0 auto;
 }
 
-.columnar > * {
+.key-value-pair > * {
 	max-width: 100%;
 	min-width: 0;
 }
 
-.columnar dt {
+.key-value-pair dt {
 	justify-self: end;
 	text-align: right;
 	color: var(--subtitle-text-color);
 }
 
-.columnar dd {
+.key-value-pair dd {
 	justify-self: start;
 	text-align: left;
 	color: white;

--- a/app/ts/components/simulationExplaining/SimulationSummary.tsx
+++ b/app/ts/components/simulationExplaining/SimulationSummary.tsx
@@ -10,7 +10,7 @@ import { addressString, bytes32String, dataStringWith0xStart, nanoString } from 
 import { identifyTransaction } from './identifyTransaction.js'
 import { identifySwap } from './SwapTransactions.js'
 import { useState } from 'preact/hooks'
-import { CellElement, convertNumberToCharacterRepresentationIfSmallEnough, upperCaseFirstCharacter } from '../ui-utils.js'
+import { convertNumberToCharacterRepresentationIfSmallEnough, upperCaseFirstCharacter } from '../ui-utils.js'
 import { EthereumTimestamp } from '../../types/wire-types.js'
 import { RpcNetwork } from '../../types/rpc.js'
 import { AddressBookEntry, Erc1155Entry, Erc20TokenEntry, Erc721Entry } from '../../types/addressBookTypes.js'
@@ -489,7 +489,7 @@ export function TransactionsAccountChangesCard({ simTx, renameAddressCallBack, a
 	const originalSummary = logSummarizer.getSummary(addressMetaDataMap, simulationAndVisualisationResults.tokenPrices, namedTokenIds)
 	const [showSummary, setShowSummary] = useState<boolean>(false)
 	const [ownAddresses, notOwnAddresses] = splitToOwnAndNotOwnAndCleanSummary(originalSummary, simulationAndVisualisationResults.activeAddress)
-	
+
 	if (notOwnAddresses === undefined || ownAddresses === undefined) throw new Error('addresses were undefined')
 	const numberOfChanges = notOwnAddresses.length + ownAddresses.length
 
@@ -708,7 +708,7 @@ export function SimulationSummary(param: SimulationSummaryParams) {
 						</div>
 					}
 				</div>
-				
+
 				<span style = 'color: var(--subtitle-text-color); line-height: 28px; display: flex; margin: 0 0 0 auto; width: fit-content; margin-top: 10px'>
 					<SimulatedInBlockNumber
 						simulationBlockNumber = { param.simulationAndVisualisationResults.blockNumber }
@@ -744,43 +744,42 @@ export function RawTransactionDetailsCard({ transaction, renameAddressCallBack, 
 		{ !showSummary
 			? <></>
 			: <div class = 'card-content'>
-				<div class = 'container' style = 'margin-bottom: 10px;'>
-					<span class = 'log-table' style = 'justify-content: center; column-gap: 5px; row-gap: 5px; grid-template-columns: auto auto'>
-						<CellElement text = 'Transaction type: '/>
-						<CellElement text =  { transaction.type }/>
-						<CellElement text = 'From: '/>
-						<CellElement text = { <SmallAddress addressBookEntry = { transaction.from } renameAddressCallBack = { renameAddressCallBack } textColor = { 'var(--subtitle-text-color)' } /> } />
-						<CellElement text = 'To: '/>
-						<CellElement text = { transaction.to === undefined ? 'No receiving Address' : <SmallAddress addressBookEntry = { transaction.to } renameAddressCallBack = { renameAddressCallBack } textColor = { 'var(--subtitle-text-color)' }/> } />
-						<CellElement text = 'Value: '/>
-						<CellElement text = { <Ether amount = { transaction.value } useFullTokenName = { true } rpcNetwork = { transaction.rpcNetwork } style = { { color: 'var(--subtitle-text-color)' } } fontSize = 'normal'/> } />
-						<CellElement text = 'Gas used: '/>
-						<CellElement text = { `${ gasSpent.toString(10) } gas (${ Number(gasSpent * 10000n / transaction.gas) / 100 }%)` }/>
-						<CellElement text = 'Gas limit: '/>
-						<CellElement text = { `${ transaction.gas.toString(10) } gas` }/>
-						<CellElement text = 'Nonce: '/>
-						<CellElement text = { transaction.nonce.toString(10) }/>
-						<CellElement text = 'Chain: '/>
-						<CellElement text = { transaction.rpcNetwork.name }/>
-						<CellElement text = 'Unsigned transaction hash: '/>
-						<CellElement text = { bytes32String(transaction.hash) } useLegibleFont />
+				<div style = { { display: 'flex', flexDirection: 'column', rowGap: '1rem' } } >
+					<dl class = 'grid columnar'>
+						<dt>Transaction type</dt>
+						<dd>{ transaction.type }</dd>
+						<dt>From</dt>
+						<dd>{ <SmallAddress addressBookEntry = { transaction.from } renameAddressCallBack = { renameAddressCallBack } textColor = { 'var(--subtitle-text-color)' } /> }</dd>
+						<dt>To</dt>
+						<dd>{ transaction.to === undefined ? 'No receiving Address' : <SmallAddress addressBookEntry = { transaction.to } renameAddressCallBack = { renameAddressCallBack } textColor = { 'var(--subtitle-text-color)' }/> }</dd>
+						<dt>Value</dt>
+						<dd>{ <Ether amount = { transaction.value } useFullTokenName = { true } rpcNetwork = { transaction.rpcNetwork } style = { { color: 'var(--subtitle-text-color)' } } fontSize = 'normal'/> }</dd>
+						<dt>Gas used</dt>
+						<dd>{ `${ gasSpent.toString(10) } gas (${ Number(gasSpent * 10000n / transaction.gas) / 100 }%)` }</dd>
+						<dt>Gas limit</dt>
+						<dd>{ `${ transaction.gas.toString(10) } gas` }</dd>
+						<dt>Nonce: </dt>
+						<dd>{ transaction.nonce.toString(10) }</dd>
+						<dt>Chain</dt>
+						<dd>{ transaction.rpcNetwork.name }</dd>
+						<dt>Unsigned transaction hash</dt>
+						<dd><span class = 'text-legible truncate'>{ bytes32String(transaction.hash) }</span></dd>
 
 
 						{ transaction.type !== '1559'
 							? <></>
 							: <>
-								<CellElement text = 'Max Fee Per Gas: '/>
-								<CellElement text = { `${ nanoString(transaction.maxFeePerGas) } nanoeth/gas` }/>
-								<CellElement text = 'Max Priority Fee Per Gas: '/>
-								<CellElement text = { `${ nanoString(transaction.maxPriorityFeePerGas) } nanoeth/gas` }/>
+								<dt>Max Fee Per Gas</dt>
+								<dd>{ `${ nanoString(transaction.maxFeePerGas) } nanoeth/gas` }</dd>
+								<dt>Max Priority Fee Per Gas</dt>
+								<dd>{ `${ nanoString(transaction.maxPriorityFeePerGas) } nanoeth/gas` }</dd>
 							</>
 						}
-					</span>
+					</dl>
 
-					<p class = 'paragraph' style = 'color: var(--subtitle-text-color)'>Raw transaction input: </p>
-
-					<div class = 'textbox'>
-						<p class = 'paragraph' style = 'color: var(--subtitle-text-color)'>{ dataStringWith0xStart(transaction.input) }</p>
+					<div>
+						<p class = 'paragraph' style = 'color: var(--subtitle-text-color)'>Raw transaction input</p>
+						<pre>{ dataStringWith0xStart(transaction.input) }</pre>
 					</div>
 					<p class = 'paragraph' style = 'color: var(--subtitle-text-color)'>Parsed transaction input: </p>
 					{ parsedInputData?.type !== 'Parsed' ? <p class = 'paragraph' style = 'color: var(--subtitle-text-color)'>No ABI available</p> : <ParsedInputData inputData = { parsedInputData } addressMetaData = { addressMetaData } renameAddressCallBack = { renameAddressCallBack }/> }

--- a/app/ts/components/simulationExplaining/SimulationSummary.tsx
+++ b/app/ts/components/simulationExplaining/SimulationSummary.tsx
@@ -745,7 +745,7 @@ export function RawTransactionDetailsCard({ transaction, renameAddressCallBack, 
 			? <></>
 			: <div class = 'card-content'>
 				<div style = { { display: 'flex', flexDirection: 'column', rowGap: '1rem' } } >
-					<dl class = 'grid columnar'>
+					<dl class = 'grid key-value-pair'>
 						<dt>Transaction type</dt>
 						<dd>{ transaction.type }</dd>
 						<dt>From</dt>


### PR DESCRIPTION
Updated the layout of raw transaction for data value to be closer to it's label and with more prominent colors. Pre-formatted data (raw) will also start using the new legible font

| <img width="496" alt="Screenshot 2024-06-21 at 10 40 50 AM" src="https://github.com/DarkFlorist/TheInterceptor/assets/1169838/83903064-9673-4db9-bf54-63a471be03f3"> | <img width="498" alt="Screenshot 2024-06-21 at 10 46 02 AM" src="https://github.com/DarkFlorist/TheInterceptor/assets/1169838/5186dc22-9078-4f2e-8bab-4b4418768fa0"> |
|:--:|:--:|
|_new_|_existing_|