### PR TITLE
handle null getblock return

### DIFF
--- a/app/ts/background/background-startup.ts
+++ b/app/ts/background/background-startup.ts
@@ -126,7 +126,7 @@ async function onContentScriptConnected(simulator: Simulator, port: browser.runt
 			connections: { [identifier]: newConnection },
 		})
 		await updateTabState(socket.tabId, (previousState: TabState) => {
-			return modifyObject(previousState, { 
+			return modifyObject(previousState, {
 				website: { websiteOrigin, icon: undefined, title: undefined },
 				tabIconDetails: { icon: ICON_NOT_ACTIVE, iconReason: 'No active address selected.' },
 			})
@@ -148,6 +148,7 @@ async function onContentScriptConnected(simulator: Simulator, port: browser.runt
 
 async function newBlockAttemptCallback(blockheader: EthereumBlockHeader, ethereumClientService: EthereumClientService, isNewBlock: boolean, simulator: Simulator) {
 	if (ethereumClientService.getChainId() !== simulator.ethereum.getChainId()) throw new Error(`Chain Id Mismatch, node is on ${ ethereumClientService.getChainId() } while simulator is on ${ simulator.ethereum.getChainId() }`)
+	if (blockheader === null) throw new Error('The latest block is null')
 	try {
 		const rpcConnectionStatus = {
 			isConnected: true,

--- a/app/ts/background/background.ts
+++ b/app/ts/background/background.ts
@@ -97,6 +97,7 @@ export const simulateGovernanceContractExecution = async (pendingTransaction: Pe
 		const contractExecutionResult = await simulateCompoundGovernanceExecution(ethereum, addr, params[0])
 		if (contractExecutionResult === undefined) return returnError('Failed to simulate governance execution')
 		const parentBlock = await ethereum.getBlock(undefined)
+		if (parentBlock === null) throw new Error('The latest block is null')
 		if (parentBlock.baseFeePerGas === undefined) return returnError('cannot build simulation from legacy block')
 		const signedExecutionTransaction = mockSignTransaction({ ...contractExecutionResult.executingTransaction, gas: contractExecutionResult.ethSimulateV1CallResult.gasUsed })
 		const tokenBalancesAfter = await getTokenBalancesAfter(ethereum, undefined, [contractExecutionResult.ethSimulateV1CallResult], parentBlock.number, [signedExecutionTransaction], [], {})

--- a/app/ts/background/windows/confirmTransaction.ts
+++ b/app/ts/background/windows/confirmTransaction.ts
@@ -199,6 +199,7 @@ export const formEthSendTransaction = async(ethereumClientService: EthereumClien
 	const from = simulationMode && transactionDetails.from !== undefined ? transactionDetails.from : activeAddress
 	const transactionCount = getSimulatedTransactionCount(ethereumClientService, requestAbortController, simulationState, from)
 	const parentBlock = await parentBlockPromise
+	if (parentBlock === null) throw new Error('The latest block is null')
 	if (parentBlock.baseFeePerGas === undefined) throw new Error(CANNOT_SIMULATE_OFF_LEGACY_BLOCK)
 	const maxPriorityFeePerGas = transactionDetails.maxPriorityFeePerGas !== undefined && transactionDetails.maxPriorityFeePerGas !== null ? transactionDetails.maxPriorityFeePerGas : 10n**8n // 0.1 nanoEth/gas
 	const transactionWithoutGas = {

--- a/app/ts/components/App.tsx
+++ b/app/ts/components/App.tsx
@@ -53,7 +53,7 @@ export function NetworkErrors({ rpcConnectionStatus } : NetworkErrorParams) {
 				<>Unable to connect to { rpcConnectionStatus.rpcNetwork.name }. Retrying in <SomeTimeAgo priorTimestamp = { nextConnectionAttempt } countBackwards = { true }/> .</>
 			}/>
 		: <></> }
-		{ rpcConnectionStatus.latestBlock !== undefined && noNewBlockForOverTwoMins(rpcConnectionStatus) ?
+		{ rpcConnectionStatus.latestBlock !== undefined && noNewBlockForOverTwoMins(rpcConnectionStatus) && rpcConnectionStatus.latestBlock !== null ?
 			<ErrorComponent warning = { true } text = {
 				<>The connected RPC ({ rpcConnectionStatus.rpcNetwork.name }) seem to be stuck at block { rpcConnectionStatus.latestBlock.number } (occured on: { humanReadableDate(rpcConnectionStatus.latestBlock.timestamp) }). Retrying in <SomeTimeAgo priorTimestamp = { nextConnectionAttempt } countBackwards = { true }/>.</>
 			}/>

--- a/app/ts/simulation/compoundGovernanceFaking.ts
+++ b/app/ts/simulation/compoundGovernanceFaking.ts
@@ -50,6 +50,7 @@ export const simulateCompoundGovernanceExecution = async (ethereumClientService:
 		}
 	]
 	const parentBlock = await ethereumClientService.getBlock(undefined)
+	if (parentBlock === null) throw new Error('The latest block is null')
 	const governanceContractCalls = (await ethereumClientService.simulateTransactionsAndSignatures(calls, [], parentBlock.number, undefined)).calls
 	for (const call of governanceContractCalls) {
 		if (call.status !== 'success') throw new Error('Failed to retrieve governance contracts information')

--- a/app/ts/simulation/services/EthereumClientService.ts
+++ b/app/ts/simulation/services/EthereumClientService.ts
@@ -36,7 +36,7 @@ export class EthereumClientService {
 	public readonly getOnErrorBlockCallback = () => this.onErrorBlockCallback
 
 	public getCachedBlock = () => {
-		if (this.cachedBlock === undefined) return undefined
+		if (this.cachedBlock === undefined || this.cachedBlock === null) return undefined
 		// if the block is older than 100 block intervals, invalidate cache
 		if ((Date.now() - this.cachedBlock.timestamp.getTime() * 1000) > TIME_BETWEEN_BLOCKS * 100) return undefined
 		return this.cachedBlock
@@ -74,6 +74,7 @@ export class EthereumClientService {
 			const response = await this.requestHandler.jsonRpcRequest({ method: 'eth_getBlockByNumber', params: ['latest', true] }, undefined, true, 6000)
 			if (this.cacheRefreshTimer === undefined) return
 			const newBlock = EthereumBlockHeader.parse(response)
+			if (newBlock === null) return
 			console.info(`Current block number: ${ newBlock.number } on ${ this.getRpcEntry().name }`)
 			const gotNewBlock = this.cachedBlock?.number !== newBlock.number
 			if (gotNewBlock) this.requestHandler.clearCache()
@@ -184,6 +185,7 @@ export class EthereumClientService {
 
 	public readonly ethSimulateV1 = async (blockStateCalls: readonly BlockCalls[], blockTag: EthereumBlockTag, requestAbortController: AbortController | undefined) => {
 		const parentBlock = await this.getBlock(requestAbortController)
+		if (parentBlock === null) throw new Error('The latest block is null')
 		const call = {
 			method: 'eth_simulateV1',
 			params: [{
@@ -214,6 +216,7 @@ export class EthereumClientService {
 		const ecRecoverMovedToAddress = 0x123456n
 		const ecRecoverAddress = 1n
 		const parentBlock = await this.getBlock(requestAbortController, blockNumber)
+		if (parentBlock === null) throw new Error(`The block ${ blockNumber } is null`)
 		const coder = AbiCoder.defaultAbiCoder()
 
 		const encodePackedHash = (messageHashAndSignature: MessageHashAndSignature) => {

--- a/app/ts/simulation/services/EthereumSubscriptionService.ts
+++ b/app/ts/simulation/services/EthereumSubscriptionService.ts
@@ -44,7 +44,7 @@ export async function sendSubscriptionMessagesForNewBlock(blockNumber: bigint, e
 
 				sendSubscriptionReplyOrCallBack(websiteTabConnections, subscriptionOrFilter.subscriptionCreatorSocket, {
 					type: 'result',
-					method: 'newHeads' as const, 
+					method: 'newHeads' as const,
 					result: { subscription: subscriptionOrFilter.type, result: newBlock } as const,
 					subscription: subscriptionOrFilter.subscriptionOrFilterId,
 				})
@@ -54,7 +54,7 @@ export async function sendSubscriptionMessagesForNewBlock(blockNumber: bigint, e
 					// post our simulated block on top (reorg it)
 					sendSubscriptionReplyOrCallBack(websiteTabConnections, subscriptionOrFilter.subscriptionCreatorSocket, {
 						type: 'result',
-						method: 'newHeads' as const, 
+						method: 'newHeads' as const,
 						result: { subscription: subscriptionOrFilter.type, result: simulatedBlock },
 						subscription: subscriptionOrFilter.subscriptionOrFilterId,
 					})
@@ -83,7 +83,7 @@ export async function createEthereumSubscription(params: EthSubscribeParams, sub
 }
 
 export async function createNewFilter(params: EthNewFilter, subscriptionCreatorSocket: WebsiteSocket, ethereumClientService: EthereumClientService, requestAbortController: AbortController | undefined, simulationState: SimulationState | undefined) {
-	const calledInlastBlock = simulationState?.blockNumber || (await ethereumClientService.getBlock(requestAbortController)).number
+	const calledInlastBlock = simulationState?.blockNumber || await ethereumClientService.getBlockNumber(requestAbortController)
 	const subscriptionOrFilterId = generateId(40)
 	await updateEthereumSubscriptionsAndFilters((subscriptionsAndfilters: EthereumSubscriptionsAndFilters) => {
 		return subscriptionsAndfilters.concat({ type: 'eth_newFilter', subscriptionOrFilterId, params, subscriptionCreatorSocket, calledInlastBlock })
@@ -96,7 +96,7 @@ export async function getEthFilterChanges(filterId: string, ethereumClientServic
 	const filter = filtersAndSubscriptions.find((subscriptionOrfilter) => subscriptionOrfilter.subscriptionOrFilterId === filterId)
 	if (filter === undefined || filter.type !== 'eth_newFilter') return undefined
 	if (filter.params.params[0].blockhash !== undefined) throw new Error('blockhash not supported for this method')
-	const calledInlastBlock = simulationState?.blockNumber || (await ethereumClientService.getBlock(requestAbortController)).number
+	const calledInlastBlock = simulationState?.blockNumber || await ethereumClientService.getBlockNumber(requestAbortController)
 	const logs = await getSimulatedLogs(ethereumClientService, requestAbortController, simulationState, { ...filter, fromBlock: filter.calledInlastBlock })
 	await updateEthereumSubscriptionsAndFilters((subscriptionsAndfilters) => {
 		return subscriptionsAndfilters.map((subscriptionOrfilter) => subscriptionOrfilter.subscriptionOrFilterId === filterId ? { ...subscriptionOrfilter, calledInlastBlock } : filter)

--- a/app/ts/types/wire-types.ts
+++ b/app/ts/types/wire-types.ts
@@ -431,10 +431,10 @@ export const EthereumBlockHeaderWithTransactionHashes = funtypes.Union(funtypes.
 ))
 
 export type EthereumBlockHeader = funtypes.Static<typeof EthereumBlockHeader>
-export const EthereumBlockHeader = funtypes.Intersect(
+export const EthereumBlockHeader = funtypes.Union(funtypes.Null, funtypes.Intersect(
 	EthereumBlockHeaderWithoutTransactions,
 	funtypes.ReadonlyObject({ transactions: funtypes.ReadonlyArray(EthereumSignedTransaction) })
-)
+))
 
 //
 // Helpers

--- a/test/tests/nethermindComparison.ts
+++ b/test/tests/nethermindComparison.ts
@@ -92,6 +92,7 @@ export async function main() {
 
 		should('getBlock with true aligns with Nethermind', async () => {
 			const block = await getSimulatedBlock(ethereum, undefined, simulationState, blockNumber, true)
+			if (block === null) throw new Error('block was null')
 			const serialized = GetBlockReturn.serialize(block)
 			const expected = parseRequest(eth_getBlockByNumber_goerli_8443561_true)
 			assertIsObject(expected)
@@ -109,6 +110,7 @@ export async function main() {
 
 		should('adding transaction and getting the next block should include all the same fields as Nethermind', async () => {
 			const block = await getSimulatedBlock(ethereum, undefined, simulationState, blockNumber, true)
+			if (block === null) throw new Error('Block was null')
 			const newState = await appendTransaction(ethereum, undefined, simulationState, {
 				transaction: exampleTransaction,
 				website: { websiteOrigin: 'test', icon: undefined, title: undefined },
@@ -118,6 +120,7 @@ export async function main() {
 				transactionIdentifier: 1n,
 			})
 			const nextBlock = await getSimulatedBlock(ethereum, undefined, newState, blockNumber + 1n, true)
+			if (nextBlock === null) throw new Error('Block was null')
 			assert.equal(JSON.stringify(Object.keys(nextBlock).sort()), JSON.stringify(Object.keys(block).sort()))
 
 			const expected = parseRequest(eth_getBlockByNumber_goerli_8443561_true)

--- a/test/tests/nethermindComparison.ts
+++ b/test/tests/nethermindComparison.ts
@@ -92,7 +92,7 @@ export async function main() {
 
 		should('getBlock with true aligns with Nethermind', async () => {
 			const block = await getSimulatedBlock(ethereum, undefined, simulationState, blockNumber, true)
-			if (block === null) throw new Error('block was null')
+			if (block === null) throw new Error('Block was null')
 			const serialized = GetBlockReturn.serialize(block)
 			const expected = parseRequest(eth_getBlockByNumber_goerli_8443561_true)
 			assertIsObject(expected)


### PR DESCRIPTION
- fix bug that we are querying block number +1 while we should query the current block number.
- Handle case where the RPC returns NULL as the block