### PR TITLE
Reduce eth_accounts latency in simulation mode

### DIFF
--- a/app/ts/background/background.ts
+++ b/app/ts/background/background.ts
@@ -324,9 +324,37 @@ function getProviderHandler(method: string) {
 	}
 }
 
+function replyWithEmptyAccounts(websiteTabConnections: WebsiteTabConnections, request: InterceptedRequest) {
+	return replyToInterceptedRequest(websiteTabConnections, { type: 'result', method: 'eth_accounts' as const, result: [], uniqueRequestIdentifier: request.uniqueRequestIdentifier })
+}
+
+function requestNeedsSimulationState(method: string) {
+	switch (method) {
+		case 'eth_getBlockByHash':
+		case 'eth_getBlockByNumber':
+		case 'eth_getBalance':
+		case 'eth_estimateGas':
+		case 'eth_getTransactionByHash':
+		case 'eth_getTransactionReceipt':
+		case 'eth_call':
+		case 'eth_blockNumber':
+		case 'eth_getCode':
+		case 'eth_getTransactionCount':
+		case 'interceptor_getSimulationStack':
+		case 'eth_getLogs':
+		case 'eth_newFilter':
+		case 'eth_getFilterChanges':
+		case 'eth_getFilterLogs':
+			return true
+		default:
+			return false
+	}
+}
+
 export const handleInterceptedRequest = async (port: browser.runtime.Port | undefined, websiteOrigin: string, websitePromise: Promise<Website> | Website, simulator: Simulator, socket: WebsiteSocket, request: InterceptedRequest, websiteTabConnections: WebsiteTabConnections): Promise<unknown> => {
-	const activeAddress = await getActiveAddress(await getSettings(), socket.tabId)
-	const access = verifyAccess(websiteTabConnections, socket, request.method === 'eth_requestAccounts' || request.method === 'eth_call', websiteOrigin, activeAddress, await getSettings())
+	const settings = await getSettings()
+	const activeAddress = await getActiveAddress(settings, socket.tabId)
+	const access = verifyAccess(websiteTabConnections, socket, request.method === 'eth_requestAccounts' || request.method === 'eth_call', websiteOrigin, activeAddress, settings)
 	if (access === 'interceptorDisabled') return replyToInterceptedRequest(websiteTabConnections, { type: 'result', ...request, ...ERROR_INTERCEPTOR_DISABLED })
 	const providerHandler = getProviderHandler(request.method)
 	const identifiedMethod = providerHandler.method
@@ -339,15 +367,21 @@ export const handleInterceptedRequest = async (port: browser.runtime.Port | unde
 	}
 	if (access === 'hasAccess' && activeAddress === undefined && request.method === 'eth_requestAccounts') {
 		// user has granted access to the site, but not to this account and the application is requesting accounts
-		const account = await askForSignerAccountsFromSignerIfNotAvailable(websiteTabConnections, socket)
+		const account = await askForSignerAccountsFromSignerIfNotAvailable(websiteTabConnections, socket, true)
 		if (account.length === 0) return refuseAccess(websiteTabConnections, request)
+		const result: unknown = await handleInterceptedRequest(port, websiteOrigin, websitePromise, simulator, socket, request, websiteTabConnections)
+		return result
+	}
+	if (access === 'hasAccess' && activeAddress === undefined && request.method === 'eth_accounts' && (!settings.simulationMode || settings.useSignersAddressAsActiveAddress)) {
+		const account = await askForSignerAccountsFromSignerIfNotAvailable(websiteTabConnections, socket, false)
+		if (account.length === 0) return replyWithEmptyAccounts(websiteTabConnections, request)
 		const result: unknown = await handleInterceptedRequest(port, websiteOrigin, websitePromise, simulator, socket, request, websiteTabConnections)
 		return result
 	}
 
 	if (access === 'noAccess' || activeAddress === undefined) {
 		switch (request.method) {
-			case 'eth_accounts': return replyToInterceptedRequest(websiteTabConnections, { type: 'result', method: 'eth_accounts' as const, result: [], uniqueRequestIdentifier: request.uniqueRequestIdentifier })
+			case 'eth_accounts': return replyWithEmptyAccounts(websiteTabConnections, request)
 			// if user has not given access, assume we are on chain 1
 			case 'eth_chainId': return replyToInterceptedRequest(websiteTabConnections, { type: 'result', method: request.method, result: 1n, uniqueRequestIdentifier: request.uniqueRequestIdentifier })
 			case 'net_version': return replyToInterceptedRequest(websiteTabConnections, { type: 'result', method: request.method, result: 1n, uniqueRequestIdentifier: request.uniqueRequestIdentifier })
@@ -369,7 +403,7 @@ export const handleInterceptedRequest = async (port: browser.runtime.Port | unde
 async function handleContentScriptMessage(simulator: Simulator, websiteTabConnections: WebsiteTabConnections, request: InterceptedRequest, website: Website, activeAddress: bigint | undefined) {
 	try {
 		const settings = await getSettings()
-		const simulationState = settings.simulationMode ? await getUpdatedSimulationState(simulator.ethereum) : undefined
+		const simulationState = settings.simulationMode && requestNeedsSimulationState(request.method) ? await getUpdatedSimulationState(simulator.ethereum) : undefined
 		const resolved = await handleRPCRequest(simulator, simulationState, websiteTabConnections, request.uniqueRequestIdentifier.requestSocket, website, request, settings, activeAddress)
 		return replyToInterceptedRequest(websiteTabConnections, { ...request, ...resolved })
 	} catch (error: unknown) {

--- a/app/ts/background/background.ts
+++ b/app/ts/background/background.ts
@@ -145,7 +145,7 @@ export async function refreshConfirmTransactionSimulation(
 
 async function handleRPCRequest(
 	simulator: Simulator,
-	simulationState: SimulationState | undefined,
+	getSimulationState: () => Promise<SimulationState | undefined>,
 	websiteTabConnections: WebsiteTabConnections,
 	socket: WebsiteSocket,
 	website: Website,
@@ -181,21 +181,22 @@ async function handleRPCRequest(
 		return { type: 'forwardToSigner' as const, replyWithSignersReply: true, ...request }
 	}
 	const parsedRequest = maybeParsedRequest.value
+	const withSimulationState = async (handler: (simulationState: SimulationState | undefined) => Promise<RPCReply>) => await handler(await getSimulationState())
 	makeSureInterceptorIsNotSleeping(simulator.ethereum)
 	switch (parsedRequest.method) {
-		case 'eth_getBlockByHash': return await getBlockByHash(simulator.ethereum, simulationState, parsedRequest)
-		case 'eth_getBlockByNumber': return await getBlockByNumber(simulator.ethereum, simulationState, parsedRequest)
-		case 'eth_getBalance': return await getBalance(simulator.ethereum, simulationState, parsedRequest)
-		case 'eth_estimateGas': return await estimateGas(simulator.ethereum, simulationState, parsedRequest)
-		case 'eth_getTransactionByHash': return await getTransactionByHash(simulator.ethereum, simulationState, parsedRequest)
-		case 'eth_getTransactionReceipt': return await getTransactionReceipt(simulator.ethereum, simulationState, parsedRequest)
-		case 'eth_call': return await call(simulator.ethereum, simulationState, parsedRequest)
-		case 'eth_blockNumber': return await blockNumber(simulator.ethereum, simulationState)
+		case 'eth_getBlockByHash': return await withSimulationState((simulationState) => getBlockByHash(simulator.ethereum, simulationState, parsedRequest))
+		case 'eth_getBlockByNumber': return await withSimulationState((simulationState) => getBlockByNumber(simulator.ethereum, simulationState, parsedRequest))
+		case 'eth_getBalance': return await withSimulationState((simulationState) => getBalance(simulator.ethereum, simulationState, parsedRequest))
+		case 'eth_estimateGas': return await withSimulationState((simulationState) => estimateGas(simulator.ethereum, simulationState, parsedRequest))
+		case 'eth_getTransactionByHash': return await withSimulationState((simulationState) => getTransactionByHash(simulator.ethereum, simulationState, parsedRequest))
+		case 'eth_getTransactionReceipt': return await withSimulationState((simulationState) => getTransactionReceipt(simulator.ethereum, simulationState, parsedRequest))
+		case 'eth_call': return await withSimulationState((simulationState) => call(simulator.ethereum, simulationState, parsedRequest))
+		case 'eth_blockNumber': return await withSimulationState((simulationState) => blockNumber(simulator.ethereum, simulationState))
 		case 'eth_subscribe': return await subscribe(socket, parsedRequest)
 		case 'eth_unsubscribe': return await unsubscribe(socket, parsedRequest)
 		case 'eth_chainId': return await chainId(simulator.ethereum)
 		case 'net_version': return await netVersion(simulator.ethereum)
-		case 'eth_getCode': return await getCode(simulator.ethereum, simulationState, parsedRequest)
+		case 'eth_getCode': return await withSimulationState((simulationState) => getCode(simulator.ethereum, simulationState, parsedRequest))
 		case 'personal_sign':
 		case 'eth_signTypedData':
 		case 'eth_signTypedData_v1':
@@ -208,8 +209,8 @@ async function handleRPCRequest(
 		case 'eth_accounts': return await getAccounts(activeAddress)
 		case 'eth_requestAccounts': return await getAccounts(activeAddress)
 		case 'eth_gasPrice': return await gasPrice(simulator.ethereum)
-		case 'eth_getTransactionCount': return await getTransactionCount(simulator.ethereum, simulationState, parsedRequest)
-		case 'interceptor_getSimulationStack': return await requestInterceptorSimulatorStack(simulationState, websiteTabConnections, parsedRequest, website, request, socket)
+		case 'eth_getTransactionCount': return await withSimulationState((simulationState) => getTransactionCount(simulator.ethereum, simulationState, parsedRequest))
+		case 'interceptor_getSimulationStack': return await withSimulationState((simulationState) => requestInterceptorSimulatorStack(simulationState, websiteTabConnections, parsedRequest, website, request, socket))
 		case 'eth_simulateV1': return { type: 'result', method: parsedRequest.method, error: { code: 10000, message: 'Cannot call eth_simulateV1 directly' } }
 		case 'wallet_addEthereumChain': {
 			if (forwardToSigner) return getForwardingMessage(parsedRequest)
@@ -219,7 +220,7 @@ async function handleRPCRequest(
 			if (forwardToSigner) return getForwardingMessage(parsedRequest)
 			return { type: 'result' as const, method: parsedRequest.method, error: { code: 10000, message: 'eth_getStorageAt not implemented' } }
 		}
-		case 'eth_getLogs': return await getLogs(simulator.ethereum, simulationState, parsedRequest)
+		case 'eth_getLogs': return await withSimulationState((simulationState) => getLogs(simulator.ethereum, simulationState, parsedRequest))
 		case 'eth_sign': return { type: 'result' as const,method: parsedRequest.method, error: { code: 10000, message: 'eth_sign is deprecated' } }
 		case 'eth_sendRawTransaction':
 		case 'eth_sendTransaction': {
@@ -228,10 +229,10 @@ async function handleRPCRequest(
 		}
 		case 'web3_clientVersion': return await web3ClientVersion(simulator.ethereum)
 		case 'eth_feeHistory': return await feeHistory(simulator.ethereum, parsedRequest)
-		case 'eth_newFilter': return await installNewFilter(socket, parsedRequest, simulator.ethereum, simulationState)
+		case 'eth_newFilter': return await withSimulationState((simulationState) => installNewFilter(socket, parsedRequest, simulator.ethereum, simulationState))
 		case 'eth_uninstallFilter': return await uninstallNewFilter(socket, parsedRequest)
-		case 'eth_getFilterChanges': return await getFilterChanges(parsedRequest, simulator.ethereum, simulationState)
-		case 'eth_getFilterLogs': return await getFilterLogs(parsedRequest, simulator.ethereum, simulationState)
+		case 'eth_getFilterChanges': return await withSimulationState((simulationState) => getFilterChanges(parsedRequest, simulator.ethereum, simulationState))
+		case 'eth_getFilterLogs': return await withSimulationState((simulationState) => getFilterLogs(parsedRequest, simulator.ethereum, simulationState))
 		case 'InterceptorError': return await handleIterceptorError(parsedRequest)
 		/*
 		Missing methods:
@@ -328,29 +329,6 @@ function replyWithEmptyAccounts(websiteTabConnections: WebsiteTabConnections, re
 	return replyToInterceptedRequest(websiteTabConnections, { type: 'result', method: 'eth_accounts' as const, result: [], uniqueRequestIdentifier: request.uniqueRequestIdentifier })
 }
 
-function requestNeedsSimulationState(method: string) {
-	switch (method) {
-		case 'eth_getBlockByHash':
-		case 'eth_getBlockByNumber':
-		case 'eth_getBalance':
-		case 'eth_estimateGas':
-		case 'eth_getTransactionByHash':
-		case 'eth_getTransactionReceipt':
-		case 'eth_call':
-		case 'eth_blockNumber':
-		case 'eth_getCode':
-		case 'eth_getTransactionCount':
-		case 'interceptor_getSimulationStack':
-		case 'eth_getLogs':
-		case 'eth_newFilter':
-		case 'eth_getFilterChanges':
-		case 'eth_getFilterLogs':
-			return true
-		default:
-			return false
-	}
-}
-
 export const handleInterceptedRequest = async (port: browser.runtime.Port | undefined, websiteOrigin: string, websitePromise: Promise<Website> | Website, simulator: Simulator, socket: WebsiteSocket, request: InterceptedRequest, websiteTabConnections: WebsiteTabConnections): Promise<unknown> => {
 	const settings = await getSettings()
 	const activeAddress = await getActiveAddress(settings, socket.tabId)
@@ -403,8 +381,13 @@ export const handleInterceptedRequest = async (port: browser.runtime.Port | unde
 async function handleContentScriptMessage(simulator: Simulator, websiteTabConnections: WebsiteTabConnections, request: InterceptedRequest, website: Website, activeAddress: bigint | undefined) {
 	try {
 		const settings = await getSettings()
-		const simulationState = settings.simulationMode && requestNeedsSimulationState(request.method) ? await getUpdatedSimulationState(simulator.ethereum) : undefined
-		const resolved = await handleRPCRequest(simulator, simulationState, websiteTabConnections, request.uniqueRequestIdentifier.requestSocket, website, request, settings, activeAddress)
+		let simulationStatePromise: Promise<SimulationState | undefined> | undefined = undefined
+		const getSimulationState = async () => {
+			if (!settings.simulationMode) return undefined
+			if (simulationStatePromise === undefined) simulationStatePromise = getUpdatedSimulationState(simulator.ethereum)
+			return await simulationStatePromise
+		}
+		const resolved = await handleRPCRequest(simulator, getSimulationState, websiteTabConnections, request.uniqueRequestIdentifier.requestSocket, website, request, settings, activeAddress)
 		return replyToInterceptedRequest(websiteTabConnections, { ...request, ...resolved })
 	} catch (error: unknown) {
 		if ((error instanceof Error && isFailedToFetchError(error))) {

--- a/app/ts/background/windows/interceptorAccess.ts
+++ b/app/ts/background/windows/interceptorAccess.ts
@@ -72,7 +72,7 @@ export async function updateInterceptorAccessViewWithPendingRequests() {
 	} })
 }
 
-export async function askForSignerAccountsFromSignerIfNotAvailable(websiteTabConnections: WebsiteTabConnections, socket: WebsiteSocket) {
+export async function askForSignerAccountsFromSignerIfNotAvailable(websiteTabConnections: WebsiteTabConnections, socket: WebsiteSocket, requestAccounts = true) {
 	const tabState = await getTabState(socket.tabId)
 	if (tabState.signerAccounts.length !== 0) return tabState.signerAccounts
 
@@ -83,7 +83,10 @@ export async function askForSignerAccountsFromSignerIfNotAvailable(websiteTabCon
 	const channel = new BroadcastChannel(INTERNAL_CHANNEL_NAME)
 	try {
 		channel.addEventListener('message', listener)
-		const messageSent = sendSubscriptionReplyOrCallBack(websiteTabConnections, socket, { type: 'result' as const, method: 'request_signer_to_eth_requestAccounts' as const, result: [] })
+		const requestSignerAccountsMessage = requestAccounts
+			? { type: 'result' as const, method: 'request_signer_to_eth_requestAccounts' as const, result: [] as const }
+			: { type: 'result' as const, method: 'request_signer_to_eth_accounts' as const, result: [] as const }
+		const messageSent = sendSubscriptionReplyOrCallBack(websiteTabConnections, socket, requestSignerAccountsMessage)
 		if (messageSent) await future
 	} finally {
 		channel.removeEventListener('message', listener)

--- a/test/tests/backgroundEthAccounts.ts
+++ b/test/tests/backgroundEthAccounts.ts
@@ -1,0 +1,183 @@
+import * as assert from 'assert'
+import { describe, run, runIfRoot, should } from '../micro-should.js'
+
+type Listener = () => void
+type PortMessage = { method?: unknown, result?: unknown, requestId?: unknown }
+
+function installBrowserMock() {
+	const storageState: Record<string, unknown> = {}
+	;(globalThis as typeof globalThis & { browser: typeof globalThis.browser }).browser = {
+		runtime: {
+			lastError: null,
+			async sendMessage() {
+				return undefined
+			},
+			getManifest: () => ({ manifest_version: 3 }),
+			onMessage: { addListener: (_listener: Listener) => undefined, removeListener: (_listener: Listener) => undefined },
+			onConnect: { addListener: (_listener: Listener) => undefined, removeListener: (_listener: Listener) => undefined },
+		},
+		storage: {
+			local: {
+				async get(keys?: string | string[] | Record<string, unknown> | null) {
+					if (keys === undefined || keys === null) return { ...storageState }
+					if (Array.isArray(keys)) return Object.fromEntries(keys.filter((key) => key in storageState).map((key) => [key, storageState[key]]))
+					if (typeof keys === 'string') return keys in storageState ? { [keys]: storageState[keys] } : {}
+					return Object.fromEntries(Object.entries(keys).map(([key, defaultValue]) => [key, key in storageState ? storageState[key] : defaultValue]))
+				},
+				async set(items: Record<string, unknown>) {
+					Object.assign(storageState, items)
+				},
+				async remove(keys: string | string[]) {
+					for (const key of Array.isArray(keys) ? keys : [keys]) delete storageState[key]
+				},
+			},
+		},
+		tabs: {
+			async query() { return [] },
+			async get() { return undefined },
+			async update() { return undefined },
+			onUpdated: { addListener: (_listener: Listener) => undefined, removeListener: (_listener: Listener) => undefined },
+			onRemoved: { addListener: (_listener: Listener) => undefined, removeListener: (_listener: Listener) => undefined },
+		},
+		windows: {
+			async get() { return undefined },
+			async update() { return undefined },
+		},
+		action: {
+			async setIcon() { return undefined },
+			async setTitle() { return undefined },
+			async setBadgeText() { return undefined },
+			async setBadgeBackgroundColor() { return undefined },
+		},
+		browserAction: {
+			async setIcon() { return undefined },
+			async setTitle() { return undefined },
+			async setBadgeText() { return undefined },
+			async setBadgeBackgroundColor() { return undefined },
+		},
+	} as unknown as typeof globalThis.browser
+	;(globalThis as typeof globalThis & { chrome: { runtime: { id: string } } }).chrome = { runtime: { id: 'test-extension' } }
+	;(globalThis as typeof globalThis & { location: Location }).location = { origin: '' } as unknown as Location
+}
+
+async function loadModules() {
+	return {
+		...await import('../../app/ts/background/background.js'),
+		...await import('../../app/ts/background/backgroundUtils.js'),
+		...await import('../../app/ts/background/settings.js'),
+		...await import('../../app/ts/background/storageVariables.js'),
+	}
+}
+
+function createPort(tabId: number, onPostMessage?: (message: PortMessage) => void) {
+	const messages: PortMessage[] = []
+	const port = {
+		name: '0x0',
+		sender: { tab: { id: tabId } },
+		postMessage(message: unknown) {
+			const typedMessage = message as PortMessage
+			messages.push(typedMessage)
+			onPostMessage?.(typedMessage)
+		},
+	} as unknown as browser.runtime.Port
+	return { port, messages }
+}
+
+function createSimulatorWithGetBlockCounter(getBlockCalls: { count: number }) {
+	return {
+		ethereum: {
+			isBlockPolling: () => true,
+			setBlockPolling: (_value: boolean) => undefined,
+			async getBlock() {
+				getBlockCalls.count += 1
+				return null
+			},
+		},
+	} as const
+}
+
+export async function main() {
+	describe('background eth_accounts', () => {
+		should('skip simulation state refresh for eth_accounts in simulation mode', async () => {
+			installBrowserMock()
+			const { handleInterceptedRequest, websiteSocketToString, changeSimulationMode, setUseSignersAddressAsActiveAddress, updateWebsiteAccess } = await loadModules()
+			const websiteOrigin = 'https://example.test'
+			const website = { websiteOrigin, icon: undefined, title: undefined }
+			const account = 0x1111111111111111111111111111111111111111n
+			await changeSimulationMode({ simulationMode: true, activeSimulationAddress: account, activeSigningAddress: undefined })
+			await setUseSignersAddressAsActiveAddress(false)
+			await updateWebsiteAccess(() => [{ website, access: true, addressAccess: undefined }])
+
+			const socket = { tabId: 1, connectionName: 0n }
+			const { port, messages } = createPort(socket.tabId)
+			const connectionKey = websiteSocketToString(socket)
+			const websiteTabConnections = new Map([[socket.tabId, { connections: {
+				[connectionKey]: { port, socket, websiteOrigin, approved: true, wantsToConnect: true },
+			} }]])
+			const getBlockCalls = { count: 0 }
+			const request = {
+				interceptorRequest: true,
+				usingInterceptorWithoutSigner: false,
+				uniqueRequestIdentifier: { requestId: 1, requestSocket: socket },
+				method: 'eth_accounts',
+			}
+
+			await handleInterceptedRequest(port, websiteOrigin, website, createSimulatorWithGetBlockCounter(getBlockCalls) as unknown as Parameters<typeof handleInterceptedRequest>[3], socket, request, websiteTabConnections)
+
+			assert.equal(getBlockCalls.count, 0)
+			assert.equal(messages.some((message) => message.method === 'request_signer_to_eth_accounts'), false)
+			const ethAccountsReplies = messages.filter((message) => message.method === 'eth_accounts' && message.requestId === 1)
+			assert.deepEqual(ethAccountsReplies.at(-1)?.result, ['0x1111111111111111111111111111111111111111'])
+		})
+
+		should('refresh signer accounts for approved eth_accounts requests when the tab cache is empty', async () => {
+			installBrowserMock()
+			const {
+				handleInterceptedRequest,
+				websiteSocketToString,
+				sendInternalWindowMessage,
+				changeSimulationMode,
+				setUseSignersAddressAsActiveAddress,
+				updateWebsiteAccess,
+				updateTabState,
+			} = await loadModules()
+			const websiteOrigin = 'https://example.test'
+			const website = { websiteOrigin, icon: undefined, title: undefined }
+			const account = 0x2222222222222222222222222222222222222222n
+			await changeSimulationMode({ simulationMode: false, activeSimulationAddress: undefined, activeSigningAddress: undefined })
+			await setUseSignersAddressAsActiveAddress(false)
+			await updateWebsiteAccess(() => [{ website, access: true, addressAccess: undefined }])
+
+			const socket = { tabId: 1, connectionName: 0n }
+			const { port, messages } = createPort(socket.tabId, (message) => {
+				if (message.method !== 'request_signer_to_eth_accounts') return
+				void (async () => {
+					await updateTabState(socket.tabId, (previousState) => ({ ...previousState, signerAccounts: [account], activeSigningAddress: account }))
+					sendInternalWindowMessage({ method: 'window_signer_accounts_changed', data: { socket } })
+				})()
+			})
+			const connectionKey = websiteSocketToString(socket)
+			const websiteTabConnections = new Map([[socket.tabId, { connections: {
+				[connectionKey]: { port, socket, websiteOrigin, approved: true, wantsToConnect: true },
+			} }]])
+			const request = {
+				interceptorRequest: true,
+				usingInterceptorWithoutSigner: false,
+				uniqueRequestIdentifier: { requestId: 7, requestSocket: socket },
+				method: 'eth_accounts',
+			}
+
+			await handleInterceptedRequest(port, websiteOrigin, website, createSimulatorWithGetBlockCounter({ count: 0 }) as unknown as Parameters<typeof handleInterceptedRequest>[3], socket, request, websiteTabConnections)
+
+			assert.equal(messages.filter((message) => message.method === 'request_signer_to_eth_accounts').length, 1)
+			assert.equal(messages.some((message) => message.method === 'request_signer_to_eth_requestAccounts'), false)
+			const ethAccountsReplies = messages.filter((message) => message.method === 'eth_accounts' && message.requestId === 7)
+			assert.deepEqual(ethAccountsReplies.at(-1)?.result, ['0x2222222222222222222222222222222222222222'])
+		})
+	})
+}
+
+await runIfRoot(async () => {
+	await main()
+	await run()
+}, import.meta)


### PR DESCRIPTION
## Summary
- avoid rebuilding simulation state for eth_accounts and other requests that do not need simulated state
- refresh signer accounts on approved eth_accounts requests when the tab cache is empty instead of waiting for a later explicit signer sync
- add regression coverage for the simulation-mode fast path and the approved-site signer refresh path

## Testing
- npm test
- npm run setup-chrome