### PR TITLE
Autofix: don't check duplicates from dark florist metadata unless we are on chain 1 or allchains

### DIFF
--- a/app/ts/background/background.ts
+++ b/app/ts/background/background.ts
@@ -699,7 +699,7 @@ export async function popupMessageHandler(
 			case 'popup_changeActiveRpc': return await popupChangeActiveRpc(simulator, websiteTabConnections, parsedRequest, settings)
 			case 'popup_changeChainDialog': return await changeChainDialog(simulator, websiteTabConnections, parsedRequest)
 			case 'popup_enableSimulationMode': return await enableSimulationMode(simulator, websiteTabConnections, parsedRequest)
-			case 'popup_addOrModifyAddressBookEntry': return await addOrModifyAddressBookEntry(simulator, websiteTabConnections, parsedRequest)
+			case 'popup_addOrModifyAddressBookEntry': return await addOrModifyAddressBookEntry(simulator, websiteTabConnections, parsedRequest, settings.currentRpcNetwork.chainId)
 			case 'popup_getAddressBookData': return await getAddressBookData(parsedRequest)
 			case 'popup_removeAddressBookEntry': return await removeAddressBookEntry(simulator, websiteTabConnections, parsedRequest)
 			case 'popup_openAddressBook': return await openNewTab('addressBook')

--- a/app/ts/background/storageVariables.ts
+++ b/app/ts/background/storageVariables.ts
@@ -254,12 +254,12 @@ export async function updateUserAddressBookEntries(updateFunc: (prevState: Addre
 	})
 }
 
-export async function addUserAddressBookEntryIfItDoesNotExist(newEntry: AddressBookEntry) {
+export async function addUserAddressBookEntryIfItDoesNotExist(newEntry: AddressBookEntry, chainId: bigint) {
 	await userAddressBookEntriesSemaphore.execute(async () => {
 		const entries = await getUserAddressBookEntries()
-		const existingEntry = entries.find((entry) => entry.address === newEntry.address)
+		const existingEntry = entries.find((entry) => entry.address === newEntry.address && entry.chainId === chainId)
 		if (existingEntry !== undefined) return
-		return await browserStorageLocalSet({ userAddressBookEntriesV2: entries.concat(newEntry) })
+		return await browserStorageLocalSet({ userAddressBookEntriesV2: entries.concat({...newEntry, chainId}) })
 	})
 }
 


### PR DESCRIPTION
Modified the addUserAddressBookEntryIfItDoesNotExist function to consider chain ID when checking for duplicate addresses. This allows users to add the same address for different chains without triggering a duplicate address complaint. 
> [!CAUTION]
> Disclaimer: This fix was created by Latta AI and you should never merge before you check the correctness of generated code!
>
> The fix provided by Latta AI might not be complete and it can serve as an inspiration.

---
This bug was fixed for free by Latta AI - https://latta.ai/ourmission

If you no longer want Latta AI to attempt fixing issues on your repository, you can block this account.
    