### PR TITLE
error handling fixes

### DIFF
--- a/app/ts/simulation/services/EthereumClientService.ts
+++ b/app/ts/simulation/services/EthereumClientService.ts
@@ -203,16 +203,7 @@ export class EthereumClientService {
 			},
 			blockTag === parentBlock.number + 1n ? blockTag - 1n : blockTag
 		] } as const
-		const unvalidatedResult = await this.requestHandler.jsonRpcRequest(call)
-		/*
-		console.log('ethSimulateV1')
-		console.log(call)
-		console.log(unvalidatedResult)
-		console.log(stringifyJSONWithBigInts(EthSimulateV1Params.serialize(call)))
-		console.log(stringifyJSONWithBigInts(unvalidatedResult))
-		console.log('end')
-		*/
-		return EthSimulateV1Result.parse(unvalidatedResult)
+		return EthSimulateV1Result.parse(await this.requestHandler.jsonRpcRequest(call))
 	}
 
 	public readonly simulate = async (simulationStateInput: SimulationStateInputMinimalData, blockNumber: bigint, requestAbortController: AbortController | undefined): Promise<EthSimulateV1Result> => {
@@ -222,7 +213,6 @@ export class EthereumClientService {
 		const blockOverrides: BlockOverrides[] = []
 		let previousBlockOverride = {
 			time: parentBlock.timestamp,
-			gasLimit: parentBlock.gasLimit,
 			feeRecipient: parentBlock.miner,
 			baseFeePerGas: parentBlock.baseFeePerGas === undefined ? 15000000n : parentBlock.baseFeePerGas
 		}

--- a/app/ts/simulation/services/EthereumJSONRpcRequestHandler.ts
+++ b/app/ts/simulation/services/EthereumJSONRpcRequestHandler.ts
@@ -51,16 +51,15 @@ export class EthereumJSONRpcRequestHandler {
 			const responseObject = response.ok ? { responseState: 'success' as const, response: await response.json() } : { responseState: 'failed' as const, response }
 			this.cache.set(hash, responseObject)
 			future.resolve(responseObject)
-			return responseObject
 		} catch(error: unknown) {
 			if (error instanceof Error) {
 				future.reject(error)
 			} else {
 				future.reject(new Error('Unknown error'))
 			}
-			throw error
 		} finally {
 			this.pendingCache.delete(hash)
+			return await future
 		}
 	}
 

--- a/app/ts/simulation/services/EthereumJSONRpcRequestHandler.ts
+++ b/app/ts/simulation/services/EthereumJSONRpcRequestHandler.ts
@@ -52,6 +52,13 @@ export class EthereumJSONRpcRequestHandler {
 			this.cache.set(hash, responseObject)
 			future.resolve(responseObject)
 			return responseObject
+		} catch(error: unknown) {
+			if (error instanceof Error) {
+				future.reject(error)
+			} else {
+				future.reject(new Error('Unknown error'))
+			}
+			throw error
 		} finally {
 			this.pendingCache.delete(hash)
 		}


### PR DESCRIPTION
- Fixed: if you make duplicated rpc calls, and the call fails, the duplicated promises never get rejected
- Fixed: If a new block arrives when new transaction is being refreshed, undefined error is thrown
- Fixed: if get code call fails, return error to UI instead showing undefined error