### PR TITLE
Fixed build error when app/js folder does not exist

### DIFF
--- a/build/bundler.mts
+++ b/build/bundler.mts
@@ -1,6 +1,6 @@
-import * as path from 'path'
-import * as url from 'url'
-import { promises as fs } from 'fs'
+import * as path from 'node:path'
+import * as url from 'node:url'
+import { promises as fs } from 'node:fs'
 
 const directoryOfThisFile = path.dirname(url.fileURLToPath(import.meta.url))
 
@@ -62,12 +62,21 @@ async function* getFiles(topDir: string): AsyncGenerator<string, any, undefined>
 	}
 }
 
+async function ensureDirectoryExists(dir: string) {
+	try {
+		await fs.access(dir)
+	} catch {
+		await fs.mkdir(dir, { recursive: true })
+	}
+}
+
 async function replaceImportsInJSFiles() {
 	const folders = [
 		path.join(directoryOfThisFile, '..', 'app', 'js'),
 		path.join(directoryOfThisFile, '..', 'app', 'vendor')
 	]
 	for (const folder of folders) {
+		await ensureDirectoryExists(folder)
 		for await (const filePath of getFiles(folder)) {
 			if (path.extname(filePath) !== '.js' && path.extname(filePath) !== '.mjs') continue
 			const replaced = replaceImport(filePath, await fs.readFile(filePath, 'utf8'))

--- a/build/vendor.mts
+++ b/build/vendor.mts
@@ -1,7 +1,7 @@
-import * as path from 'path'
-import * as url from 'url'
-import { promises as fs } from 'fs'
-import { FileType, recursiveDirectoryCopy } from '@zoltu/file-copier'
+import * as path from 'node:path'
+import * as url from 'node:url'
+import { promises as fs } from 'node:fs'
+import { type FileType, recursiveDirectoryCopy } from '@zoltu/file-copier'
 import { createHash } from 'node:crypto'
 
 const directoryOfThisFile = path.dirname(url.fileURLToPath(import.meta.url))


### PR DESCRIPTION
On a fresh checkout, `app/js` does not exist and build script can error without creating it first. Additionally added `node:` prefix to node built-in imports for future proofing. 

FWIW: Tried running bundler script (`bundler.mts`) in Node experimental and Deno with the `node:` prefix and they work without the need for temporary file outputs.