### PR TITLE
Ignore pre-simulation delay when signing

### DIFF
--- a/app/ts/background/simulationUpdating.ts
+++ b/app/ts/background/simulationUpdating.ts
@@ -42,14 +42,17 @@ export const getAddressesbeingMadeRich = async () => {
 }
 
 export const getCurrentSimulationInput = async (): Promise<SimulationStateInput> => {
-	const preSimulationBlockTimeManipulation = await getPreSimulationBlockTimeManipulation()
+	const [settings, preSimulationBlockTimeManipulation] = await Promise.all([
+		getSettings(),
+		getPreSimulationBlockTimeManipulation()
+	])
 	const richListPromise = silenceChromeUnCaughtPromise(getAddressesbeingMadeRich())
 	const stack = await getInterceptorTransactionStack()
 	const inputBlocks: SimulationStateInputBlock[] = []
 	let currentBlockTransactions: PreSimulationTransaction[] = []
 	let currentBlockSignedMessages: SignedMessageTransaction[] = []
 	let currentBlockStateOverrides = getMakeCurrentAddressRichStateOverride(await richListPromise)
-	let previousBlockTimeManipulation = preSimulationBlockTimeManipulation
+	let previousBlockTimeManipulation = settings.simulationMode ? preSimulationBlockTimeManipulation : DEFAULT_BLOCK_MANIPULATION
 
 	const pushBlock = (blockTimeManipulation: BlockTimeManipulation) => {
 		inputBlocks.push({

--- a/test/tests/simulateDelayEditor.ts
+++ b/test/tests/simulateDelayEditor.ts
@@ -62,7 +62,7 @@ async function main() {
 	const { getCurrentSimulationInput } = await import('../../app/ts/background/simulationUpdating.js')
 	const { getInterceptorTransactionStack, updateInterceptorTransactionStack } = await import('../../app/ts/background/storageVariables.js')
 	const { setTransactionOrMessageBlockTimeManipulator } = await import('../../app/ts/background/popupMessageHandlers.js')
-	const { mockSignTransaction } = await import('../../app/ts/simulation/services/SimulationModeEthereumClientService.js')
+	const { DEFAULT_BLOCK_MANIPULATION, mockSignTransaction } = await import('../../app/ts/simulation/services/SimulationModeEthereumClientService.js')
 
 	const baseTransaction = {
 		type: '1559',
@@ -150,6 +150,27 @@ async function main() {
 			assert.equal(simulationInput.length, 2)
 			assert.deepStrictEqual(simulationInput.map((block) => block.blockTimeManipulation), [
 				{ type: 'AddToTimestamp', deltaToAdd: 12n, deltaUnit: 'Seconds' },
+				newDelay,
+			])
+		})
+
+		should('signing mode ignores the pre-simulation first-transaction delay', async () => {
+			await resetStack()
+			mockBrowser.__storage.simulationMode = false
+			mockBrowser.__storage.preSimulationBlockTimeManipulation = { type: 'AddToTimestamp', deltaToAdd: 13n, deltaUnit: 'Seconds' }
+
+			await setTransactionOrMessageBlockTimeManipulator(simulator, {
+				method: 'popup_setTransactionOrMessageBlockTimeManipulator',
+				data: {
+					transactionOrMessageIdentifier: { type: 'Transaction', transactionIdentifier: 1n },
+					blockTimeManipulation: newDelay,
+				},
+			})
+
+			const simulationInput = await getCurrentSimulationInput()
+			assert.equal(simulationInput.length, 2)
+			assert.deepStrictEqual(simulationInput.map((block) => block.blockTimeManipulation), [
+				DEFAULT_BLOCK_MANIPULATION,
 				newDelay,
 			])
 		})


### PR DESCRIPTION
## Summary
- Skip the stored pre-simulation block time manipulation when building simulation input in signing mode.
- Preserve the configured pre-simulation delay only while actual simulation mode is enabled.
- Add a regression test covering the signing-mode path and verifying the first block uses the default manipulation.

## Testing
- Added/updated test in `test/tests/simulateDelayEditor.ts` to assert signing mode ignores the pre-simulation first-transaction delay.
- Not run locally.