### PR TITLE
Add fonts in build

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -20,6 +20,7 @@ COPY app/css/ /app/css/
 COPY app/ts/ /app/ts/
 COPY app/img/ /app/img/
 COPY app/inpage/ /app/inpage/
+COPY app/fonts/ /app/fonts/
 COPY build/tsconfig.json build/vendor.mts build/bundler.mts /build/
 
 COPY tsconfig-test.json /


### PR DESCRIPTION
This is to resolve the issue reported that Firefox failed to load fonts logged as

```
downloadable font: download failed (font-family: "Inter" style:normal weight:100..900 stretch:100 src index:0): status=2152857621 source: moz-extension://9c1d476d-b11a-4116-b8c3-9b7418c7b4fc/fonts/InterVariable.woff2
downloadable font: download failed (font-family: "Atkinson" style:normal weight:400 stretch:100 src index:0): status=2152857621 source: moz-extension://9c1d476d-b11a-4116-b8c3-9b7418c7b4fc/fonts/Atkinson-Hyperlegible-Regular-102a.woff2 
```