### PR TITLE
Preserve simulated block header fidelity

### DIFF
--- a/app/ts/simulation/services/SimulationModeEthereumClientService.ts
+++ b/app/ts/simulation/services/SimulationModeEthereumClientService.ts
@@ -12,7 +12,7 @@ import { EthGetLogsResponse, EthGetLogsRequest, EthTransactionReceiptResponse, P
 import { handleERC1155TransferBatch, handleERC1155TransferSingle } from '../logHandlers.js'
 import { assertNever, modifyObject } from '../../utils/typescript.js'
 import { PersonalSignParams, SignMessageParams } from '../../types/jsonRpc-signing-types.js'
-import { EthSimulateV1CallResult, EthSimulateV1Result, EthereumEvent, StateOverrides } from '../../types/ethSimulate-types.js'
+import { EthSimulateV1BlockHeader, EthSimulateV1CallResult, EthSimulateV1Result, EthereumEvent, StateOverrides } from '../../types/ethSimulate-types.js'
 import { stripLeadingZeros } from '../../utils/typed-arrays.js'
 import { getMakeCurrentAddressRich, getSettings } from '../../background/settings.js'
 import { JsonRpcResponseError } from '../../utils/errors.js'
@@ -45,6 +45,7 @@ type GroupedEthSimulateV1BlockResult = {
 	inputBlock: SimulationStateInputMinimalDataBlock
 	baseFeePerGas: bigint
 	timestamp: bigint
+	blockHeader?: EthSimulateV1BlockHeader
 	calls: readonly EthSimulateV1CallResult[]
 }
 
@@ -106,6 +107,10 @@ const transactionQueueTotalGasLimit = (simulatedTransactions: readonly Simulated
 	return simulatedTransactions.reduce((a, b) => a + b.preSimulationTransaction.signedTransaction.gas, 0n)
 }
 
+const transactionQueueTotalGasUsed = (simulatedTransactions: readonly SimulatedTransaction[]) => {
+	return simulatedTransactions.reduce((totalGasUsed, simulatedTransaction) => totalGasUsed + simulatedTransaction.ethSimulateV1CallResult.gasUsed, 0n)
+}
+
 const transactionQueueTotalGasLimitFromInput = (block: SimulationStateInputMinimalDataBlock | undefined) => {
 	if (block === undefined) return 0n
 	return block.transactions.reduce((totalGasUsed, transaction) => totalGasUsed + transaction.signedTransaction.gas, 0n)
@@ -115,6 +120,8 @@ const isEmptySimulationInput = (simulationStateInput: SimulationStateInput | Sim
 	simulationStateInput.length === 0
 	|| (simulationStateInput.length === 1 && simulationStateInput[0]?.transactions.length === 0 && simulationStateInput[0]?.signedMessages.length === 0)
 )
+
+const getSimulationBlockNumber = (simulationState: SimulationState, blockDelta: number) => simulationState.blockNumber + BigInt(blockDelta) + 1n
 
 const getHashOfSimulatedBlockFromInput = (simulationStateInput: SimulationStateInput, blockDelta: number) => {
 	return BigInt(keccak256(stringToBytes(`${ getSimulationInputHash(simulationStateInput) }:${ blockDelta }`)))
@@ -345,10 +352,15 @@ export const groupEthSimulateV1ResultByInputBlocks = (prepared: PreparedEthSimul
 		rpcBlockIndex += preparedInputBlock.rpcBlockCount
 		const firstResultBlock = resultBlocks[0]
 		if (firstResultBlock === undefined) throw new Error('grouped result block was undefined')
+		const blockHeader = preparedInputBlock.rpcBlockCount === 1 ? (() => {
+			const { calls: _calls, ...header } = firstResultBlock
+			return header
+		})() : undefined
 		return {
 			inputBlock: preparedInputBlock.inputBlock,
 			baseFeePerGas: firstResultBlock.baseFeePerGas,
 			timestamp: firstResultBlock.timestamp,
+			blockHeader,
 			calls: resultBlocks.flatMap((block) => block.calls),
 		}
 	})
@@ -410,6 +422,7 @@ const getExecutionSimulationStateBlockBase = (callResult: GroupedEthSimulateV1Bl
 	blockTimestamp: bigintSecondsToDate(callResult.timestamp),
 	blockTimeManipulation: callResult.inputBlock.blockTimeManipulation || DEFAULT_BLOCK_MANIPULATION,
 	blockBaseFeePerGas: callResult.baseFeePerGas,
+	blockHeader: callResult.blockHeader,
 })
 
 const createExecutionSimulationBlocks = (
@@ -1074,31 +1087,37 @@ async function getSimulatedMockBlock(ethereumClientService: EthereumClientServic
 	if (parentBlock === null) throw new Error('The latest block is null')
 	if (parentBlock.baseFeePerGas === undefined) throw new Error(CANNOT_SIMULATE_OFF_LEGACY_BLOCK)
 	if (simulationState.success === false) throw new JsonRpcResponseError(simulationState.jsonRpcError)
+	const simulatedBlock = simulationState.simulatedBlocks[blockDelta]
+	const blockHeaderTemplate = getSimulatedBlockHeaderTemplate(simulationState, blockDelta)
+	const parentHash = blockDelta === 0 ? blockHeaderTemplate?.parentHash ?? parentBlock.hash : getHashOfSimulatedBlock(simulationState, blockDelta - 1)
 	return {
-		author: parentBlock.miner,
-		difficulty: parentBlock.difficulty,
-		extraData: parentBlock.extraData,
-		gasLimit: parentBlock.gasLimit,
-		gasUsed: transactionQueueTotalGasLimit(simulationState.simulatedBlocks[blockDelta]?.simulatedTransactions || []),
+		author: blockHeaderTemplate?.miner ?? parentBlock.miner,
+		difficulty: blockHeaderTemplate?.difficulty ?? parentBlock.difficulty,
+		extraData: blockHeaderTemplate?.extraData ?? parentBlock.extraData,
+		gasLimit: blockHeaderTemplate?.gasLimit ?? parentBlock.gasLimit,
+		gasUsed: blockHeaderTemplate?.gasUsed ?? transactionQueueTotalGasUsed(simulatedBlock?.simulatedTransactions || []),
 		hash: getHashOfSimulatedBlock(simulationState, blockDelta),
-		logsBloom: parentBlock.logsBloom, // TODO: this is wrong
-		miner: parentBlock.miner,
-		mixHash: parentBlock.mixHash, // TODO: this is wrong
-		nonce: parentBlock.nonce,
-		number: simulationState.blockNumber + BigInt(blockDelta) + 1n,
-		parentHash: parentBlock.hash,
-		receiptsRoot: parentBlock.receiptsRoot, // TODO: this is wrong
-		sha3Uncles: parentBlock.sha3Uncles, // TODO: this is wrong
-		stateRoot: parentBlock.stateRoot, // TODO: this is wrong
-		timestamp: simulationState.simulatedBlocks[blockDelta]?.blockTimestamp || bigintSecondsToDate((dateToBigintSeconds(simulationState.blockTimestamp) + getBlockTimeManipulationSeconds(DEFAULT_BLOCK_MANIPULATION.deltaToAdd, DEFAULT_BLOCK_MANIPULATION.deltaUnit))),
-		size: parentBlock.size, // TODO: this is wrong
-		totalDifficulty: (parentBlock.totalDifficulty ?? 0n) + parentBlock.difficulty, // The difficulty increases about the same amount as previously
-		uncles: [],
-		baseFeePerGas: getNextBaseFeePerGas(parentBlock.gasUsed, parentBlock.gasLimit, parentBlock.baseFeePerGas),
-		transactionsRoot: parentBlock.transactionsRoot, // TODO: this is wrong
-		transactions: simulationState.simulatedBlocks[blockDelta]?.simulatedTransactions.map((simulatedTransaction) => simulatedTransaction.preSimulationTransaction.signedTransaction) || [],
-		withdrawals: [],
-		withdrawalsRoot: 0n, // TODO: this is wrong
+		logsBloom: blockHeaderTemplate?.logsBloom ?? parentBlock.logsBloom,
+		miner: blockHeaderTemplate?.miner ?? parentBlock.miner,
+		mixHash: blockHeaderTemplate?.mixHash ?? parentBlock.mixHash,
+		nonce: blockHeaderTemplate?.nonce ?? parentBlock.nonce,
+		number: getSimulationBlockNumber(simulationState, blockDelta),
+		parentHash,
+		receiptsRoot: blockHeaderTemplate?.receiptsRoot ?? parentBlock.receiptsRoot,
+		sha3Uncles: blockHeaderTemplate?.sha3Uncles ?? parentBlock.sha3Uncles,
+		stateRoot: blockHeaderTemplate?.stateRoot ?? parentBlock.stateRoot,
+		timestamp: simulatedBlock?.blockTimestamp || bigintSecondsToDate((dateToBigintSeconds(simulationState.blockTimestamp) + getBlockTimeManipulationSeconds(DEFAULT_BLOCK_MANIPULATION.deltaToAdd, DEFAULT_BLOCK_MANIPULATION.deltaUnit))),
+		size: blockHeaderTemplate?.size ?? parentBlock.size,
+		totalDifficulty: blockHeaderTemplate?.totalDifficulty ?? ((parentBlock.totalDifficulty ?? 0n) + parentBlock.difficulty),
+		uncles: blockHeaderTemplate?.uncles ?? [],
+		baseFeePerGas: simulatedBlock?.blockBaseFeePerGas ?? getNextBaseFeePerGas(parentBlock.gasUsed, parentBlock.gasLimit, parentBlock.baseFeePerGas),
+		transactionsRoot: blockHeaderTemplate?.transactionsRoot ?? parentBlock.transactionsRoot,
+		transactions: simulatedBlock?.simulatedTransactions.map((simulatedTransaction) => simulatedTransaction.preSimulationTransaction.signedTransaction) || [],
+		withdrawals: blockHeaderTemplate?.withdrawals ?? [],
+		...(blockHeaderTemplate?.blobGasUsed !== undefined ? { blobGasUsed: blockHeaderTemplate.blobGasUsed } : {}),
+		...(blockHeaderTemplate?.excessBlobGas !== undefined ? { excessBlobGas: blockHeaderTemplate.excessBlobGas } : {}),
+		...(blockHeaderTemplate?.parentBeaconBlockRoot !== undefined ? { parentBeaconBlockRoot: blockHeaderTemplate.parentBeaconBlockRoot } : {}),
+		...(blockHeaderTemplate?.withdrawalsRoot !== undefined ? { withdrawalsRoot: blockHeaderTemplate.withdrawalsRoot } : {}),
 	} as const
 }
 
@@ -1313,8 +1332,13 @@ const simulateTransactionsOnTopOfSimulationInput = async (ethereumClientService:
 	return last(groupEthSimulateV1ResultByInputBlocks(prepared, ethSimulateV1CallResult))?.calls || []
 }
 
-// use time as block hash as that makes it so that updated simulations with different states are different, but requires no additional calculation
-const getHashOfSimulatedBlock = (simulationState: SimulationState, blockDelta: number) => getHashOfSimulatedBlockFromInput(simulationState.simulationStateInput, blockDelta)
+// prefer the node-provided simulated block hash when available, and fall back to a deterministic synthetic hash for grouped logical blocks
+const getHashOfSimulatedBlock = (simulationState: SimulationState, blockDelta: number) => getSimulatedBlockHeaderTemplate(simulationState, blockDelta)?.hash ?? getHashOfSimulatedBlockFromInput(simulationState.simulationStateInput, blockDelta)
+
+const getSimulatedBlockHeaderTemplate = (simulationState: SimulationState, blockDelta: number) => {
+	if (simulationState.success === false) throw new JsonRpcResponseError(simulationState.jsonRpcError)
+	return simulationState.simulatedBlocks[blockDelta]?.blockHeader
+}
 
 export const getMessageHashForPersonalSign = (params: PersonalSignParams) => hashMessage({ raw: stringToUint8Array(params.params[0]) })
 

--- a/app/ts/types/accessRequest.ts
+++ b/app/ts/types/accessRequest.ts
@@ -154,6 +154,6 @@ const PendingSignableMessage = funtypes.Intersect(
 	)
 )
 
-const PendingTransactionOrSignableMessageRuntype = funtypes.Union(PendingSignableMessage, PendingTransaction)
-export type PendingTransactionOrSignableMessage = funtypes.Static<typeof PendingTransactionOrSignableMessageRuntype>
-export const PendingTransactionOrSignableMessage = PendingTransactionOrSignableMessageRuntype
+export type PendingTransactionOrSignableMessage = PendingSignableMessage | PendingTransaction
+const PendingTransactionOrSignableMessageRuntype: funtypes.Codec<PendingTransactionOrSignableMessage> = funtypes.Union(PendingSignableMessage, PendingTransaction)
+export const PendingTransactionOrSignableMessage: funtypes.Codec<PendingTransactionOrSignableMessage> = PendingTransactionOrSignableMessageRuntype

--- a/app/ts/types/accessRequest.ts
+++ b/app/ts/types/accessRequest.ts
@@ -154,6 +154,6 @@ const PendingSignableMessage = funtypes.Intersect(
 	)
 )
 
-const PendingTransactionOrSignableMessageRuntype: funtypes.Codec<PendingSignableMessage | PendingTransaction> = funtypes.Union(PendingSignableMessage, PendingTransaction)
+const PendingTransactionOrSignableMessageRuntype = funtypes.Union(PendingSignableMessage, PendingTransaction)
 export type PendingTransactionOrSignableMessage = funtypes.Static<typeof PendingTransactionOrSignableMessageRuntype>
 export const PendingTransactionOrSignableMessage = PendingTransactionOrSignableMessageRuntype

--- a/app/ts/types/accessRequest.ts
+++ b/app/ts/types/accessRequest.ts
@@ -154,5 +154,6 @@ const PendingSignableMessage = funtypes.Intersect(
 	)
 )
 
-export type PendingTransactionOrSignableMessage = funtypes.Static<typeof PendingTransactionOrSignableMessage>
-export const PendingTransactionOrSignableMessage = funtypes.Union(PendingSignableMessage, PendingTransaction)
+const PendingTransactionOrSignableMessageRuntype: funtypes.Codec<PendingSignableMessage | PendingTransaction> = funtypes.Union(PendingSignableMessage, PendingTransaction)
+export type PendingTransactionOrSignableMessage = funtypes.Static<typeof PendingTransactionOrSignableMessageRuntype>
+export const PendingTransactionOrSignableMessage = PendingTransactionOrSignableMessageRuntype

--- a/app/ts/types/accessRequest.ts
+++ b/app/ts/types/accessRequest.ts
@@ -155,5 +155,5 @@ const PendingSignableMessage = funtypes.Intersect(
 )
 
 export type PendingTransactionOrSignableMessage = PendingSignableMessage | PendingTransaction
-const PendingTransactionOrSignableMessageRuntype: funtypes.Codec<PendingTransactionOrSignableMessage> = funtypes.Union(PendingSignableMessage, PendingTransaction)
-export const PendingTransactionOrSignableMessage: funtypes.Codec<PendingTransactionOrSignableMessage> = PendingTransactionOrSignableMessageRuntype
+const PendingTransactionOrSignableMessageRuntype: funtypes.Runtype<PendingTransactionOrSignableMessage> = funtypes.Union(PendingSignableMessage, PendingTransaction)
+export const PendingTransactionOrSignableMessage: typeof PendingTransactionOrSignableMessageRuntype = PendingTransactionOrSignableMessageRuntype

--- a/app/ts/types/ethSimulate-types.ts
+++ b/app/ts/types/ethSimulate-types.ts
@@ -1,5 +1,5 @@
 import { ErrorWithCodeAndOptionalData } from './error.js'
-import { EthereumAccessList, EthereumAddress, EthereumBlockTag, EthereumBytes32, EthereumData, EthereumInput, EthereumQuantity, EthereumQuantitySmall, EthereumTimestamp, LiteralConverterParserFactory } from './wire-types.js'
+import { EthereumAccessList, EthereumAddress, EthereumBlockTag, EthereumBytes16, EthereumBytes256, EthereumBytes32, EthereumData, EthereumInput, EthereumQuantity, EthereumQuantitySmall, EthereumTimestamp, LiteralConverterParserFactory } from './wire-types.js'
 import * as funtypes from 'funtypes'
 
 type AccountOverride = funtypes.Static<typeof AccountOverride>
@@ -125,8 +125,50 @@ export const EthSimulateV1CallResult = funtypes.Union(EthSimulateCallResultFailu
 export type EthSimulateV1CallResults = funtypes.Static<typeof EthSimulateV1CallResults>
 export const EthSimulateV1CallResults = funtypes.ReadonlyArray(EthSimulateV1CallResult)
 
+type EthSimulateV1Withdrawal = funtypes.Static<typeof EthSimulateV1Withdrawal>
+const EthSimulateV1Withdrawal = funtypes.ReadonlyObject({
+	index: EthereumQuantity,
+	validatorIndex: EthereumQuantity,
+	address: EthereumAddress,
+	amount: EthereumQuantity,
+})
+
+export type EthSimulateV1BlockHeader = funtypes.Static<typeof EthSimulateV1BlockHeader>
+export const EthSimulateV1BlockHeader = funtypes.Intersect(
+	funtypes.ReadonlyObject({
+		number: EthereumQuantity,
+		hash: EthereumBytes32,
+		timestamp: EthereumQuantity,
+		gasLimit: EthereumQuantitySmall,
+		gasUsed: EthereumQuantitySmall,
+		baseFeePerGas: EthereumQuantity,
+	}),
+	funtypes.ReadonlyPartial({
+		difficulty: EthereumQuantity,
+		extraData: EthereumData,
+		logsBloom: EthereumBytes256,
+		miner: EthereumAddress,
+		mixHash: EthereumBytes32,
+		nonce: EthereumBytes16,
+		parentHash: EthereumBytes32,
+		receiptsRoot: EthereumBytes32,
+		sha3Uncles: EthereumBytes32,
+		size: EthereumQuantity,
+		stateRoot: EthereumBytes32,
+		transactions: funtypes.ReadonlyArray(EthereumBytes32),
+		transactionsRoot: EthereumBytes32,
+		uncles: funtypes.ReadonlyArray(EthereumBytes32),
+		excessBlobGas: EthereumQuantity,
+		blobGasUsed: EthereumQuantity,
+		parentBeaconBlockRoot: EthereumBytes32,
+		withdrawalsRoot: EthereumBytes32,
+		withdrawals: funtypes.ReadonlyArray(EthSimulateV1Withdrawal),
+		totalDifficulty: EthereumQuantity,
+	}),
+)
+
 type EthSimulateV1BlockResult = funtypes.Static<typeof EthSimulateV1BlockResult>
-const EthSimulateV1BlockResult = funtypes.ReadonlyObject({
+const EthSimulateV1BlockResult = funtypes.Intersect(EthSimulateV1BlockHeader, funtypes.ReadonlyObject({
 	number: EthereumQuantity,
 	hash: EthereumBytes32,
 	timestamp: EthereumQuantity,
@@ -134,7 +176,7 @@ const EthSimulateV1BlockResult = funtypes.ReadonlyObject({
 	gasUsed: EthereumQuantitySmall,
 	baseFeePerGas: EthereumQuantity,
 	calls: EthSimulateV1CallResults,
-})
+}))
 
 export type EthSimulateV1Result = funtypes.Static<typeof EthSimulateV1Result>
 export const EthSimulateV1Result = funtypes.ReadonlyArray(EthSimulateV1BlockResult)

--- a/app/ts/types/interceptor-messages.ts
+++ b/app/ts/types/interceptor-messages.ts
@@ -502,13 +502,7 @@ const UpdateConfirmTransactionDialogPendingTransactionsPartial = funtypes.Readon
 	data: funtypes.Unknown
 }).asReadonly()
 
-const UpdateConfirmTransactionDialogPendingTransactionsRuntype: funtypes.Codec<{
-	readonly method: 'popup_update_confirm_transaction_dialog_pending_transactions'
-	readonly data: {
-		readonly pendingTransactionAndSignableMessages: readonly PendingTransactionOrSignableMessage[]
-		readonly currentBlockNumber: bigint
-	}
-}> = funtypes.ReadonlyObject({
+const UpdateConfirmTransactionDialogPendingTransactionsRuntype = funtypes.ReadonlyObject({
 	method: funtypes.Literal('popup_update_confirm_transaction_dialog_pending_transactions'),
 	data: funtypes.ReadonlyObject({
 		pendingTransactionAndSignableMessages: funtypes.ReadonlyArray(PendingTransactionOrSignableMessage),

--- a/app/ts/types/interceptor-messages.ts
+++ b/app/ts/types/interceptor-messages.ts
@@ -502,14 +502,21 @@ const UpdateConfirmTransactionDialogPendingTransactionsPartial = funtypes.Readon
 	data: funtypes.Unknown
 }).asReadonly()
 
-export type UpdateConfirmTransactionDialogPendingTransactions = funtypes.Static<typeof UpdateConfirmTransactionDialogPendingTransactions>
-export const UpdateConfirmTransactionDialogPendingTransactions = funtypes.ReadonlyObject({
+const UpdateConfirmTransactionDialogPendingTransactionsRuntype: funtypes.Codec<{
+	readonly method: 'popup_update_confirm_transaction_dialog_pending_transactions'
+	readonly data: {
+		readonly pendingTransactionAndSignableMessages: readonly PendingTransactionOrSignableMessage[]
+		readonly currentBlockNumber: bigint
+	}
+}> = funtypes.ReadonlyObject({
 	method: funtypes.Literal('popup_update_confirm_transaction_dialog_pending_transactions'),
 	data: funtypes.ReadonlyObject({
 		pendingTransactionAndSignableMessages: funtypes.ReadonlyArray(PendingTransactionOrSignableMessage),
 		currentBlockNumber: EthereumQuantity,
 	})
 }).asReadonly()
+export type UpdateConfirmTransactionDialogPendingTransactions = funtypes.Static<typeof UpdateConfirmTransactionDialogPendingTransactionsRuntype>
+export const UpdateConfirmTransactionDialogPendingTransactions = UpdateConfirmTransactionDialogPendingTransactionsRuntype
 
 export type InterceptorAccessReply = funtypes.Static<typeof InterceptorAccessReply>
 export const InterceptorAccessReply = funtypes.ReadonlyObject({

--- a/app/ts/types/interceptor-messages.ts
+++ b/app/ts/types/interceptor-messages.ts
@@ -502,15 +502,21 @@ const UpdateConfirmTransactionDialogPendingTransactionsPartial = funtypes.Readon
 	data: funtypes.Unknown
 }).asReadonly()
 
-const UpdateConfirmTransactionDialogPendingTransactionsRuntype = funtypes.ReadonlyObject({
+const UpdateConfirmTransactionDialogPendingTransactionsRuntype: funtypes.Codec<UpdateConfirmTransactionDialogPendingTransactions> = funtypes.ReadonlyObject({
 	method: funtypes.Literal('popup_update_confirm_transaction_dialog_pending_transactions'),
 	data: funtypes.ReadonlyObject({
 		pendingTransactionAndSignableMessages: funtypes.ReadonlyArray(PendingTransactionOrSignableMessage),
 		currentBlockNumber: EthereumQuantity,
 	})
 }).asReadonly()
-export type UpdateConfirmTransactionDialogPendingTransactions = funtypes.Static<typeof UpdateConfirmTransactionDialogPendingTransactionsRuntype>
-export const UpdateConfirmTransactionDialogPendingTransactions = UpdateConfirmTransactionDialogPendingTransactionsRuntype
+export type UpdateConfirmTransactionDialogPendingTransactions = {
+	readonly method: 'popup_update_confirm_transaction_dialog_pending_transactions'
+	readonly data: {
+		readonly pendingTransactionAndSignableMessages: readonly PendingTransactionOrSignableMessage[]
+		readonly currentBlockNumber: funtypes.Static<typeof EthereumQuantity>
+	}
+}
+export const UpdateConfirmTransactionDialogPendingTransactions: funtypes.Codec<UpdateConfirmTransactionDialogPendingTransactions> = UpdateConfirmTransactionDialogPendingTransactionsRuntype
 
 export type InterceptorAccessReply = funtypes.Static<typeof InterceptorAccessReply>
 export const InterceptorAccessReply = funtypes.ReadonlyObject({

--- a/app/ts/types/interceptor-messages.ts
+++ b/app/ts/types/interceptor-messages.ts
@@ -502,13 +502,6 @@ const UpdateConfirmTransactionDialogPendingTransactionsPartial = funtypes.Readon
 	data: funtypes.Unknown
 }).asReadonly()
 
-const UpdateConfirmTransactionDialogPendingTransactionsRuntype: funtypes.Codec<UpdateConfirmTransactionDialogPendingTransactions> = funtypes.ReadonlyObject({
-	method: funtypes.Literal('popup_update_confirm_transaction_dialog_pending_transactions'),
-	data: funtypes.ReadonlyObject({
-		pendingTransactionAndSignableMessages: funtypes.ReadonlyArray(PendingTransactionOrSignableMessage),
-		currentBlockNumber: EthereumQuantity,
-	})
-}).asReadonly()
 export type UpdateConfirmTransactionDialogPendingTransactions = {
 	readonly method: 'popup_update_confirm_transaction_dialog_pending_transactions'
 	readonly data: {
@@ -516,7 +509,16 @@ export type UpdateConfirmTransactionDialogPendingTransactions = {
 		readonly currentBlockNumber: funtypes.Static<typeof EthereumQuantity>
 	}
 }
-export const UpdateConfirmTransactionDialogPendingTransactions: funtypes.Codec<UpdateConfirmTransactionDialogPendingTransactions> = UpdateConfirmTransactionDialogPendingTransactionsRuntype
+const createUpdateConfirmTransactionDialogPendingTransactionsRuntype = () => funtypes.ReadonlyObject({
+	method: funtypes.Literal('popup_update_confirm_transaction_dialog_pending_transactions'),
+	data: funtypes.ReadonlyObject({
+		pendingTransactionAndSignableMessages: funtypes.ReadonlyArray(PendingTransactionOrSignableMessage),
+		currentBlockNumber: EthereumQuantity,
+	})
+}).asReadonly()
+type UpdateConfirmTransactionDialogPendingTransactionsRuntype = ReturnType<typeof createUpdateConfirmTransactionDialogPendingTransactionsRuntype>
+const UpdateConfirmTransactionDialogPendingTransactionsRuntype: UpdateConfirmTransactionDialogPendingTransactionsRuntype = createUpdateConfirmTransactionDialogPendingTransactionsRuntype()
+export const UpdateConfirmTransactionDialogPendingTransactions: typeof UpdateConfirmTransactionDialogPendingTransactionsRuntype = UpdateConfirmTransactionDialogPendingTransactionsRuntype
 
 export type InterceptorAccessReply = funtypes.Static<typeof InterceptorAccessReply>
 export const InterceptorAccessReply = funtypes.ReadonlyObject({

--- a/app/ts/types/visualizer-types.ts
+++ b/app/ts/types/visualizer-types.ts
@@ -10,7 +10,7 @@ import { VisualizedPersonalSignRequest } from './personal-message-definitions.js
 import { RpcNetwork } from './rpc.js'
 import { SignMessageParams } from './jsonRpc-signing-types.js'
 import { TransactionOrMessageIdentifier } from './interceptor-messages.js'
-import { EthSimulateV1CallResult, EthSimulateV1Params, StateOverrides } from './ethSimulate-types.js'
+import { EthSimulateV1BlockHeader, EthSimulateV1CallResult, EthSimulateV1Params, StateOverrides } from './ethSimulate-types.js'
 import { EditEnsNamedHashCallBack } from '../components/subcomponents/ens.js'
 import { EnrichedEthereumEventWithMetadata, EnrichedEthereumInputData } from './EnrichedEthereumData.js'
 import { ReadonlySignal } from '@preact/signals'
@@ -190,14 +190,19 @@ export type SimulationStateInputMinimalData = funtypes.Static<typeof SimulationS
 export const SimulationStateInputMinimalData = funtypes.ReadonlyArray(SimulationStateInputMinimalDataBlock)
 
 export type SimulationStateBlock = funtypes.Static<typeof SimulationStateBlock>
-export const SimulationStateBlock = funtypes.ReadonlyObject({
-	stateOverrides: StateOverrides,
-	simulatedTransactions: funtypes.ReadonlyArray(SimulatedTransaction),
-	signedMessages: funtypes.ReadonlyArray(SignedMessageTransaction),
-	blockTimestamp: EthereumTimestamp,
-	blockTimeManipulation: BlockTimeManipulation,
-	blockBaseFeePerGas: EthereumQuantity,
-})
+export const SimulationStateBlock = funtypes.Intersect(
+	funtypes.ReadonlyObject({
+		stateOverrides: StateOverrides,
+		simulatedTransactions: funtypes.ReadonlyArray(SimulatedTransaction),
+		signedMessages: funtypes.ReadonlyArray(SignedMessageTransaction),
+		blockTimestamp: EthereumTimestamp,
+		blockTimeManipulation: BlockTimeManipulation,
+		blockBaseFeePerGas: EthereumQuantity,
+	}),
+	funtypes.ReadonlyPartial({
+		blockHeader: EthSimulateV1BlockHeader,
+	}),
+)
 
 type SimulationStateSuccess = funtypes.Static<typeof SimulationStateSuccess>
 const SimulationStateSuccess = funtypes.ReadonlyObject({

--- a/app/ts/types/wire-types.ts
+++ b/app/ts/types/wire-types.ts
@@ -204,8 +204,8 @@ export type EthereumBytes32 = funtypes.Static<typeof EthereumBytes32>
 export const EthereumBytes256 = funtypes.String.withParser(Bytes256Parser)
 export type EthereumBytes256 = funtypes.Static<typeof EthereumBytes256>
 
-const EthereumBytes16 = funtypes.String.withParser(Bytes16Parser)
-type EthereumBytes16 = funtypes.Static<typeof EthereumBytes16>
+export const EthereumBytes16 = funtypes.String.withParser(Bytes16Parser)
+export type EthereumBytes16 = funtypes.Static<typeof EthereumBytes16>
 
 export const EthereumTimestamp = funtypes.String.withParser(TimestampParser)
 export type EthereumTimestamp = funtypes.Static<typeof EthereumTimestamp>

--- a/app/ts/utils/signals.ts
+++ b/app/ts/utils/signals.ts
@@ -3,6 +3,10 @@ import { Signal, type ReadonlySignal } from '@preact/signals'
 export type SignalLike<T> = ReadonlySignal<T> | Signal<T>
 export type SignalOrValue<T> = T | SignalLike<T>
 
-export function resolveSignal<T>(value: SignalOrValue<T>) {
-	return value instanceof Signal ? value.value : value
+function isSignalLike<T>(value: SignalOrValue<T>): value is SignalLike<T> {
+	return value instanceof Signal
+}
+
+export function resolveSignal<T>(value: SignalOrValue<T>): T {
+	return isSignalLike(value) ? value.value : value
 }

--- a/app/ts/utils/storageUtils.ts
+++ b/app/ts/utils/storageUtils.ts
@@ -40,8 +40,7 @@ export const RichListElement = funtypes.ReadonlyObject({
 	type: funtypes.Union(funtypes.Literal('CurrentActiveAddress'), funtypes.Literal('PreviousActiveAddress'), funtypes.Literal('UserAdded')),
 })
 
-type LocalStorageItems = funtypes.Static<typeof LocalStorageItems>
-const LocalStorageItems = funtypes.ReadonlyPartial({
+const LocalStorageItemsRuntype = funtypes.ReadonlyPartial({
 	activeSigningAddress: EthereumAddressOrMissing,
 	activeSimulationAddress: EthereumAddressOrMissing,
 	openedPageV2: Page,
@@ -74,6 +73,8 @@ const LocalStorageItems = funtypes.ReadonlyPartial({
 	fixedAddressRichList: funtypes.ReadonlyArray(RichListElement),
 	fetchSimulationStackRequestPromise: funtypes.Union(funtypes.Undefined, PendingFetchSimulationStackRequestPromise),
 })
+type LocalStorageItems = funtypes.Static<typeof LocalStorageItemsRuntype>
+const LocalStorageItems: funtypes.Codec<LocalStorageItems> = LocalStorageItemsRuntype
 
 type LocalStorageKey = funtypes.Static<typeof LocalStorageKey>
 const LocalStorageKey = funtypes.Union(
@@ -113,7 +114,7 @@ const LocalStorageItems2Runtype = funtypes.ReadonlyPartial({
 	pendingTransactionsAndMessages: funtypes.ReadonlyArray(PendingTransactionOrSignableMessage)
 })
 type LocalStorageItems2 = funtypes.Static<typeof LocalStorageItems2Runtype>
-const LocalStorageItems2 = LocalStorageItems2Runtype
+const LocalStorageItems2: funtypes.Codec<LocalStorageItems2> = LocalStorageItems2Runtype
 
 type LocalStorageKey2 = funtypes.Static<typeof LocalStorageKey2>
 const LocalStorageKey2 = funtypes.Union(

--- a/app/ts/utils/storageUtils.ts
+++ b/app/ts/utils/storageUtils.ts
@@ -74,7 +74,7 @@ const LocalStorageItemsRuntype = funtypes.ReadonlyPartial({
 	fetchSimulationStackRequestPromise: funtypes.Union(funtypes.Undefined, PendingFetchSimulationStackRequestPromise),
 })
 type LocalStorageItems = funtypes.Static<typeof LocalStorageItemsRuntype>
-const LocalStorageItems: funtypes.Codec<LocalStorageItems> = LocalStorageItemsRuntype
+const LocalStorageItems: typeof LocalStorageItemsRuntype = LocalStorageItemsRuntype
 
 type LocalStorageKey = funtypes.Static<typeof LocalStorageKey>
 const LocalStorageKey = funtypes.Union(
@@ -110,11 +110,13 @@ const LocalStorageKey = funtypes.Union(
 	funtypes.Literal('fetchSimulationStackRequestPromise'),
 )
 
-const LocalStorageItems2Runtype = funtypes.ReadonlyPartial({
+const LocalStorageItems2Runtype: funtypes.Partial<{
+	pendingTransactionsAndMessages: funtypes.ReadonlyArray<typeof PendingTransactionOrSignableMessage>
+}, true> = funtypes.ReadonlyPartial({
 	pendingTransactionsAndMessages: funtypes.ReadonlyArray(PendingTransactionOrSignableMessage)
 })
 type LocalStorageItems2 = funtypes.Static<typeof LocalStorageItems2Runtype>
-const LocalStorageItems2: funtypes.Codec<LocalStorageItems2> = LocalStorageItems2Runtype
+const LocalStorageItems2: typeof LocalStorageItems2Runtype = LocalStorageItems2Runtype
 
 type LocalStorageKey2 = funtypes.Static<typeof LocalStorageKey2>
 const LocalStorageKey2 = funtypes.Union(

--- a/app/ts/utils/storageUtils.ts
+++ b/app/ts/utils/storageUtils.ts
@@ -109,9 +109,7 @@ const LocalStorageKey = funtypes.Union(
 	funtypes.Literal('fetchSimulationStackRequestPromise'),
 )
 
-const LocalStorageItems2Runtype: funtypes.Codec<{
-	readonly pendingTransactionsAndMessages?: readonly PendingTransactionOrSignableMessage[]
-}> = funtypes.ReadonlyPartial({
+const LocalStorageItems2Runtype = funtypes.ReadonlyPartial({
 	pendingTransactionsAndMessages: funtypes.ReadonlyArray(PendingTransactionOrSignableMessage)
 })
 type LocalStorageItems2 = funtypes.Static<typeof LocalStorageItems2Runtype>

--- a/app/ts/utils/storageUtils.ts
+++ b/app/ts/utils/storageUtils.ts
@@ -109,10 +109,13 @@ const LocalStorageKey = funtypes.Union(
 	funtypes.Literal('fetchSimulationStackRequestPromise'),
 )
 
-type LocalStorageItems2 = funtypes.Static<typeof LocalStorageItems2>
-const LocalStorageItems2 = funtypes.ReadonlyPartial({
+const LocalStorageItems2Runtype: funtypes.Codec<{
+	readonly pendingTransactionsAndMessages?: readonly PendingTransactionOrSignableMessage[]
+}> = funtypes.ReadonlyPartial({
 	pendingTransactionsAndMessages: funtypes.ReadonlyArray(PendingTransactionOrSignableMessage)
 })
+type LocalStorageItems2 = funtypes.Static<typeof LocalStorageItems2Runtype>
+const LocalStorageItems2 = LocalStorageItems2Runtype
 
 type LocalStorageKey2 = funtypes.Static<typeof LocalStorageKey2>
 const LocalStorageKey2 = funtypes.Union(

--- a/test/tests/SimulationModeEthereumClientService.test.ts
+++ b/test/tests/SimulationModeEthereumClientService.test.ts
@@ -682,6 +682,35 @@ const zeroBytes256 = `0x${'0'.repeat(512)}`
 				assert.equal(receipt.cumulativeGasUsed, receipt.gasUsed)
 			})
 
+			test('state-based receipt keeps receipt and log block numbers in sync', async () => {
+				const simulationStateInput = [{
+					stateOverrides: {},
+					transactions: [{
+						signedTransaction: mockSignTransaction({
+							...exampleTransaction,
+							nonce: 0n,
+						}),
+						website: { websiteOrigin: 'test', icon: undefined, title: undefined },
+						created: new Date(),
+						originalRequestParameters: { method: 'eth_sendTransaction', params: [{}]},
+						transactionIdentifier: 14n,
+					}],
+					signedMessages: [],
+					blockTimeManipulation: { type: 'AddToTimestamp', deltaToAdd: 12n, deltaUnit: 'Seconds' },
+					simulateWithZeroBaseFee: false,
+				}] as const
+
+				const simulationState = await createSimulationState(ethereum, undefined, simulationStateInput)
+				if (simulationState.success === false) throw new Error('simulation unexpectedly failed')
+				const transactionHash = simulationStateInput[0].transactions[0]?.signedTransaction.hash
+				if (transactionHash === undefined) throw new Error('transaction hash missing')
+				const receipt = await getReceiptFromState(simulationState, transactionHash)
+				if (receipt === null) throw new Error('receipt missing')
+
+				assert.equal(receipt.blockNumber, blockNumber + 1n)
+				assert.equal(receipt.logs[0]?.blockNumber, receipt.blockNumber)
+			})
+
 			test('state-based logs honor the first simulated execution block hash after gas splitting', async () => {
 				const splitSimulationStateInput = [{
 					stateOverrides: {},

--- a/test/tests/nethermindComparison.test.ts
+++ b/test/tests/nethermindComparison.test.ts
@@ -126,8 +126,6 @@ describe('Nethermind testing', () => {
 	})
 
 	test('adding transaction and getting the next block should include all the same fields as Nethermind', async () => {
-		const block = await getSimulatedBlock(ethereum, undefined, resolvedSimulationState, blockNumber, true)
-		if (block === null) throw new Error('Block was null')
 		const newState = await appendTransactionToInputAndSimulate(ethereum, undefined, simulationState.simulationStateInput, [{
 			signedTransaction: mockSignTransaction(exampleTransaction),
 			website: { websiteOrigin: 'test', icon: undefined, title: undefined },
@@ -135,14 +133,26 @@ describe('Nethermind testing', () => {
 			originalRequestParameters: { method: 'eth_sendTransaction', params: [{}]},
 			transactionIdentifier: 1n,
 		}])
-		const nextBlock = await getSimulatedBlock(ethereum, undefined, toResolvedSimulationState(newState), blockNumber + 2n, true)
+		const nextBlock = await getSimulatedBlock(ethereum, undefined, toResolvedSimulationState(newState), blockNumber + 1n, true)
 		if (nextBlock === null) throw new Error('Block was null')
-		assert.equal(JSON.stringify(Object.keys(nextBlock).sort()), JSON.stringify(Object.keys(block).sort()))
-
-		const expected = parseRequest(eth_getBlockByNumber_goerli_8443561_true)
-		assertIsObject(expected)
-		const requiredFields = Object.keys(expected).sort()
-		assert.equal(JSON.stringify(Object.keys(nextBlock).sort()), JSON.stringify(requiredFields))
+		const serializedNextBlock = GetBlockReturn.serialize(nextBlock)
+		const expectedSimulationResult = parseRequest(eth_simulateV1_dummy_call_result)
+		if (!Array.isArray(expectedSimulationResult)) throw new Error('Expected simulated result to be an array')
+		const expectedSimulatedBlock = expectedSimulationResult[0]
+		assertIsObject(expectedSimulatedBlock)
+		const requiredFields = [...Object.keys(expectedSimulatedBlock).filter((key) => key !== 'calls'), 'author'].sort()
+		assert.equal(JSON.stringify(Object.keys(serializedNextBlock).sort()), JSON.stringify(requiredFields))
+		assert.equal(serializedNextBlock.hash, expectedSimulatedBlock.hash)
+		assert.equal(serializedNextBlock.parentHash, expectedSimulatedBlock.parentHash)
+		assert.equal(serializedNextBlock.logsBloom, expectedSimulatedBlock.logsBloom)
+		assert.equal(serializedNextBlock.mixHash, expectedSimulatedBlock.mixHash)
+		assert.equal(serializedNextBlock.receiptsRoot, expectedSimulatedBlock.receiptsRoot)
+		assert.equal(serializedNextBlock.stateRoot, expectedSimulatedBlock.stateRoot)
+		assert.equal(serializedNextBlock.size, expectedSimulatedBlock.size)
+		assert.equal(serializedNextBlock.transactionsRoot, expectedSimulatedBlock.transactionsRoot)
+		assert.equal(serializedNextBlock.withdrawalsRoot, expectedSimulatedBlock.withdrawalsRoot)
+		assert.equal(serializedNextBlock.gasUsed, expectedSimulatedBlock.gasUsed)
+		assert.equal(serializedNextBlock.baseFeePerGas, expectedSimulatedBlock.baseFeePerGas)
 	})
 
 	test('get transaction by hash aligns with Nethermind', async () => {


### PR DESCRIPTION
## Summary
- carry node-provided eth_simulateV1 block headers through simulation state
- use those headers when building simulated blocks and hashes
- strengthen Nethermind parity checks around simulated header fields
- add required explicit codec type annotations so the expanded headers compile cleanly

## Validation
- npm test
- npm run setup-chrome