### PR TITLE
Replace ETH UI with Inline Card

### DIFF
--- a/app/ts/components/subcomponents/InlineCard.tsx
+++ b/app/ts/components/subcomponents/InlineCard.tsx
@@ -40,12 +40,14 @@ export const InlineCard = ({ icon: Icon, label, copyValue, onEditClicked, style,
 							<span>copy</span>
 						</span>
 					</button>
-					<button type = 'button' value = { copyValue } onClick = { onEditClicked } tabIndex = { 1 }>
-						<span>
-							<EditIcon />
-							<span>edit</span>
-						</span>
-					</button>
+					{ onEditClicked ? (
+						<button type = 'button' value = { copyValue } onClick = { onEditClicked } tabIndex = { 1 }>
+							<span>
+								<EditIcon />
+								<span>edit</span>
+							</span>
+						</button>
+					) : <></> }
 				</span>
 
 				{ copyStatus.value ? <span role='status'><CheckIcon /><span>Copied!</span></span> : <></> }

--- a/app/ts/components/subcomponents/coins.tsx
+++ b/app/ts/components/subcomponents/coins.tsx
@@ -11,6 +11,7 @@ import { ETHEREUM_COIN_ICON, ETHEREUM_LOGS_LOGGER_ADDRESS } from '../../utils/co
 import { RpcNetwork } from '../../types/rpc.js'
 import { Blockie } from './SVGBlockie.js'
 import { AbbreviatedValue } from './AbbreviatedValue.js'
+import { InlineCard } from './InlineCard.js'
 
 type EtherParams = {
 	amount: bigint
@@ -65,22 +66,9 @@ type EtherSymbolParams = {
 }
 
 export function EtherSymbol(param: EtherSymbolParams) {
-	const style = {
-		color: 'var(--text-color)',
-		display: 'inline-block',
-		overflow: 'hidden',
-		'text-overflow': 'ellipsis',
-		...(param.style === undefined ? {} : param.style),
-		'font-size': param.fontSize === 'big' ? 'var(--big-font-size)' : 'var(--normal-font-size)'
-	}
-	const etheName = param.useFullTokenName ? param.rpcNetwork.currencyName : param.rpcNetwork.currencyTicker
-
-	return <>
-		<div style = 'overflow: initial; height: 28px;'>
-			<img class = 'noselect nopointer' style = 'max-height: 25px; max-width: 25px;' src = { ETHEREUM_COIN_ICON }/>
-		</div>
-		<p class = 'noselect nopointer' style = { style }> { etheName } </p>
-	</>
+	const etherName = param.useFullTokenName ? param.rpcNetwork.currencyName : param.rpcNetwork.currencyTicker
+	const Icon = () => <img class = 'noselect nopointer' style = { { minWidth: '1em', minHeight: '1em' } } src = { ETHEREUM_COIN_ICON }/>
+	return <InlineCard label = { etherName } icon = { Icon } style = { { '--bg-color': '#0000001a', marginLeft: '0.25em' } } />
 }
 
 type TokenPriceParams = {


### PR DESCRIPTION
Replaced Eth symbol to use UI same with address

| <img width="287" alt="Screenshot 2024-10-22 at 1 53 08 PM" src="https://github.com/user-attachments/assets/78733a74-36b8-4780-b626-83a6d54eaa73"> | <img width="287" alt="Screenshot 2024-10-22 at 1 52 56 PM" src="https://github.com/user-attachments/assets/5db2e46b-cc51-4b17-8914-829b373950a5"> |
|--|--|

New Feature:
- [x] edit button will only appear if `onEditClicked` callback is provided as props