### PR TITLE
Align zero prefix numbers to bottom of text

### DIFF
--- a/app/ts/components/subcomponents/coins.tsx
+++ b/app/ts/components/subcomponents/coins.tsx
@@ -40,15 +40,16 @@ type EtherAmountParams = {
 }
 
 export function EtherAmount(param: EtherAmountParams) {
-	const style = {
+	const style:JSX.CSSProperties = {
 		display: 'inline-flex',
 		overflow: 'hidden',
-		'align-items': 'center',
-		'text-overflow': 'ellipsis',
+		alignItems: 'baseline',
+		textOverflow: 'ellipsis',
 		color: 'var(--text-color)',
 		...(param.style === undefined ? {} : param.style),
-		'font-size': param.fontSize === 'big' ? 'var(--big-font-size)' : 'var(--normal-font-size)'
+		fontSize: param.fontSize === 'big' ? 'var(--big-font-size)' : 'var(--normal-font-size)'
 	}
+
 	return <>
 		<CopyToClipboard content = { bigintToDecimalString(abs(param.amount), 18n) } copyMessage = 'Ether amount copied!' >
 			<p class = 'noselect nopointer' style = { style }>
@@ -174,12 +175,12 @@ type TokenAmountParams = Omit<TokenSymbolParams, 'renameAddressCallBack'> & {
 
 export function TokenAmount(param: TokenAmountParams) {
 	const sign = param.showSign ? (param.amount >= 0 ? ' + ' : ' - '): ''
-	const style = {
+	const style:JSX.CSSProperties = {
 		color: 'var(--text-color)',
 		display: 'inline-flex',
-		'align-items': 'center',
+		alignItems: 'baseline',
 		...(param.style === undefined ? {} : param.style),
-		'font-size': param.fontSize === 'big' ? 'var(--big-font-size)' : 'var(--normal-font-size)'
+		fontSize: param.fontSize === 'big' ? 'var(--big-font-size)' : 'var(--normal-font-size)'
 	}
 
 	if (!('decimals' in param.tokenEntry) || param.tokenEntry.decimals === undefined) {


### PR DESCRIPTION
Adjusted text alignment of numbers to baseline text. Fixes #1166 

| <img width="161" alt="Screenshot 2024-10-29 at 1 46 33 PM" src="https://github.com/user-attachments/assets/826d654a-bc5f-4c54-8b5c-2dec1bf1b72d"> | <img width="202" alt="Screenshot 2024-10-29 at 1 46 04 PM" src="https://github.com/user-attachments/assets/e9e18052-d01b-49bb-ba04-495a783559d7"> |
|--|--|


- Add CSS property type and use JS notation for completion