### PR TITLE
Refactor signer bridge sync in inpage provider

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,6 @@
+# Agent Notes
+
+- After making code changes, run `npm test`.
+- After making code changes, run `npm run setup-chrome`.
+- Do not stop after local edits if either validation step fails; fix the failures or explain the blocker clearly.
+- Prefer targeted changes that keep the existing architecture intact unless a broader refactor is explicitly requested.

--- a/app/inpage/ts/inpage.ts
+++ b/app/inpage/ts/inpage.ts
@@ -141,10 +141,8 @@ type WindowEthereum = InjectFunctions & {
 	chainId?: string,
 	networkVersion?: string,
 }
-interface Window {
-	dispatchEvent: (event: Event) => boolean
-	addEventListener: (type: string, listener: (event: unknown) => void) => void
-	postMessage: (message: unknown, targetOrigin: string) => void
+
+type InpageWindow = Window & {
 	ethereum?: WindowEthereum
 	web3?: {
 		currentProvider: WindowEthereum
@@ -152,7 +150,7 @@ interface Window {
 	}
 }
 
-declare const window: Window
+const inpageWindow = window as InpageWindow
 
 interface EIP6963ProviderInfo {
 	uuid: string
@@ -230,12 +228,12 @@ class InterceptorMessageListener {
 		const fullPayload = typeof payload === 'string' ? { method: payload, id: 1, params: [] } : payload
 		if (maybeCallBack !== undefined && typeof maybeCallBack === 'function') return this.WindowEthereumSendAsync(fullPayload, maybeCallBack)
 		if (this.metamaskCompatibilityMode) {
-			if (window.ethereum === undefined) throw new Error('window.ethereum is missing')
+			if (inpageWindow.ethereum === undefined) throw new Error('window.ethereum is missing')
 			switch (fullPayload.method) {
 				case 'eth_coinbase':
-				case 'eth_accounts': return { jsonrpc: '2.0', id: fullPayload.id, result: window.ethereum.selectedAddress === undefined || window.ethereum.selectedAddress === null ? [] : [window.ethereum.selectedAddress] }
-				case 'net_version': return { jsonrpc: '2.0', id: fullPayload.id, result: window.ethereum.networkVersion }
-				case 'eth_chainId': return { jsonrpc: '2.0', id: fullPayload.id, result: window.ethereum.chainId }
+				case 'eth_accounts': return { jsonrpc: '2.0', id: fullPayload.id, result: inpageWindow.ethereum.selectedAddress === undefined || inpageWindow.ethereum.selectedAddress === null ? [] : [inpageWindow.ethereum.selectedAddress] }
+				case 'net_version': return { jsonrpc: '2.0', id: fullPayload.id, result: inpageWindow.ethereum.networkVersion }
+				case 'eth_chainId': return { jsonrpc: '2.0', id: fullPayload.id, result: inpageWindow.ethereum.chainId }
 				default: throw new EthereumJsonRpcError(METAMASK_INVALID_METHOD_PARAMS, `Invalid method parameter for window.ethereum.send: ${ fullPayload.method }`)
 			}
 		}
@@ -272,7 +270,7 @@ class InterceptorMessageListener {
 	static exhaustivenessCheck = (_thing: never) => {}
 
 	private readonly WindowEthereumOn = (kind: OnMessage, callback: AnyCallBack) => {
-		if (window.ethereum === undefined) throw new Error('window.ethereum is not defined')
+		if (inpageWindow.ethereum === undefined) throw new Error('window.ethereum is not defined')
 		switch (kind) {
 			case 'accountsChanged':
 				this.onAccountsChangedCallBacks.add(callback as (accounts: readonly string[]) => void)
@@ -294,11 +292,11 @@ class InterceptorMessageListener {
 				break
 			default: InterceptorMessageListener.exhaustivenessCheck(kind)
 		}
-		return window.ethereum
+		return inpageWindow.ethereum
 	}
 
 	private readonly WindowEthereumRemoveListener = (kind: OnMessage, callback: AnyCallBack) => {
-		if (window.ethereum === undefined) throw new Error('window.ethereum is not defined')
+		if (inpageWindow.ethereum === undefined) throw new Error('window.ethereum is not defined')
 		switch (kind) {
 			case 'accountsChanged':
 				this.onAccountsChangedCallBacks.delete(callback as (accounts: readonly string[]) => void)
@@ -320,7 +318,7 @@ class InterceptorMessageListener {
 				break
 			default: InterceptorMessageListener.exhaustivenessCheck(kind)
 		}
-		return window.ethereum
+		return inpageWindow.ethereum
 	}
 
 	private readonly WindowEthereumEnable = async () => this.WindowEthereumRequest({ method: 'eth_requestAccounts' })
@@ -424,9 +422,9 @@ class InterceptorMessageListener {
 					const replyAddress = reply[0] ?? ''
 					if (this.currentAddress === replyAddress) return
 					this.currentAddress = replyAddress
-					if (this.metamaskCompatibilityMode && window.ethereum !== undefined) {
-						try { window.ethereum.selectedAddress = replyAddress } catch(error) {}
-						if ('web3' in window && window.web3 !== undefined) try { window.web3.accounts = reply } catch(error) {}
+					if (this.metamaskCompatibilityMode && inpageWindow.ethereum !== undefined) {
+						try { inpageWindow.ethereum.selectedAddress = replyAddress } catch(error) {}
+						if ('web3' in inpageWindow && inpageWindow.web3 !== undefined) try { inpageWindow.web3.accounts = reply } catch(error) {}
 					}
 					for (const callback of this.onAccountsChangedCallBacks) {
 						callback(reply)
@@ -453,9 +451,9 @@ class InterceptorMessageListener {
 					const reply = replyRequest.result as string
 					if (this.activeChainId === reply) return
 					this.activeChainId = reply
-					if (this.metamaskCompatibilityMode && this.signerWindowEthereumRequest === undefined && window.ethereum !== undefined) {
-						try { window.ethereum.chainId = reply } catch(error) {}
-						try { window.ethereum.networkVersion = Number(reply).toString(10) } catch(error) {}
+					if (this.metamaskCompatibilityMode && this.signerWindowEthereumRequest === undefined && inpageWindow.ethereum !== undefined) {
+						try { inpageWindow.ethereum.chainId = reply } catch(error) {}
+						try { inpageWindow.ethereum.networkVersion = Number(reply).toString(10) } catch(error) {}
 					}
 					for (const callback of this.onChainChangedCallBacks) {
 						callback(reply)
@@ -518,7 +516,7 @@ class InterceptorMessageListener {
 			|| !('interceptorApproved' in messageEvent.data)
 		) return
 		try {
-			if (!('ethereum' in window) || !window.ethereum) throw new Error('window.ethereum missing')
+			if (!('ethereum' in inpageWindow) || !inpageWindow.ethereum) throw new Error('window.ethereum missing')
 			if (!('method' in messageEvent.data)) throw new Error('missing method field')
 			if (!('type' in messageEvent)) throw new Error('missing type field')
 			const forwardRequest = messageEvent.data as InterceptedRequestForward //use 'as' here as we don't want to inject funtypes here
@@ -529,23 +527,23 @@ class InterceptorMessageListener {
 				return pending.reject(new EthereumJsonRpcError(forwardRequest.error.code, forwardRequest.error.message, forwardRequest.error.data))
 			}
 			if (forwardRequest.type === 'result' && 'result' in forwardRequest) {
-				if (this.metamaskCompatibilityMode && this.signerWindowEthereumRequest === undefined && window.ethereum !== undefined) {
+				if (this.metamaskCompatibilityMode && this.signerWindowEthereumRequest === undefined && inpageWindow.ethereum !== undefined) {
 					switch (messageEvent.data.method) {
 						case 'eth_requestAccounts':
 						case 'eth_accounts': {
 							if (!Array.isArray(forwardRequest.result) || forwardRequest.result === null) throw new Error('wrong type')
 							const addrArray = forwardRequest.result as string[]
 							const addr = addrArray[0] ?? ''
-							try { window.ethereum.selectedAddress = addr } catch(e) {}
-							if ('web3' in window && window.web3 !== undefined) try { window.web3.accounts = addrArray } catch(e) {}
+							try { inpageWindow.ethereum.selectedAddress = addr } catch(e) {}
+							if ('web3' in inpageWindow && inpageWindow.web3 !== undefined) try { inpageWindow.web3.accounts = addrArray } catch(e) {}
 							this.currentAddress = addr
 							break
 						}
 						case 'eth_chainId': {
 							if (typeof forwardRequest.result !== 'string') throw new Error('wrong type')
 							const chainId = forwardRequest.result as string
-							try { window.ethereum.chainId = chainId } catch(e) {}
-							try { window.ethereum.networkVersion = Number(chainId).toString(10) } catch(e) {}
+							try { inpageWindow.ethereum.chainId = chainId } catch(e) {}
+							try { inpageWindow.ethereum.networkVersion = Number(chainId).toString(10) } catch(e) {}
 							this.activeChainId = chainId
 							break
 						}
@@ -605,12 +603,12 @@ class InterceptorMessageListener {
 	private enableMetamaskCompatibilityMode(enable: boolean) {
 		this.metamaskCompatibilityMode = enable
 		if (enable) {
-			if (window.ethereum === undefined) return
-			if (!('isMetamask' in window.ethereum)) try { window.ethereum.isMetaMask = true } catch(e) {}
-			if ('web3' in window && window.web3 !== undefined) {
-				try { window.web3.currentProvider = window.ethereum } catch(e) {}
+			if (inpageWindow.ethereum === undefined) return
+			if (!('isMetamask' in inpageWindow.ethereum)) try { inpageWindow.ethereum.isMetaMask = true } catch(e) {}
+			if ('web3' in inpageWindow && inpageWindow.web3 !== undefined) {
+				try { inpageWindow.web3.currentProvider = inpageWindow.ethereum } catch(e) {}
 			} else {
-				try { window.web3 = { accounts: [], currentProvider: window.ethereum } } catch(e) {}
+				try { inpageWindow.web3 = { accounts: [], currentProvider: inpageWindow.ethereum } } catch(e) {}
 			}
 		}
 	}
@@ -625,8 +623,8 @@ class InterceptorMessageListener {
 				&& 'activeAddress' in connectSignerReply && connectSignerReply.activeAddress !== null
 				&& connectSignerReply.activeAddress !== undefined && typeof connectSignerReply.activeAddress === 'string') {
 					this.currentAddress = connectSignerReply.activeAddress
-					if (connectSignerReply.metamaskCompatibilityMode && window.ethereum !== undefined) {
-						try { window.ethereum.selectedAddress = this.currentAddress } catch(error) { }
+					if (connectSignerReply.metamaskCompatibilityMode && inpageWindow.ethereum !== undefined) {
+						try { inpageWindow.ethereum.selectedAddress = this.currentAddress } catch(error) { }
 					}
 				return connectSignerReply as { metamaskCompatibilityMode: boolean, activeAddress: string }
 			}
@@ -669,8 +667,8 @@ class InterceptorMessageListener {
 				rdns: 'dark.florist'
 			}
 
-			if (window.ethereum === undefined || !window.ethereum.isInterceptor) interceptorMessageListener.injectEthereumIntoWindow()
-			const provider = window.ethereum
+			if (inpageWindow.ethereum === undefined || !inpageWindow.ethereum.isInterceptor) interceptorMessageListener.injectEthereumIntoWindow()
+			const provider = inpageWindow.ethereum
 			if (provider === undefined) throw new Error('The Interceptor provider was not initialized')
 			window.dispatchEvent(new CustomEvent('eip6963:announceProvider', { detail: Object.freeze({ info, provider }) }))
 		}
@@ -679,48 +677,48 @@ class InterceptorMessageListener {
 	}
 
 	public readonly injectEthereumIntoWindow = () => {
-		if (!('ethereum' in window) || !window.ethereum) {
+		if (!('ethereum' in inpageWindow) || !inpageWindow.ethereum) {
 			// no existing signer found
-			window.ethereum = {
+			inpageWindow.ethereum = {
 				isInterceptor: true,
-				isConnected: this.WindowEthereumIsConnected.bind(window.ethereum),
-				request: this.WindowEthereumRequest.bind(window.ethereum),
-				send: this.WindowEthereumSend.bind(window.ethereum),
-				sendAsync: this.WindowEthereumSendAsync.bind(window.ethereum),
-				on: this.WindowEthereumOn.bind(window.ethereum),
-				removeListener: this.WindowEthereumRemoveListener.bind(window.ethereum),
-				enable: this.WindowEthereumEnable.bind(window.ethereum),
-				...this.unsupportedMethods(window.ethereum),
+				isConnected: this.WindowEthereumIsConnected.bind(inpageWindow.ethereum),
+				request: this.WindowEthereumRequest.bind(inpageWindow.ethereum),
+				send: this.WindowEthereumSend.bind(inpageWindow.ethereum),
+				sendAsync: this.WindowEthereumSendAsync.bind(inpageWindow.ethereum),
+				on: this.WindowEthereumOn.bind(inpageWindow.ethereum),
+				removeListener: this.WindowEthereumRemoveListener.bind(inpageWindow.ethereum),
+				enable: this.WindowEthereumEnable.bind(inpageWindow.ethereum),
+				...this.unsupportedMethods(inpageWindow.ethereum),
 			}
 			this.connected = true
 			this.connectToSigner('NoSigner')
 			return
 		}
-		if (window.ethereum.isInterceptor) return
+		if (inpageWindow.ethereum.isInterceptor) return
 
 		// subscribe for signers events
-		window.ethereum.on('accountsChanged', (accounts: readonly string[]) => {
+		inpageWindow.ethereum.on('accountsChanged', (accounts: readonly string[]) => {
 			this.WindowEthereumRequest({ method: 'eth_accounts_reply', params: [{ type: 'success', accounts, requestAccounts: false }] })
 		})
-		window.ethereum.on('connect', (_connectInfo: ProviderConnectInfo) => {
+		inpageWindow.ethereum.on('connect', (_connectInfo: ProviderConnectInfo) => {
 			this.connectToSigner(this.currentSigner)
 		})
-		window.ethereum.on('disconnect', (_error: ProviderRpcError) => {
+		inpageWindow.ethereum.on('disconnect', (_error: ProviderRpcError) => {
 			this.sendMessageToBackgroundPage({ method: 'connected_to_signer', params: [false, this.currentSigner] })
 		})
-		window.ethereum.on('chainChanged', (chainId: string) => {
+		inpageWindow.ethereum.on('chainChanged', (chainId: string) => {
 			// TODO: this is a hack to get coinbase working that calls this numbers in base 10 instead of in base 16
 			const params = /\d/.test(chainId) ? [`0x${parseInt(chainId).toString(16)}`] : [chainId]
 			this.WindowEthereumRequest({ method: 'signer_chainChanged', params })
 		})
 
-		this.connected = !window.ethereum.isConnected || window.ethereum.isConnected()
-		this.signerWindowEthereumRequest = window.ethereum.request.bind(window.ethereum) // store the request object to signer
+		this.connected = !inpageWindow.ethereum.isConnected || inpageWindow.ethereum.isConnected()
+		this.signerWindowEthereumRequest = inpageWindow.ethereum.request.bind(inpageWindow.ethereum) // store the request object to signer
 
-		if (window.ethereum.isBraveWallet || window.ethereum.providerMap || window.ethereum.isCoinbaseWallet) {
-			const signerName = window.ethereum.providerMap || window.ethereum.isCoinbaseWallet ? 'CoinbaseWallet' : 'Brave'
-			const oldWinEthereum = (window.ethereum.providerMap ? window.ethereum.providerMap.get('CoinbaseWallet') : undefined) ?? window.ethereum
-			window.ethereum = {
+		if (inpageWindow.ethereum.isBraveWallet || inpageWindow.ethereum.providerMap || inpageWindow.ethereum.isCoinbaseWallet) {
+			const signerName = inpageWindow.ethereum.providerMap || inpageWindow.ethereum.isCoinbaseWallet ? 'CoinbaseWallet' : 'Brave'
+			const oldWinEthereum = (inpageWindow.ethereum.providerMap ? inpageWindow.ethereum.providerMap.get('CoinbaseWallet') : undefined) ?? inpageWindow.ethereum
+			inpageWindow.ethereum = {
 				isInterceptor: true,
 				isConnected: this.WindowEthereumIsConnected.bind(oldWinEthereum),
 				request: this.WindowEthereumRequest.bind(oldWinEthereum),
@@ -735,18 +733,18 @@ class InterceptorMessageListener {
 			return
 		}
 		// we cannot inject window.ethereum alone here as it seems like window.ethereum is cached (maybe ethers.js does that?)
-		Object.assign(window.ethereum, {
+		Object.assign(inpageWindow.ethereum, {
 			isInterceptor: true,
-			isConnected: this.WindowEthereumIsConnected.bind(window.ethereum),
-			request: this.WindowEthereumRequest.bind(window.ethereum),
-			send: this.WindowEthereumSend.bind(window.ethereum),
-			sendAsync: this.WindowEthereumSendAsync.bind(window.ethereum),
-			on: this.WindowEthereumOn.bind(window.ethereum),
-			removeListener: this.WindowEthereumRemoveListener.bind(window.ethereum),
-			enable: this.WindowEthereumEnable.bind(window.ethereum),
-			...this.unsupportedMethods(window.ethereum),
+			isConnected: this.WindowEthereumIsConnected.bind(inpageWindow.ethereum),
+			request: this.WindowEthereumRequest.bind(inpageWindow.ethereum),
+			send: this.WindowEthereumSend.bind(inpageWindow.ethereum),
+			sendAsync: this.WindowEthereumSendAsync.bind(inpageWindow.ethereum),
+			on: this.WindowEthereumOn.bind(inpageWindow.ethereum),
+			removeListener: this.WindowEthereumRemoveListener.bind(inpageWindow.ethereum),
+			enable: this.WindowEthereumEnable.bind(inpageWindow.ethereum),
+			...this.unsupportedMethods(inpageWindow.ethereum),
 		})
-		this.connectToSigner(window.ethereum.isMetaMask ? 'MetaMask' : 'NotRecognizedSigner')
+		this.connectToSigner(inpageWindow.ethereum.isMetaMask ? 'MetaMask' : 'NotRecognizedSigner')
 	}
 }
 

--- a/app/inpage/ts/inpage.ts
+++ b/app/inpage/ts/inpage.ts
@@ -142,7 +142,7 @@ type WindowEthereum = InjectFunctions & {
 	networkVersion?: string,
 }
 
-type InpageWindow = Window & {
+interface Window {
 	ethereum?: WindowEthereum
 	web3?: {
 		currentProvider: WindowEthereum
@@ -150,7 +150,7 @@ type InpageWindow = Window & {
 	}
 }
 
-const inpageWindow = window as InpageWindow
+const inpageWindow = window
 
 interface EIP6963ProviderInfo {
 	uuid: string

--- a/app/inpage/ts/inpage.ts
+++ b/app/inpage/ts/inpage.ts
@@ -143,12 +143,16 @@ type WindowEthereum = InjectFunctions & {
 }
 interface Window {
 	dispatchEvent: (event: Event) => boolean
+	addEventListener: (type: string, listener: (event: unknown) => void) => void
+	postMessage: (message: unknown, targetOrigin: string) => void
 	ethereum?: WindowEthereum
 	web3?: {
 		currentProvider: WindowEthereum
 		accounts: readonly string[]
 	}
 }
+
+declare const window: Window
 
 interface EIP6963ProviderInfo {
 	uuid: string
@@ -180,7 +184,6 @@ class InterceptorMessageListener {
 	private activeChainId = ''
 	private currentSigner: Signer = 'NoSigner'
 
-	private waitForAccountsFromWallet: InterceptorFuture<boolean> | undefined = undefined
 	private signerAccounts: string[] = []
 	private pendingSignerAddressRequest: InterceptorFuture<boolean> | undefined = undefined
 
@@ -214,7 +217,6 @@ class InterceptorMessageListener {
 
 	// sends a message to interceptors background script
 	private readonly WindowEthereumRequest = async (methodAndParams: { readonly method: string, readonly params?: readonly unknown[] }) => {
-		if (this.waitForAccountsFromWallet !== undefined) await this.waitForAccountsFromWallet // wait for wallet to return to us before continuing with other requests
 		try {
 			// make a message that the background script will catch and reply us. We'll wait until the background script replies to us and return only after that
 			return await this.sendMessageToBackgroundPage({ method: methodAndParams.method, params: methodAndParams.params })
@@ -329,16 +331,14 @@ class InterceptorMessageListener {
 		try {
 			const reply = await this.signerWindowEthereumRequest({ method: 'eth_accounts', params: [] })
 			if (!Array.isArray(reply)) throw new Error('Signer returned something else than an array')
+			if (!InterceptorMessageListener.isStringArray(reply)) throw new Error('Signer did not return a string array')
+			this.signerAccounts = reply
 			await this.sendMessageToBackgroundPage({ method: 'eth_accounts_reply', params: [{ type: 'success', accounts: this.signerAccounts, requestAccounts: false }] })
 			return
 		} catch (error: unknown) {
 			if (InterceptorMessageListener.getErrorCodeAndMessage(error)) return await this.sendMessageToBackgroundPage({ method: 'eth_accounts_reply', params: [{ type: 'error', requestAccounts: false, error }] })
 			if (error instanceof Error) return await this.sendMessageToBackgroundPage({ method: 'eth_accounts_reply', params: [{ type: 'error', requestAccounts: false, error: { message: error.message, code: METAMASK_ERROR_BLANKET_ERROR } }] })
 			return await this.sendMessageToBackgroundPage({ method: 'eth_accounts_reply', params: [{ type: 'error', requestAccounts: false, error: { message: 'unknown error', code: METAMASK_ERROR_BLANKET_ERROR } }] })
-		} finally {
-			if (this.waitForAccountsFromWallet === undefined) return
-			this.waitForAccountsFromWallet.resolve(true)
-			this.waitForAccountsFromWallet = undefined
 		}
 	}
 
@@ -421,7 +421,7 @@ class InterceptorMessageListener {
 			switch (replyRequest.method) {
 				case 'accountsChanged': {
 					const reply = replyRequest.result as readonly string[]
-					const replyAddress = reply.length > 0 ? reply[0] : ''
+					const replyAddress = reply[0] ?? ''
 					if (this.currentAddress === replyAddress) return
 					this.currentAddress = replyAddress
 					if (this.metamaskCompatibilityMode && window.ethereum !== undefined) {
@@ -535,7 +535,7 @@ class InterceptorMessageListener {
 						case 'eth_accounts': {
 							if (!Array.isArray(forwardRequest.result) || forwardRequest.result === null) throw new Error('wrong type')
 							const addrArray = forwardRequest.result as string[]
-							const addr = addrArray.length > 0 ? addrArray[0] : ''
+							const addr = addrArray[0] ?? ''
 							try { window.ethereum.selectedAddress = addr } catch(e) {}
 							if ('web3' in window && window.web3 !== undefined) try { window.web3.accounts = addrArray } catch(e) {}
 							this.currentAddress = addr
@@ -634,10 +634,8 @@ class InterceptorMessageListener {
 		}
 
 		if (signerName !== 'NoSigner') {
-			if (this.waitForAccountsFromWallet === undefined && this.signerAccounts.length === 0) this.waitForAccountsFromWallet = new InterceptorFuture()
 			this.enableMetamaskCompatibilityMode((await connectToSigner()).metamaskCompatibilityMode)
 			await this.requestChainIdFromSigner()
-			await this.getAccountsFromSigner()
 		} else {
 			this.enableMetamaskCompatibilityMode((await connectToSigner()).metamaskCompatibilityMode)
 		}

--- a/app/inpage/ts/inpage.ts
+++ b/app/inpage/ts/inpage.ts
@@ -142,7 +142,7 @@ type WindowEthereum = InjectFunctions & {
 	networkVersion?: string,
 }
 
-interface Window {
+type InpageWindow = Window & {
 	ethereum?: WindowEthereum
 	web3?: {
 		currentProvider: WindowEthereum
@@ -150,7 +150,7 @@ interface Window {
 	}
 }
 
-const inpageWindow = window
+const inpageWindow: InpageWindow = window
 
 interface EIP6963ProviderInfo {
 	uuid: string

--- a/app/inpage/ts/listenContentScript.ts
+++ b/app/inpage/ts/listenContentScript.ts
@@ -61,7 +61,7 @@ function listenContentScript(connectionName: string | undefined) {
 				console.error('Malformed message:')
 				console.error(messageEvent)
 				if (extensionPort === undefined) return
-				extensionPort.postMessage({ data: { interceptorRequest: true, usingInterceptorWithoutSigner: false, requestId: -1, method: 'InterceptorError', params: [messageEvent] } })
+				extensionPort.postMessage({ data: { interceptorRequest: true, usingInterceptorWithoutSigner: false, requestId: -1, method: 'InterceptorError', params: [JSON.stringify(messageEvent)] } })
 				return
 			}
 			try {

--- a/app/ts/background/accessManagement.ts
+++ b/app/ts/background/accessManagement.ts
@@ -161,11 +161,6 @@ function connectToPort(websiteTabConnections: WebsiteTabConnections, socket: Web
 	sendSubscriptionReplyOrCallBack(websiteTabConnections, socket, { type: 'result' as const, method: 'accountsChanged', result: connectWithActiveAddress !== undefined ? [connectWithActiveAddress] : [] })
 
 	sendSubscriptionReplyOrCallBack(websiteTabConnections, socket, { type: 'result' as const, method: 'chainChanged', result: settings.activeRpcNetwork.chainId })
-
-	if (!settings.simulationMode || settings.useSignersAddressAsActiveAddress) {
-		sendSubscriptionReplyOrCallBack(websiteTabConnections, socket, { type: 'result' as const, method: 'request_signer_to_eth_requestAccounts', result: [] })
-		sendSubscriptionReplyOrCallBack(websiteTabConnections, socket, { type: 'result' as const, method: 'request_signer_chainId', result: [] })
-	}
 	return true
 }
 

--- a/app/ts/background/providerMessageHandlers.ts
+++ b/app/ts/background/providerMessageHandlers.ts
@@ -14,9 +14,11 @@ import { handleUnexpectedError } from '../utils/errors.js'
 import { resolvePendingTransactionOrMessage, updateConfirmTransactionView } from './windows/confirmTransaction.js'
 import { addressString } from '../utils/bigint.js'
 import { modifyObject } from '../utils/typescript.js'
+import { sendSubscriptionReplyOrCallBackToPort } from './messageSending.js'
 
-export async function ethAccountsReply(simulator: Simulator, websiteTabConnections: WebsiteTabConnections, port: browser.runtime.Port, request: ProviderMessage, _connectInfoapproval: ApprovalState, _activeAddress: bigint | undefined) {
+export async function ethAccountsReply(simulator: Simulator, websiteTabConnections: WebsiteTabConnections, port: browser.runtime.Port, request: ProviderMessage, approval: ApprovalState, _activeAddress: bigint | undefined) {
 	const returnValue = { type: 'result' as const, method: 'eth_accounts_reply' as const, result: '0x' as const }
+	if (approval !== 'hasAccess') return returnValue
 	if (!('params' in request)) return returnValue
 	if (port.sender?.tab?.id === undefined) return returnValue
 
@@ -84,11 +86,18 @@ export async function walletSwitchEthereumChainReply(simulator: Simulator, websi
 	return returnValue
 }
 
-export async function connectedToSigner(_simulator: Simulator, _websiteTabConnections: WebsiteTabConnections, _port: browser.runtime.Port, request: ProviderMessage, _approval: ApprovalState, activeAddress: bigint | undefined) {
+export async function connectedToSigner(_simulator: Simulator, _websiteTabConnections: WebsiteTabConnections, port: browser.runtime.Port, request: ProviderMessage, approval: ApprovalState, activeAddress: bigint | undefined) {
 	const [signerConnected, signerName] = ConnectedToSigner.parse(request).params
+	if (approval !== 'hasAccess') {
+		return { type: 'result' as const, method: 'connected_to_signer' as const, result: { metamaskCompatibilityMode: await getMetamaskCompatibilityMode(), activeAddress: '' } }
+	}
 	await setDefaultSignerName(signerName)
 	await updateTabState(request.uniqueRequestIdentifier.requestSocket.tabId, (previousState: TabState) => modifyObject(previousState, { signerName, signerConnected }))
 	await sendPopupMessageToOpenWindows({ method: 'popup_signer_name_changed' })
+	const settings = await getSettings()
+	if (!settings.simulationMode || settings.useSignersAddressAsActiveAddress) {
+		sendSubscriptionReplyOrCallBackToPort(port, { type: 'result', method: 'request_signer_chainId', result: [] })
+	}
 	return { type: 'result' as const, method: 'connected_to_signer' as const, result: { metamaskCompatibilityMode: await getMetamaskCompatibilityMode(), activeAddress: activeAddress === undefined ? '' : addressString(activeAddress) } }
 }
 

--- a/app/ts/background/providerMessageHandlers.ts
+++ b/app/ts/background/providerMessageHandlers.ts
@@ -8,7 +8,6 @@ import { getMetamaskCompatibilityMode, getSettings } from './settings.js'
 import { resolveSignerChainChange } from './windows/changeChain.js'
 import { ApprovalState } from './accessManagement.js'
 import { ProviderMessage } from '../utils/requests.js'
-import { sendSubscriptionReplyOrCallBackToPort } from './messageSending.js'
 import { Simulator } from '../simulation/simulator.js'
 import { METAMASK_ERROR_USER_REJECTED_REQUEST } from '../utils/constants.js'
 import { handleUnexpectedError } from '../utils/errors.js'
@@ -85,20 +84,11 @@ export async function walletSwitchEthereumChainReply(simulator: Simulator, websi
 	return returnValue
 }
 
-export async function connectedToSigner(_simulator: Simulator, _websiteTabConnections: WebsiteTabConnections, port: browser.runtime.Port, request: ProviderMessage, approval: ApprovalState, activeAddress: bigint | undefined) {
+export async function connectedToSigner(_simulator: Simulator, _websiteTabConnections: WebsiteTabConnections, _port: browser.runtime.Port, request: ProviderMessage, _approval: ApprovalState, activeAddress: bigint | undefined) {
 	const [signerConnected, signerName] = ConnectedToSigner.parse(request).params
 	await setDefaultSignerName(signerName)
 	await updateTabState(request.uniqueRequestIdentifier.requestSocket.tabId, (previousState: TabState) => modifyObject(previousState, { signerName, signerConnected }))
 	await sendPopupMessageToOpenWindows({ method: 'popup_signer_name_changed' })
-	const settings = await getSettings()
-	if (!settings.simulationMode || settings.useSignersAddressAsActiveAddress) {
-		if (approval === 'hasAccess') {
-			sendSubscriptionReplyOrCallBackToPort(port, { type: 'result' as const, method: 'request_signer_to_eth_requestAccounts' as const, result: [] })
-		} else {
-			sendSubscriptionReplyOrCallBackToPort(port, { type: 'result' as const, method: 'request_signer_to_eth_accounts' as const, result: [] })
-		}
-		sendSubscriptionReplyOrCallBackToPort(port, { type: 'result' as const, method: 'request_signer_chainId' as const, result: [] })
-	}
 	return { type: 'result' as const, method: 'connected_to_signer' as const, result: { metamaskCompatibilityMode: await getMetamaskCompatibilityMode(), activeAddress: activeAddress === undefined ? '' : addressString(activeAddress) } }
 }
 

--- a/app/ts/background/windows/interceptorAccess.ts
+++ b/app/ts/background/windows/interceptorAccess.ts
@@ -250,7 +250,11 @@ export async function requestAddressChange(websiteTabConnections: WebsiteTabConn
 	const newRequests = await updatePendingAccessRequests(async (previousPendingAccessRequests) => {
 		if (message.data.requestAccessToAddress === undefined) throw new Error('Requesting account change on site level access request')
 		async function getProposedAddress() {
-			if (message.method === 'popup_interceptorAccessRefresh' || message.data.newActiveAddress === 'signer') {
+			if (message.method === 'popup_interceptorAccessRefresh') {
+				const tabState = await getTabState(message.data.socket.tabId)
+				return tabState.signerAccounts[0]
+			}
+			if (message.data.newActiveAddress === 'signer') {
 				const signerAccounts = await askForSignerAccountsFromSignerIfNotAvailable(websiteTabConnections, message.data.socket)
 				return signerAccounts[0]
 			}

--- a/test/tests/inpageSignerBridge.ts
+++ b/test/tests/inpageSignerBridge.ts
@@ -1,0 +1,160 @@
+import * as assert from 'assert'
+import { describe, runIfRoot, should, run } from '../micro-should.js'
+
+type Listener = (event: { type: string, data?: unknown, detail?: unknown, ports?: readonly unknown[] }) => void
+
+function createFakeWindow() {
+	const listeners = new Map<string, Set<Listener>>()
+	const signerRequests: string[] = []
+	const backgroundEthAccountsReplies: unknown[] = []
+	const signerAccounts = ['0x1111111111111111111111111111111111111111']
+
+	const fakeSigner = {
+		isMetaMask: true,
+		isConnected: () => true,
+		request: async ({ method }: { method: string }) => {
+			signerRequests.push(method)
+			switch (method) {
+				case 'eth_chainId':
+					return '0x1'
+				case 'eth_accounts':
+				case 'eth_requestAccounts':
+					return signerAccounts
+				default:
+					throw new Error(`Unexpected signer request: ${method}`)
+			}
+		},
+		on: () => fakeSigner,
+		removeListener: () => fakeSigner,
+	}
+
+	const fakeWindow = {
+		ethereum: fakeSigner,
+		addEventListener: (type: string, listener: Listener) => {
+			const existing = listeners.get(type)
+			if (existing === undefined) {
+				listeners.set(type, new Set([listener]))
+				return
+			}
+			existing.add(listener)
+		},
+		removeEventListener: (type: string, listener: Listener) => {
+			listeners.get(type)?.delete(listener)
+		},
+		dispatchEvent: (event: { type: string, data?: unknown, detail?: unknown, ports?: readonly unknown[] }) => {
+			for (const listener of listeners.get(event.type) ?? []) listener(event)
+			return true
+		},
+		postMessage: (data: unknown) => {
+			queueMicrotask(() => {
+				if (typeof data !== 'object' || data === null || !('interceptorRequest' in data) || (data as { interceptorRequest?: unknown }).interceptorRequest !== true) return
+				const request = data as unknown as { method: string, requestId: number, params?: readonly unknown[] }
+				switch (request.method) {
+					case 'connected_to_signer':
+						fakeWindow.dispatchEvent({
+							type: 'message',
+							data: {
+								interceptorApproved: true,
+								requestId: request.requestId,
+								type: 'result',
+								method: 'connected_to_signer',
+								result: { metamaskCompatibilityMode: false, activeAddress: '' },
+							},
+						})
+						return
+					case 'eth_accounts_reply':
+						backgroundEthAccountsReplies.push((request.params?.[0] as { accounts?: unknown } | undefined) ?? {})
+						return
+					default:
+						fakeWindow.dispatchEvent({
+							type: 'message',
+							data: {
+								interceptorApproved: true,
+								requestId: request.requestId,
+								type: 'result',
+								method: request.method,
+								result: '0x',
+							},
+						})
+				}
+			})
+		},
+	}
+
+	return { fakeWindow, signerRequests, backgroundEthAccountsReplies, signerAccounts }
+}
+
+async function waitFor(condition: () => boolean, timeoutMs = 2000) {
+	const start = Date.now()
+	while (!condition()) {
+		if (Date.now() - start > timeoutMs) throw new Error('Timed out waiting for condition')
+		await new Promise((resolve) => setTimeout(resolve, 0))
+	}
+}
+
+export async function main() {
+	describe('inpage signer bridge', () => {
+		should('avoid hidden signer account sync on connect and preserve explicit account replies', async () => {
+			const previousWindow = (globalThis as { window?: unknown }).window
+			const previousCustomEvent = (globalThis as { CustomEvent?: typeof CustomEvent }).CustomEvent
+			const { fakeWindow, signerRequests, backgroundEthAccountsReplies, signerAccounts } = createFakeWindow()
+			;(globalThis as unknown as { window: typeof fakeWindow }).window = fakeWindow
+			if (typeof (globalThis as { CustomEvent?: typeof CustomEvent }).CustomEvent !== 'function') {
+				;(globalThis as { CustomEvent: typeof CustomEvent }).CustomEvent = class CustomEvent<T = unknown> extends Event {
+					public detail: T
+					constructor(type: string, init?: CustomEventInit<T>) {
+						super(type)
+						this.detail = init?.detail as T
+					}
+					public initCustomEvent(): void {}
+				}
+			}
+
+			try {
+				await import('../../app/inpage/ts/inpage.js')
+				await waitFor(() => signerRequests.length >= 1)
+				assert.deepEqual(signerRequests, ['eth_chainId'])
+
+				fakeWindow.dispatchEvent({
+					type: 'message',
+					data: {
+						interceptorApproved: true,
+						type: 'result',
+						method: 'request_signer_to_eth_accounts',
+						result: [],
+					},
+				})
+				await waitFor(() => signerRequests.includes('eth_accounts'))
+				assert.deepEqual(signerRequests, ['eth_chainId', 'eth_accounts'])
+				await waitFor(() => backgroundEthAccountsReplies.length === 1)
+				assert.deepEqual((backgroundEthAccountsReplies[0] as { accounts?: unknown }).accounts, signerAccounts)
+
+				fakeWindow.dispatchEvent({
+					type: 'message',
+					data: {
+						interceptorApproved: true,
+						type: 'result',
+						method: 'request_signer_to_eth_requestAccounts',
+						result: [],
+					},
+				})
+				await waitFor(() => signerRequests.filter((method) => method === 'eth_requestAccounts').length === 1)
+				assert.deepEqual(signerRequests, ['eth_chainId', 'eth_accounts', 'eth_requestAccounts'])
+				await waitFor(() => backgroundEthAccountsReplies.length === 2)
+				assert.deepEqual((backgroundEthAccountsReplies[1] as { accounts?: unknown }).accounts, signerAccounts)
+			} finally {
+				;(globalThis as { window?: unknown }).window = previousWindow
+				if (previousCustomEvent === undefined) {
+					delete (globalThis as { CustomEvent?: typeof CustomEvent }).CustomEvent
+				} else {
+					;(globalThis as { CustomEvent: typeof CustomEvent }).CustomEvent = previousCustomEvent
+				}
+			}
+		})
+	})
+}
+
+await runIfRoot(async () => {
+	await main()
+	await run()
+}, import.meta)


### PR DESCRIPTION
## Summary
- Removed the implicit signer account sync during connect and now rely on explicit account reply handling.
- Updated inpage provider access to use a typed `window` reference consistently for ethereum/web3 interactions.
- Adjusted background handling so signer connection and access refresh flows no longer depend on hidden account fetches.
- Added coverage for the signer bridge to verify connect only requests chain ID and explicit account requests still propagate correctly.

## Testing
- Not run (PR content only).
- Existing test added: `test/tests/inpageSignerBridge.ts` covers connect flow and explicit `eth_accounts` / `eth_requestAccounts` replies.
- Repo instructions in `AGENTS.md` require running `npm test` and `npm run setup-chrome` after code changes.