### PR TITLE
remove unnecessary try catch

### DIFF
--- a/app/ts/background/windows/personalSign.ts
+++ b/app/ts/background/windows/personalSign.ts
@@ -92,25 +92,20 @@ export async function craftPersonalSignPopupMessage(ethereumClientService: Ether
 		const hashes = getMessageAndDomainHash(originalParams.originalRequestParameters)
 		// if we fail to parse the message, that means it's a message type we do not identify, let's just show it as a nonidentified EIP712 message
 		if (validateEIP712Types(namedParams.param) === false) throw new Error('Not a valid EIP712 Message')
-		try {
-			const message = await extractEIP712Message(ethereumClientService, requestAbortController, namedParams.param)
-			const chainid = message.domain.chainId?.type === 'unsignedInteger' ? message.domain.chainId.value : undefined
-			return {
-				method: originalParams.originalRequestParameters.method,
-				...basicParams,
-				rpcNetwork: chainid !== undefined && rpcNetwork.chainId !== chainid ? await getRpcNetworkForChain(chainid) : rpcNetwork,
-				type: 'EIP712' as const,
-				message,
-				account,
-				...chainid === undefined ? { quarantine: false, quarantineReasons: [] } : await getQuarrantineCodes(chainid, account, activeAddressWithMetadata, undefined),
-				stringifiedMessage: stringifyJSONWithBigInts(namedParams.param, 4),
-				rawMessage: stringifyJSONWithBigInts(namedParams.param),
-				isValidMessage: isValid.valid,
-				...hashes,
-			}
-		} catch(e: unknown) {
-			console.error(e)
-			throw new Error('Not a valid EIP712 Message')
+		const message = await extractEIP712Message(ethereumClientService, requestAbortController, namedParams.param)
+		const chainid = message.domain.chainId?.type === 'unsignedInteger' ? message.domain.chainId.value : undefined
+		return {
+			method: originalParams.originalRequestParameters.method,
+			...basicParams,
+			rpcNetwork: chainid !== undefined && rpcNetwork.chainId !== chainid ? await getRpcNetworkForChain(chainid) : rpcNetwork,
+			type: 'EIP712' as const,
+			message,
+			account,
+			...chainid === undefined ? { quarantine: false, quarantineReasons: [] } : await getQuarrantineCodes(chainid, account, activeAddressWithMetadata, undefined),
+			stringifiedMessage: stringifyJSONWithBigInts(namedParams.param, 4),
+			rawMessage: stringifyJSONWithBigInts(namedParams.param),
+			isValidMessage: isValid.valid,
+			...hashes,
 		}
 	}
 	const hashes = getMessageAndDomainHash(originalParams.originalRequestParameters)

--- a/app/ts/utils/eip712.ts
+++ b/app/ts/utils/eip712.ts
@@ -388,7 +388,7 @@ export const getMessageAndDomainHash = (params: SignTypedDataParams) => {
 	return { messageHash, domainHash }
 }
 
-export const isValidMessage = (params: SignMessageParams): { valid: true} | { valid: false, reason: string } => {
+export const isValidMessage = (params: SignMessageParams): { valid: true } | { valid: false, reason: string } => {
 	switch (params.method) {
 		case 'eth_signTypedData': return { valid: false, reason: 'No support for eth_signTypedData' }
 		case 'eth_signTypedData_v1':


### PR DESCRIPTION
the try catch is unnecessary nowadays as we are checking above already if its valid eip712 message and if its not, we return