### PR TITLE
Add browser simulator popup lifecycle benchmark suite

### DIFF
--- a/app/ts/background/background-startup.ts
+++ b/app/ts/background/background-startup.ts
@@ -23,6 +23,7 @@ import { AddressBookEntries, AddressBookEntry } from '../types/addressBookTypes.
 import { getUniqueItemsByProperties } from '../utils/typed-arrays.js'
 import { updateDeclarativeNetRequestBlocks } from './accessManagement.js'
 import { updatePopupVisualisationIfNeeded } from './popupVisualisationUpdater.js'
+import { POPUP_PERFORMANCE_MARKS, markPerformance } from '../utils/popupPerformance.js'
 
 const websiteTabConnections = new Map<number, TabConnection>()
 
@@ -256,6 +257,7 @@ async function startup() {
 	const onCloseTab = async (id: number) => await catchAllErrorsAndCall(async () => await onCloseWindowOrTab({ type: 'tab' as const, id }, simulator, websiteTabConnections))
 	addWindowTabListeners(onCloseWindow, onCloseTab)
 	await updateDeclarativeNetRequestBlocks(websiteTabConnections)
+	markPerformance(POPUP_PERFORMANCE_MARKS.backgroundStartupReady)
 }
 
 startup()

--- a/app/ts/background/popupMessageHandlers.ts
+++ b/app/ts/background/popupMessageHandlers.ts
@@ -39,6 +39,7 @@ import { resolveFetchSimulationStackRequest } from './windows/fetchSimulationSta
 import { updateChainChangeViewWithPendingRequest } from './windows/changeChain.js'
 import { updateInterceptorAccessViewWithPendingRequests } from './windows/interceptorAccess.js'
 import { updateFetchSimulationStackRequestWithPendingRequest } from './windows/fetchSimulationStack.js'
+import { POPUP_PERFORMANCE_MARKS, markPerformance } from '../utils/popupPerformance.js'
 
 type TimestampedPopupVisualisation = {
 	data: {
@@ -445,38 +446,43 @@ export async function requestNewHomeData(simulator: Simulator, requestAbortContr
 }
 
 export async function refreshHomeData(simulator: Simulator, refreshSimulation = true, requestAbortController: AbortController | undefined = undefined) {
-	const currentSettings = await getSettings()
-	if (currentSettings.simulationMode) await updateSimulationMetadata(simulator.ethereum, requestAbortController)
-	if (refreshSimulation) await updatePopupVisualisationIfNeeded(simulator, false, false, true)
-	const settingsPromise = silenceChromeUnCaughtPromise(getSettings())
-	const rpcConnectionStatusPromise = silenceChromeUnCaughtPromise(getRpcConnectionStatus())
-	const rpcEntriesPromise = silenceChromeUnCaughtPromise(getRpcList())
-	const preSimulationBlockTimeManipulationPromise = silenceChromeUnCaughtPromise(getPreSimulationBlockTimeManipulation())
+	markPerformance(POPUP_PERFORMANCE_MARKS.backgroundRefreshStart)
+	try {
+		const currentSettings = await getSettings()
+		if (currentSettings.simulationMode) await updateSimulationMetadata(simulator.ethereum, requestAbortController)
+		if (refreshSimulation) await updatePopupVisualisationIfNeeded(simulator, false, false, true)
+		const settingsPromise = silenceChromeUnCaughtPromise(getSettings())
+		const rpcConnectionStatusPromise = silenceChromeUnCaughtPromise(getRpcConnectionStatus())
+		const rpcEntriesPromise = silenceChromeUnCaughtPromise(getRpcList())
+		const preSimulationBlockTimeManipulationPromise = silenceChromeUnCaughtPromise(getPreSimulationBlockTimeManipulation())
 
-	const visualizedSimulatorStatePromise: Promise<CompleteVisualizedSimulation> = silenceChromeUnCaughtPromise(getPopupVisualisationState())
-	const tabId = await getLastKnownCurrentTabId()
-	const tabState = tabId === undefined ? await getTabState(-1) : await getTabState(tabId)
-	const settings = await settingsPromise
-	if (settings.activeRpcNetwork.httpsRpc !== undefined) makeSureInterceptorIsNotSleeping(simulator.ethereum)
-	const websiteOrigin = tabState.website?.websiteOrigin
-	const interceptorDisabled = websiteOrigin === undefined ? false : settings.websiteAccess.find((entry) => entry.website.websiteOrigin === websiteOrigin && entry.interceptorDisabled === true) !== undefined
-	const updatedPage: UpdateHomePage = {
-		method: 'popup_UpdateHomePage' as const,
-		data: {
-			visualizedSimulatorState: await visualizedSimulatorStatePromise,
-			websiteAccessAddressMetadata: await getAddressMetadataForAccess(settings.websiteAccess),
-			tabState,
-			activeSigningAddressInThisTab: tabState?.activeSigningAddress,
-			currentBlockNumber: simulator.ethereum.getCachedBlock()?.number,
-			settings: settings,
-			rpcConnectionStatus: await rpcConnectionStatusPromise,
-			tabId,
-			rpcEntries: await rpcEntriesPromise,
-			interceptorDisabled,
-			preSimulationBlockTimeManipulation: await preSimulationBlockTimeManipulationPromise
+		const visualizedSimulatorStatePromise: Promise<CompleteVisualizedSimulation> = silenceChromeUnCaughtPromise(getPopupVisualisationState())
+		const tabId = await getLastKnownCurrentTabId()
+		const tabState = tabId === undefined ? await getTabState(-1) : await getTabState(tabId)
+		const settings = await settingsPromise
+		if (settings.activeRpcNetwork.httpsRpc !== undefined) makeSureInterceptorIsNotSleeping(simulator.ethereum)
+		const websiteOrigin = tabState.website?.websiteOrigin
+		const interceptorDisabled = websiteOrigin === undefined ? false : settings.websiteAccess.find((entry) => entry.website.websiteOrigin === websiteOrigin && entry.interceptorDisabled === true) !== undefined
+		const updatedPage: UpdateHomePage = {
+			method: 'popup_UpdateHomePage' as const,
+			data: {
+				visualizedSimulatorState: await visualizedSimulatorStatePromise,
+				websiteAccessAddressMetadata: await getAddressMetadataForAccess(settings.websiteAccess),
+				tabState,
+				activeSigningAddressInThisTab: tabState?.activeSigningAddress,
+				currentBlockNumber: simulator.ethereum.getCachedBlock()?.number,
+				settings: settings,
+				rpcConnectionStatus: await rpcConnectionStatusPromise,
+				tabId,
+				rpcEntries: await rpcEntriesPromise,
+				interceptorDisabled,
+				preSimulationBlockTimeManipulation: await preSimulationBlockTimeManipulationPromise
+			}
 		}
+		await sendPopupMessageToOpenWindows(serialize(UpdateHomePage, updatedPage))
+	} finally {
+		markPerformance(POPUP_PERFORMANCE_MARKS.backgroundRefreshEnd)
 	}
-	await sendPopupMessageToOpenWindows(serialize(UpdateHomePage, updatedPage))
 }
 
 export async function settingsOpened() {

--- a/app/ts/background/simulationModeHanders.ts
+++ b/app/ts/background/simulationModeHanders.ts
@@ -14,6 +14,7 @@ import { METAMASK_ERROR_BLANKET_ERROR } from '../utils/constants.js'
 import { openConfirmTransactionDialogForMessage, openConfirmTransactionDialogForTransaction } from './windows/confirmTransaction.js'
 import { handleUnexpectedError } from '../utils/errors.js'
 import { openFetchSimulationStackDialogOrGetCachedResult } from './windows/fetchSimulationStack.js'
+import { POPUP_PERFORMANCE_MARKS, markPerformance } from '../utils/popupPerformance.js'
 
 export async function getBlockByHash(ethereumClientService: EthereumClientService, simulationState: SimulationState | undefined, request: EthBlockByHashParams) {
 	return { type: 'result' as const, method: request.method, result: await getSimulatedBlockByHash(ethereumClientService, undefined, simulationState, request.params[0], request.params[1]) }
@@ -42,6 +43,7 @@ export async function sendTransaction(
 	websiteTabConnections: WebsiteTabConnections,
 	simulationMode = true,
 ) {
+	markPerformance(POPUP_PERFORMANCE_MARKS.backgroundTransactionRequestReceived)
 	const action = await openConfirmTransactionDialogForTransaction(simulator, request, transactionParams, simulationMode, activeAddress, website, websiteTabConnections)
 	if (action.type === 'doNotReply') return action
 	return { method: transactionParams.method, ...action }

--- a/app/ts/background/windows/confirmTransaction.ts
+++ b/app/ts/background/windows/confirmTransaction.ts
@@ -26,6 +26,7 @@ import * as funtypes from 'funtypes'
 import { assertNever, modifyObject } from '../../utils/typescript.js'
 import { simulateGnosisSafeTransactionOnPass } from '../popupMessageHandlers.js'
 import { updatePopupVisualisationIfNeeded } from '../popupVisualisationUpdater.js'
+import { POPUP_PERFORMANCE_MARKS, markPerformance } from '../../utils/popupPerformance.js'
 
 const pendingConfirmationSemaphore = new Semaphore(1)
 
@@ -167,6 +168,7 @@ export async function resolvePendingTransactionOrMessage(simulator: Simulator, w
 				{ type: 'Transaction' as const, preSimulationTransaction: transaction}
 			] }))
 			await updatePopupVisualisationIfNeeded(simulator, false)
+			markPerformance(POPUP_PERFORMANCE_MARKS.backgroundTransactionStackAppended)
 			return reply({ type: 'result', result: EthereumBytes32.serialize(signedTransaction.hash) })
 		}
 		default: assertNever(pendingTransactionOrMessage)
@@ -383,6 +385,7 @@ export async function openConfirmTransactionDialogForTransaction(
 			const transactionToSimulate = await transactionToSimulatePromise
 			const openedDialog = await getPendingTransactionWindow(simulator, websiteTabConnections)
 			if (openedDialog === undefined) return formRejectMessage(METAMASK_ERROR_FAILED_TO_PARSE_REQUEST, 'Failed to get pending transaction window')
+			markPerformance(POPUP_PERFORMANCE_MARKS.backgroundTransactionConfirmPopupOpened)
 
 			const pendingTransaction = {
 				type: 'Transaction' as const,
@@ -399,14 +402,16 @@ export async function openConfirmTransactionDialogForTransaction(
 			}
 			await appendPendingTransactionOrMessage(pendingTransaction)
 			await updateConfirmTransactionView(simulator)
+			markPerformance(POPUP_PERFORMANCE_MARKS.backgroundTransactionSimulationStart)
 			const simulationResultsPromise = silenceChromeUnCaughtPromise(refreshConfirmTransactionSimulation(simulator, activeAddress, simulationMode, request.uniqueRequestIdentifier, transactionToSimulate))
 			if (transactionToSimulate.success) {
 				await updatePendingTransactionOrMessage(pendingTransaction.uniqueRequestIdentifier, async (transaction) => ({ ...transaction, transactionToSimulate: transactionToSimulate, transactionOrMessageCreationStatus: 'Simulating' as const }))
 				await updateConfirmTransactionView(simulator)
 			}
+			const popupVisualisation = await simulationResultsPromise
+			markPerformance(POPUP_PERFORMANCE_MARKS.backgroundTransactionSimulationEnd)
 			await updatePendingTransactionOrMessage(pendingTransaction.uniqueRequestIdentifier, async (transaction) => {
 				if (transaction.type !== 'Transaction') return transaction
-				const popupVisualisation = await simulationResultsPromise
 				if (popupVisualisation === undefined) return transaction
 				if (transaction.transactionOrMessageCreationStatus === 'Simulated' || transaction.transactionOrMessageCreationStatus === 'FailedToSimulate') {
 					if ('popupVisualisation' in transaction && !shouldReplacePopupVisualisation(transaction.popupVisualisation, popupVisualisation)) return transaction

--- a/app/ts/backgroundServiceWorker.ts
+++ b/app/ts/backgroundServiceWorker.ts
@@ -1,8 +1,11 @@
+import { POPUP_PERFORMANCE_MARKS, markPerformance } from './utils/popupPerformance.js'
 import './background/background-startup.js'
 import { getHtmlFile } from './background/backgroundUtils.js'
 import { clearTabStates } from './background/storageVariables.js'
 import { updateContentScriptInjectionStrategyManifestV3 } from './utils/contentScriptsUpdating.js'
 import { checkAndThrowRuntimeLastError } from './utils/requests.js'
+
+markPerformance(POPUP_PERFORMANCE_MARKS.backgroundLoaded)
 
 const setPopupFile = async () => {
 	// see https://issues.chromium.org/issues/337214677
@@ -15,6 +18,9 @@ self.addEventListener('install', () => {
 	console.info('The Interceptor installed')
 })
 
-self.addEventListener('activate', () => clearTabStates())
+self.addEventListener('activate', () => {
+	markPerformance(POPUP_PERFORMANCE_MARKS.backgroundActivated)
+	clearTabStates()
+})
 
 updateContentScriptInjectionStrategyManifestV3()

--- a/app/ts/components/App.tsx
+++ b/app/ts/components/App.tsx
@@ -30,6 +30,7 @@ import { EnrichedRichListElement, UnexpectedErrorOccured } from '../types/interc
 import { PopupMessageReplyRequests } from '../types/interceptor-reply-messages.js'
 import { ImportSimulationStack } from './pages/ImportSimulationStack.js'
 import { CenterToPageTextSpinner } from './subcomponents/Spinner.js'
+import { POPUP_PERFORMANCE_MARKS, markPerformance, markPerformanceOnce } from '../utils/popupPerformance.js'
 
 type ProviderErrorsParam = {
 	tabState: Signal<TabState | undefined>
@@ -93,6 +94,7 @@ export function App() {
 	const unexpectedError = useSignal<UnexpectedErrorOccured | undefined>(undefined)
 	const boundaryResetKey = useSignal(0)
 	const preSimulationBlockTimeManipulation = useSignal<BlockTimeManipulation | undefined>(undefined)
+	const popupRefreshAppliedGeneration = useSignal(0)
 
 	const fixedAddressRichList = useSignal<readonly EnrichedRichListElement[]>([])
 	const makeCurrentAddressRich = useSignal<boolean>(false)
@@ -164,6 +166,14 @@ export function App() {
 	}, [])
 
 	useEffect(() => {
+		if (popupRefreshAppliedGeneration.value === 0) return
+		if (popupRefreshAppliedGeneration.value === 1) {
+			markPerformanceOnce(POPUP_PERFORMANCE_MARKS.homeFirstCommit)
+		}
+		markPerformanceOnce(POPUP_PERFORMANCE_MARKS.refreshRendered)
+	}, [popupRefreshAppliedGeneration.value])
+
+	useEffect(() => {
 		const setSimulationState = (
 			simState: SimulationState | undefined,
 			addressBookEntries: AddressBookEntries,
@@ -218,6 +228,8 @@ export function App() {
 			if (!wasLoaded) {
 				preSimulationBlockTimeManipulation.value = data.preSimulationBlockTimeManipulation
 			}
+			markPerformance(POPUP_PERFORMANCE_MARKS.refreshComplete)
+			popupRefreshAppliedGeneration.value += 1
 		}
 		const updateHomePageSettings = (settings: Settings, updateQuery: boolean) => {
 			if (updateQuery && appPage.value.page === 'Unknown') {

--- a/app/ts/components/pages/ConfirmTransaction.tsx
+++ b/app/ts/components/pages/ConfirmTransaction.tsx
@@ -30,6 +30,7 @@ import { EditEnsLabelHash } from './EditEnsLabelHash.js'
 import { ReadonlySignal, Signal, useComputed, useSignal } from '@preact/signals'
 import { RpcEntries } from '../../types/rpc.js'
 import { noReplyExpectingBrowserRuntimeOnMessageListener } from '../../utils/browser.js'
+import { POPUP_PERFORMANCE_MARKS, markPerformance, markPerformanceOnce } from '../../utils/popupPerformance.js'
 
 type UnderTransactionsParams = {
 	pendingTransactionsAndSignableMessages: ReadonlySignal<PendingTransactionOrSignableMessage[]>
@@ -473,6 +474,10 @@ export function ConfirmTransaction() {
 				rpcConnectionStatus.value = parsed.data.rpcConnectionStatus
 				return false
 			}
+			if (parsed.method === 'popup_confirm_transaction_simulation_started') {
+				markPerformanceOnce(POPUP_PERFORMANCE_MARKS.confirmTransactionSimulationStarted)
+				return false
+			}
 			if (parsed.method === 'popup_update_confirm_transaction_dialog') {
 				const { role: _role, ...popupUpdateConfirmTransactionDialog } = parsed
 				updatePendingTransactionsAndSignableMessages(UpdateConfirmTransactionDialog.parse(popupUpdateConfirmTransactionDialog))
@@ -485,6 +490,12 @@ export function ConfirmTransaction() {
 				const firstMessage = updateConfirmTransactionDialogPendingTransactions.data.pendingTransactionAndSignableMessages[0]
 				if (firstMessage === undefined) throw new Error('message data was undefined')
 				currentPendingTransactionOrSignableMessage.value = firstMessage
+				if (firstMessage.type === 'Transaction' && firstMessage.transactionOrMessageCreationStatus === 'Simulating') {
+					markPerformanceOnce(POPUP_PERFORMANCE_MARKS.confirmTransactionSimulationStarted)
+				}
+				if (firstMessage.type === 'Transaction' && (firstMessage.transactionOrMessageCreationStatus === 'Simulated' || firstMessage.transactionOrMessageCreationStatus === 'FailedToSimulate')) {
+					markPerformance(POPUP_PERFORMANCE_MARKS.confirmTransactionSimulationReady)
+				}
 				if (firstMessage.type === 'Transaction' && (firstMessage.transactionOrMessageCreationStatus === 'Simulated' || firstMessage.transactionOrMessageCreationStatus === 'FailedToSimulate') && firstMessage.popupVisualisation !== undefined && firstMessage.popupVisualisation.statusCode === 'success' && (currentBlockNumber.value === undefined || firstMessage.popupVisualisation.data.simulationState.blockNumber > currentBlockNumber.value)) {
 					currentBlockNumber.value = firstMessage.popupVisualisation.data.simulationState.blockNumber
 				}

--- a/app/ts/popup.ts
+++ b/app/ts/popup.ts
@@ -1,9 +1,21 @@
 import * as preact from 'preact'
 import { App } from './components/App.js'
 import { ErrorBoundary } from './components/subcomponents/Error.js'
+import { POPUP_PERFORMANCE_MARKS, markPerformance } from './utils/popupPerformance.js'
+
+function scheduleFrame(callback: FrameRequestCallback) {
+	if (typeof globalThis.requestAnimationFrame === 'function') return globalThis.requestAnimationFrame(callback)
+	return globalThis.setTimeout(() => callback(performance.now()), 16)
+}
 
 function rerender() {
+	markPerformance(POPUP_PERFORMANCE_MARKS.scriptStart)
 	preact.render(preact.createElement(ErrorBoundary, {}, preact.createElement(App, {})), document.body)
+	scheduleFrame(() => {
+		scheduleFrame(() => {
+			markPerformance(POPUP_PERFORMANCE_MARKS.shellPaint)
+		})
+	})
 }
 
 rerender()

--- a/app/ts/simulation/services/EthereumJSONRpcRequestHandler.ts
+++ b/app/ts/simulation/services/EthereumJSONRpcRequestHandler.ts
@@ -4,6 +4,7 @@ import { EthereumQuantity, serialize } from '../../types/wire-types.js'
 import { keccak256, toUtf8Bytes } from 'ethers'
 import { fetchWithTimeout } from '../../utils/requests.js'
 import { Future } from '../../utils/future.js'
+import { recordBenchmarkRpcRequest } from '../../utils/benchmarking.js'
 
 type ResolvedResponse = { responseState: 'failed', response: Response } | { responseState: 'success', response: unknown }
 
@@ -32,8 +33,13 @@ export class EthereumJSONRpcRequestHandler {
 			body: JSON.stringify({ jsonrpc: '2.0', id: requestId, ...serialized })
 		}
 		if (!this.caching) {
-			const response = await fetchWithTimeout(this.rpcUrl, payload, timeoutMs, requestAbortController)
-			return response.ok ? { responseState: 'success' as const, response: await response.json() } : { responseState: 'failed' as const, response }
+			const startedAt = performance.now()
+			try {
+				const response = await fetchWithTimeout(this.rpcUrl, payload, timeoutMs, requestAbortController)
+				return response.ok ? { responseState: 'success' as const, response: await response.json() } : { responseState: 'failed' as const, response }
+			} finally {
+				recordBenchmarkRpcRequest(request.method, performance.now() - startedAt)
+			}
 		}
 		const hash = keccak256(toUtf8Bytes(JSON.stringify(serialized)))
 		if (bypassCache === false) {
@@ -45,6 +51,7 @@ export class EthereumJSONRpcRequestHandler {
 		}
 		const future = new Future<ResolvedResponse>()
 		this.pendingCache.set(hash, future)
+		const startedAt = performance.now()
 		try {
 			const response = await fetchWithTimeout(this.rpcUrl, payload, timeoutMs, requestAbortController)
 			const responseObject = response.ok ? { responseState: 'success' as const, response: await response.json() } : { responseState: 'failed' as const, response }
@@ -60,6 +67,7 @@ export class EthereumJSONRpcRequestHandler {
 				future.reject(new ErrorWithData('Unknown error', error))
 			}
 		} finally {
+			recordBenchmarkRpcRequest(request.method, performance.now() - startedAt)
 			this.pendingCache.delete(hash)
 		}
 		return await future

--- a/app/ts/utils/benchmarking.ts
+++ b/app/ts/utils/benchmarking.ts
@@ -1,0 +1,19 @@
+export type BenchmarkRpcRequestSample = {
+	method: string
+	durationMs: number
+}
+
+export const BENCHMARK_RPC_REQUESTS_GLOBAL = '__interceptorBenchmarkRpcRequests' as const
+
+type BenchmarkGlobal = typeof globalThis & {
+	[ BENCHMARK_RPC_REQUESTS_GLOBAL ]?: BenchmarkRpcRequestSample[]
+}
+
+const benchmarkGlobal = globalThis as BenchmarkGlobal
+
+export function recordBenchmarkRpcRequest(method: string, durationMs: number) {
+	const samples = benchmarkGlobal[ BENCHMARK_RPC_REQUESTS_GLOBAL ]
+	if (samples === undefined) return
+	samples.push({ method, durationMs })
+}
+

--- a/app/ts/utils/popupPerformance.ts
+++ b/app/ts/utils/popupPerformance.ts
@@ -1,0 +1,44 @@
+export const POPUP_PERFORMANCE_MARKS = {
+	scriptStart: 'interceptor:popup:script-start',
+	shellPaint: 'interceptor:popup:shell-painted',
+	homeFirstCommit: 'interceptor:popup:home-first-commit',
+	refreshComplete: 'interceptor:popup:refresh-complete',
+	refreshRendered: 'interceptor:popup:refresh-rendered',
+	backgroundLoaded: 'interceptor:background:loaded',
+	backgroundActivated: 'interceptor:background:activated',
+	backgroundStartupReady: 'interceptor:background:startup-ready',
+	backgroundRefreshStart: 'interceptor:background:refresh-home-start',
+	backgroundRefreshEnd: 'interceptor:background:refresh-home-end',
+	backgroundTransactionRequestReceived: 'interceptor:background:transaction-request-received',
+	backgroundTransactionConfirmPopupOpened: 'interceptor:background:transaction-confirm-popup-opened',
+	backgroundTransactionSimulationStart: 'interceptor:background:transaction-simulation-start',
+	backgroundTransactionSimulationEnd: 'interceptor:background:transaction-simulation-end',
+	backgroundTransactionStackAppended: 'interceptor:background:transaction-stack-appended',
+	confirmTransactionSimulationStarted: 'interceptor:popup:confirm-transaction-simulation-started',
+	confirmTransactionSimulationReady: 'interceptor:popup:confirm-transaction-simulation-ready',
+} as const
+
+const marked = new Set<string>()
+
+export function markPerformance(mark: string) {
+	try {
+		performance.mark(mark)
+	} catch {
+		// Ignore environments that do not support performance marks.
+	}
+}
+
+export function markPerformanceOnce(mark: string) {
+	if (marked.has(mark)) return
+	marked.add(mark)
+	markPerformance(mark)
+}
+
+export function clearPerformanceMarks() {
+	marked.clear()
+	try {
+		performance.clearMarks()
+	} catch {
+		// Ignore environments that do not support clearing performance marks.
+	}
+}

--- a/package.json
+++ b/package.json
@@ -4,10 +4,12 @@
 	"type": "module",
 	"scripts": {
 		"test": "bun --bun tsc --project tsconfig-test.json && bun ./test/js/test/run-all.js",
+		"install-chrome": "bash ./scripts/install-chrome.sh",
 		"setup-firefox": "bun run vendor && bun run inpage && bun run build-firefox",
 		"setup-chrome": "bun run vendor && bun run inpage && bun run build-chrome",
 		"build-firefox": "bun run firefox",
 		"build-chrome": "bun --bun tsc --project tsconfig.json && bun run bundle && bun run chrome",
+		"benchmark:popup-lifecycle": "bun ./test/benchmarks/popupLifecycleChrome.ts",
 		"vendor": "cd build && bun install --frozen-lockfile && bun run vendor",
 		"bundle": "cd build && bun run bundle",
 		"firefox": "bun -e 'await Bun.write(`app/manifest.json`, Bun.file(`app/manifestV2.json`))'",

--- a/scripts/install-chrome.sh
+++ b/scripts/install-chrome.sh
@@ -1,0 +1,30 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+if command -v chromium >/dev/null 2>&1; then
+  echo "chromium is already installed at: $(command -v chromium)"
+  exit 0
+fi
+
+if ! command -v apt-get >/dev/null 2>&1; then
+  cat >&2 <<'EOF'
+This helper only supports Debian/Ubuntu systems with apt-get.
+Install Chromium manually, then rerun:
+  CHROME_BIN=/path/to/chromium bun run benchmark:popup-lifecycle
+EOF
+  exit 1
+fi
+
+run_as_root() {
+  if [ "$(id -u)" -eq 0 ]; then
+    "$@"
+  else
+    sudo "$@"
+  fi
+}
+
+run_as_root apt-get update
+run_as_root apt-get install -y --no-install-recommends chromium xauth xvfb
+
+echo "Chromium installed. The benchmark can use:"
+echo "  bun run benchmark:popup-lifecycle"

--- a/test/benchmarks/README.md
+++ b/test/benchmarks/README.md
@@ -1,0 +1,49 @@
+# Popup Benchmark Setup
+
+The real-Chrome popup benchmark needs a browser binary. On Debian 12 in this workspace, the repo ships a command for that:
+
+```bash
+bun run install-chrome
+```
+
+That command installs Chromium plus the small display helpers the benchmark uses in headless environments (`xauth` and `xvfb`). The benchmark will then discover `/usr/bin/chromium` automatically.
+
+If you already have Chrome installed elsewhere, point the benchmark at it directly:
+
+```bash
+CHROME_BIN=/path/to/chrome bun run benchmark:popup-lifecycle
+```
+
+The real browser benchmark now uses the extension's built-in mainnet RPC configuration, so network latency is part of the measurement. It also opens the popup through the extension action API and fails if that API is unavailable.
+It also prints the RPC methods observed during the run and their durations, grouped by method.
+
+The benchmark is:
+
+```bash
+bun run benchmark:popup-lifecycle
+```
+
+It currently reports the `cold`, `warm`, and `stacked` popup-open scenarios. The `stacked` scenario opens a real local HTTP test page that first requests account access, then sends one `eth_sendTransaction`, waits for the confirm popup, fetches the user's balance, and then opens the main popup.
+
+For `stacked`, the output is split into two timing families:
+
+- `send transaction path / ...` starts when the transaction test page loads. These timings include the webpage, confirm popup, and background work before the main popup is opened.
+- `main popup only / ...` starts later, exactly when the benchmark requests the main popup to open. These timings exclude the send-transaction setup path.
+
+The `stacked` report also includes an end-to-end section that combines both halves into the full path:
+
+- load webpage
+- send transaction
+- wait for transaction popup
+- query balance
+- open main popup
+- main popup rendered
+
+Run just the stacked case with:
+
+```bash
+BENCH_SCENARIO=stacked bun run benchmark:popup-lifecycle
+```
+
+The real browser benchmark does not seed `browser.storage.local` and it does not use a local JSON-RPC fixture server.
+For the `stacked` scenario, it prints the send-transaction setup phases, the end-to-end send-transaction-to-main-popup path, the RPCs from the transaction/balance setup, and the RPCs observed while the main popup itself is opening.

--- a/test/benchmarks/chromeHarness.ts
+++ b/test/benchmarks/chromeHarness.ts
@@ -1,0 +1,526 @@
+import { spawn } from 'child_process'
+import { access, mkdtemp, readFile, rm } from 'fs/promises'
+import * as fsConstants from 'fs'
+import * as os from 'os'
+import * as path from 'path'
+import { fileURLToPath } from 'url'
+
+export type TargetInfo = {
+	id: string
+	type: string
+	url: string
+	title: string
+	webSocketDebuggerUrl?: string
+}
+
+export type PerformanceMarkSnapshot = {
+	timeOrigin: number
+	marks: readonly {
+		name: string
+		startTime: number
+		duration: number
+		entryType: string
+	}[]
+}
+
+export type ChromeSession = {
+	profileDir: string
+	process: ReturnType<typeof spawnChrome>
+	browserDebugPort: number
+	browserWebSocketUrl: string
+	browserConnection: CdpConnection
+	close: () => Promise<void>
+}
+
+const REPO_ROOT = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '../..')
+const EXTENSION_DIR = path.join(REPO_ROOT, 'app')
+
+function sleep(ms: number) {
+	return new Promise<void>((resolve) => {
+		setTimeout(resolve, ms)
+	})
+}
+
+function getTargetUrlExtensionId(url: string) {
+	const match = /^chrome-extension:\/\/([^/]+)/.exec(url)
+	return match?.[1]
+}
+
+function normalizeTargetInfo(target: Partial<TargetInfo> & { targetId?: string, id?: string }): TargetInfo | undefined {
+	const id = target.targetId ?? target.id
+	if (id === undefined) return undefined
+	const url = target.url ?? ''
+	const title = target.title ?? ''
+	const normalized: TargetInfo = {
+		id,
+		type: target.type ?? 'other',
+		url,
+		title,
+	}
+	if (target.webSocketDebuggerUrl !== undefined) {
+		return {
+			...normalized,
+			webSocketDebuggerUrl: target.webSocketDebuggerUrl,
+		}
+	}
+	return normalized
+}
+
+async function waitForCondition(condition: () => Promise<boolean> | boolean, timeoutMs: number, label: string) {
+	const start = Date.now()
+	while (true) {
+		if (await condition()) return
+		if (Date.now() - start > timeoutMs) throw new Error(`Timed out waiting for ${ label } after ${ timeoutMs }ms`)
+		await sleep(50)
+	}
+}
+
+export class CdpConnection {
+	private socket: WebSocket | undefined
+	private nextId = 1
+	private pending = new Map<number, {
+		resolve: (value: unknown) => void
+		reject: (reason: Error) => void
+	}>()
+	private eventListeners = new Map<string, Set<(params: unknown) => void>>()
+
+	public constructor(public readonly url: string) {}
+
+	public async connect() {
+		if (this.socket !== undefined) return
+		await new Promise<void>((resolve, reject) => {
+			const socket = new WebSocket(this.url)
+			socket.onopen = () => {
+				this.socket = socket
+				socket.onmessage = (event) => this.handleMessage(event)
+				socket.onerror = () => {
+					reject(new Error(`Failed to connect to CDP websocket ${ this.url }`))
+				}
+				socket.onclose = () => {
+					const pending = this.pending
+					this.pending = new Map()
+					for (const { reject: rejectPending } of pending.values()) {
+						rejectPending(new Error(`CDP websocket closed for ${ this.url }`))
+					}
+					this.socket = undefined
+				}
+				resolve()
+			}
+			socket.onerror = () => {
+				reject(new Error(`Failed to open CDP websocket ${ this.url }`))
+			}
+		})
+	}
+
+	private handleMessage(event: MessageEvent) {
+		const data = typeof event.data === 'string' ? event.data : new TextDecoder().decode(event.data as ArrayBuffer)
+		const message = JSON.parse(data) as { id?: number, method?: string, params?: unknown, result?: unknown, error?: { message?: string, code?: number } }
+		if (message.id !== undefined) {
+			const pending = this.pending.get(message.id)
+			if (pending === undefined) return
+			this.pending.delete(message.id)
+			if (message.error !== undefined) {
+				pending.reject(new Error(message.error.message ?? `CDP call failed with code ${ message.error.code ?? 'unknown' }`))
+				return
+			}
+			pending.resolve(message.result)
+			return
+		}
+		if (message.method === undefined) return
+		const listeners = this.eventListeners.get(message.method)
+		if (listeners === undefined) return
+		for (const listener of listeners) listener(message.params)
+	}
+
+	public async send<T = unknown>(method: string, params: Record<string, unknown> = {}): Promise<T> {
+		await this.connect()
+		const socket = this.socket
+		if (socket === undefined) throw new Error(`CDP websocket ${ this.url } is not connected`)
+		const id = this.nextId
+		this.nextId += 1
+		const promise = new Promise<T>((resolve, reject) => {
+			this.pending.set(id, {
+				resolve: resolve as (value: unknown) => void,
+				reject,
+			})
+		})
+		socket.send(JSON.stringify({ id, method, params }))
+		return await promise
+	}
+
+	public on(eventName: string, listener: (params: unknown) => void) {
+		const listeners = this.eventListeners.get(eventName) ?? new Set<(params: unknown) => void>()
+		listeners.add(listener)
+		this.eventListeners.set(eventName, listeners)
+	}
+
+	public off(eventName: string, listener: (params: unknown) => void) {
+		const listeners = this.eventListeners.get(eventName)
+		if (listeners === undefined) return
+		listeners.delete(listener)
+		if (listeners.size === 0) this.eventListeners.delete(eventName)
+	}
+
+	public async evaluate<T = unknown>(expression: string, options: { awaitPromise?: boolean, userGesture?: boolean } = {}) {
+		const result = await this.send<{
+			result: { value?: T, type?: string, description?: string, unserializableValue?: string }
+			exceptionDetails?: { text?: string, exception?: { description?: string } }
+		}>('Runtime.evaluate', {
+			expression,
+			awaitPromise: options.awaitPromise ?? true,
+			returnByValue: true,
+			userGesture: options.userGesture ?? false,
+		})
+		if (result.exceptionDetails !== undefined) {
+			throw new Error(result.exceptionDetails.text ?? result.exceptionDetails.exception?.description ?? 'Runtime.evaluate failed')
+		}
+		return result.result.value
+	}
+
+	public close() {
+		this.socket?.close()
+		this.socket = undefined
+	}
+}
+
+async function readTargets(browserDebugPort: number) {
+	const response = await fetch(`http://127.0.0.1:${ browserDebugPort }/json/list`)
+	if (!response.ok) throw new Error(`Failed to query Chrome targets on port ${ browserDebugPort }: ${ response.status } ${ response.statusText }`)
+	const parsed = await response.json() as readonly (TargetInfo & { targetId?: string })[]
+	return parsed.map((target) => normalizeTargetInfo(target)).filter((target): target is TargetInfo => target !== undefined)
+}
+
+async function readVersion(browserDebugPort: number) {
+	const response = await fetch(`http://127.0.0.1:${ browserDebugPort }/json/version`)
+	if (!response.ok) throw new Error(`Failed to query Chrome version on port ${ browserDebugPort }: ${ response.status } ${ response.statusText }`)
+	return await response.json() as { webSocketDebuggerUrl?: string }
+}
+
+async function waitForTarget(browserDebugPort: number, predicate: (target: TargetInfo) => boolean, timeoutMs: number, label: string) {
+	await waitForCondition(async () => (await readTargets(browserDebugPort)).some(predicate), timeoutMs, label)
+	const targets = await readTargets(browserDebugPort)
+	const target = targets.find(predicate)
+	if (target === undefined) throw new Error(`Target not found: ${ label }`)
+	return target
+}
+
+export async function waitForTargetGone(browserDebugPort: number, predicate: (target: TargetInfo) => boolean, timeoutMs: number, label: string) {
+	await waitForCondition(async () => (await readTargets(browserDebugPort)).some(predicate) === false, timeoutMs, label)
+}
+
+async function waitForDevToolsActivePort(profileDir: string, timeoutMs: number) {
+	const portFile = path.join(profileDir, 'DevToolsActivePort')
+	await waitForCondition(async () => await access(portFile).then(() => true).catch(() => false), timeoutMs, 'DevToolsActivePort file')
+	const contents = await readFile(portFile, 'utf8')
+	const [portLine] = contents.trim().split('\n')
+	const browserDebugPort = Number(portLine)
+	if (!Number.isFinite(browserDebugPort)) throw new Error(`Chrome wrote an invalid remote debugging port: ${ portLine }`)
+	return browserDebugPort
+}
+
+export async function findChromeBinary() {
+	const envCandidates = [
+		process.env.CHROME_BIN,
+		process.env.GOOGLE_CHROME_BIN,
+		process.env.CHROME_PATH,
+		process.env.CHROMIUM_PATH,
+		process.env.CHROMIUM_BIN,
+	].filter((candidate): candidate is string => candidate !== undefined && candidate.length > 0)
+	const pathCandidates = [
+		'/usr/bin/google-chrome',
+		'/usr/bin/google-chrome-stable',
+		'/usr/bin/chromium',
+		'/usr/bin/chromium-browser',
+		'/snap/bin/chromium',
+		'/opt/google/chrome/chrome',
+	]
+	for (const candidate of [...envCandidates, ...pathCandidates]) {
+		try {
+			await access(candidate, fsConstants.constants.X_OK)
+			return candidate
+		} catch {
+			continue
+		}
+	}
+	throw new Error('Could not find a Chrome/Chromium binary. Run `bun run install-chrome` on Debian/Ubuntu or set CHROME_BIN, then rerun the benchmark.')
+}
+
+function buildChromeArgs(profileDir: string, extensionDir: string) {
+	return [
+		`--user-data-dir=${ profileDir }`,
+		'--remote-debugging-port=0',
+		'--no-first-run',
+		'--no-default-browser-check',
+		'--disable-background-networking',
+		'--disable-background-timer-throttling',
+		'--disable-backgrounding-occluded-windows',
+		'--disable-breakpad',
+		'--disable-client-side-phishing-detection',
+		'--disable-component-update',
+		'--disable-default-apps',
+		'--disable-dev-shm-usage',
+		'--disable-features=Translate,BackForwardCache,ImprovedCookieControls,MediaRouter',
+		'--disable-gpu',
+		'--disable-popup-blocking',
+		'--disable-renderer-backgrounding',
+		'--disable-sync',
+		'--force-color-profile=srgb',
+		'--metrics-recording-only',
+		'--mute-audio',
+		'--no-sandbox',
+		'--password-store=basic',
+		'--use-mock-keychain',
+		`--disable-extensions-except=${ extensionDir }`,
+		`--load-extension=${ extensionDir }`,
+		'about:blank',
+	]
+}
+
+function spawnChrome(binary: string, profileDir: string, extensionDir: string) {
+	const args = buildChromeArgs(profileDir, extensionDir)
+	const useXvfb = process.env.DISPLAY === undefined || process.env.DISPLAY.length === 0
+	const command = useXvfb ? 'xvfb-run' : binary
+	const commandArgs = useXvfb
+		? ['-a', '-s', '-screen 0 1280x900x24', binary, ...args]
+		: args
+	const child = spawn(command, commandArgs, {
+		cwd: REPO_ROOT,
+		detached: true,
+		stdio: ['ignore', 'pipe', 'pipe'],
+		env: {
+			...process.env,
+			CHROME_LOG_FILE: process.env.CHROME_LOG_FILE ?? '',
+		},
+	})
+	return child
+}
+
+function killChromeProcessGroup(chromeProcess: ReturnType<typeof spawnChrome>, signal: NodeJS.Signals) {
+	if (chromeProcess.pid === undefined) {
+		chromeProcess.kill(signal)
+		return
+	}
+	try {
+		globalThis.process.kill(-chromeProcess.pid, signal)
+	} catch {
+		chromeProcess.kill(signal)
+	}
+}
+
+export async function connectTarget(browserDebugPort: number, targetId: string) {
+	const target = await waitForTarget(browserDebugPort, (item) => item.id === targetId, 15_000, `target ${ targetId }`)
+	if (target.webSocketDebuggerUrl === undefined) throw new Error(`Target ${ targetId } does not expose a websocket debugger URL`)
+	const connection = new CdpConnection(target.webSocketDebuggerUrl)
+	await connection.connect()
+	return connection
+}
+
+export async function waitForAnyExtensionServiceWorker(browserDebugPort: number, timeoutMs = 15_000) {
+	return await waitForTarget(browserDebugPort, (target) => target.type === 'service_worker' && target.url.startsWith('chrome-extension://'), timeoutMs, 'extension service worker')
+}
+
+export async function waitForTargetByUrl(browserDebugPort: number, urlPrefix: string, timeoutMs = 15_000) {
+	return await waitForTarget(browserDebugPort, (target) => target.url.startsWith(urlPrefix), timeoutMs, `target url ${ urlPrefix }`)
+}
+
+export async function waitForServiceWorker(browserDebugPort: number, extensionId: string, timeoutMs = 15_000) {
+	return await waitForTarget(browserDebugPort, (target) => target.type === 'service_worker' && target.url.startsWith(`chrome-extension://${ extensionId }/`), timeoutMs, `service worker for extension ${ extensionId }`)
+}
+
+export async function waitForPopupTarget(browserDebugPort: number, extensionId: string, timeoutMs = 15_000) {
+	return await waitForTarget(browserDebugPort, (target) => target.url.startsWith(`chrome-extension://${ extensionId }/html3/popupV3.html`), timeoutMs, `popup target for extension ${ extensionId }`)
+}
+
+export async function getExtensionIdFromTargets(browserDebugPort: number) {
+	const targets = await readTargets(browserDebugPort)
+	const workerTarget = targets.find((target) => target.type === 'service_worker' && target.url.startsWith('chrome-extension://'))
+	if (workerTarget !== undefined) {
+		const id = getTargetUrlExtensionId(workerTarget.url)
+		if (id !== undefined) return id
+	}
+	const popupTarget = targets.find((target) => target.url.startsWith('chrome-extension://'))
+	if (popupTarget !== undefined) {
+		const id = getTargetUrlExtensionId(popupTarget.url)
+		if (id !== undefined) return id
+	}
+	return undefined
+}
+
+export async function stopAllWorkers(browserConnection: CdpConnection, browserDebugPort: number) {
+	const targets = await readTargets(browserDebugPort)
+	for (const target of targets) {
+		if (target.type !== 'service_worker') continue
+		if (!target.url.startsWith('chrome-extension://')) continue
+		await closeTarget(browserConnection, target.id).catch(() => undefined)
+	}
+}
+
+export async function startWorker(browserConnection: CdpConnection, scopeURL: string) {
+	await browserConnection.send('ServiceWorker.startWorker', { scopeURL })
+}
+
+export async function createTargetPage(browserConnection: CdpConnection, url: string) {
+	const result = await browserConnection.send<{ targetId: string }>('Target.createTarget', {
+		url,
+	})
+	await browserConnection.send('Target.activateTarget', { targetId: result.targetId })
+	return result.targetId
+}
+
+export async function createPopupPage(browserConnection: CdpConnection, popupUrl: string) {
+	return await createTargetPage(browserConnection, popupUrl)
+}
+
+export async function closeTarget(browserConnection: CdpConnection, targetId: string) {
+	await browserConnection.send('Target.closeTarget', { targetId })
+}
+
+export async function snapshotPerformance(connection: CdpConnection): Promise<PerformanceMarkSnapshot> {
+	const snapshot = await connection.evaluate<PerformanceMarkSnapshot>(`(() => {
+		const marks = performance.getEntriesByType('mark').map((entry) => ({
+			name: entry.name,
+			startTime: entry.startTime,
+			duration: entry.duration,
+			entryType: entry.entryType,
+		}))
+		return { timeOrigin: performance.timeOrigin, marks }
+	})()`)
+	if (snapshot === undefined) throw new Error('Failed to snapshot performance marks')
+	return snapshot
+}
+
+export async function waitForPerformanceMark(connection: CdpConnection, markName: string, timeoutMs = 30_000) {
+	await waitForCondition(async () => {
+		const snapshot = await snapshotPerformance(connection)
+		return snapshot.marks.some((mark) => mark.name === markName)
+	}, timeoutMs, `performance mark ${ markName }`)
+}
+
+export async function waitForPerformanceMarks(connection: CdpConnection, markNames: readonly string[], timeoutMs = 30_000) {
+	const missing = new Set(markNames)
+	await waitForCondition(async () => {
+		const snapshot = await snapshotPerformance(connection)
+		for (const mark of snapshot.marks) missing.delete(mark.name)
+		return missing.size === 0
+	}, timeoutMs, `performance marks ${ markNames.join(', ') }`)
+}
+
+export async function getPerformanceSnapshot(connection: CdpConnection): Promise<PerformanceMarkSnapshot> {
+	return await snapshotPerformance(connection)
+}
+
+export function latestMark(snapshot: PerformanceMarkSnapshot, markName: string) {
+	const filtered = snapshot.marks.filter((mark) => mark.name === markName)
+	return filtered.at(-1)
+}
+
+export function relativeTime(snapshot: PerformanceMarkSnapshot, markName: string) {
+	const mark = latestMark(snapshot, markName)
+	if (mark === undefined) return undefined
+	return mark.startTime
+}
+
+export function absoluteTime(snapshot: PerformanceMarkSnapshot, markName: string) {
+	const mark = latestMark(snapshot, markName)
+	if (mark === undefined) return undefined
+	return snapshot.timeOrigin + mark.startTime
+}
+
+export function roundToTwoDecimals(value: number) {
+	return Math.round(value * 100) / 100
+}
+
+export function makeLaunchDelta(launchEpochMs: number, snapshot: PerformanceMarkSnapshot, markName: string) {
+	const absolute = absoluteTime(snapshot, markName)
+	if (absolute === undefined) return undefined
+	return absolute - launchEpochMs
+}
+
+export function makePopupUrl(extensionId: string) {
+	return `chrome-extension://${ extensionId }/html3/popupV3.html`
+}
+
+export function makeBackgroundWorkerUrl(extensionId: string) {
+	return `chrome-extension://${ extensionId }/js/backgroundServiceWorker.js`
+}
+
+export async function ensureExtensionDirReady(extensionDir = EXTENSION_DIR) {
+	try {
+		await access(path.join(extensionDir, 'manifest.json'), fsConstants.constants.R_OK)
+	} catch {
+		throw new Error(`Missing ${ path.join(extensionDir, 'manifest.json') }. Run \`npm run setup-chrome\` before the Chrome benchmark.`)
+	}
+}
+
+export async function waitForBrowserTargets(browserDebugPort: number) {
+	return await readTargets(browserDebugPort)
+}
+
+export async function closeChromeSession(session: ChromeSession) {
+	const browserClosePromise = session.browserConnection.send('Browser.close').catch(() => undefined)
+	await Promise.race([
+		browserClosePromise,
+		sleep(1_000),
+	]).catch(() => undefined)
+	session.browserConnection.close()
+	killChromeProcessGroup(session.process, 'SIGTERM')
+	await Promise.race([
+		new Promise<void>((resolve) => {
+			session.process.once('exit', () => resolve())
+		}),
+		sleep(2_000),
+	]).catch(() => undefined)
+	if (session.process.exitCode === null && session.process.signalCode === null) killChromeProcessGroup(session.process, 'SIGKILL')
+	await rm(session.profileDir, { recursive: true, force: true }).catch(() => undefined)
+}
+
+export async function launchChromeSession(extensionDir = EXTENSION_DIR): Promise<ChromeSession> {
+	await ensureExtensionDirReady(extensionDir)
+	const chromeBinary = await findChromeBinary()
+	const profileDir = await mkdtemp(path.join(os.tmpdir(), 'interceptor-chrome-profile-'))
+	const process = spawnChrome(chromeBinary, profileDir, extensionDir)
+	let stdout = ''
+	let stderr = ''
+	const capture = (chunk: Buffer, buffer: string) => {
+		const text = chunk.toString('utf8')
+		const combined = `${ buffer }${ text }`
+		return combined.length > 8_192 ? combined.slice(-8_192) : combined
+	}
+	process.stdout.on('data', (chunk: Buffer) => {
+		stdout = capture(chunk, stdout)
+	})
+	process.stderr.on('data', (chunk: Buffer) => {
+		stderr = capture(chunk, stderr)
+	})
+	const browserDebugPort = await waitForDevToolsActivePort(profileDir, 30_000).catch(async (error) => {
+		killChromeProcessGroup(process, 'SIGTERM')
+		await sleep(1_000)
+		if (process.exitCode === null && process.signalCode === null) killChromeProcessGroup(process, 'SIGKILL')
+		await rm(profileDir, { recursive: true, force: true }).catch(() => undefined)
+		const extra = [`stdout:\n${ stdout }`, `stderr:\n${ stderr }`].filter((line) => line.length > 0).join('\n')
+		throw new Error(`${ error instanceof Error ? error.message : String(error) }${ extra.length > 0 ? `\n${ extra }` : '' }`)
+	})
+	const browserVersion = await readVersion(browserDebugPort)
+	if (browserVersion.webSocketDebuggerUrl === undefined) throw new Error('Chrome did not expose a browser websocket debugger URL')
+	const browserConnection = new CdpConnection(browserVersion.webSocketDebuggerUrl)
+	await browserConnection.connect()
+	return {
+		profileDir,
+		process,
+		browserDebugPort,
+		browserWebSocketUrl: browserVersion.webSocketDebuggerUrl,
+		browserConnection,
+		close: async () => {
+			const browserClosePromise = browserConnection.send('Browser.close').catch(() => undefined)
+			await Promise.race([
+				browserClosePromise,
+				sleep(1_000),
+			]).catch(() => undefined)
+			browserConnection.close()
+			killChromeProcessGroup(process, 'SIGTERM')
+			await sleep(500)
+			if (process.exitCode === null && process.signalCode === null) killChromeProcessGroup(process, 'SIGKILL')
+			await rm(profileDir, { recursive: true, force: true }).catch(() => undefined)
+		},
+	}
+}

--- a/test/benchmarks/popupLifecycleChrome.ts
+++ b/test/benchmarks/popupLifecycleChrome.ts
@@ -1,0 +1,588 @@
+import { performance } from 'perf_hooks'
+import { BENCHMARK_RPC_REQUESTS_GLOBAL } from '../../app/ts/utils/benchmarking.js'
+import { POPUP_PERFORMANCE_MARKS } from '../../app/ts/utils/popupPerformance.js'
+import { launchChromeSession, waitForAnyExtensionServiceWorker, waitForServiceWorker, createTargetPage, connectTarget, closeTarget, waitForPerformanceMark, waitForPerformanceMarks, getPerformanceSnapshot, roundToTwoDecimals, absoluteTime, waitForPopupTarget, waitForTargetByUrl, waitForTargetGone, waitForBrowserTargets } from './chromeHarness.js'
+import { startTransactionStackPageServer } from './transactionStackPageServer.js'
+import type { CdpConnection, ChromeSession, PerformanceMarkSnapshot } from './chromeHarness.js'
+import type { BenchmarkRpcRequestSample } from '../../app/ts/utils/benchmarking.js'
+
+type ScenarioName = 'cold' | 'warm' | 'stacked'
+
+type Sample = {
+	scenario: ScenarioName
+	launchMode: 'real-chrome-extension-page'
+	popupLaunchEpochMs: number
+	popupScriptStartMs: number
+	popupShellPaintMs: number
+	popupHomeFirstCommitMs: number
+	popupRefreshCompleteMs: number | undefined
+	popupRefreshRenderedMs: number | undefined
+	workerRefreshStartMs: number
+	workerRefreshEndMs: number
+	rpcRequests: readonly BenchmarkRpcRequestSample[]
+	setupRpcRequests: readonly BenchmarkRpcRequestSample[]
+	stackedSetup?: StackedSetupSample
+}
+
+type StackedSetupSample = {
+	launchEpochMs: number
+	pageSnapshot: PerformanceMarkSnapshot
+	confirmPopupSnapshot: PerformanceMarkSnapshot
+	workerSnapshot: PerformanceMarkSnapshot
+}
+
+type Stats = {
+	averageMs: number
+	medianMs: number
+	minMs: number
+	maxMs: number
+}
+
+type ScenarioStats = {
+	name: ScenarioName
+	iterations: number
+	launchMode: string
+	popupScriptStart: Stats
+	popupShellPaint: Stats
+	popupHomeFirstCommit: Stats
+	popupRefreshComplete: Stats | undefined
+	popupRefreshRendered: Stats | undefined
+	workerRefreshStart: Stats
+	workerRefreshEnd: Stats
+	rpcTotalRequests: number
+	rpcTotalDurationMs: number
+	rpcMethods: readonly RpcMethodStats[]
+}
+
+type RpcMethodStats = Stats & {
+	method: string
+	count: number
+}
+
+type BenchmarkContext = {
+	chrome: ChromeSession
+	extensionId: string
+	anchorTargetId: string
+}
+
+type TransactionStackPageState = {
+	phase: 'loading' | 'provider-ready' | 'requesting-access' | 'access-granted' | 'requesting-transaction' | 'submitted' | 'requesting-balance' | 'balance-fetched' | 'error'
+	txHash?: string
+	balance?: string
+	error?: string
+}
+
+const BENCHMARK_TRANSACTION_PAGE_STATE_GLOBAL = '__interceptorBenchmarkTxPageState' as const
+
+const POPUP_MARK_NAMES = [
+		'interceptor:popup:script-start',
+		'interceptor:popup:shell-painted',
+		'interceptor:popup:home-first-commit',
+] as const
+
+const POPUP_REFRESH_COMPLETE_MARK = 'interceptor:popup:refresh-complete'
+const POPUP_REFRESH_RENDERED_MARK = 'interceptor:popup:refresh-rendered'
+
+const WORKER_MARK_NAMES = [
+		'interceptor:background:refresh-home-start',
+		'interceptor:background:refresh-home-end',
+] as const
+
+function stats(values: readonly (number | undefined)[]): Stats | undefined {
+	const cleanValues = values.filter((value): value is number => value !== undefined)
+	if (cleanValues.length === 0) return undefined
+	const sorted = [...cleanValues].sort((a, b) => a - b)
+	const total = sorted.reduce((sum, value) => sum + value, 0)
+	return {
+		averageMs: total / sorted.length,
+		medianMs: sorted[Math.floor(sorted.length / 2)] ?? 0,
+		minMs: sorted[0] ?? 0,
+		maxMs: sorted.at(-1) ?? 0,
+	}
+}
+
+function formatStats(label: string, result: Stats | undefined) {
+	if (result === undefined) return `${ label }: n/a`
+	return `${ label }: avg ${ roundToTwoDecimals(result.averageMs) } ms, median ${ roundToTwoDecimals(result.medianMs) } ms, min/max ${ roundToTwoDecimals(result.minMs) } / ${ roundToTwoDecimals(result.maxMs) } ms`
+}
+
+function printStatsGroup(title: string, entries: readonly (readonly [string, Stats | undefined])[]) {
+	console.log(title)
+	for (const [label, result] of entries) {
+		console.log(formatStats(`    ${ label }`, result))
+	}
+}
+
+function requireStats(result: Stats | undefined, label: string) {
+	if (result === undefined) throw new Error(`Missing ${ label } statistics`)
+	return result
+}
+
+function requireRpcMethodStats(result: RpcMethodStats | undefined, label: string) {
+	if (result === undefined) throw new Error(`Missing ${ label } rpc statistics`)
+	return result
+}
+
+function extractExtensionId(url: string) {
+	const match = /^chrome-extension:\/\/([^/]+)/.exec(url)
+	if (match?.[1] === undefined) throw new Error(`Could not determine extension id from ${ url }`)
+	return match[1]
+}
+
+function requiredTiming(launchEpochMs: number, snapshot: PerformanceMarkSnapshot, markName: string) {
+	const absolute = absoluteTime(snapshot, markName)
+	if (absolute === undefined) throw new Error(`Missing performance mark: ${ markName }`)
+	const delta = absolute - launchEpochMs
+	if (delta < -50) throw new Error(`Performance mark ${ markName } was stale for the measured popup open`)
+	return delta
+}
+
+function timingFromSnapshot(launchEpochMs: number | undefined, snapshot: PerformanceMarkSnapshot | undefined, markName: string) {
+	if (launchEpochMs === undefined || snapshot === undefined) return undefined
+	return requiredTiming(launchEpochMs, snapshot, markName)
+}
+
+function stackedSetupTiming(setups: readonly StackedSetupSample[], source: 'page' | 'worker' | 'confirm', markName: string) {
+	return stats(setups.map((setup) => {
+		try {
+			const snapshot = source === 'page' ? setup.pageSnapshot : source === 'worker' ? setup.workerSnapshot : setup.confirmPopupSnapshot
+			return timingFromSnapshot(setup.launchEpochMs, snapshot, markName)
+		} catch {
+			return undefined
+		}
+	}))
+}
+
+function stackedSampleTiming(samples: readonly Sample[], selector: (sample: Sample, setup: StackedSetupSample) => number | undefined) {
+	return stats(samples.map((sample) => {
+		if (sample.stackedSetup === undefined) return undefined
+		try {
+			return selector(sample, sample.stackedSetup)
+		} catch {
+			return undefined
+		}
+	}))
+}
+
+function formatRpcMethodStats(label: string, result: RpcMethodStats | undefined) {
+	if (result === undefined) return `${ label }: n/a`
+	return `${ label }: ${ result.count } call${ result.count === 1 ? '' : 's' }, avg ${ roundToTwoDecimals(result.averageMs) } ms, median ${ roundToTwoDecimals(result.medianMs) } ms, min/max ${ roundToTwoDecimals(result.minMs) } / ${ roundToTwoDecimals(result.maxMs) } ms`
+}
+
+function aggregateRpcRequests(rpcRequests: readonly BenchmarkRpcRequestSample[]) {
+	const totalRequests = rpcRequests.length
+	const totalDurationMs = rpcRequests.reduce((sum, request) => sum + request.durationMs, 0)
+	const grouped = new Map<string, number[]>()
+	for (const request of rpcRequests) {
+		const durations = grouped.get(request.method) ?? []
+		durations.push(request.durationMs)
+		grouped.set(request.method, durations)
+	}
+	const methods = [...grouped.entries()].map(([method, durations]) => {
+		const result = stats(durations)
+		if (result === undefined) throw new Error(`Missing rpc method durations for ${ method }`)
+		return {
+			method,
+			count: durations.length,
+			...result,
+		}
+	})
+	return {
+		totalRequests,
+		totalDurationMs,
+		methods,
+	}
+}
+
+function rpcRequestCollectorExpression() {
+	return `(() => globalThis[${ JSON.stringify(BENCHMARK_RPC_REQUESTS_GLOBAL) }] ?? [])()`
+}
+
+function rpcRequestCollectorResetExpression() {
+	return `(() => {
+		globalThis[${ JSON.stringify(BENCHMARK_RPC_REQUESTS_GLOBAL) }] = []
+		return true
+	})()`
+}
+
+async function clearWorkerPerformanceMarks(workerConnection: CdpConnection) {
+	await workerConnection.evaluate(`(async () => {
+		performance.clearMarks()
+		return true
+	})()`)
+}
+
+async function waitForCondition(condition: () => Promise<boolean> | boolean, timeoutMs: number, label: string) {
+	const start = Date.now()
+	while (true) {
+		if (await condition()) return
+		if (Date.now() - start > timeoutMs) throw new Error(`Timed out waiting for ${ label } after ${ timeoutMs }ms`)
+		await new Promise<void>((resolve) => {
+			setTimeout(resolve, 50)
+		})
+	}
+}
+
+async function getTransactionPageState(connection: CdpConnection): Promise<TransactionStackPageState | undefined> {
+	const state = await connection.evaluate<TransactionStackPageState | undefined>(`(() => globalThis[${ JSON.stringify(BENCHMARK_TRANSACTION_PAGE_STATE_GLOBAL) }] ?? undefined)()`)
+	return state
+}
+
+async function waitForTransactionPagePhase(connection: CdpConnection, phase: TransactionStackPageState['phase'], timeoutMs: number) {
+	await waitForCondition(async () => {
+		const state = await getTransactionPageState(connection)
+		if (state?.phase === 'error') throw new Error(`Transaction page failed: ${ state.error ?? 'unknown error' }`)
+		return state?.phase === phase
+	}, timeoutMs, `transaction page phase ${ phase }`)
+}
+
+async function waitForButtonEnabled(connection: CdpConnection, selector: string, timeoutMs: number) {
+	await waitForCondition(async () => {
+		return Boolean(await connection.evaluate<boolean>(`(() => {
+			const element = document.querySelector(${ JSON.stringify(selector) })
+			return element instanceof HTMLButtonElement && element.disabled === false
+		})()`).catch(() => false))
+	}, timeoutMs, `button ${ selector } to be enabled`)
+}
+
+async function clickButton(connection: CdpConnection, selector: string) {
+	await connection.evaluate(`(() => {
+		const element = document.querySelector(${ JSON.stringify(selector) })
+		if (!(element instanceof HTMLButtonElement)) throw new Error('Could not find button ${ selector }')
+		element.click()
+		return true
+	})()`)
+}
+
+async function triggerPopupOpen(workerConnection: CdpConnection) {
+	await workerConnection.evaluate(`(async () => {
+		const openPopup = browser.action.openPopup
+		if (typeof openPopup !== 'function') throw new Error('browser.action.openPopup is unavailable')
+		await openPopup()
+		return true
+	})()`, { userGesture: true })
+}
+
+async function ensureAnchorTarget(context: BenchmarkContext) {
+	const targets = await waitForBrowserTargets(context.chrome.browserDebugPort)
+	const existingAnchor = targets.find((target) => target.id === context.anchorTargetId)
+	if (existingAnchor === undefined) {
+		context.anchorTargetId = await createTargetPage(context.chrome.browserConnection, 'about:blank')
+		return
+	}
+	await context.chrome.browserConnection.send('Target.activateTarget', { targetId: context.anchorTargetId })
+}
+
+async function prepareBenchmarkContext(): Promise<BenchmarkContext> {
+	const chrome = await launchChromeSession()
+	try {
+		const initialWorkerTarget = await waitForAnyExtensionServiceWorker(chrome.browserDebugPort, 30_000)
+		const extensionId = extractExtensionId(initialWorkerTarget.url)
+		const anchorTargetId = await createTargetPage(chrome.browserConnection, 'about:blank')
+		const workerConnection = await connectTarget(chrome.browserDebugPort, initialWorkerTarget.id)
+		try {
+			await waitForPerformanceMarks(workerConnection, ['interceptor:background:loaded'], 30_000)
+			await clearWorkerPerformanceMarks(workerConnection)
+		} finally {
+			workerConnection.close()
+		}
+		return {
+			chrome,
+			extensionId,
+			anchorTargetId,
+		}
+	} catch (error) {
+		await chrome.close().catch(() => undefined)
+		throw error
+	}
+}
+
+async function openPopupAndCollect(context: BenchmarkContext, scenario: ScenarioName): Promise<Sample> {
+	const workerTarget = await waitForServiceWorker(context.chrome.browserDebugPort, context.extensionId, 30_000)
+	const workerConnection = await connectTarget(context.chrome.browserDebugPort, workerTarget.id)
+	let popupTargetId: string | undefined
+	try {
+		await ensureAnchorTarget(context)
+		await clearWorkerPerformanceMarks(workerConnection)
+		await workerConnection.evaluate(rpcRequestCollectorResetExpression())
+		const launchEpochMs = performance.timeOrigin + performance.now()
+		await triggerPopupOpen(workerConnection)
+		const popupTarget = await waitForPopupTarget(context.chrome.browserDebugPort, context.extensionId, 30_000)
+		popupTargetId = popupTarget.id
+		const popupConnection = await connectTarget(context.chrome.browserDebugPort, popupTargetId)
+		try {
+			await waitForPerformanceMarks(popupConnection, POPUP_MARK_NAMES, 60_000)
+			const popupSnapshot = await getPerformanceSnapshot(popupConnection)
+			await waitForPerformanceMarks(workerConnection, WORKER_MARK_NAMES, 60_000)
+			const workerSnapshot = await getPerformanceSnapshot(workerConnection)
+			let popupRefreshCompleteSnapshot = popupSnapshot
+			try {
+				await waitForPerformanceMark(popupConnection, POPUP_REFRESH_COMPLETE_MARK, 15_000)
+				popupRefreshCompleteSnapshot = await getPerformanceSnapshot(popupConnection)
+			} catch {
+				// Best effort: the popup may never acknowledge the refresh in this real-browser setup.
+			}
+			let popupRefreshRenderedSnapshot = popupRefreshCompleteSnapshot
+			try {
+				await waitForPerformanceMark(popupConnection, POPUP_REFRESH_RENDERED_MARK, 15_000)
+				popupRefreshRenderedSnapshot = await getPerformanceSnapshot(popupConnection)
+			} catch {
+				// Best effort: the popup may not emit a separate post-render mark in every run.
+			}
+			const popupRefreshCompleteMs = absoluteTime(popupRefreshCompleteSnapshot, POPUP_REFRESH_COMPLETE_MARK) === undefined ? undefined : requiredTiming(launchEpochMs, popupRefreshCompleteSnapshot, POPUP_REFRESH_COMPLETE_MARK)
+			const popupRefreshRenderedMs = absoluteTime(popupRefreshRenderedSnapshot, POPUP_REFRESH_RENDERED_MARK) === undefined ? undefined : requiredTiming(launchEpochMs, popupRefreshRenderedSnapshot, POPUP_REFRESH_RENDERED_MARK)
+			const rpcRequests = (await workerConnection.evaluate<readonly BenchmarkRpcRequestSample[] | undefined>(rpcRequestCollectorExpression())) ?? []
+			return {
+				scenario,
+				launchMode: 'real-chrome-extension-page',
+				popupLaunchEpochMs: launchEpochMs,
+				popupScriptStartMs: requiredTiming(launchEpochMs, popupSnapshot, 'interceptor:popup:script-start'),
+				popupShellPaintMs: requiredTiming(launchEpochMs, popupSnapshot, 'interceptor:popup:shell-painted'),
+				popupHomeFirstCommitMs: requiredTiming(launchEpochMs, popupSnapshot, 'interceptor:popup:home-first-commit'),
+				popupRefreshCompleteMs,
+				popupRefreshRenderedMs,
+				workerRefreshStartMs: requiredTiming(launchEpochMs, workerSnapshot, 'interceptor:background:refresh-home-start'),
+				workerRefreshEndMs: requiredTiming(launchEpochMs, workerSnapshot, 'interceptor:background:refresh-home-end'),
+				rpcRequests,
+				setupRpcRequests: [],
+			}
+		} finally {
+			popupConnection.close()
+		}
+	} finally {
+		if (popupTargetId !== undefined) await closeTarget(context.chrome.browserConnection, popupTargetId).catch(() => undefined)
+		workerConnection.close()
+	}
+}
+
+async function runColdScenario(context: BenchmarkContext) {
+	return await openPopupAndCollect(context, 'cold')
+}
+
+async function runWarmScenario(context: BenchmarkContext) {
+	await openPopupAndCollect(context, 'cold')
+	return await openPopupAndCollect(context, 'warm')
+}
+
+async function prepareStackedTransaction(context: BenchmarkContext, transactionPageUrl: string) {
+	const workerTarget = await waitForServiceWorker(context.chrome.browserDebugPort, context.extensionId, 30_000)
+	const workerConnection = await connectTarget(context.chrome.browserDebugPort, workerTarget.id)
+	await clearWorkerPerformanceMarks(workerConnection)
+	await workerConnection.evaluate(rpcRequestCollectorResetExpression())
+	const launchEpochMs = performance.timeOrigin + performance.now()
+	const pageTargetId = await createTargetPage(context.chrome.browserConnection, transactionPageUrl)
+	const pageConnection = await connectTarget(context.chrome.browserDebugPort, pageTargetId)
+	let accessTargetId: string | undefined
+	let confirmTargetId: string | undefined
+	try {
+		await waitForTransactionPagePhase(pageConnection, 'requesting-access', 30_000)
+		const accessTarget = await waitForTargetByUrl(context.chrome.browserDebugPort, `chrome-extension://${ context.extensionId }/html3/interceptorAccessV3.html`, 30_000).catch(async (error) => {
+			const targets = await waitForBrowserTargets(context.chrome.browserDebugPort)
+			const state = await getTransactionPageState(pageConnection)
+			throw new Error(`${ error instanceof Error ? error.message : String(error) }\ntransaction page state: ${ JSON.stringify(state) }\ncurrent targets:\n${ targets.map((target) => `- ${ target.type } ${ target.url } (${ target.id })`).join('\n') }`)
+		})
+		accessTargetId = accessTarget.id
+		const accessConnection = await connectTarget(context.chrome.browserDebugPort, accessTarget.id)
+		try {
+			await waitForButtonEnabled(accessConnection, 'nav.popup-button-row button.is-primary:not(.is-danger)', 30_000)
+			await clickButton(accessConnection, 'nav.popup-button-row button.is-primary:not(.is-danger)')
+		} finally {
+			accessConnection.close()
+		}
+		await waitForTransactionPagePhase(pageConnection, 'requesting-transaction', 30_000)
+
+		const confirmTarget = await waitForTargetByUrl(context.chrome.browserDebugPort, `chrome-extension://${ context.extensionId }/html3/confirmTransactionV3.html`, 30_000)
+		confirmTargetId = confirmTarget.id
+		await waitForTargetGone(context.chrome.browserDebugPort, (target) => target.id === accessTargetId, 30_000, 'interceptor access popup to close')
+		const confirmConnection = await connectTarget(context.chrome.browserDebugPort, confirmTarget.id)
+		try {
+			await waitForButtonEnabled(confirmConnection, 'button.button.is-primary.button-overflow.dialog-button-right', 120_000)
+			const confirmPopupSnapshot = await getPerformanceSnapshot(confirmConnection)
+			await clickButton(confirmConnection, 'button.button.is-primary.button-overflow.dialog-button-right')
+			await waitForTransactionPagePhase(pageConnection, 'balance-fetched', 60_000)
+			const pageSnapshot = await getPerformanceSnapshot(pageConnection)
+			const workerSnapshot = await getPerformanceSnapshot(workerConnection)
+			const setupRpcRequests = (await workerConnection.evaluate<readonly BenchmarkRpcRequestSample[] | undefined>(rpcRequestCollectorExpression())) ?? []
+			const stackLength = (await workerConnection.evaluate<number | undefined>(`(async () => {
+				const stack = await browser.storage.local.get('interceptorTransactionStack')
+				return stack.interceptorTransactionStack?.operations?.length ?? 0
+			})()`)) ?? 0
+			if (stackLength < 1) throw new Error('Transaction stack was not appended')
+			return {
+				stackLength,
+				setupRpcRequests,
+				stackedSetup: {
+					launchEpochMs,
+					pageSnapshot,
+					confirmPopupSnapshot,
+					workerSnapshot,
+				},
+			}
+		} finally {
+			confirmConnection.close()
+		}
+	} finally {
+		await waitForTargetGone(context.chrome.browserDebugPort, (target) => target.id === confirmTargetId, 30_000, 'confirm transaction popup to close').catch(() => undefined)
+		pageConnection.close()
+		workerConnection.close()
+		if (confirmTargetId !== undefined) await closeTarget(context.chrome.browserConnection, confirmTargetId).catch(() => undefined)
+		if (accessTargetId !== undefined) await closeTarget(context.chrome.browserConnection, accessTargetId).catch(() => undefined)
+	}
+}
+
+async function runStackedScenario(context: BenchmarkContext, transactionPageUrl: string) {
+	const { stackLength, setupRpcRequests, stackedSetup } = await prepareStackedTransaction(context, transactionPageUrl)
+	console.log(`  transaction stack prepared with ${ stackLength } operation${ stackLength === 1 ? '' : 's' }`)
+	const sample = await openPopupAndCollect(context, 'stacked')
+	return { ...sample, setupRpcRequests, stackedSetup }
+}
+
+async function runScenarioOnce(scenario: ScenarioName, transactionPageUrl?: string): Promise<Sample> {
+	const context = await prepareBenchmarkContext()
+	try {
+		if (scenario === 'cold') return await runColdScenario(context)
+		if (scenario === 'warm') return await runWarmScenario(context)
+		if (transactionPageUrl === undefined) throw new Error('Missing transaction page URL for stacked scenario')
+		return await runStackedScenario(context, transactionPageUrl)
+	} finally {
+		await context.chrome.close().catch(() => undefined)
+	}
+}
+
+async function runScenarioManyTimes(scenario: ScenarioName, iterations: number, transactionPageUrl?: string): Promise<Sample[]> {
+	const samples: Sample[] = []
+	for (let index = 0; index < iterations; index += 1) {
+		samples.push(await runScenarioOnce(scenario, transactionPageUrl))
+	}
+	return samples
+}
+
+async function main() {
+	const scenarioFilter = (process.env.BENCH_SCENARIO ?? 'all').toLowerCase()
+	const iterations = Number(process.env.BENCH_ITERATIONS ?? '1')
+	if (!Number.isFinite(iterations) || iterations <= 0) throw new Error(`Invalid BENCH_ITERATIONS value: ${ process.env.BENCH_ITERATIONS ?? '1' }`)
+	const transactionPageServer = scenarioFilter === 'all' || scenarioFilter === 'stacked'
+		? await startTransactionStackPageServer()
+		: undefined
+	try {
+		const scenarios: ScenarioName[] = scenarioFilter === 'all'
+			? ['cold', 'warm', 'stacked']
+			: scenarioFilter === 'cold' || scenarioFilter === 'warm' || scenarioFilter === 'stacked'
+				? [scenarioFilter]
+				: (() => { throw new Error(`Unknown BENCH_SCENARIO value: ${ scenarioFilter }`) })()
+
+		const runs: { scenario: ScenarioName, samples: Sample[] }[] = []
+		for (const scenario of scenarios) {
+			const samples = await runScenarioManyTimes(scenario, iterations, transactionPageServer?.baseUrl)
+			runs.push({ scenario, samples })
+		}
+
+		for (const run of runs) {
+			const popupScriptStart = stats(run.samples.map((sample) => sample.popupScriptStartMs))
+			const popupShellPaint = stats(run.samples.map((sample) => sample.popupShellPaintMs))
+			const popupHomeFirstCommit = stats(run.samples.map((sample) => sample.popupHomeFirstCommitMs))
+			const popupRefreshComplete = stats(run.samples.map((sample) => sample.popupRefreshCompleteMs))
+			const popupRefreshRendered = stats(run.samples.map((sample) => sample.popupRefreshRenderedMs))
+			const workerRefreshStart = stats(run.samples.map((sample) => sample.workerRefreshStartMs))
+			const workerRefreshEnd = stats(run.samples.map((sample) => sample.workerRefreshEndMs))
+			const rpcRequests = run.samples.flatMap((sample) => sample.rpcRequests)
+			const setupRpcRequests = run.samples.flatMap((sample) => sample.setupRpcRequests)
+			const stackedSetups = run.samples.flatMap((sample) => sample.stackedSetup === undefined ? [] : [sample.stackedSetup])
+			const rpcSummary = aggregateRpcRequests(rpcRequests)
+			const rpcMethodStats = rpcSummary.methods
+			const setupRpcSummary = aggregateRpcRequests(setupRpcRequests)
+			const setupRpcMethodStats = setupRpcSummary.methods
+
+			const summary: ScenarioStats = {
+				name: run.scenario,
+				iterations: run.samples.length,
+				launchMode: run.samples[0]?.launchMode ?? 'real-chrome-extension-page',
+				popupScriptStart: requireStats(popupScriptStart, 'popup script start'),
+				popupShellPaint: requireStats(popupShellPaint, 'popup shell paint'),
+				popupHomeFirstCommit: requireStats(popupHomeFirstCommit, 'popup Home first commit'),
+				popupRefreshComplete,
+				popupRefreshRendered,
+				workerRefreshStart: requireStats(workerRefreshStart, 'worker refresh start'),
+				workerRefreshEnd: requireStats(workerRefreshEnd, 'worker refresh end'),
+				rpcTotalRequests: rpcSummary.totalRequests,
+				rpcTotalDurationMs: rpcSummary.totalDurationMs,
+				rpcMethods: rpcMethodStats,
+			}
+
+			console.log(`${ summary.name } (${ summary.iterations } run${ summary.iterations === 1 ? '' : 's' }, ${ summary.launchMode }):`)
+			if (stackedSetups.length > 0) {
+				console.log('  note: the next three groups start when the transaction test page loads, before the main popup is opened.')
+				printStatsGroup('  send transaction path / page load -> page milestones:', [
+					['provider ready', stackedSetupTiming(stackedSetups, 'page', 'interceptor:benchmark:tx:provider-ready')],
+					['access request shown', stackedSetupTiming(stackedSetups, 'page', 'interceptor:benchmark:tx:requesting-access')],
+					['access granted', stackedSetupTiming(stackedSetups, 'page', 'interceptor:benchmark:tx:access-granted')],
+					['transaction request started', stackedSetupTiming(stackedSetups, 'page', 'interceptor:benchmark:tx:requesting-transaction')],
+					['transaction submitted', stackedSetupTiming(stackedSetups, 'page', 'interceptor:benchmark:tx:submitted')],
+					['balance request started', stackedSetupTiming(stackedSetups, 'page', 'interceptor:benchmark:tx:requesting-balance')],
+					['balance fetched', stackedSetupTiming(stackedSetups, 'page', 'interceptor:benchmark:tx:balance-fetched')],
+				])
+				printStatsGroup('  send transaction path / page load -> confirm popup milestones:', [
+					['confirm popup simulation started', stackedSetupTiming(stackedSetups, 'confirm', POPUP_PERFORMANCE_MARKS.confirmTransactionSimulationStarted)],
+					['confirm popup simulation ready', stackedSetupTiming(stackedSetups, 'confirm', POPUP_PERFORMANCE_MARKS.confirmTransactionSimulationReady)],
+				])
+				printStatsGroup('  send transaction path / page load -> background milestones:', [
+					['background received transaction request', stackedSetupTiming(stackedSetups, 'worker', 'interceptor:background:transaction-request-received')],
+					['confirm popup opened', stackedSetupTiming(stackedSetups, 'worker', 'interceptor:background:transaction-confirm-popup-opened')],
+					['background simulation started', stackedSetupTiming(stackedSetups, 'worker', 'interceptor:background:transaction-simulation-start')],
+					['background simulation ended', stackedSetupTiming(stackedSetups, 'worker', 'interceptor:background:transaction-simulation-end')],
+					['transaction stack appended', stackedSetupTiming(stackedSetups, 'worker', 'interceptor:background:transaction-stack-appended')],
+				])
+				printStatsGroup('  send transaction path / end-to-end page load -> main popup milestones:', [
+					['main popup open requested', stackedSampleTiming(run.samples, (sample, setup) => sample.popupLaunchEpochMs - setup.launchEpochMs)],
+					['main popup script start', stackedSampleTiming(run.samples, (sample, setup) => sample.popupLaunchEpochMs - setup.launchEpochMs + sample.popupScriptStartMs)],
+					['main popup shell paint', stackedSampleTiming(run.samples, (sample, setup) => sample.popupLaunchEpochMs - setup.launchEpochMs + sample.popupShellPaintMs)],
+					['main popup first commit', stackedSampleTiming(run.samples, (sample, setup) => sample.popupLaunchEpochMs - setup.launchEpochMs + sample.popupHomeFirstCommitMs)],
+					['main popup rendered with refreshed state', stackedSampleTiming(run.samples, (sample, setup) => {
+						const rendered = sample.popupRefreshRenderedMs ?? sample.popupHomeFirstCommitMs
+						return sample.popupLaunchEpochMs - setup.launchEpochMs + rendered
+					})],
+				])
+			}
+			if (run.scenario === 'stacked') {
+				console.log('  note: the next two groups start later, at main popup open, so they exclude the send-transaction setup path above.')
+			}
+			printStatsGroup('  main popup only / open path (starts at main popup open):', [
+				['script start', summary.popupScriptStart],
+				['shell paint', summary.popupShellPaint],
+				['Home first commit', summary.popupHomeFirstCommit],
+			])
+			printStatsGroup('  main popup only / refresh path (same main popup open):', [
+				['refresh state applied in popup', summary.popupRefreshComplete],
+				['refresh rendered in popup', summary.popupRefreshRendered],
+				['background refresh start', summary.workerRefreshStart],
+				['background refresh end', summary.workerRefreshEnd],
+			])
+			if (setupRpcRequests.length > 0) {
+				console.log(`  rpc / setup (${ setupRpcSummary.totalRequests } request${ setupRpcSummary.totalRequests === 1 ? '' : 's' }, ${ roundToTwoDecimals(setupRpcSummary.totalDurationMs) } ms cumulative):`)
+				if (setupRpcMethodStats.length === 0) {
+					console.log('    n/a')
+				} else {
+					for (const methodStats of setupRpcMethodStats) {
+						console.log(formatRpcMethodStats(`    ${ methodStats.method }`, requireRpcMethodStats(methodStats, methodStats.method)))
+					}
+				}
+			}
+			console.log(`  rpc / popup (${ summary.rpcTotalRequests } request${ summary.rpcTotalRequests === 1 ? '' : 's' }, ${ roundToTwoDecimals(summary.rpcTotalDurationMs) } ms cumulative):`)
+			if (summary.rpcMethods.length === 0) {
+				console.log('    n/a')
+			} else {
+				for (const methodStats of summary.rpcMethods) {
+					console.log(formatRpcMethodStats(`    ${ methodStats.method }`, requireRpcMethodStats(methodStats, methodStats.method)))
+				}
+			}
+			if (summary.popupRefreshComplete === undefined) {
+				console.log('  popup refresh state applied was not observed within the benchmark wait window.')
+			}
+			console.log('')
+		}
+	} finally {
+		if (transactionPageServer !== undefined) await transactionPageServer.close().catch(() => undefined)
+	}
+}
+
+await main()

--- a/test/benchmarks/transactionStackPage.html
+++ b/test/benchmarks/transactionStackPage.html
@@ -1,0 +1,143 @@
+<!DOCTYPE html>
+<html lang="en">
+	<head>
+		<meta charset="utf-8" />
+		<meta name="viewport" content="width=device-width, initial-scale=1" />
+		<title>The Interceptor tx stack benchmark</title>
+		<style>
+			:root {
+				color-scheme: dark;
+				--bg: #0f1115;
+				--panel: #171a21;
+				--text: #ecf1ff;
+				--muted: #9aa6bf;
+				--accent: #66d9ef;
+			}
+
+			html,
+			body {
+				margin: 0;
+				min-height: 100%;
+				background: radial-gradient(circle at top, #182133 0%, var(--bg) 58%);
+				color: var(--text);
+				font-family: system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+			}
+
+			body {
+				min-height: 100vh;
+				display: grid;
+				place-items: center;
+			}
+
+			main {
+				width: min(42rem, calc(100vw - 2rem));
+				padding: 1.5rem 1.75rem;
+				border: 1px solid rgba(255, 255, 255, 0.08);
+				border-radius: 1rem;
+				background: color-mix(in srgb, var(--panel) 90%, transparent);
+				box-shadow: 0 1rem 3rem rgba(0, 0, 0, 0.35);
+			}
+
+			h1 {
+				margin: 0 0 0.5rem;
+				font-size: 1.25rem;
+			}
+
+			p {
+				margin: 0.25rem 0 0;
+				line-height: 1.5;
+			}
+
+			#status {
+				margin-top: 1rem;
+				padding: 0.75rem 0.9rem;
+				border-radius: 0.75rem;
+				background: rgba(255, 255, 255, 0.05);
+				color: var(--accent);
+				font-family: ui-monospace, "SFMono-Regular", Consolas, monospace;
+				word-break: break-word;
+			}
+		</style>
+	</head>
+	<body>
+		<main>
+			<h1>Transaction stack benchmark page</h1>
+			<p>This page requests account access, sends one real transaction through the extension, fetches the user's balance afterwards, approves the popup flow, and leaves the transaction in the simulation stack.</p>
+			<p id="status">Waiting for provider injection...</p>
+		</main>
+		<script>
+			(() => {
+				const state = globalThis.__interceptorBenchmarkTxPageState = {
+					phase: 'loading',
+					txHash: undefined,
+					balance: undefined,
+					error: undefined,
+				}
+				const statusElement = document.getElementById('status')
+				const senderAddress = '0xd8da6bf26964af9d7eed9e03e53415d37aa96045'
+				const recipientAddress = '0x000000000000000000000000000000000000dEaD'
+				const transaction = {
+					from: senderAddress,
+					to: recipientAddress,
+					value: '0x0',
+					gas: '0x5208',
+				}
+
+				const mark = (phase) => {
+					performance.mark(`interceptor:benchmark:tx:${ phase }`)
+				}
+
+				const updateState = (phase, extra = {}) => {
+					state.phase = phase
+					state.error = extra.error
+					state.txHash = extra.txHash
+					state.balance = extra.balance
+					if (statusElement !== null) {
+						statusElement.textContent = phase === 'error'
+							? `error: ${ extra.error ?? 'unknown error' }`
+							: phase === 'submitted'
+								? `submitted: ${ extra.txHash ?? 'unknown hash' }`
+								: phase === 'balance-fetched'
+									? `balance: ${ extra.balance ?? 'unknown balance' }`
+								: phase
+					}
+					mark(phase)
+				}
+
+				const waitForEthereum = async () => {
+					while (true) {
+						if (globalThis.ethereum !== undefined && typeof globalThis.ethereum.request === 'function') return globalThis.ethereum
+						await new Promise((resolve) => requestAnimationFrame(() => resolve()))
+					}
+				}
+
+				(async () => {
+					try {
+						const ethereum = await waitForEthereum()
+						updateState('provider-ready')
+						updateState('requesting-access')
+						await ethereum.request({
+							method: 'eth_requestAccounts',
+						})
+						updateState('access-granted')
+						updateState('requesting-transaction')
+						const txHash = await ethereum.request({
+							method: 'eth_sendTransaction',
+							params: [transaction],
+						})
+						updateState('submitted', { txHash })
+						updateState('requesting-balance')
+						const balance = await ethereum.request({
+							method: 'eth_getBalance',
+							params: [senderAddress, 'latest'],
+						})
+						updateState('balance-fetched', { balance })
+					} catch (error) {
+						const message = error instanceof Error ? error.message : String(error)
+						updateState('error', { error: message })
+					}
+				})()
+			})()
+		</script>
+	</body>
+</html>

--- a/test/benchmarks/transactionStackPageServer.ts
+++ b/test/benchmarks/transactionStackPageServer.ts
@@ -1,0 +1,41 @@
+import { createServer } from 'node:http'
+import { readFile } from 'node:fs/promises'
+
+export type TransactionStackPageServer = {
+	baseUrl: string
+	close: () => Promise<void>
+}
+
+export async function startTransactionStackPageServer(): Promise<TransactionStackPageServer> {
+	const html = await readFile(new URL('./transactionStackPage.html', import.meta.url), 'utf8')
+	const server = createServer((request, response) => {
+		if (request.url === '/favicon.ico') {
+			response.writeHead(204, { 'Cache-Control': 'no-store' })
+			response.end()
+			return
+		}
+
+		response.writeHead(200, {
+			'Content-Type': 'text/html; charset=utf-8',
+			'Cache-Control': 'no-store',
+		})
+		response.end(html)
+	})
+
+	await new Promise<void>((resolve, reject) => {
+		server.once('error', reject)
+		server.listen(0, '127.0.0.1', () => resolve())
+	})
+
+	const address = server.address()
+	if (address === null || typeof address === 'string') throw new Error('Could not start the transaction stack benchmark page server')
+
+	return {
+		baseUrl: `http://127.0.0.1:${ address.port }/`,
+		close: async () => {
+			await new Promise<void>((resolve) => {
+				server.close(() => resolve())
+			}).catch(() => undefined)
+		},
+	}
+}


### PR DESCRIPTION
## Summary
- add a real-Chrome browser simulator popup lifecycle benchmark suite
- add popup and background performance marks plus RPC timing collection used by the benchmark
- document the scenario boundaries and report both end-to-end stacked timings and main-popup-only timings

## Validation
- npm test
- npm run setup-chrome
- npm run benchmark:popup-lifecycle