### PR TITLE
add rename to website access and fix renaming

### DIFF
--- a/app/ts/components/pages/ConfirmTransaction.tsx
+++ b/app/ts/components/pages/ConfirmTransaction.tsx
@@ -323,7 +323,7 @@ const WebsiteErrors = ({ website, websiteSocket, simulationMode }: NetworkErrorP
 }
 
 type ModalState =
-	{ page: 'modifyAddress', state: ModifyAddressWindowState } |
+	{ page: 'modifyAddress', state: Signal<ModifyAddressWindowState> } |
 	{ page: 'editEns', state: EditEnsNamedHashWindowState } |
 	{ page: 'noModal' }
 
@@ -516,7 +516,7 @@ export function ConfirmTransaction() {
 	function renameAddressCallBack(entry: AddressBookEntry) {
 		modalState.value = {
 			page: 'modifyAddress',
-			state: {
+			state: new Signal({
 				windowStateId: addressString(entry.address),
 				errorState: undefined,
 				incompleteAddressBookEntry: {
@@ -532,7 +532,7 @@ export function ConfirmTransaction() {
 					...entry,
 					address: checksummedAddress(entry.address),
 				}
-			}
+			})
 		}
 	}
 
@@ -556,7 +556,6 @@ export function ConfirmTransaction() {
 		await sendPopupMessageToBackgroundPage( { method: 'popup_clearUnexpectedError' } )
 	}
 
-	const modifyAddressSignal: ReadonlySignal<ModifyAddressWindowState | undefined> = useComputed(() => modalState.value.page === 'modifyAddress' ? modalState.value.state : undefined)
 	if (currentPendingTransactionOrSignableMessage.value === undefined || (currentPendingTransactionOrSignableMessage.value.transactionOrMessageCreationStatus !== 'Simulated' && currentPendingTransactionOrSignableMessage.value.transactionOrMessageCreationStatus !== 'FailedToSimulate')) {
 		return <>
 			<main>
@@ -568,17 +567,13 @@ export function ConfirmTransaction() {
 								editEnsNamedHashWindowState = { modalState.value.state }
 							/>
 						: <></> }
-						{ modifyAddressSignal.value !== undefined ?
+						{ modalState.value.page === 'modifyAddress' ?
 							<AddNewAddress
 								setActiveAddressAndInformAboutIt = { undefined }
-								modifyAddressWindowState = { modifyAddressSignal }
+								modifyAddressWindowState = { modalState.value.state }
 								close = { () => { modalState.value = { page: 'noModal' } } }
 								activeAddress = { currentPendingTransactionOrSignableMessage.value?.activeAddress }
 								rpcEntries = { rpcEntries }
-								modifyStateCallBack = { (newState: ModifyAddressWindowState) => {
-									if (modalState.value.page !== 'modifyAddress') return
-									modalState.value = { page: modalState.value.page, state: newState }
-								} }
 							/>
 						: <></> }
 					</div>
@@ -606,17 +601,13 @@ export function ConfirmTransaction() {
 							editEnsNamedHashWindowState = { modalState.value.state }
 						/>
 					: <></> }
-					{ modifyAddressSignal !== undefined ?
+					{ modalState.value.page === 'modifyAddress' ?
 						<AddNewAddress
 							setActiveAddressAndInformAboutIt = { undefined }
-							modifyAddressWindowState = { modifyAddressSignal }
+							modifyAddressWindowState = { modalState.value.state }
 							close = { () => { modalState.value = { page: 'noModal' } } }
 							activeAddress = { currentPendingTransactionOrSignableMessage.value?.activeAddress }
 							rpcEntries = { rpcEntries }
-							modifyStateCallBack = { (newState: ModifyAddressWindowState) => {
-								if (modalState.value.page !== 'modifyAddress') return
-								modalState.value = { page: modalState.value.page, state: newState }
-							} }
 						/>
 					: <></> }
 				</div>

--- a/app/ts/components/pages/Home.tsx
+++ b/app/ts/components/pages/Home.tsx
@@ -246,8 +246,6 @@ export function Home(param: HomeParams) {
 		param.interceptorDisabled,
 	])
 
-	const changeActiveAddress = () => param.setAndSaveAppPage({ page: 'ChangeActiveAddress' })
-
 	function enableSimulationMode(enabled: boolean ) {
 		sendPopupMessageToBackgroundPage( { method: 'popup_enableSimulationMode', data: enabled } )
 	}
@@ -286,7 +284,7 @@ export function Home(param: HomeParams) {
 			rpcNetwork = { param.rpcNetwork }
 			changeActiveRpc = { param.setActiveRpcAndInformAboutIt }
 			simulationMode = { simulationMode }
-			changeActiveAddress = { changeActiveAddress }
+			changeActiveAddress = { param.changeActiveAddress }
 			makeMeRich = { makeMeRich }
 			tabState = { tabState }
 			tabIconDetails = { tabIconDetails }

--- a/app/ts/components/pages/InterceptorAccessList.tsx
+++ b/app/ts/components/pages/InterceptorAccessList.tsx
@@ -103,8 +103,6 @@ export function InterceptorAccessList(param: InterceptorAccessListParams) {
 		setMetadata(new Map(param.websiteAccessAddressMetadata.map((x) => [addressString(x.address), x])))
 	}, [param.websiteAccessAddressMetadata])
 
-	const goHome = () => param.setAndSaveAppPage({ page: 'Home' })
-
 	function setWebsiteAccess(index: number, changes: AccessChanges) {
 		if (editableAccessList === undefined) return
 		setEditableAccessList(editableAccessList.map((x , i) => {
@@ -169,8 +167,8 @@ export function InterceptorAccessList(param: InterceptorAccessListParams) {
 	}
 
 	function saveChanges() {
-		if (!areThereChanges()) return goHome()
-		if (editableAccessList === undefined) return goHome()
+		if (!areThereChanges()) return param.goHome()
+		if (editableAccessList === undefined) return param.goHome()
 		const changedEntry = (editable: EditableAccess) => {
 			return {
 				oldEntry: editable.websiteAccess,
@@ -192,7 +190,7 @@ export function InterceptorAccessList(param: InterceptorAccessListParams) {
 		const newEntries = editableAccessList.filter((state) => !state.removed).map((x) => changedEntry(x).newEntry)
 		updateEditableAccessList(newEntries)
 		param.setWebsiteAccess(newEntries)
-		return goHome()
+		return param.goHome()
 	}
 
 	return ( <>
@@ -209,7 +207,7 @@ export function InterceptorAccessList(param: InterceptorAccessListParams) {
 						Website Access
 					</p>
 				</div>
-				<button class = 'card-header-icon' aria-label = 'close' onClick = { goHome }>
+				<button class = 'card-header-icon' aria-label = 'close' onClick = { param.goHome }>
 					<XMarkIcon />
 				</button>
 			</header>
@@ -308,7 +306,7 @@ export function InterceptorAccessList(param: InterceptorAccessListParams) {
 			</section>
 
 			<footer class = 'modal-card-foot window-footer' style = 'border-bottom-left-radius: unset; border-bottom-right-radius: unset; border-top: unset; padding: 10px;'>
-				<button class = 'button is-primary' style = 'background-color: var(--negative-color)' onClick = { goHome }>Cancel</button>
+				<button class = 'button is-primary' style = 'background-color: var(--negative-color)' onClick = { param.goHome }>Cancel</button>
 				<button class = 'button is-success is-primary' onClick = { saveChanges }> { areThereChanges() ? 'Save Changes' : 'Close' } </button>
 			</footer>
 		</div>

--- a/app/ts/types/user-interface-types.ts
+++ b/app/ts/types/user-interface-types.ts
@@ -5,7 +5,6 @@ import { SimulatedAndVisualizedTransaction, SimulationAndVisualisationResults, S
 import { IdentifiedSwapWithMetadata } from '../components/simulationExplaining/SwapTransactions.js'
 import { InterceptedRequest, WebsiteSocket } from '../utils/requests.js'
 import { AddressBookEntries, AddressBookEntry } from './addressBookTypes.js'
-import { Page } from './exportedSettingsTypes.js'
 import { PopupOrTabId, Website, WebsiteAccessArray } from './websiteAccessTypes.js'
 import { SignerName } from './signerTypes.js'
 import { ICON_ACCESS_DENIED, ICON_ACCESS_DENIED_WITH_SHIELD, ICON_ACTIVE, ICON_ACTIVE_WITH_SHIELD, ICON_INTERCEPTOR_DISABLED, ICON_NOT_ACTIVE, ICON_NOT_ACTIVE_WITH_SHIELD, ICON_SIGNING, ICON_SIGNING_NOT_SUPPORTED, ICON_SIGNING_NOT_SUPPORTED_WITH_SHIELD, ICON_SIGNING_WITH_SHIELD, ICON_SIMULATING, ICON_SIMULATING_WITH_SHIELD } from '../utils/constants.js'
@@ -13,10 +12,10 @@ import { CodeMessageError, RpcEntries, RpcEntry, RpcNetwork } from './rpc.js'
 import { TransactionOrMessageIdentifier } from './interceptor-messages.js'
 import { EditEnsNamedHashCallBack } from '../components/subcomponents/ens.js'
 import { EnrichedEthereumEventWithMetadata } from './EnrichedEthereumData.js'
-import { ReadonlySignal, Signal } from '@preact/signals'
+import { Signal } from '@preact/signals'
 
 export type InterceptorAccessListParams = {
-	setAndSaveAppPage: (page: Page) => void,
+	goHome: () => void,
 	setWebsiteAccess: Dispatch<StateUpdater<WebsiteAccessArray | undefined>>,
 	websiteAccess: WebsiteAccessArray | undefined,
 	websiteAccessAddressMetadata: AddressBookEntries,
@@ -26,14 +25,13 @@ export type InterceptorAccessListParams = {
 export type AddAddressParam = {
 	close: () => void
 	setActiveAddressAndInformAboutIt: ((address: bigint | 'signer') => Promise<void>) | undefined
-	modifyAddressWindowState: ReadonlySignal<ModifyAddressWindowState | undefined>
-	modifyStateCallBack: (newState: ModifyAddressWindowState) => void
+	modifyAddressWindowState: Signal<ModifyAddressWindowState | undefined>
 	activeAddress: bigint | undefined
 	rpcEntries: Signal<RpcEntries>
 }
 
 export type HomeParams = {
-	setAndSaveAppPage: (page: Page) => void,
+	changeActiveAddress: () => void,
 	makeMeRich: boolean,
 	activeAddresses: AddressBookEntries,
 	tabState: TabState | undefined,

--- a/app/ts/types/websiteAccessTypes.ts
+++ b/app/ts/types/websiteAccessTypes.ts
@@ -24,7 +24,6 @@ export const WebsiteAccess = funtypes.Intersect(
 		access: funtypes.Boolean,
 		interceptorDisabled: funtypes.Boolean,
 		declarativeNetRequestBlockMode: funtypes.Union(funtypes.Literal('block-all'), funtypes.Literal('disabled'))
-		
 	})
 )
 


### PR DESCRIPTION
- fix https://github.com/DarkFlorist/TheInterceptor/issues/1131
- fix address renaming. There's couple bugs in address renaming:
   -> we are modifying readonly signal
   -> when etherscan abi is retrieved and there's no abi, the error just blinks as there's a loop to clear it
   -> address renaming code is also a bit mess, and now its nicer as we modify signals instead of always looping around background page 