### PR TITLE
If rpc method doesnt use simulation results, just use simulation inputs

### DIFF
--- a/app/ts/background/background-startup.ts
+++ b/app/ts/background/background-startup.ts
@@ -1,6 +1,6 @@
 import 'webextension-polyfill'
 import { defaultRpcs, getSettings } from './settings.js'
-import { handleInterceptedRequest, popupMessageHandler } from './background.js'
+import { getUpdatedSimulationState, handleInterceptedRequest, popupMessageHandler } from './background.js'
 import { retrieveWebsiteDetails, updateExtensionBadge, updateExtensionIcon } from './iconHandler.js'
 import { clearTabStates, getPrimaryRpcForChain, removeTabState, setRpcConnectionStatus, updateTabState, updateUserAddressBookEntries, updateUserAddressBookEntriesV2Old } from './storageVariables.js'
 import { Simulator } from '../simulation/simulator.js'
@@ -196,10 +196,10 @@ async function newBlockAttemptCallback(blockheader: EthereumBlockHeader, ethereu
 				const updatePopupVisualisationPromise = updatePopupVisualisationIfNeeded(simulator, false, false)
 				silenceChromeUnCaughtPromise(updatePopupVisualisationPromise)
 				await sendPopupMessageToOpenWindows({ method: 'popup_new_block_arrived', data: { rpcConnectionStatus } })
-				return await sendSubscriptionMessagesForNewBlock(blockheader.number, ethereumClientService, settings.simulationMode, websiteTabConnections)
+				return await sendSubscriptionMessagesForNewBlock(blockheader.number, ethereumClientService, settings.simulationMode, websiteTabConnections, getUpdatedSimulationState)
 			}
 			await sendPopupMessageToOpenWindows({ method: 'popup_new_block_arrived', data: { rpcConnectionStatus } })
-			return await sendSubscriptionMessagesForNewBlock(blockheader.number, ethereumClientService, settings.simulationMode, websiteTabConnections)
+			return await sendSubscriptionMessagesForNewBlock(blockheader.number, ethereumClientService, settings.simulationMode, websiteTabConnections, getUpdatedSimulationState)
 		}
 		await sendPopupMessageToOpenWindows({ method: 'popup_new_block_arrived', data: { rpcConnectionStatus } })
 	} catch(error) {

--- a/app/ts/background/background.ts
+++ b/app/ts/background/background.ts
@@ -5,7 +5,7 @@ import { getTabState, promoteRpcAsPrimary, setLatestUnexpectedError, updateInter
 import { changeSimulationMode, getFixedAddressRichList, getSettings, setFixedMakeMeRichList } from './settings.js'
 import { blockNumber, call, chainId, estimateGas, gasPrice, getAccounts, getBalance, getBlockByNumber, getCode, getLogs, getPermissions, getTransactionByHash, getTransactionCount, getTransactionReceipt, netVersion, personalSign, sendTransaction, subscribe, switchEthereumChain, unsubscribe, web3ClientVersion, getBlockByHash, feeHistory, installNewFilter, uninstallNewFilter, getFilterChanges, getFilterLogs, handleIterceptorError, requestInterceptorSimulatorStack } from './simulationModeHanders.js'
 import { changeActiveAddress, changePage, confirmDialog, removeTransactionOrSignedMessage, requestAccountsFromSigner, refreshPopupConfirmTransactionSimulation, confirmRequestAccess, changeInterceptorAccess, changeChainDialog, popupChangeActiveRpc, enableSimulationMode, addOrModifyAddressBookEntry, getAddressBookData, removeAddressBookEntry, refreshHomeData, interceptorAccessChangeAddressOrRefresh, refreshPopupConfirmTransactionMetadata, changeSettings, importSettings, exportSettings, setNewRpcList, simulateGovernanceContractExecutionOnPass, openNewTab, settingsOpened, changeAddOrModifyAddressWindowState, requestAbiAndNameFromBlockExplorer, openWebPage, disableInterceptor, requestNewHomeData, setEnsNameForHash, simulateGnosisSafeTransactionOnPass, retrieveWebsiteAccess, blockOrAllowExternalRequests, removeWebsiteAccess, allowOrPreventAddressAccessForWebsite, removeWebsiteAddressAccess, forceSetGasLimitForTransaction, changePreSimulationBlockTimeManipulation, setTransactionOrMessageBlockTimeManipulator, modifyMakeMeRich, requestMakeMeRichList, requestActiveAddresses, requestSimulationMode, requestLatestUnexpectedError, fetchSimulationStackRequestConfirmation, handleUnexpectedErrorInWindow, requestInterceptorSimulationInput, importSimulationStack, requestCompleteVisualizedSimulation, requestSimulationMetadata, requestIdentifyAddress, popupReadyAndListening } from './popupMessageHandlers.js'
-import { SimulationState, WebsiteCreatedEthereumUnsignedTransactionOrFailed } from '../types/visualizer-types.js'
+import { SimulationState, SimulationStateInput, WebsiteCreatedEthereumUnsignedTransactionOrFailed } from '../types/visualizer-types.js'
 import { WebsiteTabConnections } from '../types/user-interface-types.js'
 import { askForSignerAccountsFromSignerIfNotAvailable, interceptorAccessMetadataRefresh, requestAccessFromUser } from './windows/interceptorAccess.js'
 import { METAMASK_ERROR_FAILED_TO_PARSE_REQUEST, METAMASK_ERROR_NOT_AUTHORIZED, METAMASK_ERROR_NOT_CONNECTED_TO_CHAIN, ERROR_INTERCEPTOR_DISABLED, NEW_BLOCK_ABORT } from '../utils/constants.js'
@@ -28,7 +28,7 @@ import { Interface } from 'ethers'
 import { connectedToSigner, ethAccountsReply, signerChainChanged, signerReply, walletSwitchEthereumChainReply } from './providerMessageHandlers.js'
 import { makeSureInterceptorIsNotSleeping } from './sleeping.js'
 import { decodeEthereumError } from '../utils/errorDecoding.js'
-import { createSimulationStateWithNonceAndBaseFeeFixing, getCurrentSimulationInput, visualizeSimulatorState } from './simulationUpdating.js'
+import { buildSimulationStateFromPreparedInput, createSimulationStateWithNonceAndBaseFeeFixing, getCurrentSimulationInput, prepareSimulationInputForRpc, visualizeSimulatorState } from './simulationUpdating.js'
 import { PopupReplyOption } from '../types/interceptor-reply-messages.js'
 import { updatePopupVisualisationIfNeeded } from './popupVisualisationUpdater.js'
 
@@ -145,6 +145,7 @@ export async function refreshConfirmTransactionSimulation(
 
 async function handleRPCRequest(
 	simulator: Simulator,
+	getSimulationInput: () => Promise<SimulationStateInput | undefined>,
 	getSimulationState: () => Promise<SimulationState | undefined>,
 	websiteTabConnections: WebsiteTabConnections,
 	socket: WebsiteSocket,
@@ -181,22 +182,23 @@ async function handleRPCRequest(
 		return { type: 'forwardToSigner' as const, replyWithSignersReply: true, ...request }
 	}
 	const parsedRequest = maybeParsedRequest.value
+	const withSimulationInput = async (handler: (simulationInput: SimulationStateInput | undefined) => Promise<RPCReply>) => await handler(await getSimulationInput())
 	const withSimulationState = async (handler: (simulationState: SimulationState | undefined) => Promise<RPCReply>) => await handler(await getSimulationState())
 	makeSureInterceptorIsNotSleeping(simulator.ethereum)
 	switch (parsedRequest.method) {
-		case 'eth_getBlockByHash': return await withSimulationState((simulationState) => getBlockByHash(simulator.ethereum, simulationState, parsedRequest))
-		case 'eth_getBlockByNumber': return await withSimulationState((simulationState) => getBlockByNumber(simulator.ethereum, simulationState, parsedRequest))
-		case 'eth_getBalance': return await withSimulationState((simulationState) => getBalance(simulator.ethereum, simulationState, parsedRequest))
-		case 'eth_estimateGas': return await withSimulationState((simulationState) => estimateGas(simulator.ethereum, simulationState, parsedRequest))
-		case 'eth_getTransactionByHash': return await withSimulationState((simulationState) => getTransactionByHash(simulator.ethereum, simulationState, parsedRequest))
+		case 'eth_getBlockByHash': return await withSimulationInput((simulationInput) => getBlockByHash(simulator.ethereum, simulationInput, parsedRequest))
+		case 'eth_getBlockByNumber': return await withSimulationInput((simulationInput) => getBlockByNumber(simulator.ethereum, simulationInput, parsedRequest))
+		case 'eth_getBalance': return await withSimulationInput((simulationInput) => getBalance(simulator.ethereum, simulationInput, parsedRequest))
+		case 'eth_estimateGas': return await withSimulationInput((simulationInput) => estimateGas(simulator.ethereum, simulationInput, parsedRequest))
+		case 'eth_getTransactionByHash': return await withSimulationInput((simulationInput) => getTransactionByHash(simulator.ethereum, simulationInput, parsedRequest))
 		case 'eth_getTransactionReceipt': return await withSimulationState((simulationState) => getTransactionReceipt(simulator.ethereum, simulationState, parsedRequest))
-		case 'eth_call': return await withSimulationState((simulationState) => call(simulator.ethereum, simulationState, parsedRequest))
-		case 'eth_blockNumber': return await withSimulationState((simulationState) => blockNumber(simulator.ethereum, simulationState))
+		case 'eth_call': return await withSimulationInput((simulationInput) => call(simulator.ethereum, simulationInput, parsedRequest))
+		case 'eth_blockNumber': return await withSimulationInput((simulationInput) => blockNumber(simulator.ethereum, simulationInput))
 		case 'eth_subscribe': return await subscribe(socket, parsedRequest)
 		case 'eth_unsubscribe': return await unsubscribe(socket, parsedRequest)
 		case 'eth_chainId': return await chainId(simulator.ethereum)
 		case 'net_version': return await netVersion(simulator.ethereum)
-		case 'eth_getCode': return await withSimulationState((simulationState) => getCode(simulator.ethereum, simulationState, parsedRequest))
+		case 'eth_getCode': return await withSimulationInput((simulationInput) => getCode(simulator.ethereum, simulationInput, parsedRequest))
 		case 'personal_sign':
 		case 'eth_signTypedData':
 		case 'eth_signTypedData_v1':
@@ -209,7 +211,7 @@ async function handleRPCRequest(
 		case 'eth_accounts': return await getAccounts(activeAddress)
 		case 'eth_requestAccounts': return await getAccounts(activeAddress)
 		case 'eth_gasPrice': return await gasPrice(simulator.ethereum)
-		case 'eth_getTransactionCount': return await withSimulationState((simulationState) => getTransactionCount(simulator.ethereum, simulationState, parsedRequest))
+		case 'eth_getTransactionCount': return await withSimulationInput((simulationInput) => getTransactionCount(simulator.ethereum, simulationInput, parsedRequest))
 		case 'interceptor_getSimulationStack': return await withSimulationState((simulationState) => requestInterceptorSimulatorStack(simulationState, websiteTabConnections, parsedRequest, website, request, socket))
 		case 'eth_simulateV1': return { type: 'result', method: parsedRequest.method, error: { code: 10000, message: 'Cannot call eth_simulateV1 directly' } }
 		case 'wallet_addEthereumChain': {
@@ -229,7 +231,7 @@ async function handleRPCRequest(
 		}
 		case 'web3_clientVersion': return await web3ClientVersion(simulator.ethereum)
 		case 'eth_feeHistory': return await feeHistory(simulator.ethereum, parsedRequest)
-		case 'eth_newFilter': return await withSimulationState((simulationState) => installNewFilter(socket, parsedRequest, simulator.ethereum, simulationState))
+		case 'eth_newFilter': return await withSimulationInput((simulationInput) => installNewFilter(socket, parsedRequest, simulator.ethereum, simulationInput))
 		case 'eth_uninstallFilter': return await uninstallNewFilter(socket, parsedRequest)
 		case 'eth_getFilterChanges': return await withSimulationState((simulationState) => getFilterChanges(parsedRequest, simulator.ethereum, simulationState))
 		case 'eth_getFilterLogs': return await withSimulationState((simulationState) => getFilterLogs(parsedRequest, simulator.ethereum, simulationState))
@@ -381,13 +383,23 @@ export const handleInterceptedRequest = async (port: browser.runtime.Port | unde
 async function handleContentScriptMessage(simulator: Simulator, websiteTabConnections: WebsiteTabConnections, request: InterceptedRequest, website: Website, activeAddress: bigint | undefined) {
 	try {
 		const settings = await getSettings()
+		let simulationInputPromise: Promise<SimulationStateInput | undefined> | undefined = undefined
 		let simulationStatePromise: Promise<SimulationState | undefined> | undefined = undefined
+		const getSimulationInput = async () => {
+			if (!settings.simulationMode) return undefined
+			if (simulationInputPromise === undefined) simulationInputPromise = (async () => await prepareSimulationInputForRpc(await getCurrentSimulationInput(), simulator.ethereum))()
+			return await simulationInputPromise
+		}
 		const getSimulationState = async () => {
 			if (!settings.simulationMode) return undefined
-			if (simulationStatePromise === undefined) simulationStatePromise = getUpdatedSimulationState(simulator.ethereum)
+			if (simulationStatePromise === undefined) simulationStatePromise = (async () => {
+				const simulationInput = await getSimulationInput()
+				if (simulationInput === undefined) return undefined
+				return await buildSimulationStateFromPreparedInput(simulationInput, simulator.ethereum)
+			})()
 			return await simulationStatePromise
 		}
-		const resolved = await handleRPCRequest(simulator, getSimulationState, websiteTabConnections, request.uniqueRequestIdentifier.requestSocket, website, request, settings, activeAddress)
+		const resolved = await handleRPCRequest(simulator, getSimulationInput, getSimulationState, websiteTabConnections, request.uniqueRequestIdentifier.requestSocket, website, request, settings, activeAddress)
 		return replyToInterceptedRequest(websiteTabConnections, { ...request, ...resolved })
 	} catch (error: unknown) {
 		if ((error instanceof Error && isFailedToFetchError(error))) {

--- a/app/ts/background/popupSimulationFingerprint.ts
+++ b/app/ts/background/popupSimulationFingerprint.ts
@@ -2,15 +2,7 @@ import { keccak256, toUtf8Bytes } from 'ethers'
 import { stringifyJSONWithBigInts } from '../utils/bigint.js'
 import { RpcNetwork } from '../types/rpc.js'
 import { SimulationStateInput } from '../types/visualizer-types.js'
-
-export function getSimulationInputHash(simulationStateInput: SimulationStateInput) {
-	const messages = stringifyJSONWithBigInts(simulationStateInput.map((x) => x.signedMessages.map((x) => x.originalRequestParameters)))
-	const overrides = stringifyJSONWithBigInts(simulationStateInput.map((x) => x.stateOverrides))
-	const transactions = stringifyJSONWithBigInts(simulationStateInput.map((x) => x.transactions.map((x) => x.originalRequestParameters)))
-	const blockTime = stringifyJSONWithBigInts(simulationStateInput.map((x) => x.blockTimeManipulation))
-	const baseFee = stringifyJSONWithBigInts(simulationStateInput.map((x) => x.simulateWithZeroBaseFee))
-	return keccak256(toUtf8Bytes(JSON.stringify([messages, overrides, transactions, blockTime, baseFee])))
-}
+import { getSimulationInputHash } from '../utils/simulationFingerprint.js'
 
 export function getPopupVisualisationFingerprint(simulationStateInput: SimulationStateInput, rpcNetwork: RpcNetwork, blockNumber: bigint) {
 	return keccak256(toUtf8Bytes(stringifyJSONWithBigInts([getSimulationInputHash(simulationStateInput), normalizeRpcNetworkForFingerprint(rpcNetwork), blockNumber])))

--- a/app/ts/background/simulationModeHanders.ts
+++ b/app/ts/background/simulationModeHanders.ts
@@ -1,9 +1,9 @@
 import { EthereumClientService } from '../simulation/services/EthereumClientService.js'
 import { createEthereumSubscription, createNewFilter, getEthFilterChanges, getEthFilterLogs, removeEthereumSubscription } from '../simulation/services/EthereumSubscriptionService.js'
-import { getSimulatedBalance, getSimulatedBlock, getSimulatedBlockNumber, getSimulatedCode, getSimulatedLogs, getSimulatedTransactionByHash, getSimulatedTransactionReceipt, simulatedCall, simulateEstimateGas, getInputFieldFromDataOrInput, getSimulatedBlockByHash, getSimulatedFeeHistory, getSimulatedTransactionCount } from '../simulation/services/SimulationModeEthereumClientService.js'
+import { getSimulatedBalanceFromInput, getSimulatedBlockByHashFromInput, getSimulatedBlockFromInput, getSimulatedBlockNumberFromInput, getSimulatedCodeFromInput, getSimulatedLogs, getSimulatedTransactionByHashFromInput, getSimulatedTransactionReceipt, simulatedCallFromInput, simulateEstimateGasFromInput, getInputFieldFromDataOrInput, getSimulatedFeeHistory, getSimulatedTransactionCountFromInput } from '../simulation/services/SimulationModeEthereumClientService.js'
 import { DEFAULT_CALL_ADDRESS, ERROR_INTERCEPTOR_GET_CODE_FAILED } from '../utils/constants.js'
 import { WebsiteTabConnections } from '../types/user-interface-types.js'
-import { SimulationState } from '../types/visualizer-types.js'
+import { SimulationState, SimulationStateInput } from '../types/visualizer-types.js'
 import { openChangeChainDialog } from './windows/changeChain.js'
 import { InterceptedRequest, WebsiteSocket } from '../utils/requests.js'
 import { EstimateGasParams, EthBalanceParams, EthBlockByHashParams, EthBlockByNumberParams, EthCallParams, EthNewFilter, EthGetLogsParams, EthSubscribeParams, EthUnSubscribeParams, FeeHistory, GetCode, GetFilterChanges, GetSimulationStack, GetTransactionCount, SendRawTransactionParams, SendTransactionParams, SwitchEthereumChainParams, TransactionByHashParams, TransactionReceiptParams, UninstallFilter, GetFilterLogs, InterceptorError } from '../types/JsonRpc-types.js'
@@ -16,18 +16,18 @@ import { handleUnexpectedError } from '../utils/errors.js'
 import { openFetchSimulationStackDialogOrGetCachedResult } from './windows/fetchSimulationStack.js'
 import { POPUP_PERFORMANCE_MARKS, markPerformance } from '../utils/popupPerformance.js'
 
-export async function getBlockByHash(ethereumClientService: EthereumClientService, simulationState: SimulationState | undefined, request: EthBlockByHashParams) {
-	return { type: 'result' as const, method: request.method, result: await getSimulatedBlockByHash(ethereumClientService, undefined, simulationState, request.params[0], request.params[1]) }
+export async function getBlockByHash(ethereumClientService: EthereumClientService, simulationInput: SimulationStateInput | undefined, request: EthBlockByHashParams) {
+	return { type: 'result' as const, method: request.method, result: await getSimulatedBlockByHashFromInput(ethereumClientService, undefined, simulationInput, request.params[0], request.params[1]) }
 }
-export async function getBlockByNumber(ethereumClientService: EthereumClientService, simulationState: SimulationState | undefined, request: EthBlockByNumberParams) {
-	return { type: 'result' as const, method: request.method, result: await getSimulatedBlock(ethereumClientService, undefined, simulationState, request.params[0], request.params[1]) }
+export async function getBlockByNumber(ethereumClientService: EthereumClientService, simulationInput: SimulationStateInput | undefined, request: EthBlockByNumberParams) {
+	return { type: 'result' as const, method: request.method, result: await getSimulatedBlockFromInput(ethereumClientService, undefined, simulationInput, request.params[0], request.params[1]) }
 }
-export async function getBalance(ethereumClientService: EthereumClientService, simulationState: SimulationState | undefined, request: EthBalanceParams) {
-	return { type: 'result' as const, method: request.method, result: await getSimulatedBalance(ethereumClientService, undefined, simulationState, request.params[0]) }
+export async function getBalance(ethereumClientService: EthereumClientService, simulationInput: SimulationStateInput | undefined, request: EthBalanceParams) {
+	return { type: 'result' as const, method: request.method, result: await getSimulatedBalanceFromInput(ethereumClientService, undefined, simulationInput, request.params[0], request.params[1]) }
 }
-export async function getTransactionByHash(ethereumClientService: EthereumClientService, simulationState: SimulationState | undefined, request: TransactionByHashParams) {
-	const result = await getSimulatedTransactionByHash(ethereumClientService, undefined, simulationState, request.params[0])
-	if (result === undefined) return { type: 'result' as const, method: request.method, result: null }
+export async function getTransactionByHash(ethereumClientService: EthereumClientService, simulationInput: SimulationStateInput | undefined, request: TransactionByHashParams) {
+	const result = await getSimulatedTransactionByHashFromInput(ethereumClientService, undefined, simulationInput, request.params[0])
+	if (result === null) return { type: 'result' as const, method: request.method, result: null }
 	return { type: 'result' as const, method: request.method, result: result }
 }
 export async function getTransactionReceipt(ethereumClientService: EthereumClientService, simulationState: SimulationState | undefined, request: TransactionReceiptParams) {
@@ -49,7 +49,7 @@ export async function sendTransaction(
 	return { method: transactionParams.method, ...action }
 }
 
-async function singleCallWithFromOverride(ethereumClientService: EthereumClientService, simulationState: SimulationState | undefined, request: EthCallParams, from: bigint) {
+async function singleCallWithFromOverride(ethereumClientService: EthereumClientService, simulationInput: SimulationStateInput | undefined, request: EthCallParams, from: bigint) {
 	const callParams = request.params[0]
 	const blockTag = request.params.length > 1 ? request.params[1] : 'latest' as const
 	const gasPrice = callParams.gasPrice !== undefined ? callParams.gasPrice : 0n
@@ -67,22 +67,22 @@ async function singleCallWithFromOverride(ethereumClientService: EthereumClientS
 		accessList: [],
 	}
 
-	return await simulatedCall(ethereumClientService, undefined, simulationState, callTransaction, blockTag)
+	return await simulatedCallFromInput(ethereumClientService, undefined, simulationInput, callTransaction, blockTag)
 }
 
-export async function call(ethereumClientService: EthereumClientService, simulationState: SimulationState | undefined, request: EthCallParams) {
+export async function call(ethereumClientService: EthereumClientService, simulationInput: SimulationStateInput | undefined, request: EthCallParams) {
 	const callParams = request.params[0]
 	const from = callParams.from !== undefined ? callParams.from : DEFAULT_CALL_ADDRESS
-	const callResult = await singleCallWithFromOverride(ethereumClientService, simulationState, request, from)
+	const callResult = await singleCallWithFromOverride(ethereumClientService, simulationInput, request, from)
 	return { type: 'result' as const, method: request.method, ...callResult }
 }
 
-export async function blockNumber(ethereumClientService: EthereumClientService, simulationState: SimulationState | undefined) {
-	return { type: 'result' as const, method: 'eth_blockNumber' as const, result: await getSimulatedBlockNumber(ethereumClientService, undefined, simulationState) }
+export async function blockNumber(ethereumClientService: EthereumClientService, simulationInput: SimulationStateInput | undefined) {
+	return { type: 'result' as const, method: 'eth_blockNumber' as const, result: await getSimulatedBlockNumberFromInput(ethereumClientService, undefined, simulationInput) }
 }
 
-export async function estimateGas(ethereumClientService: EthereumClientService, simulationState: SimulationState | undefined, request: EstimateGasParams){
-	const estimatedGas = await simulateEstimateGas(ethereumClientService, undefined, simulationState, request.params[0])
+export async function estimateGas(ethereumClientService: EthereumClientService, simulationInput: SimulationStateInput | undefined, request: EstimateGasParams){
+	const estimatedGas = await simulateEstimateGasFromInput(ethereumClientService, undefined, simulationInput, request.params[0])
 	if ('error' in estimatedGas) return { type: 'result' as const, method: request.method, ...estimatedGas }
 	return { type: 'result' as const, method: request.method, result: estimatedGas.gas }
 }
@@ -136,8 +136,8 @@ export async function switchEthereumChain(simulator: Simulator, websiteTabConnec
 	return { type: 'result' as const, method: params.method, ...change }
 }
 
-export async function getCode(ethereumClientService: EthereumClientService, simulationState: SimulationState | undefined, request: GetCode) {
-	const code = await getSimulatedCode(ethereumClientService, undefined, simulationState, request.params[0], request.params[1])
+export async function getCode(ethereumClientService: EthereumClientService, simulationInput: SimulationStateInput | undefined, request: GetCode) {
+	const code = await getSimulatedCodeFromInput(ethereumClientService, undefined, simulationInput, request.params[0], request.params[1])
 	if (code.statusCode === 'failure') return { type: 'result' as const, method: request.method, ...ERROR_INTERCEPTOR_GET_CODE_FAILED }
 	return { type: 'result' as const, method: request.method, result: code.getCodeReturn }
 }
@@ -146,8 +146,8 @@ export async function getPermissions() {
 	return { type: 'result' as const, method: 'wallet_getPermissions', params: [], result: [ { eth_accounts: {} } ] } as const
 }
 
-export async function getTransactionCount(ethereumClientService: EthereumClientService, simulationState: SimulationState | undefined, request: GetTransactionCount) {
-	return { type: 'result' as const, method: request.method, result: await getSimulatedTransactionCount(ethereumClientService, undefined, simulationState, request.params[0], request.params[1]) }
+export async function getTransactionCount(ethereumClientService: EthereumClientService, simulationInput: SimulationStateInput | undefined, request: GetTransactionCount) {
+	return { type: 'result' as const, method: request.method, result: await getSimulatedTransactionCountFromInput(ethereumClientService, undefined, simulationInput, request.params[0], request.params[1]) }
 }
 
 export async function getLogs(ethereumClientService: EthereumClientService, simulationState: SimulationState | undefined, request: EthGetLogsParams) {
@@ -162,8 +162,8 @@ export async function feeHistory(ethereumClientService: EthereumClientService, r
 	return { type: 'result' as const, method: 'eth_feeHistory' as const, result: await getSimulatedFeeHistory(ethereumClientService, undefined, request) }
 }
 
-export async function installNewFilter(socket: WebsiteSocket, request: EthNewFilter, ethereumClientService: EthereumClientService, simulationState: SimulationState | undefined) {
-	return { type: 'result' as const, method: request.method, result: await createNewFilter(request, socket, ethereumClientService, undefined, simulationState) }
+export async function installNewFilter(socket: WebsiteSocket, request: EthNewFilter, ethereumClientService: EthereumClientService, simulationInput: SimulationStateInput | undefined) {
+	return { type: 'result' as const, method: request.method, result: await createNewFilter(request, socket, ethereumClientService, undefined, simulationInput) }
 }
 
 export async function uninstallNewFilter(socket: WebsiteSocket, request: UninstallFilter) {

--- a/app/ts/background/simulationUpdating.ts
+++ b/app/ts/background/simulationUpdating.ts
@@ -306,16 +306,21 @@ export const updateSimulationMetadata = async (ethereum: EthereumClientService, 
 	})
 }
 
-export const createSimulationStateWithNonceAndBaseFeeFixing = async (simulationInput: SimulationStateInput, ethereum: EthereumClientService) => {
+export const prepareSimulationInputForRpc = async (simulationInput: SimulationStateInput, ethereum: EthereumClientService) => {
 	const parentBlock = await ethereum.getBlock(undefined)
 	const baseFeeFixedInputStateBlocks = parentBlock === undefined ? simulationInput : simulationInput.map((block) => (
 		modifyObject(block, { transactions: getBaseFeeAdjustedTransactions(parentBlock, block.transactions) })
 	))
-	const newSimulationState = await createSimulationState(ethereum, undefined, baseFeeFixedInputStateBlocks)
-	// rerun the simulation if nonce issues are found after fixing the nonce issues
-	const nonceFixed = await getNonceFixedSimulationStateInput(ethereum, undefined, newSimulationState)
-	if (nonceFixed.nonceFixed) return await createSimulationState(ethereum, undefined, nonceFixed.simulationStateInput)
-	return newSimulationState
+	const nonceFixed = await getNonceFixedSimulationStateInput(ethereum, undefined, baseFeeFixedInputStateBlocks)
+	return nonceFixed.nonceFixed ? nonceFixed.simulationStateInput : baseFeeFixedInputStateBlocks
+}
+
+export const buildSimulationStateFromPreparedInput = async (preparedSimulationInput: SimulationStateInput, ethereum: EthereumClientService) => {
+	return await createSimulationState(ethereum, undefined, preparedSimulationInput)
+}
+
+export const createSimulationStateWithNonceAndBaseFeeFixing = async (simulationInput: SimulationStateInput, ethereum: EthereumClientService) => {
+	return await buildSimulationStateFromPreparedInput(await prepareSimulationInputForRpc(simulationInput, ethereum), ethereum)
 }
 
 export async function visualizeSimulatorState(simulationState: SimulationState, ethereum: EthereumClientService, tokenPriceService: TokenPriceService, requestAbortController: AbortController | undefined): Promise<VisualizedSimulatorState> {

--- a/app/ts/background/windows/fetchSimulationStack.ts
+++ b/app/ts/background/windows/fetchSimulationStack.ts
@@ -4,7 +4,7 @@ import { Future } from '../../utils/future.js'
 import { FetchSimulationStackRequestConfirmation } from '../../types/interceptor-messages.js'
 import { WebsiteTabConnections } from '../../types/user-interface-types.js'
 import { getHtmlFile, sendPopupMessageToOpenWindows, websiteSocketToString } from '../backgroundUtils.js'
-import { getSimulationInputHash } from '../popupSimulationFingerprint.js'
+import { getSimulationInputHash } from '../../utils/simulationFingerprint.js'
 import { getFetchSimulationStackRequestPromise, setFetchSimulationStackRequestPromise } from '../storageVariables.js'
 import { InterceptedRequest, UniqueRequestIdentifier, WebsiteSocket, doesUniqueRequestIdentifiersMatch } from '../../utils/requests.js'
 import { replyToInterceptedRequest } from '../messageSending.js'
@@ -139,7 +139,7 @@ export async function openFetchSimulationStackDialogOrGetCachedResult(simulation
 	const identifier = websiteSocketToString(socket)
 	const newHash = getSimulationStackHash(input)
 	const previousDecision = simulationStackDecisions.find((x) => x.identifier === identifier)
-	if (previousDecision?.hash === newHash) {
+	if (previousDecision !== undefined && previousDecision.hash === newHash) {
 		if (previousDecision.accept) return { result: await getSimulationStack(simulationState, params.params[0]) }
 		return { type: 'result' as const, method: params.method, error: userDeniedChange.error }
 	}

--- a/app/ts/simulation/services/EthereumClientService.ts
+++ b/app/ts/simulation/services/EthereumClientService.ts
@@ -28,6 +28,8 @@ export type PreparedEthSimulateV1InputBlock = {
 export type PreparedEthSimulateV1Input = {
 	readonly request: EthSimulateV1Params
 	readonly inputBlocks: readonly PreparedEthSimulateV1InputBlock[]
+	readonly rpcBlocks: readonly SimulationStateInputMinimalDataBlock[]
+	readonly blockOverrides: readonly BlockOverrides[]
 }
 export class EthereumClientService {
 	private cachedBlock: EthereumBlockHeader | undefined = undefined
@@ -326,6 +328,8 @@ export class EthereumClientService {
 		if (parentBlock === null) throw new Error('The latest block is null')
 		return {
 			inputBlocks: preparedBlocks,
+			rpcBlocks,
+			blockOverrides,
 			request: {
 				method: 'eth_simulateV1',
 				params: [{

--- a/app/ts/simulation/services/EthereumSubscriptionService.ts
+++ b/app/ts/simulation/services/EthereumSubscriptionService.ts
@@ -2,12 +2,11 @@ import { EthNewFilter, EthSubscribeParams } from '../../types/JsonRpc-types.js'
 import { assertNever } from '../../utils/typescript.js'
 import { EthereumClientService } from './EthereumClientService.js'
 import { getEthereumSubscriptionsAndFilters, updateEthereumSubscriptionsAndFilters } from '../../background/storageVariables.js'
-import { EthereumSubscriptionsAndFilters, SimulationState } from '../../types/visualizer-types.js'
+import { EthereumSubscriptionsAndFilters, SimulationState, SimulationStateInput } from '../../types/visualizer-types.js'
 import { WebsiteTabConnections } from '../../types/user-interface-types.js'
-import { getSimulatedBlock, getSimulatedLogs } from './SimulationModeEthereumClientService.js'
+import { getSimulatedBlockFromInput, getSimulatedBlockNumber, getSimulatedBlockNumberFromInput, getSimulatedLogs } from './SimulationModeEthereumClientService.js'
 import { sendSubscriptionReplyOrCallBack } from '../../background/messageSending.js'
 import { WebsiteSocket } from '../../utils/requests.js'
-import { getUpdatedSimulationState } from '../../background/background.js'
 
 const dec2hex = (dec: number) => dec.toString(16).padStart(2, '0')
 
@@ -32,7 +31,13 @@ export async function removeEthereumSubscription(socket: WebsiteSocket, subscrip
 	return false
 }
 
-export async function sendSubscriptionMessagesForNewBlock(blockNumber: bigint, ethereumClientService: EthereumClientService, isSimulation: boolean, websiteTabConnections: WebsiteTabConnections) {
+export async function sendSubscriptionMessagesForNewBlock(
+	blockNumber: bigint,
+	ethereumClientService: EthereumClientService,
+	isSimulation: boolean,
+	websiteTabConnections: WebsiteTabConnections,
+	getSimulationState: (ethereumClientService: EthereumClientService) => Promise<SimulationState | undefined>,
+) {
 	const ethereumSubscriptionsAndFilters = await getEthereumSubscriptionsAndFilters()
 	for (const subscriptionOrFilter of ethereumSubscriptionsAndFilters) {
 		if (websiteTabConnections.get(subscriptionOrFilter.subscriptionCreatorSocket.tabId) === undefined) { // connection removed
@@ -51,15 +56,20 @@ export async function sendSubscriptionMessagesForNewBlock(blockNumber: bigint, e
 				})
 
 				if (isSimulation) {
-					const simulationState = await getUpdatedSimulationState(ethereumClientService)
-					const simulatedBlock = await getSimulatedBlock(ethereumClientService, undefined, simulationState, blockNumber + 1n, false)
-					// post our simulated block on top (reorg it)
-					sendSubscriptionReplyOrCallBack(websiteTabConnections, subscriptionOrFilter.subscriptionCreatorSocket, {
-						type: 'result',
-						method: 'newHeads' as const,
-						result: { subscription: subscriptionOrFilter.type, result: simulatedBlock },
-						subscription: subscriptionOrFilter.subscriptionOrFilterId,
-					})
+					const simulationState = await getSimulationState(ethereumClientService)
+					if (simulationState?.success !== true) break
+					const simulatedHead = await getSimulatedBlockNumberFromInput(ethereumClientService, undefined, simulationState.simulationStateInput)
+					for (let simulatedBlockNumber = blockNumber + 1n; simulatedBlockNumber <= simulatedHead; simulatedBlockNumber++) {
+						const simulatedBlock = await getSimulatedBlockFromInput(ethereumClientService, undefined, simulationState.simulationStateInput, simulatedBlockNumber, false)
+						if (simulatedBlock === null) continue
+						// post our simulated blocks on top (reorg them)
+						sendSubscriptionReplyOrCallBack(websiteTabConnections, subscriptionOrFilter.subscriptionCreatorSocket, {
+							type: 'result',
+							method: 'newHeads' as const,
+							result: { subscription: subscriptionOrFilter.type, result: simulatedBlock },
+							subscription: subscriptionOrFilter.subscriptionOrFilterId,
+						})
+					}
 				}
 				break
 			}
@@ -84,8 +94,8 @@ export async function createEthereumSubscription(params: EthSubscribeParams, sub
 	}
 }
 
-export async function createNewFilter(params: EthNewFilter, subscriptionCreatorSocket: WebsiteSocket, ethereumClientService: EthereumClientService, requestAbortController: AbortController | undefined, simulationState: SimulationState | undefined) {
-	const calledInlastBlock = simulationState?.blockNumber || await ethereumClientService.getBlockNumber(requestAbortController)
+export async function createNewFilter(params: EthNewFilter, subscriptionCreatorSocket: WebsiteSocket, ethereumClientService: EthereumClientService, requestAbortController: AbortController | undefined, simulationInput: SimulationStateInput | undefined) {
+	const calledInlastBlock = await getSimulatedBlockNumberFromInput(ethereumClientService, requestAbortController, simulationInput)
 	const subscriptionOrFilterId = generateId(40)
 	await updateEthereumSubscriptionsAndFilters((subscriptionsAndfilters: EthereumSubscriptionsAndFilters) => {
 		return subscriptionsAndfilters.concat({ type: 'eth_newFilter', subscriptionOrFilterId, params, subscriptionCreatorSocket, calledInlastBlock })
@@ -98,10 +108,12 @@ export async function getEthFilterChanges(filterId: string, ethereumClientServic
 	const filter = filtersAndSubscriptions.find((subscriptionOrfilter) => subscriptionOrfilter.subscriptionOrFilterId === filterId)
 	if (filter === undefined || filter.type !== 'eth_newFilter') return undefined
 	if (filter.params.params[0].blockhash !== undefined) throw new Error('blockhash not supported for this method')
-	const calledInlastBlock = simulationState?.blockNumber || await ethereumClientService.getBlockNumber(requestAbortController)
-	const logs = await getSimulatedLogs(ethereumClientService, requestAbortController, simulationState, { ...filter, fromBlock: filter.calledInlastBlock })
+	const calledInlastBlock = await getSimulatedBlockNumber(ethereumClientService, requestAbortController, simulationState)
+	const logs = calledInlastBlock > filter.calledInlastBlock
+		? await getSimulatedLogs(ethereumClientService, requestAbortController, simulationState, { ...filter.params.params[0], fromBlock: filter.calledInlastBlock + 1n, toBlock: calledInlastBlock })
+		: []
 	await updateEthereumSubscriptionsAndFilters((subscriptionsAndfilters) => {
-		return subscriptionsAndfilters.map((subscriptionOrfilter) => subscriptionOrfilter.subscriptionOrFilterId === filterId ? { ...subscriptionOrfilter, calledInlastBlock } : filter)
+		return subscriptionsAndfilters.map((subscriptionOrfilter) => subscriptionOrfilter.subscriptionOrFilterId === filterId ? { ...subscriptionOrfilter, calledInlastBlock } : subscriptionOrfilter)
 	})
 	return logs
 }

--- a/app/ts/simulation/services/SimulationModeEthereumClientService.ts
+++ b/app/ts/simulation/services/SimulationModeEthereumClientService.ts
@@ -3,8 +3,8 @@ import type { PreparedEthSimulateV1Input } from './EthereumClientService.js'
 import { EthereumUnsignedTransaction, EthereumSignedTransactionWithBlockData, EthereumBlockTag, EthereumAddress, EthereumBlockHeader, EthereumBlockHeaderWithTransactionHashes, EthereumData, EthereumQuantity, EthereumBytes32, EthereumSendableSignedTransaction, EthereumBlockHeaderTransaction } from '../../types/wire-types.js'
 import { addressString, bigintSecondsToDate, bigintToUint8Array, bytes32String, calculateWeightedPercentile, dataStringWith0xStart, dateToBigintSeconds, max, min, stringToUint8Array } from '../../utils/bigint.js'
 import { CANNOT_SIMULATE_OFF_LEGACY_BLOCK, ERROR_INTERCEPTOR_GAS_ESTIMATION_FAILED, ETHEREUM_LOGS_LOGGER_ADDRESS, ETHEREUM_EIP1559_BASEFEECHANGEDENOMINATOR, ETHEREUM_EIP1559_ELASTICITY_MULTIPLIER, MOCK_ADDRESS, MULTICALL3, Multicall3ABI, DEFAULT_CALL_ADDRESS, GAS_PER_BLOB } from '../../utils/constants.js'
-import { Interface, ethers, hashMessage, keccak256, } from 'ethers'
-import { SimulatedTransaction, SimulationState, TokenBalancesAfter, PreSimulationTransaction, SimulationStateBlock, SimulationStateInput, SimulationStateInputMinimalDataBlock, BlockTimeManipulationDeltaUnit } from '../../types/visualizer-types.js'
+import { Interface, ethers, hashMessage, keccak256, toUtf8Bytes } from 'ethers'
+import { SimulatedTransaction, SimulationState, TokenBalancesAfter, PreSimulationTransaction, SimulationStateBlock, SimulationStateInput, SimulationStateInputMinimalData, SimulationStateInputMinimalDataBlock, BlockTimeManipulationDeltaUnit } from '../../types/visualizer-types.js'
 import { EthereumUnsignedTransactionToUnsignedTransaction, IUnsignedTransaction1559, rlpEncode, serializeSignedTransactionToBytes } from '../../utils/ethereum.js'
 import { EthGetLogsResponse, EthGetLogsRequest, EthTransactionReceiptResponse, PartialEthereumTransaction, EthGetFeeHistoryResponse, FeeHistory } from '../../types/JsonRpc-types.js'
 import { handleERC1155TransferBatch, handleERC1155TransferSingle } from '../logHandlers.js'
@@ -18,6 +18,7 @@ import { getMessageAndDomainHash } from '../../utils/eip712.js'
 import { deduplicateByFunction } from '../../utils/array.js'
 import { promiseAllMapAbortSafe } from '../../utils/requests.js'
 import { ErrorWithCodeAndOptionalData } from '../../types/error.js'
+import { getSimulationInputHash } from '../../utils/simulationFingerprint.js'
 
 const MOCK_PUBLIC_PRIVATE_KEY = 0x1n // key used to sign mock transactions
 const MOCK_SIMULATION_PRIVATE_KEY = 0x2n // key used to sign simulated transatons
@@ -35,6 +36,49 @@ type GroupedEthSimulateV1BlockResult = {
 
 type GroupedEthSimulateV1Result = readonly GroupedEthSimulateV1BlockResult[]
 
+type PreparedSimulationExecutionBlock = {
+	inputBlock: SimulationStateInputMinimalDataBlock
+	blockNumber: bigint
+	blockHash: bigint
+	parentHash: bigint
+	blockTimestamp: Date
+	gasUsed: bigint
+	baseFeePerGas: bigint | undefined
+	totalDifficulty: bigint
+}
+
+type PreparedSimulationExecutionContext = {
+	simulationStateInput: SimulationStateInput
+	parentBlock: NonNullable<EthereumBlockHeader>
+	prepared: PreparedEthSimulateV1Input
+	executionBlocks: readonly PreparedSimulationExecutionBlock[]
+}
+
+type SimulationInspectionBase = {
+	simulationStateInput: SimulationStateInput
+	blockNumber: bigint
+	blockTimestamp: Date
+	baseFeePerGas: bigint
+	simulationConductedTimestamp: Date
+	rpcNetwork: SimulationState['rpcNetwork']
+}
+
+type SimulationInputInspection = {
+	success: true
+	base: SimulationInspectionBase
+	groupedEthSimulateV1CallResult: GroupedEthSimulateV1Result
+} | {
+	success: false
+	base: SimulationInspectionBase
+	jsonRpcError: ReturnType<JsonRpcResponseError['serialize']>
+}
+
+type SuccessfulSimulationState = Extract<SimulationState, { success: true }>
+
+type PreparedSimulatedExecutionBlock = PreparedSimulationExecutionBlock & {
+	simulatedTransactions: readonly SimulatedTransaction[]
+}
+
 export const getWebsiteCreatedEthereumUnsignedTransactions = (simulatedTransactions: readonly SimulatedTransaction[]) => {
 	return simulatedTransactions.map((simulatedTransaction) => ({
 		transaction: simulatedTransaction.preSimulationTransaction.signedTransaction,
@@ -48,6 +92,113 @@ export const getWebsiteCreatedEthereumUnsignedTransactions = (simulatedTransacti
 
 const transactionQueueTotalGasLimit = (simulatedTransactions: readonly SimulatedTransaction[]) => {
 	return simulatedTransactions.reduce((a, b) => a + b.preSimulationTransaction.signedTransaction.gas, 0n)
+}
+
+const transactionQueueTotalGasLimitFromInput = (block: SimulationStateInputMinimalDataBlock | undefined) => {
+	if (block === undefined) return 0n
+	return block.transactions.reduce((totalGasUsed, transaction) => totalGasUsed + transaction.signedTransaction.gas, 0n)
+}
+
+const isEmptySimulationInput = (simulationStateInput: SimulationStateInput | SimulationStateInputMinimalData) => (
+	simulationStateInput.length === 0
+	|| (simulationStateInput.length === 1 && simulationStateInput[0]?.transactions.length === 0 && simulationStateInput[0]?.signedMessages.length === 0)
+)
+
+const getHashOfSimulatedBlockFromInput = (simulationStateInput: SimulationStateInput, blockDelta: number) => {
+	return BigInt(keccak256(toUtf8Bytes(`${ getSimulationInputHash(simulationStateInput) }:${ blockDelta }`)))
+}
+
+const createPreparedSimulationExecutionContext = async (
+	ethereumClientService: EthereumClientService,
+	requestAbortController: AbortController | undefined,
+	simulationStateInput: SimulationStateInput | undefined,
+	baseBlockTag: EthereumBlockTag = 'latest',
+): Promise<PreparedSimulationExecutionContext | undefined> => {
+	if (simulationStateInput === undefined) return undefined
+	if (isEmptySimulationInput(simulationStateInput)) return undefined
+	const parentBlock = await ethereumClientService.getBlock(requestAbortController, baseBlockTag)
+	if (parentBlock === null) throw new Error('The latest block is null')
+	const prepared = await ethereumClientService.prepareEthSimulateV1Input(simulationStateInput, parentBlock.number, requestAbortController)
+	let previousBlockHash = parentBlock.hash
+	let previousGasUsed = parentBlock.gasUsed
+	let previousBaseFeePerGas = parentBlock.baseFeePerGas
+	let previousBlockNumber = parentBlock.number
+	let previousTotalDifficulty = parentBlock.totalDifficulty ?? 0n
+	const executionBlocks = prepared.rpcBlocks.map((inputBlock, blockIndex) => {
+		const blockOverride = prepared.blockOverrides[blockIndex]
+		if (blockOverride === undefined) throw new Error('missing block override for prepared simulation block')
+		if (blockOverride.time === undefined) throw new Error('missing timestamp for prepared simulation block')
+		const gasUsed = transactionQueueTotalGasLimitFromInput(inputBlock)
+		const baseFeePerGas = previousBaseFeePerGas === undefined ? undefined : getNextBaseFeePerGas(previousGasUsed, parentBlock.gasLimit, previousBaseFeePerGas)
+		const blockHash = getHashOfSimulatedBlockFromInput(simulationStateInput, blockIndex)
+		const executionBlock = {
+			inputBlock,
+			blockNumber: previousBlockNumber + 1n,
+			blockHash,
+			parentHash: previousBlockHash,
+			blockTimestamp: blockOverride.time,
+			gasUsed,
+			baseFeePerGas,
+			totalDifficulty: previousTotalDifficulty + parentBlock.difficulty,
+		}
+		previousBlockHash = blockHash
+		previousGasUsed = gasUsed
+		previousBaseFeePerGas = baseFeePerGas
+		previousBlockNumber = executionBlock.blockNumber
+		previousTotalDifficulty = executionBlock.totalDifficulty
+		return executionBlock
+	})
+	return {
+		simulationStateInput,
+		parentBlock,
+		prepared,
+		executionBlocks,
+	}
+}
+
+const resolveSimulationBlockTag = (
+	baseBlockNumber: bigint,
+	executionBlockCount: number,
+	blockTag: EthereumBlockTag = 'latest',
+) => {
+	if (blockTag === 'latest' || blockTag === 'pending') return baseBlockNumber + BigInt(executionBlockCount)
+	return blockTag
+}
+
+const canQueryNodeDirectlyFromInput = (
+	baseBlockNumber: bigint,
+	executionBlockCount: number,
+	blockTag: EthereumBlockTag = 'latest',
+) => {
+	if (blockTag === 'finalized') return true
+	if (executionBlockCount === 0) return true
+	if (typeof blockTag === 'bigint' && blockTag <= baseBlockNumber) return true
+	return false
+}
+
+const getExecutionBlockIndexForTag = (
+	baseBlockNumber: bigint,
+	executionBlockCount: number,
+	blockTag: EthereumBlockTag = 'latest',
+) => {
+	const resolvedBlockTag = resolveSimulationBlockTag(baseBlockNumber, executionBlockCount, blockTag)
+	if (typeof resolvedBlockTag !== 'bigint') return undefined
+	if (resolvedBlockTag <= baseBlockNumber) return undefined
+	if (resolvedBlockTag > baseBlockNumber + BigInt(executionBlockCount)) return undefined
+	return Number(resolvedBlockTag - baseBlockNumber - 1n)
+}
+
+const getExecutionBlocksUpToTag = (
+	context: PreparedSimulationExecutionContext,
+	blockTag: EthereumBlockTag = 'latest',
+) => {
+	const resolvedBlockTag = resolveSimulationBlockTag(context.parentBlock.number, context.executionBlocks.length, blockTag)
+	if (typeof resolvedBlockTag !== 'bigint' || resolvedBlockTag <= context.parentBlock.number) return []
+	const includedBlockCount = min(
+		BigInt(context.executionBlocks.length),
+		resolvedBlockTag - context.parentBlock.number,
+	)
+	return context.executionBlocks.slice(0, Number(includedBlockCount))
 }
 
 export const simulationGasLeft = (simulationStateBlock: SimulationStateBlock | undefined, blockHeader: EthereumBlockHeader) => {
@@ -189,29 +340,13 @@ export const groupEthSimulateV1ResultByInputBlocks = (prepared: PreparedEthSimul
 	return groupedResults
 }
 
-export const createSimulationState = async (ethereumClientService: EthereumClientService, requestAbortController: AbortController | undefined, simulationStateInput: SimulationStateInput): Promise<SimulationState> => {
+export const inspectSimulationInput = async (
+	ethereumClientService: EthereumClientService,
+	requestAbortController: AbortController | undefined,
+	simulationStateInput: SimulationStateInput,
+): Promise<SimulationInputInspection> => {
 	const parentBlock = await ethereumClientService.getBlock(requestAbortController)
 	if (parentBlock === null) throw new Error('The latest block is null')
-	if (simulationStateInput.length === 0 || (simulationStateInput[0]?.transactions.length === 0 && simulationStateInput[0]?.transactions.length === 0 && simulationStateInput.length === 1)) {
-		// if there's no blocks, or there's an empty block (that can have state overrides), skip simulation and return empty results
-		return {
-			rpcNetwork: ethereumClientService.getRpcEntry(),
-			success: true,
-			simulationStateInput,
-			simulatedBlocks: simulationStateInput.map(() => ({
-				simulatedTransactions: [],
-				signedMessages: [],
-				stateOverrides: simulationStateInput[0]?.stateOverrides || {},
-				blockTimestamp: new Date(getNextBlockTimeStampOverride(parentBlock.timestamp, simulationStateInput[0]?.blockTimeManipulation || DEFAULT_BLOCK_MANIPULATION)),
-				blockTimeManipulation: simulationStateInput[0]?.blockTimeManipulation || DEFAULT_BLOCK_MANIPULATION,
-				blockBaseFeePerGas: parentBlock.baseFeePerGas || 0n,
-			})),
-			blockNumber: parentBlock.number,
-			blockTimestamp: new Date(),
-			simulationConductedTimestamp: new Date(),
-			baseFeePerGas: 0n,
-		}
-	}
 	const base = {
 		simulationStateInput,
 		blockNumber: parentBlock.number,
@@ -220,33 +355,48 @@ export const createSimulationState = async (ethereumClientService: EthereumClien
 		simulationConductedTimestamp: new Date(),
 		rpcNetwork: ethereumClientService.getRpcEntry(),
 	}
+	if (isEmptySimulationInput(simulationStateInput)) {
+		let previousTimestamp = parentBlock.timestamp
+		return {
+			success: true,
+			base,
+			groupedEthSimulateV1CallResult: simulationStateInput.map((inputBlock) => {
+				previousTimestamp = getNextBlockTimeStampOverride(previousTimestamp, inputBlock.blockTimeManipulation || DEFAULT_BLOCK_MANIPULATION)
+				return {
+					inputBlock,
+					baseFeePerGas: parentBlock.baseFeePerGas || 0n,
+					timestamp: dateToBigintSeconds(previousTimestamp),
+					calls: [],
+				}
+			}),
+		}
+	}
 	try {
 		const { prepared, result: ethSimulateV1CallResult } = await ethereumClientService.simulatePrepared(simulationStateInput, parentBlock.number, requestAbortController)
 		const groupedEthSimulateV1CallResult = groupEthSimulateV1ResultByInputBlocks(prepared, ethSimulateV1CallResult)
-		const baseFeePerGas = groupedEthSimulateV1CallResult[0]?.baseFeePerGas ?? 0n
-
-		const tokenBalancesAfter = await getTokenBalancesAfter(
-			ethereumClientService,
-			requestAbortController,
-			groupedEthSimulateV1CallResult,
-			simulationStateInput,
-		)
 		return {
 			success: true,
-			simulatedBlocks: groupedEthSimulateV1CallResult.map((callResult, blockIndex) => ({
-				simulatedTransactions: callResult.calls.map((singleResult, transactionIndex) => {
-					const tokenBalancesAfterForIndex = tokenBalancesAfter.blocks[blockIndex]?.transactions[transactionIndex]?.tokenBalancesAfter
-					const signedTx = simulationStateInput[blockIndex]?.transactions[transactionIndex]
-					if (signedTx === undefined) throw Error('invalid transaction index')
-					if (tokenBalancesAfterForIndex === undefined) throw Error('invalid tokenBalancesAfterForIndex index')
-					return {
-						type: 'transaction',
-						ethSimulateV1CallResult: singleResult,
-						realizedGasPrice: calculateRealizedEffectiveGasPrice(signedTx.signedTransaction, callResult.baseFeePerGas),
-						preSimulationTransaction: signedTx,
-						tokenBalancesAfter: tokenBalancesAfterForIndex,
-					}
-				}),
+			base: {
+				...base,
+				baseFeePerGas: groupedEthSimulateV1CallResult[0]?.baseFeePerGas ?? 0n,
+			},
+			groupedEthSimulateV1CallResult,
+		}
+	} catch(error: unknown) {
+		if (error instanceof JsonRpcResponseError) return { success: false, base, jsonRpcError: error.serialize() }
+		throw error
+	}
+}
+
+export const createSimulationState = async (ethereumClientService: EthereumClientService, requestAbortController: AbortController | undefined, simulationStateInput: SimulationStateInput): Promise<SimulationState> => {
+	const simulationInspection = await inspectSimulationInput(ethereumClientService, requestAbortController, simulationStateInput)
+	if (simulationInspection.success === false) return { ...simulationInspection.base, success: false, jsonRpcError: simulationInspection.jsonRpcError }
+	const { base, groupedEthSimulateV1CallResult } = simulationInspection
+	if (isEmptySimulationInput(simulationStateInput)) {
+		return {
+			success: true,
+			simulatedBlocks: groupedEthSimulateV1CallResult.map((callResult) => ({
+				simulatedTransactions: [],
 				signedMessages: callResult.inputBlock.signedMessages || [],
 				stateOverrides: callResult.inputBlock.stateOverrides || {},
 				blockTimestamp: bigintSecondsToDate(callResult.timestamp),
@@ -254,12 +404,70 @@ export const createSimulationState = async (ethereumClientService: EthereumClien
 				blockBaseFeePerGas: callResult.baseFeePerGas,
 			})),
 			...base,
-			baseFeePerGas: baseFeePerGas,
 		}
-	} catch(error: unknown) {
-		if (error instanceof JsonRpcResponseError) return { ...base, success: false, jsonRpcError: error.serialize() }
-		throw error
 	}
+	const tokenBalancesAfter = await getTokenBalancesAfter(
+		ethereumClientService,
+		requestAbortController,
+		groupedEthSimulateV1CallResult,
+		simulationStateInput,
+	)
+	return {
+		success: true,
+		simulatedBlocks: groupedEthSimulateV1CallResult.map((callResult, blockIndex) => ({
+			simulatedTransactions: callResult.calls.map((singleResult, transactionIndex) => {
+				const tokenBalancesAfterForIndex = tokenBalancesAfter.blocks[blockIndex]?.transactions[transactionIndex]?.tokenBalancesAfter
+				const signedTx = simulationStateInput[blockIndex]?.transactions[transactionIndex]
+				if (signedTx === undefined) throw Error('invalid transaction index')
+				if (tokenBalancesAfterForIndex === undefined) throw Error('invalid tokenBalancesAfterForIndex index')
+				return {
+					type: 'transaction',
+					ethSimulateV1CallResult: singleResult,
+					realizedGasPrice: calculateRealizedEffectiveGasPrice(signedTx.signedTransaction, callResult.baseFeePerGas),
+					preSimulationTransaction: signedTx,
+					tokenBalancesAfter: tokenBalancesAfterForIndex,
+				}
+			}),
+			signedMessages: callResult.inputBlock.signedMessages || [],
+			stateOverrides: callResult.inputBlock.stateOverrides || {},
+			blockTimestamp: bigintSecondsToDate(callResult.timestamp),
+			blockTimeManipulation: callResult.inputBlock.blockTimeManipulation || DEFAULT_BLOCK_MANIPULATION,
+			blockBaseFeePerGas: callResult.baseFeePerGas,
+		})),
+		...base,
+	}
+}
+
+const createPreparedSimulatedExecutionBlocks = async (
+	ethereumClientService: EthereumClientService,
+	requestAbortController: AbortController | undefined,
+	simulationState: SuccessfulSimulationState,
+): Promise<readonly PreparedSimulatedExecutionBlock[]> => {
+	const context = await createPreparedSimulationExecutionContext(ethereumClientService, requestAbortController, simulationState.simulationStateInput, simulationState.blockNumber)
+	if (context === undefined) return []
+	let executionBlockOffset = 0
+	return context.prepared.inputBlocks.flatMap((preparedInputBlock, inputBlockIndex) => {
+		const simulatedBlock = simulationState.simulatedBlocks[inputBlockIndex]
+		if (simulatedBlock === undefined) throw new Error('missing simulated block while splitting execution blocks')
+		let transactionOffset = 0
+		const executionBlocksForInputBlock = Array.from({ length: preparedInputBlock.rpcBlockCount }, () => {
+			const executionBlock = context.executionBlocks[executionBlockOffset]
+			const rpcBlock = context.prepared.rpcBlocks[executionBlockOffset]
+			executionBlockOffset += 1
+			if (executionBlock === undefined) throw new Error('missing prepared execution block while splitting simulation results')
+			if (rpcBlock === undefined) throw new Error('missing prepared rpc block while splitting simulation results')
+			const transactionCount = rpcBlock.transactions.length
+			const simulatedTransactions = simulatedBlock.simulatedTransactions.slice(transactionOffset, transactionOffset + transactionCount)
+			if (simulatedTransactions.length !== transactionCount) throw new Error('prepared rpc block transaction count did not match simulated transactions')
+			transactionOffset += transactionCount
+			return {
+				...executionBlock,
+				simulatedTransactions,
+			}
+		})
+		if (transactionOffset !== simulatedBlock.simulatedTransactions.length) throw new Error('simulated transactions remained after splitting execution blocks')
+		return executionBlocksForInputBlock
+	})
 }
 
 export const getPreSimulated = (simulatedTransactions: readonly SimulatedTransaction[]) => simulatedTransactions.map((transaction) => transaction.preSimulationTransaction)
@@ -300,38 +508,44 @@ export const appendTransactionToInputAndSimulate = async (ethereumClientService:
 	return await createSimulationState(ethereumClientService, requestAbortController, simulationStateInput)
 }
 
-export const getNonceFixedSimulationStateInput = async(ethereumClientService: EthereumClientService, requestAbortController: AbortController | undefined, oldSimulationState: SimulationState) => {
-	const isFixableNonceError = (transaction: SimulatedTransaction) => {
-		return transaction.ethSimulateV1CallResult.status === 'failure'
-		&& transaction.ethSimulateV1CallResult.error.message === 'wrong transaction nonce' //TODO, change to error code
-		&& transaction.preSimulationTransaction.originalRequestParameters.method === 'eth_sendTransaction'
+export const getNonceFixedSimulationStateInput = async(ethereumClientService: EthereumClientService, requestAbortController: AbortController | undefined, simulationStateInput: SimulationStateInput) => {
+	const isFixableNonceError = (transaction: PreSimulationTransaction, callResult: EthSimulateV1CallResult) => {
+		return callResult.status === 'failure'
+		&& callResult.error.message === 'wrong transaction nonce' //TODO, change to error code
+		&& transaction.originalRequestParameters.method === 'eth_sendTransaction'
 	}
-	if (oldSimulationState.success === false) return { nonceFixed: false, simulationStateInput: oldSimulationState.simulationStateInput }
+	const simulationInspection = await inspectSimulationInput(ethereumClientService, requestAbortController, simulationStateInput)
+	if (simulationInspection.success === false) return { nonceFixed: false, simulationStateInput }
 	const knownPreviousNonce = new Map<string, bigint>()
-	const blocks = oldSimulationState.simulatedBlocks || []
+	const blocks = simulationInspection.groupedEthSimulateV1CallResult
 
 	const areThereNonceIssues = () => {
-		const nonceFixable = blocks.find((block) => block.simulatedTransactions.find((transaction) => isFixableNonceError(transaction)))
+		const nonceFixable = blocks.find((block, blockIndex) => block.calls.find((callResult, transactionIndex) => {
+			const transaction = simulationStateInput[blockIndex]?.transactions[transactionIndex]
+			if (transaction === undefined) return false
+			return isFixableNonceError(transaction, callResult)
+		}))
 		return nonceFixable !== undefined
 	}
-	if (!areThereNonceIssues()) return { nonceFixed: false, simulationStateInput: oldSimulationState.simulationStateInput  }
+	if (!areThereNonceIssues()) return { nonceFixed: false, simulationStateInput }
 	let simulationInputBlocks = []
 	for (const [blockIndex, block] of blocks.entries()) {
 		const processedTransactions: PreSimulationTransaction[] = []
-		for (const transaction of block.simulatedTransactions) {
-			const preSimulationTransaction = transaction.preSimulationTransaction
+		for (const [transactionIndex, callResult] of block.calls.entries()) {
+			const preSimulationTransaction = simulationStateInput[blockIndex]?.transactions[transactionIndex]
+			if (preSimulationTransaction === undefined) throw new Error('missing transaction when checking for nonces')
 			const fromString = addressString(preSimulationTransaction.signedTransaction.from)
-			const fixTransaction = async (transaction: SimulatedTransaction) => {
-				if (!isFixableNonceError(transaction)) return preSimulationTransaction
+			const fixTransaction = async () => {
+				if (!isFixableNonceError(preSimulationTransaction, callResult)) return preSimulationTransaction
 				const prevNonce = knownPreviousNonce.get(fromString)
 				const newNonce = prevNonce === undefined ? await ethereumClientService.getTransactionCount(preSimulationTransaction.signedTransaction.from, 'latest', requestAbortController) : prevNonce + 1n
-				return modifyObject(preSimulationTransaction, { signedTransaction: modifyObject(transaction.preSimulationTransaction.signedTransaction, { nonce: newNonce }) })
+				return modifyObject(preSimulationTransaction, { signedTransaction: modifyObject(preSimulationTransaction.signedTransaction, { nonce: newNonce }) })
 			}
-			const fixedTransaction = await fixTransaction(transaction)
+			const fixedTransaction = await fixTransaction()
 			processedTransactions.push(fixedTransaction)
 			knownPreviousNonce.set(fromString, fixedTransaction.signedTransaction.nonce)
 		}
-		const oldBlock = oldSimulationState.simulationStateInput[blockIndex]
+		const oldBlock = simulationStateInput[blockIndex]
 		if (oldBlock === undefined) throw new Error('missing block when checking for nonces')
 		simulationInputBlocks.push({ ...oldBlock, transactions: processedTransactions })
 	}
@@ -353,7 +567,7 @@ const canQueryNodeDirectly = async (simulationState: SimulationState, blockTag: 
 	if (simulationState === undefined
 		|| blockTag === 'finalized'
 		|| (simulationState.success && simulationState.simulatedBlocks.length === 0)
-		|| (simulationState.success && typeof blockTag === 'bigint' && blockTag <= simulationState.blockNumber + BigInt(simulationState.simulatedBlocks.length))
+		|| (simulationState.success && typeof blockTag === 'bigint' && blockTag <= simulationState.blockNumber)
 	){
 		return true
 	}
@@ -365,8 +579,6 @@ export const getDeployedContractAddress = (from: EthereumAddress, nonce: Ethereu
 }
 
 export const getSimulatedTransactionReceipt = async (ethereumClientService: EthereumClientService, requestAbortController: AbortController | undefined, simulationState: SimulationState | undefined, hash: bigint): Promise<EthTransactionReceiptResponse> => {
-	let cumGas = 0n
-	let currentLogIndex = 0
 	if (simulationState === undefined) { return await ethereumClientService.getTransactionReceipt(hash, requestAbortController) }
 	if (simulationState.success === false) throw new JsonRpcResponseError(simulationState.jsonRpcError)
 	const getTransactionSpecificFields = (signedTransaction: EthereumSendableSignedTransaction) => {
@@ -383,45 +595,48 @@ export const getSimulatedTransactionReceipt = async (ethereumClientService: Ethe
 				type: signedTransaction.type,
 				authorizationList: signedTransaction.authorizationList
 			}
-			default: assertNever(signedTransaction)
-		}
-	}
-
-	const blockNum = await ethereumClientService.getBlockNumber(requestAbortController)
-	for (const [blockDelta, block] of simulationState.simulatedBlocks.entries()) {
-		for (const [transactionIndex, simulatedTransaction] of block.simulatedTransactions.entries()) {
-			cumGas += simulatedTransaction.ethSimulateV1CallResult.gasUsed
-			if (hash === simulatedTransaction.preSimulationTransaction.signedTransaction.hash) {
-				return {
-					...getTransactionSpecificFields(simulatedTransaction.preSimulationTransaction.signedTransaction),
-					blockHash: getHashOfSimulatedBlock(simulationState, blockDelta),
-					blockNumber: blockNum + BigInt(blockDelta) + 1n,
-					transactionHash: simulatedTransaction.preSimulationTransaction.signedTransaction.hash,
-					transactionIndex: BigInt(transactionIndex),
-					contractAddress: simulatedTransaction.preSimulationTransaction.signedTransaction.to !== null ? null : getDeployedContractAddress(simulatedTransaction.preSimulationTransaction.signedTransaction.from, simulatedTransaction.preSimulationTransaction.signedTransaction.nonce),
-					cumulativeGasUsed: cumGas,
-					gasUsed: simulatedTransaction.ethSimulateV1CallResult.gasUsed,
-					effectiveGasPrice: calculateRealizedEffectiveGasPrice(simulatedTransaction.preSimulationTransaction.signedTransaction, simulationState.baseFeePerGas),
-					from: simulatedTransaction.preSimulationTransaction.signedTransaction.from,
-					to: simulatedTransaction.preSimulationTransaction.signedTransaction.to,
-					logs: simulatedTransaction.ethSimulateV1CallResult.status === 'success'
-						? simulatedTransaction.ethSimulateV1CallResult.logs.map((x, logIndex) => ({
-							removed: false,
-							blockHash: getHashOfSimulatedBlock(simulationState, blockDelta),
-							address: x.address,
-							logIndex: BigInt(currentLogIndex + logIndex),
-							data: x.data,
-							topics: x.topics,
-							blockNumber: blockNum,
-							transactionIndex: BigInt(transactionIndex),
-							transactionHash: simulatedTransaction.preSimulationTransaction.signedTransaction.hash
-						}))
-						: [],
-					logsBloom: 0x0n, //TODO: what should this be?
-					status: simulatedTransaction.ethSimulateV1CallResult.status
-				}
+				default: assertNever(signedTransaction)
 			}
-			currentLogIndex += simulatedTransaction.ethSimulateV1CallResult.status === 'success' ? simulatedTransaction.ethSimulateV1CallResult.logs.length : 0
+		}
+
+	const executionBlocks = await createPreparedSimulatedExecutionBlocks(ethereumClientService, requestAbortController, simulationState)
+	for (const executionBlock of executionBlocks) {
+		let cumulativeGasUsed = 0n
+		let currentLogIndex = 0
+		for (const [transactionIndex, simulatedTransaction] of executionBlock.simulatedTransactions.entries()) {
+			cumulativeGasUsed += simulatedTransaction.ethSimulateV1CallResult.gasUsed
+			if (hash !== simulatedTransaction.preSimulationTransaction.signedTransaction.hash) {
+				currentLogIndex += simulatedTransaction.ethSimulateV1CallResult.status === 'success' ? simulatedTransaction.ethSimulateV1CallResult.logs.length : 0
+				continue
+			}
+			return {
+				...getTransactionSpecificFields(simulatedTransaction.preSimulationTransaction.signedTransaction),
+				blockHash: executionBlock.blockHash,
+				blockNumber: executionBlock.blockNumber,
+				transactionHash: simulatedTransaction.preSimulationTransaction.signedTransaction.hash,
+				transactionIndex: BigInt(transactionIndex),
+				contractAddress: simulatedTransaction.preSimulationTransaction.signedTransaction.to !== null ? null : getDeployedContractAddress(simulatedTransaction.preSimulationTransaction.signedTransaction.from, simulatedTransaction.preSimulationTransaction.signedTransaction.nonce),
+				cumulativeGasUsed,
+				gasUsed: simulatedTransaction.ethSimulateV1CallResult.gasUsed,
+				effectiveGasPrice: calculateRealizedEffectiveGasPrice(simulatedTransaction.preSimulationTransaction.signedTransaction, executionBlock.baseFeePerGas || 0n),
+				from: simulatedTransaction.preSimulationTransaction.signedTransaction.from,
+				to: simulatedTransaction.preSimulationTransaction.signedTransaction.to,
+				logs: simulatedTransaction.ethSimulateV1CallResult.status === 'success'
+					? simulatedTransaction.ethSimulateV1CallResult.logs.map((x, logIndex) => ({
+						removed: false,
+						blockHash: executionBlock.blockHash,
+						address: x.address,
+						logIndex: BigInt(currentLogIndex + logIndex),
+						data: x.data,
+						topics: x.topics,
+						blockNumber: executionBlock.blockNumber,
+						transactionIndex: BigInt(transactionIndex),
+						transactionHash: simulatedTransaction.preSimulationTransaction.signedTransaction.hash
+					}))
+					: [],
+				logsBloom: 0x0n, //TODO: what should this be?
+				status: simulatedTransaction.ethSimulateV1CallResult.status
+			}
 		}
 	}
 	return await ethereumClientService.getTransactionReceipt(hash, requestAbortController)
@@ -491,6 +706,322 @@ const getNextBaseFeePerGas = (parentGasUsed: bigint, parentGasLimit: bigint, par
 	return max(0n, parentBaseFeePerGas - parentBaseFeePerGas * (parentGasTarget - parentGasUsed) / parentGasTarget / ETHEREUM_EIP1559_BASEFEECHANGEDENOMINATOR)
 }
 
+const getSimulatedMockBlockFromPreparedContext = async (
+	context: PreparedSimulationExecutionContext,
+	blockIndex: number,
+) => {
+	const block = context.executionBlocks[blockIndex]
+	if (block === undefined) return null
+	const parentBlock = context.parentBlock
+	return {
+		author: parentBlock.miner,
+		difficulty: parentBlock.difficulty,
+		extraData: parentBlock.extraData,
+		gasLimit: parentBlock.gasLimit,
+		gasUsed: block.gasUsed,
+		hash: block.blockHash,
+		logsBloom: parentBlock.logsBloom, // TODO: this is wrong
+		miner: parentBlock.miner,
+		mixHash: parentBlock.mixHash, // TODO: this is wrong
+		nonce: parentBlock.nonce,
+		number: block.blockNumber,
+		parentHash: block.parentHash,
+		receiptsRoot: parentBlock.receiptsRoot, // TODO: this is wrong
+		sha3Uncles: parentBlock.sha3Uncles, // TODO: this is wrong
+		stateRoot: parentBlock.stateRoot, // TODO: this is wrong
+		timestamp: block.blockTimestamp,
+		size: parentBlock.size, // TODO: this is wrong
+		totalDifficulty: block.totalDifficulty,
+		uncles: [],
+		baseFeePerGas: block.baseFeePerGas,
+		transactionsRoot: parentBlock.transactionsRoot, // TODO: this is wrong
+		transactions: block.inputBlock.transactions.map((transaction) => transaction.signedTransaction),
+		withdrawals: [],
+		withdrawalsRoot: 0n, // TODO: this is wrong
+	} as const
+}
+
+const getSimulatedTransactionCountFromPreparedInputContext = async (
+	ethereumClientService: EthereumClientService,
+	requestAbortController: AbortController | undefined,
+	context: PreparedSimulationExecutionContext | undefined,
+	address: bigint,
+	blockTag: EthereumBlockTag = 'latest',
+) => {
+	if (context === undefined) {
+		return await ethereumClientService.getTransactionCount(address, blockTag, requestAbortController)
+	}
+	const baseBlockNumber = context.parentBlock.number
+	if (canQueryNodeDirectlyFromInput(baseBlockNumber, context.executionBlocks.length, blockTag)) {
+		return await ethereumClientService.getTransactionCount(address, blockTag, requestAbortController)
+	}
+	const resolvedBlockTag = resolveSimulationBlockTag(baseBlockNumber, context.executionBlocks.length, blockTag)
+	const blockNumToUseForChain = typeof resolvedBlockTag === 'bigint' ? min(resolvedBlockTag, await ethereumClientService.getBlockNumber(requestAbortController)) : resolvedBlockTag
+	let addedTransactions = 0n
+	for (const block of getExecutionBlocksUpToTag(context, blockTag)) {
+		for (const transaction of block.inputBlock.transactions) {
+			if (transaction.signedTransaction.from === address) addedTransactions += 1n
+		}
+	}
+	return (await ethereumClientService.getTransactionCount(address, blockNumToUseForChain, requestAbortController)) + addedTransactions
+}
+
+export const getSimulatedTransactionCountFromInput = async (
+	ethereumClientService: EthereumClientService,
+	requestAbortController: AbortController | undefined,
+	simulationStateInput: SimulationStateInput | undefined,
+	address: bigint,
+	blockTag: EthereumBlockTag = 'latest',
+) => {
+	const context = await createPreparedSimulationExecutionContext(ethereumClientService, requestAbortController, simulationStateInput)
+	return await getSimulatedTransactionCountFromPreparedInputContext(ethereumClientService, requestAbortController, context, address, blockTag)
+}
+
+export const getSimulatedBlockNumberFromInput = async (
+	ethereumClientService: EthereumClientService,
+	requestAbortController: AbortController | undefined,
+	simulationStateInput: SimulationStateInput | undefined,
+) => {
+	if (simulationStateInput === undefined) return await ethereumClientService.getBlockNumber(requestAbortController)
+	const context = await createPreparedSimulationExecutionContext(ethereumClientService, requestAbortController, simulationStateInput)
+	if (context === undefined) return await ethereumClientService.getBlockNumber(requestAbortController)
+	return context.parentBlock.number + BigInt(context.executionBlocks.length)
+}
+
+export async function getSimulatedBlockFromInput(ethereumClientService: EthereumClientService, requestAbortController: AbortController | undefined, simulationStateInput: SimulationStateInput | undefined, blockTag?: EthereumBlockTag, fullObjects?: true): Promise<EthereumBlockHeader>
+export async function getSimulatedBlockFromInput(ethereumClientService: EthereumClientService, requestAbortController: AbortController | undefined, simulationStateInput: SimulationStateInput | undefined, blockTag: EthereumBlockTag, fullObjects: boolean): Promise<EthereumBlockHeader | EthereumBlockHeaderWithTransactionHashes>
+export async function getSimulatedBlockFromInput(ethereumClientService: EthereumClientService, requestAbortController: AbortController | undefined, simulationStateInput: SimulationStateInput | undefined, blockTag: EthereumBlockTag, fullObjects: false): Promise<EthereumBlockHeaderWithTransactionHashes>
+export async function getSimulatedBlockFromInput(ethereumClientService: EthereumClientService, requestAbortController: AbortController | undefined, simulationStateInput: SimulationStateInput | undefined, blockTag: EthereumBlockTag = 'latest', fullObjects = true): Promise<EthereumBlockHeader | EthereumBlockHeaderWithTransactionHashes> {
+	if (simulationStateInput === undefined) return await ethereumClientService.getBlock(requestAbortController, blockTag, fullObjects)
+	const context = await createPreparedSimulationExecutionContext(ethereumClientService, requestAbortController, simulationStateInput)
+	if (context === undefined || canQueryNodeDirectlyFromInput(context.parentBlock.number, context.executionBlocks.length, blockTag)) {
+		return await ethereumClientService.getBlock(requestAbortController, blockTag, fullObjects)
+	}
+	const blockIndex = getExecutionBlockIndexForTag(context.parentBlock.number, context.executionBlocks.length, blockTag)
+	if (blockIndex === undefined) return null
+	const block = await getSimulatedMockBlockFromPreparedContext(context, blockIndex)
+	if (block === null) return null
+	if (fullObjects) return block
+	return { ...block, transactions: block.transactions.map((transaction) => transaction.hash) }
+}
+
+export const getSimulatedBlockByHashFromInput = async (
+	ethereumClientService: EthereumClientService,
+	requestAbortController: AbortController | undefined,
+	simulationStateInput: SimulationStateInput | undefined,
+	blockHash: EthereumBytes32,
+	fullObjects: boolean,
+): Promise<EthereumBlockHeader | EthereumBlockHeaderWithTransactionHashes> => {
+	if (simulationStateInput === undefined) return await ethereumClientService.getBlockByHash(blockHash, requestAbortController, fullObjects)
+	const context = await createPreparedSimulationExecutionContext(ethereumClientService, requestAbortController, simulationStateInput)
+	if (context === undefined) return await ethereumClientService.getBlockByHash(blockHash, requestAbortController, fullObjects)
+	const blockIndex = context.executionBlocks.findIndex((block) => block.blockHash === blockHash)
+	if (blockIndex < 0) return await ethereumClientService.getBlockByHash(blockHash, requestAbortController, fullObjects)
+	const block = await getSimulatedMockBlockFromPreparedContext(context, blockIndex)
+	if (block === null) return null
+	if (fullObjects) return block
+	return { ...block, transactions: block.transactions.map((transaction) => transaction.hash) }
+}
+
+export const getSimulatedTransactionByHashFromInput = async (
+	ethereumClientService: EthereumClientService,
+	requestAbortController: AbortController | undefined,
+	simulationStateInput: SimulationStateInput | undefined,
+	hash: bigint,
+): Promise<EthereumSignedTransactionWithBlockData | null> => {
+	if (simulationStateInput === undefined) return await ethereumClientService.getTransactionByHash(hash, requestAbortController)
+		const context = await createPreparedSimulationExecutionContext(ethereumClientService, requestAbortController, simulationStateInput)
+		if (context === undefined) return await ethereumClientService.getTransactionByHash(hash, requestAbortController)
+		for (const executionBlock of context.executionBlocks) {
+			for (const [transactionIndex, transaction] of executionBlock.inputBlock.transactions.entries()) {
+				if (transaction.signedTransaction.hash !== hash) continue
+				const v = getSignedTransactionV(transaction.signedTransaction)
+				const gasPrice = 'gasPrice' in transaction.signedTransaction
+					? transaction.signedTransaction.gasPrice
+					: calculateRealizedEffectiveGasPrice(transaction.signedTransaction, executionBlock.baseFeePerGas || 0n)
+				return {
+				...transaction.signedTransaction,
+				blockHash: executionBlock.blockHash,
+				blockNumber: executionBlock.blockNumber,
+				transactionIndex: BigInt(transactionIndex),
+				data: transaction.signedTransaction.input,
+				v,
+				gasPrice,
+			}
+		}
+	}
+	return await ethereumClientService.getTransactionByHash(hash, requestAbortController)
+}
+
+const simulatedCallWithPreparedInputContext = async (
+	ethereumClientService: EthereumClientService,
+	requestAbortController: AbortController | undefined,
+	context: PreparedSimulationExecutionContext | undefined,
+	params: Pick<IUnsignedTransaction1559, 'to' | 'maxFeePerGas' | 'maxPriorityFeePerGas' | 'input' | 'value'> & Partial<Pick<IUnsignedTransaction1559, 'from' | 'gasLimit'>>,
+	blockTag: EthereumBlockTag = 'latest',
+) => {
+	if (blockTag === 'finalized') {
+		try {
+			return { result: EthereumData.parse(ethereumClientService.call(params, 'finalized', requestAbortController)) }
+		} catch(error: unknown) {
+			if (error instanceof JsonRpcResponseError) {
+				const safeParsedData = EthereumData.safeParse(error.data)
+				return { error: { code: error.code, message: error.message, data: safeParsedData.success ? dataStringWith0xStart(safeParsedData.value) : '0x' } }
+			}
+			throw error
+		}
+	}
+	const from = params.from ?? DEFAULT_CALL_ADDRESS
+	const transaction = {
+		...params,
+		type: '1559',
+		gas: params.gasLimit,
+		from,
+		nonce: await getSimulatedTransactionCountFromPreparedInputContext(ethereumClientService, requestAbortController, context, from, blockTag),
+		chainId: ethereumClientService.getChainId(),
+	} as const
+	try {
+		const currentBlock = context?.parentBlock ?? await ethereumClientService.getBlock(requestAbortController)
+		if (currentBlock === null) throw new Error('cannot perform call on top of missing block')
+		const simulatedTransactions = await simulateTransactionsOnTopOfSimulationInput(ethereumClientService, requestAbortController, context?.simulationStateInput, [{ ...transaction, gas: params.gasLimit === undefined ? currentBlock.gasLimit : params.gasLimit }])
+		const callResult = simulatedTransactions[simulatedTransactions.length - 1]
+		if (callResult === undefined) throw new Error('failed to get last call in eth simulate')
+		if (callResult.status === 'failure') return { error: callResult.error }
+		return { result: callResult.returnData }
+	} catch(error: unknown) {
+		if (error instanceof JsonRpcResponseError) {
+			const safeParsedData = EthereumData.safeParse(error.data)
+			return { error: { code: error.code, message: error.message, data: safeParsedData.success ? dataStringWith0xStart(safeParsedData.value) : '0x' } }
+		}
+		throw error
+	}
+}
+
+export const simulatedCallFromInput = async (
+	ethereumClientService: EthereumClientService,
+	requestAbortController: AbortController | undefined,
+	simulationStateInput: SimulationStateInput | undefined,
+	params: Pick<IUnsignedTransaction1559, 'to' | 'maxFeePerGas' | 'maxPriorityFeePerGas' | 'input' | 'value'> & Partial<Pick<IUnsignedTransaction1559, 'from' | 'gasLimit'>>,
+	blockTag: EthereumBlockTag = 'latest',
+) => {
+	return await simulatedCallWithPreparedInputContext(
+		ethereumClientService,
+		requestAbortController,
+		await createPreparedSimulationExecutionContext(ethereumClientService, requestAbortController, simulationStateInput),
+		params,
+		blockTag,
+	)
+}
+
+export const getSimulatedCodeFromInput = async (
+	ethereumClientService: EthereumClientService,
+	requestAbortController: AbortController | undefined,
+	simulationStateInput: SimulationStateInput | undefined,
+	address: bigint,
+	blockTag: EthereumBlockTag = 'latest',
+) => {
+	const context = await createPreparedSimulationExecutionContext(ethereumClientService, requestAbortController, simulationStateInput)
+	if (context === undefined || canQueryNodeDirectlyFromInput(context.parentBlock.number, context.executionBlocks.length, blockTag)) {
+		return {
+			statusCode: 'success',
+			getCodeReturn: await ethereumClientService.getCode(address, blockTag, requestAbortController)
+		} as const
+	}
+	const atInterface = new ethers.Interface(['function at(address) returns (bytes)'])
+	const input = stringToUint8Array(atInterface.encodeFunctionData('at', [addressString(address)]))
+	const getCodeTransaction = {
+		type: '1559',
+		from: MOCK_ADDRESS,
+		chainId: ethereumClientService.getChainId(),
+		maxFeePerGas: 0n,
+		maxPriorityFeePerGas: 0n,
+		gas: context.parentBlock.gasLimit,
+		to: GET_CODE_CONTRACT,
+		value: 0n,
+		input,
+		accessList: []
+	} as const
+	try {
+		const result = await simulatedCallWithPreparedInputContext(ethereumClientService, requestAbortController, context, getCodeTransaction, blockTag)
+		if ('error' in result) return { statusCode: 'failure' } as const
+		const parsed = atInterface.decodeFunctionResult('at', result.result)
+		return { statusCode: 'success', getCodeReturn: EthereumData.parse(parsed.toString()) } as const
+	} catch(error: unknown) {
+		if (error instanceof JsonRpcResponseError) return { statusCode: 'failure' } as const
+		throw error
+	}
+}
+
+export const getSimulatedBalanceFromInput = async (
+	ethereumClientService: EthereumClientService,
+	requestAbortController: AbortController | undefined,
+	simulationStateInput: SimulationStateInput | undefined,
+	address: bigint,
+	blockTag: EthereumBlockTag = 'latest',
+): Promise<bigint> => {
+	if (simulationStateInput === undefined) return await ethereumClientService.getBalance(address, blockTag, requestAbortController)
+	const context = await createPreparedSimulationExecutionContext(ethereumClientService, requestAbortController, simulationStateInput)
+	if (context === undefined || canQueryNodeDirectlyFromInput(context.parentBlock.number, context.executionBlocks.length, blockTag)) {
+		return await ethereumClientService.getBalance(address, blockTag, requestAbortController)
+	}
+	const executionBlocksToApply = getExecutionBlocksUpToTag(context, blockTag)
+	if (executionBlocksToApply.length === 0) return await ethereumClientService.getBalance(address, blockTag, requestAbortController)
+	const tokenBalances = await getSimulatedTokenBalances(
+		ethereumClientService,
+		requestAbortController,
+		executionBlocksToApply.map((block) => block.inputBlock),
+		[{ token: ETHEREUM_LOGS_LOGGER_ADDRESS, owner: address, type: 'ERC20' }],
+	)
+	const balance = tokenBalances.at(-1)?.balance
+	if (balance !== undefined) return balance
+	return await ethereumClientService.getBalance(address, blockTag, requestAbortController)
+}
+
+export const simulateEstimateGasFromInput = async (
+	ethereumClientService: EthereumClientService,
+	requestAbortController: AbortController | undefined,
+	simulationStateInput: SimulationStateInput | undefined,
+	data: PartialEthereumTransaction,
+	blockDelta: number | undefined = undefined,
+): Promise<{ error: ErrorWithCodeAndOptionalData } | { gas: bigint }> => {
+	if (simulationStateInput === undefined) return { gas: await ethereumClientService.estimateGas(data, requestAbortController) }
+	const context = await createPreparedSimulationExecutionContext(ethereumClientService, requestAbortController, simulationStateInput)
+	if (context === undefined) return { gas: await ethereumClientService.estimateGas(data, requestAbortController) }
+	const sendAddress = data.from !== undefined ? data.from : MOCK_ADDRESS
+	const transactionCount = getSimulatedTransactionCountFromPreparedInputContext(ethereumClientService, requestAbortController, context, sendAddress)
+	const latestSimulatedBlock = await getSimulatedMockBlockFromPreparedContext(context, context.executionBlocks.length - 1)
+	const fallbackBlock = latestSimulatedBlock ?? context.parentBlock
+	const simulatedBlockIncrement = blockDelta === undefined ? context.executionBlocks.length : blockDelta
+	const maxGas = max(fallbackBlock.gasLimit * 1023n / 1024n - transactionQueueTotalGasLimitFromInput(context.prepared.rpcBlocks[simulatedBlockIncrement]), 0n)
+	const estimateGasTransaction = {
+		type: '1559' as const,
+		from: sendAddress,
+		chainId: ethereumClientService.getChainId(),
+		nonce: await transactionCount,
+		maxFeePerGas: 0n,
+		maxPriorityFeePerGas: 0n ,
+		gas: data.gas === undefined ? maxGas : data.gas,
+		to: data.to === undefined ? null : data.to,
+		value: data.value === undefined ? 0n : data.value,
+		input: getInputFieldFromDataOrInput(data),
+		accessList: []
+	}
+	try {
+		const simulatedTransactions = await simulateTransactionsOnTopOfSimulationInput(ethereumClientService, requestAbortController, simulationStateInput, [estimateGasTransaction], {}, true)
+		const lastResult = simulatedTransactions[simulatedTransactions.length - 1]
+		if (lastResult === undefined) return { error: { code: ERROR_INTERCEPTOR_GAS_ESTIMATION_FAILED, message: 'ETH Simulate Failed to estimate gas', data: '0x' } }
+		if (lastResult.status === 'failure') return { error: { ...lastResult.error, data: dataStringWith0xStart(lastResult.returnData) } }
+		const gasSpent = lastResult.gasUsed * 125n * 64n / (100n * 63n)
+		return { gas: gasSpent < maxGas ? gasSpent : maxGas }
+	} catch (error: unknown) {
+		if (error instanceof JsonRpcResponseError) {
+			const safeParsedData = EthereumData.safeParse(error.data)
+			return { error: { code: error.code, message: error.message, data: safeParsedData.success ? dataStringWith0xStart(safeParsedData.value) : '0x' } }
+		}
+		throw error
+	}
+}
+
 async function getSimulatedMockBlock(ethereumClientService: EthereumClientService, requestAbortController: AbortController | undefined, simulationState: SimulationState, blockDelta: number) {
 	// make a mock block based on the previous block
 	const parentBlock = await ethereumClientService.getBlock(requestAbortController)
@@ -552,11 +1083,8 @@ export async function getSimulatedBlock(ethereumClientService: EthereumClientSer
 	return { ...block, transactions: block.transactions.map((transaction) => transaction.hash) }
 }
 
-const getLogsOfSimulatedBlock = (simulationState: SimulationState, blockDelta: number, logFilter: EthGetLogsRequest): EthGetLogsResponse => {
-	if (simulationState.success === false) throw new JsonRpcResponseError(simulationState.jsonRpcError)
-	const block = simulationState?.simulatedBlocks[blockDelta]
-	if (block === undefined) return []
-	const events: EthGetLogsResponse = block.simulatedTransactions.reduce((acc, sim, transactionIndex) => {
+const getLogsOfPreparedSimulatedExecutionBlock = (executionBlock: PreparedSimulatedExecutionBlock, logFilter: EthGetLogsRequest): EthGetLogsResponse => {
+	const events: EthGetLogsResponse = executionBlock.simulatedTransactions.reduce((acc, sim, transactionIndex) => {
 		if (sim.ethSimulateV1CallResult.status === 'failure') return acc
 		return [
 			...acc,
@@ -565,8 +1093,8 @@ const getLogsOfSimulatedBlock = (simulationState: SimulationState, blockDelta: n
 				logIndex: BigInt(acc.length + logIndex),
 				transactionIndex: BigInt(transactionIndex),
 				transactionHash: sim.preSimulationTransaction.signedTransaction.hash,
-				blockHash: getHashOfSimulatedBlock(simulationState, blockDelta),
-				blockNumber: simulationState.blockNumber + BigInt(blockDelta) + 1n,
+				blockHash: executionBlock.blockHash,
+				blockNumber: executionBlock.blockNumber,
 				address: event.address,
 				data: event.data,
 				topics: event.topics
@@ -594,9 +1122,15 @@ const getLogsOfSimulatedBlock = (simulationState: SimulationState, blockDelta: n
 	)
 }
 
+const resolveLogsBlockTag = (blockTag: EthereumBlockTag, latestBlockNumber: bigint) => {
+	if (blockTag === 'latest' || blockTag === 'pending') return latestBlockNumber
+	return blockTag
+}
+
 export const getSimulatedLogs = async (ethereumClientService: EthereumClientService, requestAbortController: AbortController | undefined, simulationState: SimulationState | undefined, logFilter: EthGetLogsRequest): Promise<EthGetLogsResponse> => {
 	if (simulationState === undefined) return await ethereumClientService.getLogs(logFilter, requestAbortController)
 	if (simulationState.success === false) throw new JsonRpcResponseError(simulationState.jsonRpcError)
+	const executionBlocks = await createPreparedSimulatedExecutionBlocks(ethereumClientService, requestAbortController, simulationState)
 
 	const toBlock = 'toBlock' in logFilter && logFilter.toBlock !== undefined ? logFilter.toBlock : 'latest'
 	const fromBlock = 'fromBlock' in logFilter && logFilter.fromBlock !== undefined ? logFilter.fromBlock : 'latest'
@@ -604,26 +1138,32 @@ export const getSimulatedLogs = async (ethereumClientService: EthereumClientServ
 	if ((fromBlock === 'latest' && toBlock !== 'latest') || (fromBlock !== 'latest' && toBlock !== 'latest' && fromBlock > toBlock )) throw new Error(`From block '${ fromBlock }' is later than to block '${ toBlock }' `)
 
 	if (toBlock === 'finalized' || fromBlock === 'finalized') return await ethereumClientService.getLogs(logFilter, requestAbortController)
+	const simulatedHead = simulationState.blockNumber + BigInt(executionBlocks.length)
 	if ('blockHash' in logFilter) {
-		const blockDelta = simulationState.simulatedBlocks.findIndex((_block, index) => logFilter.blockHash === getHashOfSimulatedBlock(simulationState, index))
-		if (blockDelta > 0) return getLogsOfSimulatedBlock(simulationState, blockDelta, logFilter)
+		const executionBlock = executionBlocks.find((block) => logFilter.blockHash === block.blockHash)
+		if (executionBlock !== undefined) return getLogsOfPreparedSimulatedExecutionBlock(executionBlock, logFilter)
+		return await ethereumClientService.getLogs(logFilter, requestAbortController)
 	}
-	if (simulationState && (toBlock === 'latest' || toBlock > simulationState.blockNumber)) {
-		const logParamsToNode = fromBlock !== 'latest' && fromBlock >= simulationState.blockNumber ? { ...logFilter, fromBlock: simulationState.blockNumber - BigInt(simulationState.simulatedBlocks.length), toBlock: simulationState.blockNumber - BigInt(simulationState.simulatedBlocks.length) } : { ...logFilter, toBlock: simulationState.blockNumber - BigInt(simulationState.simulatedBlocks.length) }
-
-		const fromBlockNum = fromBlock === 'latest' ? simulationState.blockNumber + BigInt(simulationState.simulatedBlocks.length) : fromBlock
-		const toBlockNum = toBlock === 'latest' ? simulationState.blockNumber + BigInt(simulationState.simulatedBlocks.length) : toBlock
-		const blockDeltas = simulationState.simulatedBlocks.map((_block, blockDelta) => {
-			const thisBlockNum = simulationState.blockNumber + BigInt(blockDelta) + 1n
-			if (thisBlockNum >= fromBlockNum && thisBlockNum <= toBlockNum) return blockDelta
-			return undefined
-		}).filter((blockDelta): blockDelta is number => blockDelta !== undefined)
-		return [...await ethereumClientService.getLogs(logParamsToNode, requestAbortController), ...blockDeltas.flatMap((blockDelta) => getLogsOfSimulatedBlock(simulationState, blockDelta, logFilter))]
-	}
+	const fromBlockNum = resolveLogsBlockTag(fromBlock, simulatedHead)
+	const toBlockNum = resolveLogsBlockTag(toBlock, simulatedHead)
+	if (typeof fromBlockNum !== 'bigint' || typeof toBlockNum !== 'bigint') return await ethereumClientService.getLogs(logFilter, requestAbortController)
+	if (fromBlockNum > toBlockNum) return []
+	const nodeLogs = fromBlockNum <= simulationState.blockNumber
+		? await ethereumClientService.getLogs({
+			...logFilter,
+			fromBlock: fromBlockNum,
+			toBlock: min(simulationState.blockNumber, toBlockNum),
+		}, requestAbortController)
+		: []
+	const simulatedLogs = executionBlocks
+		.filter((block) => block.blockNumber >= fromBlockNum && block.blockNumber <= toBlockNum)
+		.flatMap((block) => getLogsOfPreparedSimulatedExecutionBlock(block, logFilter))
+	if (nodeLogs.length > 0 || simulatedLogs.length > 0) return [...nodeLogs, ...simulatedLogs]
+	if (toBlockNum > simulationState.blockNumber) return []
 	return await ethereumClientService.getLogs(logFilter, requestAbortController)
 }
 export const getSimulatedBlockNumber = async (ethereumClientService: EthereumClientService, requestAbortController: AbortController | undefined, simulationState: SimulationState | undefined) => {
-	if (simulationState !== undefined) return (await ethereumClientService.getBlockNumber(requestAbortController)) + 1n
+	if (simulationState !== undefined) return await getSimulatedBlockNumberFromInput(ethereumClientService, requestAbortController, simulationState.simulationStateInput)
 	return await ethereumClientService.getBlockNumber(requestAbortController)
 }
 
@@ -708,7 +1248,7 @@ export const simulatedCall = async (ethereumClientService: EthereumClientService
 	}
 }
 
-const simulateTransactionsOnTopOfSimulationInput = async (ethereumClientService: EthereumClientService, requestAbortController: AbortController | undefined, simulationStateInput: SimulationStateInput | undefined, transactions: EthereumUnsignedTransaction[], extraOverrides: StateOverrides = {}, simulateWithZeroBaseFee: boolean = false) => {
+const simulateTransactionsOnTopOfSimulationInput = async (ethereumClientService: EthereumClientService, requestAbortController: AbortController | undefined, simulationStateInput: SimulationStateInputMinimalData | undefined, transactions: EthereumUnsignedTransaction[], extraOverrides: StateOverrides = {}, simulateWithZeroBaseFee: boolean = false) => {
 	if (transactions.length === 0) return []
 	const signedTransactions = transactions.map((transaction) => mockSignTransaction(transaction))
 	const newTransactions = {
@@ -724,7 +1264,7 @@ const simulateTransactionsOnTopOfSimulationInput = async (ethereumClientService:
 }
 
 // use time as block hash as that makes it so that updated simulations with different states are different, but requires no additional calculation
-const getHashOfSimulatedBlock = (simulationState: SimulationState, blockDelta: number) => BigInt(simulationState.simulationConductedTimestamp.getTime() * 100000 + blockDelta)
+const getHashOfSimulatedBlock = (simulationState: SimulationState, blockDelta: number) => getHashOfSimulatedBlockFromInput(simulationState.simulationStateInput, blockDelta)
 
 export const getMessageHashForPersonalSign = (params: PersonalSignParams) => hashMessage(params.params[0])
 
@@ -759,7 +1299,7 @@ type BalanceQuery = {
 	tokenId: bigint,
 }
 
-const getSimulatedTokenBalances = async (ethereumClientService: EthereumClientService, requestAbortController: AbortController | undefined, simulationStateInput: SimulationStateInput, balanceQueries: BalanceQuery[]): Promise<TokenBalancesAfter> => {
+const getSimulatedTokenBalances = async (ethereumClientService: EthereumClientService, requestAbortController: AbortController | undefined, simulationStateInput: SimulationStateInputMinimalData, balanceQueries: BalanceQuery[]): Promise<TokenBalancesAfter> => {
 	if (balanceQueries.length === 0) return []
 	const deduplicatedBalanceQueries = deduplicateByFunction(balanceQueries, (query: BalanceQuery) => `${ query.type }-${ query.token }-${ query.owner }${ query.type === 'ERC1155' ? `${ query.tokenId }` : '' }`)
 	const IMulticall3 = new Interface(Multicall3ABI)

--- a/app/ts/utils/simulationFingerprint.ts
+++ b/app/ts/utils/simulationFingerprint.ts
@@ -1,0 +1,16 @@
+import { keccak256, toUtf8Bytes } from 'ethers'
+import { dataStringWith0xStart, stringifyJSONWithBigInts } from './bigint.js'
+import { EthereumSignedTransactionToSignedTransaction, serializeSignedTransactionToBytes } from './ethereum.js'
+import { SimulationStateInput } from '../types/visualizer-types.js'
+
+export function getSimulationInputHash(simulationStateInput: SimulationStateInput) {
+	const messages = stringifyJSONWithBigInts(simulationStateInput.map((x) => x.signedMessages.map((signedMessage) => ({
+		fakeSignedFor: signedMessage.fakeSignedFor,
+		originalRequestParameters: signedMessage.originalRequestParameters,
+	}))))
+	const overrides = stringifyJSONWithBigInts(simulationStateInput.map((x) => x.stateOverrides))
+	const transactions = stringifyJSONWithBigInts(simulationStateInput.map((x) => x.transactions.map((transaction) => dataStringWith0xStart(serializeSignedTransactionToBytes(EthereumSignedTransactionToSignedTransaction(transaction.signedTransaction))))))
+	const blockTime = stringifyJSONWithBigInts(simulationStateInput.map((x) => x.blockTimeManipulation))
+	const baseFee = stringifyJSONWithBigInts(simulationStateInput.map((x) => x.simulateWithZeroBaseFee))
+	return keccak256(toUtf8Bytes(JSON.stringify([messages, overrides, transactions, blockTime, baseFee])))
+}

--- a/test/tests/EthereumSubscriptionService.ts
+++ b/test/tests/EthereumSubscriptionService.ts
@@ -1,0 +1,260 @@
+import * as assert from 'assert'
+import { ethers } from 'ethers'
+import { describe, run, runIfRoot, should } from '../micro-should.js'
+import { EthereumClientService } from '../../app/ts/simulation/services/EthereumClientService.js'
+import { createSimulationState, mockSignTransaction } from '../../app/ts/simulation/services/SimulationModeEthereumClientService.js'
+import { InterceptorMessageToInpage } from '../../app/ts/types/interceptor-messages.js'
+import { JsonRpcResponse, EthereumJsonRpcRequest } from '../../app/ts/types/JsonRpc-types.js'
+import { EthSimulateV1Result } from '../../app/ts/types/ethSimulate-types.js'
+import { dataStringWith0xStart } from '../../app/ts/utils/bigint.js'
+import { Multicall3ABI } from '../../app/ts/utils/constants.js'
+import { eth_getBlockByNumber_goerli_8443561_false, eth_getBlockByNumber_goerli_8443561_true, eth_simulateV1_dummy_call_result, eth_simulateV1_dummy_call_result_2calls, eth_simulateV1_get_eth_balance_multicall } from '../RPCResponses.js'
+
+function parseRequest<T>(data: string): T {
+	const jsonRpcResponse = JsonRpcResponse.parse(JSON.parse(data))
+	if ('error' in jsonRpcResponse) throw Error(`Ethereum Client Error: ${ jsonRpcResponse.error.message }`)
+	return jsonRpcResponse.result as T
+}
+
+const ethSimulateSingleBlockResult = parseRequest<EthSimulateV1Result>(eth_simulateV1_dummy_call_result)
+const ethSimulateSplitBlocksResult = parseRequest<EthSimulateV1Result>(eth_simulateV1_dummy_call_result_2calls)
+const ethSimulateAggregate3Result = parseRequest<EthSimulateV1Result>(eth_simulateV1_get_eth_balance_multicall)
+const multicallInterface = new ethers.Interface(Multicall3ABI)
+
+function buildAggregate3BalanceBlock(balanceQueryCount: number) {
+	const aggregate3BalanceBlock = ethSimulateAggregate3Result[ethSimulateAggregate3Result.length - 1]
+	const aggregate3Call = aggregate3BalanceBlock?.calls[0]
+	if (aggregate3BalanceBlock === undefined) throw new Error('missing aggregate3 simulation fixture block')
+	if (aggregate3Call === undefined) throw new Error('missing aggregate3 simulation fixture call')
+	return {
+		...aggregate3BalanceBlock,
+		calls: [{
+			...aggregate3Call,
+			returnData: multicallInterface.encodeFunctionResult('aggregate3', [Array.from({ length: balanceQueryCount }, (_, index) => ({
+				success: true,
+				returnData: ethers.AbiCoder.defaultAbiCoder().encode(['uint256'], [BigInt(index + 1)]),
+			}))]),
+		}],
+	}
+}
+
+function createMockEthSimulateV1Result(blockStateCallCount: number, aggregate3BalanceQueryCount: number | undefined) {
+	const singleTransactionBlock = ethSimulateSingleBlockResult[0]
+	const followupTransactionBlock = ethSimulateSplitBlocksResult[1]
+	if (singleTransactionBlock === undefined) throw new Error('missing single transaction simulation fixture')
+	if (followupTransactionBlock === undefined) throw new Error('missing followup simulation fixture block')
+
+	const includesAggregate3BalanceCall = aggregate3BalanceQueryCount !== undefined
+	const nonAggregateBlockCount = includesAggregate3BalanceCall ? Math.max(blockStateCallCount - 1, 0) : blockStateCallCount
+	const nonAggregateBlocks = Array.from({ length: nonAggregateBlockCount }, (_, blockIndex) => blockIndex === 0 ? singleTransactionBlock : followupTransactionBlock)
+	if (!includesAggregate3BalanceCall) return nonAggregateBlocks
+	return [...nonAggregateBlocks, buildAggregate3BalanceBlock(aggregate3BalanceQueryCount)]
+}
+
+function installBrowserMock() {
+	const storageState: Record<string, unknown> = {}
+	globalThis.browser = {
+		runtime: {
+			lastError: null,
+		},
+		storage: {
+			local: {
+				async get(keys?: string | string[] | Record<string, unknown> | null) {
+					if (keys === undefined || keys === null) return { ...storageState }
+					if (Array.isArray(keys)) return Object.fromEntries(keys.map((key) => [key, storageState[key]]))
+					if (typeof keys === 'string') return { [keys]: storageState[keys] }
+					return Object.fromEntries(Object.entries(keys).map(([key, defaultValue]) => [key, key in storageState ? storageState[key] : defaultValue]))
+				},
+				async set(items: Record<string, unknown>) {
+					Object.assign(storageState, items)
+				},
+				async remove(keys: string | string[]) {
+					for (const key of Array.isArray(keys) ? keys : [keys]) delete storageState[key]
+				},
+			},
+		},
+	} as unknown as typeof globalThis.browser
+	return storageState
+}
+
+async function loadModules() {
+	return {
+		...await import('../../app/ts/simulation/services/EthereumSubscriptionService.js'),
+		...await import('../../app/ts/background/storageVariables.js'),
+	}
+}
+
+export async function main() {
+	const blockNumber = 8443561n
+	const rpcNetwork = {
+		name: 'Goerli',
+		chainId: 5n,
+		httpsRpc: 'https://rpc.dark.florist/flipcardtrustone',
+		currencyName: 'Goerli Testnet ETH',
+		currencyTicker: 'GÖETH',
+		primary: true,
+		minimized: true,
+		weth: 0xb4fbf271143f4fbf7b91a5ded31805e42b2208d6n,
+	}
+
+	class MockEthereumJSONRpcRequestHandler {
+		public rpcUrl = 'https://rpc.dark.florist/flipcardtrustone'
+
+		public clearCache = () => {}
+
+		public getChainId = async () => 5n
+
+		public readonly jsonRpcRequest = async (rpcRequest: EthereumJsonRpcRequest) => {
+			switch (rpcRequest.method) {
+				case 'eth_blockNumber': return `0x${ blockNumber.toString(16) }`
+				case 'eth_getBlockByNumber': {
+					if (rpcRequest.params[0] !== blockNumber && rpcRequest.params[0] !== 'latest') throw new Error('Unsupported block number')
+					if (rpcRequest.params[1] === true) return parseRequest(eth_getBlockByNumber_goerli_8443561_true)
+					return parseRequest(eth_getBlockByNumber_goerli_8443561_false)
+				}
+				case 'eth_getLogs': return []
+				case 'eth_simulateV1': {
+					const lastCallInput = rpcRequest.params[0]?.blockStateCalls.at(-1)?.calls[0]?.input
+					const aggregate3BalanceQueryCount = lastCallInput !== undefined && dataStringWith0xStart(lastCallInput).startsWith('0x82ad56cb')
+						? multicallInterface.decodeFunctionData('aggregate3', dataStringWith0xStart(lastCallInput))[0].length
+						: undefined
+					return createMockEthSimulateV1Result(
+						rpcRequest.params[0]?.blockStateCalls.length ?? 0,
+						aggregate3BalanceQueryCount,
+					)
+				}
+				default: throw new Error(`unsupported method ${ rpcRequest.method }`)
+			}
+		}
+	}
+
+	const exampleTransaction = {
+		type: '1559',
+		from: 0xd8da6bf26964af9d7eed9e03e53415d37aa96045n,
+		nonce: 0n,
+		maxFeePerGas: 1n,
+		maxPriorityFeePerGas: 1n,
+		gas: 21000n,
+		to: 0xda9dfa130df4de4673b89022ee50ff26f6ea73cfn,
+		value: 10n,
+		input: new Uint8Array(0),
+		chainId: 1n,
+	} as const
+
+	const createEthereum = () => new EthereumClientService(new MockEthereumJSONRpcRequestHandler(), async () => {}, async () => {}, rpcNetwork)
+	const createSimulationInput = (gas: bigint, nonce: bigint, transactionIdentifier: bigint) => [{
+		stateOverrides: {},
+		transactions: [{
+			signedTransaction: mockSignTransaction({
+				...exampleTransaction,
+				gas,
+				nonce,
+			}),
+			website: { websiteOrigin: 'test', icon: undefined, title: undefined },
+			created: new Date(),
+			originalRequestParameters: { method: 'eth_sendTransaction', params: [{}]},
+			transactionIdentifier,
+		}],
+		signedMessages: [],
+		blockTimeManipulation: { type: 'AddToTimestamp', deltaToAdd: 12n, deltaUnit: 'Seconds' },
+		simulateWithZeroBaseFee: false,
+	}] as const
+
+	describe('EthereumSubscriptionService', () => {
+		should('eth_getFilterChanges only returns newly simulated logs once', async () => {
+			installBrowserMock()
+			const { createNewFilter, getEthFilterChanges, getEthereumSubscriptionsAndFilters } = await loadModules()
+			const ethereum = createEthereum()
+			const socket = { tabId: 1, connectionName: 1n } as const
+			const filterId = await createNewFilter({ method: 'eth_newFilter', params: [{}] }, socket, ethereum, undefined, undefined)
+			const simulationState = await createSimulationState(ethereum, undefined, createSimulationInput(21_000n, 0n, 1n))
+			if (simulationState.success === false) throw new Error('simulation unexpectedly failed')
+
+			const firstChanges = await getEthFilterChanges(filterId, ethereum, undefined, simulationState)
+			const secondChanges = await getEthFilterChanges(filterId, ethereum, undefined, simulationState)
+			const storedFilters = await getEthereumSubscriptionsAndFilters()
+			const storedFilter = storedFilters.find((filter) => filter.type === 'eth_newFilter' && filter.subscriptionOrFilterId === filterId)
+			if (storedFilter === undefined || storedFilter.type !== 'eth_newFilter') throw new Error('stored filter missing')
+
+			assert.equal(firstChanges?.length, 1)
+			assert.equal(firstChanges?.[0]?.blockNumber, blockNumber + 1n)
+			assert.deepEqual(secondChanges, [])
+			assert.equal(storedFilter.calledInlastBlock, blockNumber + 1n)
+		})
+
+		should('newHeads emits each simulated execution block after a gas split', async () => {
+			installBrowserMock()
+			const { createEthereumSubscription, sendSubscriptionMessagesForNewBlock } = await loadModules()
+			const ethereum = createEthereum()
+			const socket = { tabId: 1, connectionName: 1n } as const
+			const postedMessages: InterceptorMessageToInpage[] = []
+			const port = {
+				postMessage(message: unknown) {
+					postedMessages.push(InterceptorMessageToInpage.parse(message))
+				},
+			} as unknown as browser.runtime.Port
+			const websiteTabConnections = new Map([
+				[1, {
+					connections: {
+						'1-0x1': {
+							port,
+							socket,
+							websiteOrigin: 'test',
+							approved: true,
+							wantsToConnect: false,
+						},
+					},
+				}],
+			])
+			await createEthereumSubscription({ method: 'eth_subscribe', params: ['newHeads'] }, socket)
+			const splitSimulationInput = [{
+				stateOverrides: {},
+				transactions: [
+					{
+						signedTransaction: mockSignTransaction({
+							...exampleTransaction,
+							nonce: 0n,
+							gas: 20_000_000n,
+						}),
+						website: { websiteOrigin: 'test', icon: undefined, title: undefined },
+						created: new Date(),
+						originalRequestParameters: { method: 'eth_sendTransaction', params: [{}]},
+						transactionIdentifier: 2n,
+					},
+					{
+						signedTransaction: mockSignTransaction({
+							...exampleTransaction,
+							nonce: 1n,
+							gas: 20_000_000n,
+						}),
+						website: { websiteOrigin: 'test', icon: undefined, title: undefined },
+						created: new Date(),
+						originalRequestParameters: { method: 'eth_sendTransaction', params: [{}]},
+						transactionIdentifier: 3n,
+					},
+				],
+				signedMessages: [],
+				blockTimeManipulation: { type: 'AddToTimestamp', deltaToAdd: 12n, deltaUnit: 'Seconds' },
+				simulateWithZeroBaseFee: false,
+			}] as const
+			const simulationState = await createSimulationState(ethereum, undefined, splitSimulationInput)
+			if (simulationState.success === false) throw new Error('simulation unexpectedly failed')
+
+			await sendSubscriptionMessagesForNewBlock(blockNumber, ethereum, true, websiteTabConnections, async () => simulationState)
+
+			const emittedBlockNumbers = postedMessages.flatMap((message) => {
+				if (message.type !== 'result' || !('method' in message) || message.method !== 'newHeads') return []
+				if (!('result' in message) || !('result' in message.result)) throw new Error('wrong subscription payload')
+				if (message.result.result === null) throw new Error('missing simulated block payload')
+				return [message.result.result.number]
+			})
+			assert.equal(emittedBlockNumbers.length, 3)
+			assert.deepEqual(emittedBlockNumbers, [blockNumber, blockNumber + 1n, blockNumber + 2n])
+		})
+	})
+}
+
+await runIfRoot(async () => {
+	await main()
+	await run()
+}, import.meta)

--- a/test/tests/SimulationModeEthereumClientService.ts
+++ b/test/tests/SimulationModeEthereumClientService.ts
@@ -3,16 +3,53 @@ import { describe, runIfRoot, should, run } from '../micro-should.js'
 import * as assert from 'assert'
 import { EthereumClientService } from '../../app/ts/simulation/services/EthereumClientService.js'
 import { EthereumSignedTransactionToSignedTransaction, EthereumUnsignedTransactionToUnsignedTransaction, serializeSignedTransactionToBytes, serializeUnsignedTransactionToBytes } from '../../app/ts/utils/ethereum.js'
-import { bytes32String } from '../../app/ts/utils/bigint.js'
+import { bytes32String, dataStringWith0xStart } from '../../app/ts/utils/bigint.js'
 import { EthereumSignatureParity, EthereumSignedTransaction, EthereumSignedTransaction1559, EthereumSignedTransactionWithBlockData, EthereumUnsignedTransaction } from '../../app/ts/types/wire-types.js'
-import { groupEthSimulateV1ResultByInputBlocks, mockSignTransaction } from '../../app/ts/simulation/services/SimulationModeEthereumClientService.js'
+import { createSimulationState, getSimulatedBlockByHashFromInput, getSimulatedBlockFromInput, getSimulatedBlockNumberFromInput, getSimulatedLogs, getSimulatedTransactionByHashFromInput, getSimulatedTransactionReceipt, groupEthSimulateV1ResultByInputBlocks, mockSignTransaction } from '../../app/ts/simulation/services/SimulationModeEthereumClientService.js'
 import { EthTransactionReceiptResponse, JsonRpcResponse, EthereumJsonRpcRequest } from '../../app/ts/types/JsonRpc-types.js'
-import { eth_getBlockByNumber_goerli_8443561_false, eth_getBlockByNumber_goerli_8443561_true, eth_simulateV1_dummy_call_result, eth_simulateV1_dummy_call_result_2calls } from '../RPCResponses.js'
+import { EthSimulateV1Result } from '../../app/ts/types/ethSimulate-types.js'
+import { Multicall3ABI } from '../../app/ts/utils/constants.js'
+import { eth_getBlockByNumber_goerli_8443561_false, eth_getBlockByNumber_goerli_8443561_true, eth_simulateV1_dummy_call_result, eth_simulateV1_dummy_call_result_2calls, eth_simulateV1_get_eth_balance_multicall } from '../RPCResponses.js'
 
-function parseRequest(data: string) {
+function parseRequest<T>(data: string): T {
 	const jsonRpcResponse = JsonRpcResponse.parse(JSON.parse(data))
 	if ('error' in jsonRpcResponse) throw Error(`Ethereum Client Error: ${ jsonRpcResponse.error.message }`)
-	return jsonRpcResponse.result
+	return jsonRpcResponse.result as T
+}
+
+const ethSimulateSingleBlockResult = parseRequest<EthSimulateV1Result>(eth_simulateV1_dummy_call_result)
+const ethSimulateSplitBlocksResult = parseRequest<EthSimulateV1Result>(eth_simulateV1_dummy_call_result_2calls)
+const ethSimulateAggregate3Result = parseRequest<EthSimulateV1Result>(eth_simulateV1_get_eth_balance_multicall)
+const multicallInterface = new ethers.Interface(Multicall3ABI)
+
+function buildAggregate3BalanceBlock(balanceQueryCount: number) {
+	const aggregate3BalanceBlock = ethSimulateAggregate3Result[ethSimulateAggregate3Result.length - 1]
+	const aggregate3Call = aggregate3BalanceBlock?.calls[0]
+	if (aggregate3BalanceBlock === undefined) throw new Error('missing aggregate3 simulation fixture block')
+	if (aggregate3Call === undefined) throw new Error('missing aggregate3 simulation fixture call')
+	return {
+		...aggregate3BalanceBlock,
+		calls: [{
+			...aggregate3Call,
+			returnData: multicallInterface.encodeFunctionResult('aggregate3', [Array.from({ length: balanceQueryCount }, (_, index) => ({
+				success: true,
+				returnData: ethers.AbiCoder.defaultAbiCoder().encode(['uint256'], [BigInt(index + 1)]),
+			}))]),
+		}],
+	}
+}
+
+function createMockEthSimulateV1Result(blockStateCallCount: number, aggregate3BalanceQueryCount: number | undefined) {
+	const singleTransactionBlock = ethSimulateSingleBlockResult[0]
+	const followupTransactionBlock = ethSimulateSplitBlocksResult[1]
+	if (singleTransactionBlock === undefined) throw new Error('missing single transaction simulation fixture')
+	if (followupTransactionBlock === undefined) throw new Error('missing followup simulation fixture block')
+
+	const includesAggregate3BalanceCall = aggregate3BalanceQueryCount !== undefined
+	const nonAggregateBlockCount = includesAggregate3BalanceCall ? Math.max(blockStateCallCount - 1, 0) : blockStateCallCount
+	const nonAggregateBlocks = Array.from({ length: nonAggregateBlockCount }, (_, blockIndex) => blockIndex === 0 ? singleTransactionBlock : followupTransactionBlock)
+	if (!includesAggregate3BalanceCall) return nonAggregateBlocks
+	return [...nonAggregateBlocks, buildAggregate3BalanceBlock(aggregate3BalanceQueryCount)]
 }
 
 function testBytes32(suffix: string) {
@@ -50,8 +87,14 @@ export async function main() {
 					return parseRequest(eth_getBlockByNumber_goerli_8443561_false)
 				}
 				case 'eth_simulateV1': {
-					if (rpcRequest.params[0]?.blockStateCalls.length === 2) return parseRequest(eth_simulateV1_dummy_call_result_2calls)
-					return parseRequest(eth_simulateV1_dummy_call_result)
+					const lastCallInput = rpcRequest.params[0]?.blockStateCalls.at(-1)?.calls[0]?.input
+					const aggregate3BalanceQueryCount = lastCallInput !== undefined && dataStringWith0xStart(lastCallInput).startsWith('0x82ad56cb')
+						? multicallInterface.decodeFunctionData('aggregate3', dataStringWith0xStart(lastCallInput))[0].length
+						: undefined
+					return createMockEthSimulateV1Result(
+						rpcRequest.params[0]?.blockStateCalls.length ?? 0,
+						aggregate3BalanceQueryCount,
+					)
 				}
 				default: throw new Error(`unsupported method ${ rpcRequest.method }`)
 			}
@@ -381,8 +424,292 @@ export async function main() {
 			assert.equal(groupedBlock.calls[0]?.gasUsed, 0x5208n)
 			assert.equal(groupedBlock.calls[1]?.gasUsed, 0x6dd4n)
 		})
-	})
-}
+
+			should('input-based block number counts split execution blocks', async () => {
+				const splitSimulationStateInput = [{
+				stateOverrides: {},
+				transactions: [
+					{
+						signedTransaction: mockSignTransaction({
+							...exampleTransaction,
+							nonce: 0n,
+							gas: 20_000_000n,
+						}),
+						website: { websiteOrigin: 'test', icon: undefined, title: undefined },
+						created: new Date(),
+						originalRequestParameters: { method: 'eth_sendTransaction', params: [{}]},
+						transactionIdentifier: 2n,
+					},
+					{
+						signedTransaction: mockSignTransaction({
+							...exampleTransaction,
+							nonce: 1n,
+							gas: 20_000_000n,
+						}),
+						website: { websiteOrigin: 'test', icon: undefined, title: undefined },
+						created: new Date(),
+						originalRequestParameters: { method: 'eth_sendTransaction', params: [{}]},
+						transactionIdentifier: 3n,
+					},
+				],
+				signedMessages: [],
+				blockTimeManipulation: { type: 'AddToTimestamp', deltaToAdd: 12n, deltaUnit: 'Seconds' },
+				simulateWithZeroBaseFee: false,
+			}] as const
+
+				assert.equal(await getSimulatedBlockNumberFromInput(ethereum, undefined, splitSimulationStateInput), blockNumber + 2n)
+			})
+
+			should('input-based block number ignores the default empty simulation block', async () => {
+				const emptySimulationStateInput = [{
+					stateOverrides: {},
+					transactions: [],
+					signedMessages: [],
+					blockTimeManipulation: { type: 'AddToTimestamp', deltaToAdd: 12n, deltaUnit: 'Seconds' },
+					simulateWithZeroBaseFee: false,
+				}] as const
+
+				assert.equal(await getSimulatedBlockNumberFromInput(ethereum, undefined, emptySimulationStateInput), blockNumber)
+			})
+
+			should('input-based simulated block hash is deterministic and round-trips through getBlockByHash', async () => {
+			const simulationStateInput = [{
+				stateOverrides: {},
+				transactions: [{
+					signedTransaction: mockSignTransaction({
+						...exampleTransaction,
+						nonce: 0n,
+					}),
+					website: { websiteOrigin: 'test', icon: undefined, title: undefined },
+					created: new Date(),
+					originalRequestParameters: { method: 'eth_sendTransaction', params: [{}]},
+					transactionIdentifier: 4n,
+				}],
+				signedMessages: [],
+				blockTimeManipulation: { type: 'AddToTimestamp', deltaToAdd: 12n, deltaUnit: 'Seconds' },
+				simulateWithZeroBaseFee: false,
+			}] as const
+
+			const latestBlock = await getSimulatedBlockFromInput(ethereum, undefined, simulationStateInput, 'latest', true)
+			if (latestBlock === null) throw new Error('latest simulated block missing')
+			const sameBlock = await getSimulatedBlockFromInput(ethereum, undefined, simulationStateInput, 'latest', true)
+			if (sameBlock === null) throw new Error('latest simulated block missing on second read')
+			const roundTripped = await getSimulatedBlockByHashFromInput(ethereum, undefined, simulationStateInput, latestBlock.hash, true)
+			if (roundTripped === null) throw new Error('round-tripped block missing')
+
+			assert.equal(latestBlock.hash, sameBlock.hash)
+				assert.equal(roundTripped.hash, latestBlock.hash)
+				assert.equal(roundTripped.number, latestBlock.number)
+			})
+
+			should('input-based simulated block hash changes when transaction contents change', async () => {
+				const baseSimulationStateInput = [{
+					stateOverrides: {},
+					transactions: [{
+						signedTransaction: mockSignTransaction({
+							...exampleTransaction,
+							nonce: 0n,
+						}),
+						website: { websiteOrigin: 'test', icon: undefined, title: undefined },
+						created: new Date(),
+						originalRequestParameters: { method: 'eth_sendTransaction', params: [{}]},
+						transactionIdentifier: 7n,
+					}],
+					signedMessages: [],
+					blockTimeManipulation: { type: 'AddToTimestamp', deltaToAdd: 12n, deltaUnit: 'Seconds' },
+					simulateWithZeroBaseFee: false,
+				}] as const
+
+				const changedSimulationStateInput = [{
+					...baseSimulationStateInput[0],
+					transactions: [{
+						...baseSimulationStateInput[0].transactions[0],
+						signedTransaction: mockSignTransaction({
+							...exampleTransaction,
+							nonce: 1n,
+						}),
+					}],
+				}] as const
+
+				const firstBlock = await getSimulatedBlockFromInput(ethereum, undefined, baseSimulationStateInput, 'latest', true)
+				const secondBlock = await getSimulatedBlockFromInput(ethereum, undefined, changedSimulationStateInput, 'latest', true)
+				if (firstBlock === null || secondBlock === null) throw new Error('simulated block missing')
+
+				assert.notEqual(firstBlock.hash, secondBlock.hash)
+			})
+
+			should('input-based transaction lookup uses execution block positions after gas splitting', async () => {
+				const splitSimulationStateInput = [{
+				stateOverrides: {},
+				transactions: [
+					{
+						signedTransaction: mockSignTransaction({
+							...exampleTransaction,
+							nonce: 0n,
+							gas: 20_000_000n,
+						}),
+						website: { websiteOrigin: 'test', icon: undefined, title: undefined },
+						created: new Date(),
+						originalRequestParameters: { method: 'eth_sendTransaction', params: [{}]},
+						transactionIdentifier: 5n,
+					},
+					{
+						signedTransaction: mockSignTransaction({
+							...exampleTransaction,
+							nonce: 1n,
+							gas: 20_000_000n,
+						}),
+						website: { websiteOrigin: 'test', icon: undefined, title: undefined },
+						created: new Date(),
+						originalRequestParameters: { method: 'eth_sendTransaction', params: [{}]},
+						transactionIdentifier: 6n,
+					},
+				],
+				signedMessages: [],
+				blockTimeManipulation: { type: 'AddToTimestamp', deltaToAdd: 12n, deltaUnit: 'Seconds' },
+				simulateWithZeroBaseFee: false,
+			}] as const
+
+			const secondHash = splitSimulationStateInput[0].transactions[1]?.signedTransaction.hash
+			if (secondHash === undefined) throw new Error('second transaction hash missing')
+			const found = await getSimulatedTransactionByHashFromInput(ethereum, undefined, splitSimulationStateInput, secondHash)
+			if (found === null) throw new Error('second transaction not found in input-only lookup')
+
+				assert.equal(found.blockNumber, blockNumber + 2n)
+				assert.equal(found.transactionIndex, 0n)
+			})
+
+			should('input-based execution blocks link together after gas splitting', async () => {
+				const splitSimulationStateInput = [{
+					stateOverrides: {},
+					transactions: [
+						{
+							signedTransaction: mockSignTransaction({
+								...exampleTransaction,
+								nonce: 0n,
+								gas: 20_000_000n,
+							}),
+							website: { websiteOrigin: 'test', icon: undefined, title: undefined },
+							created: new Date(),
+							originalRequestParameters: { method: 'eth_sendTransaction', params: [{}]},
+							transactionIdentifier: 8n,
+						},
+						{
+							signedTransaction: mockSignTransaction({
+								...exampleTransaction,
+								nonce: 1n,
+								gas: 20_000_000n,
+							}),
+							website: { websiteOrigin: 'test', icon: undefined, title: undefined },
+							created: new Date(),
+							originalRequestParameters: { method: 'eth_sendTransaction', params: [{}]},
+							transactionIdentifier: 9n,
+						},
+					],
+					signedMessages: [],
+					blockTimeManipulation: { type: 'AddToTimestamp', deltaToAdd: 12n, deltaUnit: 'Seconds' },
+					simulateWithZeroBaseFee: false,
+				}] as const
+
+				const firstBlock = await getSimulatedBlockFromInput(ethereum, undefined, splitSimulationStateInput, blockNumber + 1n, true)
+				const secondBlock = await getSimulatedBlockFromInput(ethereum, undefined, splitSimulationStateInput, blockNumber + 2n, true)
+				if (firstBlock === null || secondBlock === null) throw new Error('split execution block missing')
+
+				assert.equal(secondBlock.parentHash, firstBlock.hash)
+				assert.equal(secondBlock.number, firstBlock.number + 1n)
+			})
+
+			should('state-based receipt uses execution block placement after gas splitting', async () => {
+				const splitSimulationStateInput = [{
+					stateOverrides: {},
+					transactions: [
+						{
+							signedTransaction: mockSignTransaction({
+								...exampleTransaction,
+								nonce: 0n,
+								gas: 20_000_000n,
+							}),
+							website: { websiteOrigin: 'test', icon: undefined, title: undefined },
+							created: new Date(),
+							originalRequestParameters: { method: 'eth_sendTransaction', params: [{}]},
+							transactionIdentifier: 10n,
+						},
+						{
+							signedTransaction: mockSignTransaction({
+								...exampleTransaction,
+								nonce: 1n,
+								gas: 20_000_000n,
+							}),
+							website: { websiteOrigin: 'test', icon: undefined, title: undefined },
+							created: new Date(),
+							originalRequestParameters: { method: 'eth_sendTransaction', params: [{}]},
+							transactionIdentifier: 11n,
+						},
+					],
+					signedMessages: [],
+					blockTimeManipulation: { type: 'AddToTimestamp', deltaToAdd: 12n, deltaUnit: 'Seconds' },
+					simulateWithZeroBaseFee: false,
+				}] as const
+
+				const simulationState = await createSimulationState(ethereum, undefined, splitSimulationStateInput)
+				if (simulationState.success === false) throw new Error('simulation unexpectedly failed')
+				const secondHash = splitSimulationStateInput[0].transactions[1]?.signedTransaction.hash
+				if (secondHash === undefined) throw new Error('second transaction hash missing')
+				const secondBlock = await getSimulatedBlockFromInput(ethereum, undefined, splitSimulationStateInput, blockNumber + 2n, true)
+				if (secondBlock === null) throw new Error('second simulated block missing')
+				const receipt = await getSimulatedTransactionReceipt(ethereum, undefined, simulationState, secondHash)
+				if (receipt === null) throw new Error('receipt missing')
+
+				assert.equal(receipt.blockNumber, blockNumber + 2n)
+				assert.equal(receipt.blockHash, secondBlock.hash)
+				assert.equal(receipt.transactionIndex, 0n)
+				assert.equal(receipt.cumulativeGasUsed, receipt.gasUsed)
+			})
+
+			should('state-based logs honor the first simulated execution block hash after gas splitting', async () => {
+				const splitSimulationStateInput = [{
+					stateOverrides: {},
+					transactions: [
+						{
+							signedTransaction: mockSignTransaction({
+								...exampleTransaction,
+								nonce: 0n,
+								gas: 20_000_000n,
+							}),
+							website: { websiteOrigin: 'test', icon: undefined, title: undefined },
+							created: new Date(),
+							originalRequestParameters: { method: 'eth_sendTransaction', params: [{}]},
+							transactionIdentifier: 12n,
+						},
+						{
+							signedTransaction: mockSignTransaction({
+								...exampleTransaction,
+								nonce: 1n,
+								gas: 20_000_000n,
+							}),
+							website: { websiteOrigin: 'test', icon: undefined, title: undefined },
+							created: new Date(),
+							originalRequestParameters: { method: 'eth_sendTransaction', params: [{}]},
+							transactionIdentifier: 13n,
+						},
+					],
+					signedMessages: [],
+					blockTimeManipulation: { type: 'AddToTimestamp', deltaToAdd: 12n, deltaUnit: 'Seconds' },
+					simulateWithZeroBaseFee: false,
+				}] as const
+
+				const simulationState = await createSimulationState(ethereum, undefined, splitSimulationStateInput)
+				if (simulationState.success === false) throw new Error('simulation unexpectedly failed')
+				const firstBlock = await getSimulatedBlockFromInput(ethereum, undefined, splitSimulationStateInput, blockNumber + 1n, true)
+				if (firstBlock === null) throw new Error('first simulated block missing')
+				const logs = await getSimulatedLogs(ethereum, undefined, simulationState, { blockHash: firstBlock.hash })
+
+				assert.equal(logs.length, 1)
+				assert.equal(logs[0]?.blockHash, firstBlock.hash)
+				assert.equal(logs[0]?.blockNumber, blockNumber + 1n)
+			})
+		})
+	}
 
 await runIfRoot(async  () => {
 	await main()


### PR DESCRIPTION
## Summary
- split simulation-backed RPC handling between prepared simulation input and full simulation state
- move simulated block, transaction, receipt, log, filter, and `newHeads` behavior onto a consistent execution-block view
- derive deterministic simulated block hashes from prepared input and add regression coverage for subscriptions and gas-split execution blocks

## Testing
- npm test
- npm run setup-chrome