### PR TITLE
add space between number and token symbol in token price

### DIFF
--- a/app/ts/components/simulationExplaining/SimulationSummary.tsx
+++ b/app/ts/components/simulationExplaining/SimulationSummary.tsx
@@ -753,11 +753,11 @@ export function RawTransactionDetailsCard({ transaction, renameAddressCallBack, 
 						<dt>Transaction type</dt>
 						<dd>{ transaction.type }</dd>
 						<dt>From</dt>
-						<dd>{ <SmallAddress addressBookEntry = { transaction.from } renameAddressCallBack = { renameAddressCallBack } textColor = { 'var(--subtitle-text-color)' } /> }</dd>
+						<dd>{ <SmallAddress addressBookEntry = { transaction.from } renameAddressCallBack = { renameAddressCallBack }/> }</dd>
 						<dt>To</dt>
-						<dd>{ transaction.to === undefined ? 'No receiving Address' : <SmallAddress addressBookEntry = { transaction.to } renameAddressCallBack = { renameAddressCallBack } textColor = { 'var(--subtitle-text-color)' }/> }</dd>
+						<dd>{ transaction.to === undefined ? 'No receiving Address' : <SmallAddress addressBookEntry = { transaction.to } renameAddressCallBack = { renameAddressCallBack }/> }</dd>
 						<dt>Value</dt>
-						<dd>{ <Ether amount = { transaction.value } useFullTokenName = { true } rpcNetwork = { transaction.rpcNetwork } style = { { color: 'var(--subtitle-text-color)' } } fontSize = 'normal'/> }</dd>
+						<dd>{ <Ether amount = { transaction.value } useFullTokenName = { true } rpcNetwork = { transaction.rpcNetwork } fontSize = 'normal'/> }</dd>
 						<dt>Gas used</dt>
 						<dd>{ `${ gasSpent.toString(10) } gas (${ Number(gasSpent * 10000n / transaction.gas) / 100 }%)` }</dd>
 						<dt>Gas limit</dt>

--- a/app/ts/components/subcomponents/coins.tsx
+++ b/app/ts/components/subcomponents/coins.tsx
@@ -94,7 +94,7 @@ type TokenPriceParams = {
 export function TokenPrice(param: TokenPriceParams) {
 	const value = getTokenAmountsWorth(param.amount, param.tokenPriceEstimate)
 	const style = (param.style === undefined ? {} : param.style)
-	return <TokenWithAmount 
+	return <TokenWithAmount
 		amount = { value }
 		tokenEntry = { param.quoteTokenEntry }
 		style = { style }
@@ -218,6 +218,7 @@ type TokenWithAmountParams = TokenSymbolParams & {
 export function TokenWithAmount(param: TokenWithAmountParams) {
 	return <div style = 'width: fit-content; display: flex'>
 		<TokenAmount { ...param } />
+		<p>&nbsp;</p>
 		<TokenSymbol { ...param }/>
 	</div>
 }


### PR DESCRIPTION
- add space between number and token symbol in token price
- in raw transaction view, don't show some values in gray