### PR TITLE
empty parentheses for price

### DIFF
--- a/app/ts/components/simulationExplaining/SimulationSummary.tsx
+++ b/app/ts/components/simulationExplaining/SimulationSummary.tsx
@@ -45,16 +45,17 @@ function Erc20BalanceChange(param: Erc20BalanceChangeParams) {
 						renameAddressCallBack = { param.renameAddressCallBack }
 						fontSize = 'normal'
 					/>
-					
-					<p style = { style }>&nbsp;(</p>
-					<TokenPrice
-						amount = { erc20TokenBalanceChange.changeAmount }
-						tokenPriceEstimate = { erc20TokenBalanceChange.tokenPriceEstimate }
-						style = { style }
-						quoteTokenEntry = { erc20TokenBalanceChange.tokenPriceEstimateQuoteToken }
-						renameAddressCallBack = { param.renameAddressCallBack }
-					/>
-					<p style = { style }>)</p>
+					{ erc20TokenBalanceChange.tokenPriceEstimate !== undefined && erc20TokenBalanceChange.tokenPriceEstimateQuoteToken !== undefined ? <>
+						<p style = { style }>&nbsp;(</p>
+						<TokenPrice
+							amount = { erc20TokenBalanceChange.changeAmount }
+							tokenPriceEstimate = { erc20TokenBalanceChange.tokenPriceEstimate }
+							style = { style }
+							quoteTokenEntry = { erc20TokenBalanceChange.tokenPriceEstimateQuoteToken }
+							renameAddressCallBack = { param.renameAddressCallBack }
+						/>
+						<p style = { style }>)</p>
+					</> : <></> }
 				</div>
 			</div>
 		})}

--- a/app/ts/components/subcomponents/coins.tsx
+++ b/app/ts/components/subcomponents/coins.tsx
@@ -85,14 +85,13 @@ export function EtherSymbol(param: EtherSymbolParams) {
 
 type TokenPriceParams = {
 	amount: bigint,
-	quoteTokenEntry: Erc20TokenEntry | undefined
-	tokenPriceEstimate: TokenPriceEstimate | undefined
+	quoteTokenEntry: Erc20TokenEntry
+	tokenPriceEstimate: TokenPriceEstimate
 	style?: JSX.CSSProperties
 	renameAddressCallBack: RenameAddressCallBack
 }
 
 export function TokenPrice(param: TokenPriceParams) {
-	if (param.tokenPriceEstimate === undefined || param.quoteTokenEntry === undefined) return <></>
 	const value = getTokenAmountsWorth(param.amount, param.tokenPriceEstimate)
 	const style = (param.style === undefined ? {} : param.style)
 	return <TokenWithAmount 


### PR DESCRIPTION
if there's no price estimate, this shows `( )`. Nowadays we just leave it out