### PR TITLE
Only show "No access" message for user-denied sites

### DIFF
--- a/app/ts/components/pages/WebsiteAccess.tsx
+++ b/app/ts/components/pages/WebsiteAccess.tsx
@@ -279,6 +279,9 @@ const NoAccessPrompt = ({ websiteAccess }: { websiteAccess: Signal<WebsiteAccess
 	const { selectedDomain } = useWebsiteAccess()
 	const website = useComputed(() => websiteAccess.value.website)
 
+	// If the website has been granted access, don't show this message
+	if (websiteAccess.value.access === true) return <></>
+
 	const confirmOrRejectRemoval = async (returnValue: string) => {
 		if (returnValue !== 'confirm' || !websiteAccess.value) return
 		await sendPopupMessageToBackgroundPage({ method: 'popup_removeWebsiteAccess',  data: { websiteOrigin: websiteAccess.value.website.websiteOrigin } })


### PR DESCRIPTION
This message should only be shown if user denied interceptor access to the website and is currently shown by default in #1221 

| <img width="526" alt="Screenshot 2024-12-10 at 11 01 40 AM" src="https://github.com/user-attachments/assets/d5d42b4f-0155-4e95-8982-1c0cde864139"> |
|:--:|
| _No access prompt_ |
