### PR TITLE
block cache constant

### DIFF
--- a/app/ts/simulation/services/EthereumClientService.ts
+++ b/app/ts/simulation/services/EthereumClientService.ts
@@ -1,6 +1,6 @@
 import { EthereumSignedTransactionWithBlockData, EthereumQuantity, EthereumBlockTag, EthereumData, EthereumBlockHeader, EthereumBlockHeaderWithTransactionHashes, EthereumBytes32, OptionalEthereumUnsignedTransaction } from '../../types/wire-types.js'
 import { IUnsignedTransaction1559 } from '../../utils/ethereum.js'
-import { TIME_BETWEEN_BLOCKS } from '../../utils/constants.js'
+import { MAX_BLOCK_CACHE, TIME_BETWEEN_BLOCKS } from '../../utils/constants.js'
 import { IEthereumJSONRpcRequestHandler } from './EthereumJSONRpcRequestHandler.js'
 import { AbiCoder, Signature, ethers } from 'ethers'
 import { addressString, bytes32String } from '../../utils/bigint.js'
@@ -37,8 +37,8 @@ export class EthereumClientService {
 
 	public getCachedBlock = () => {
 		if (this.cachedBlock === undefined || this.cachedBlock === null) return undefined
-		// if the block is older than 100 block intervals, invalidate cache
-		if ((Date.now() - this.cachedBlock.timestamp.getTime() * 1000) > TIME_BETWEEN_BLOCKS * 100) return undefined
+		// if the block is older than MAX_BLOCK_CACHE block intervals, invalidate cache
+		if ((Date.now() - this.cachedBlock.timestamp.getTime() * 1000) > TIME_BETWEEN_BLOCKS * MAX_BLOCK_CACHE) return undefined
 		return this.cachedBlock
 	}
 	public cleanup = () => this.setBlockPolling(false)

--- a/app/ts/utils/constants.ts
+++ b/app/ts/utils/constants.ts
@@ -150,6 +150,8 @@ export const ETHEREUM_COIN_ICON = '../../img/coins/ethereum.png'
 
 export const DEFAULT_CALL_ADDRESS = 0x1n
 
+export const MAX_BLOCK_CACHE = 5
+
 export const TIME_BETWEEN_BLOCKS = 12
 export const GAS_PER_BLOB = 2n**17n
 export const METAMASK_LOGO = '../img/signers/metamask.svg'


### PR DESCRIPTION
- fix https://github.com/DarkFlorist/TheInterceptor/issues/1153
- make the cache 5 blocks instead of 100. This means that if we notice the cache is older than 5 blocks, we don't use it anymore. This happens when interceptor has went to sleep and the user returns to do stuff, then while interceptor is retrieving the new block, we might use older blocks up to 5.