### PR TITLE
Fixes divide by zero bug for low-liquidity pools.

### DIFF
--- a/app/ts/utils/uniswap.ts
+++ b/app/ts/utils/uniswap.ts
@@ -110,7 +110,7 @@ export function calculatePricesFromUniswapLikeReturnData(multicallData: { succes
 
 		if (reserve0 === 0n || reserve1 === 0n || sqrtPriceX96 === 0n) return undefined
 		// necessary to avoid divide by 0 error in equation below, pool cannot have epsilon liquidity
-		if (sqrtPriceX96 <= 2n**96n/10n**9n) return undefined
+		if (sqrtPriceX96 <= 2n ** 96n / 10n ** 9n) return undefined
 
 		const price = poolAddresses.token0IsQuote
 			? (10n ** 36n) / ((((sqrtPriceX96 * 10n ** 18n) / (2n ** 96n)) ** 2n) / (10n ** 18n))


### PR DESCRIPTION
I believe this code is called when trying to normalize prices in the UI.  It already handles missing pools, but it doesn't do well with pools with extremely low liquidity and will divide by zero.