### PR TITLE
Make test TypeScript config viable

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -16,6 +16,7 @@
       },
       "devDependencies": {
         "@types/firefox-webext-browser": "120.0.3",
+        "@types/node": "20.11.17",
         "typescript": "5.4.5",
       },
     },
@@ -43,6 +44,8 @@
 
     "@types/firefox-webext-browser": ["@types/firefox-webext-browser@120.0.3", "", {}, "sha512-APbBSxOvFMbKwXy/4YrEVa5Di6N0C9yl4w0WA0xzdkOrChAfPQ/KlcC8QLyhemHCHpF1CB/zHy52+oUQurViOg=="],
 
+    "@types/node": ["@types/node@20.11.17", "", { "dependencies": { "undici-types": "~5.26.4" } }, "sha512-QmgQZGWu1Yw9TDyAP9ZzpFJKynYNeOvwMJmaxABfieQoVoiVOS6MN1WSpqpRcbeA5+RW82kraAVxCCJg+780Qw=="],
+
     "abitype": ["abitype@1.2.3", "", { "peerDependencies": { "typescript": ">=5.0.4", "zod": "^3.22.0 || ^4.0.0" }, "optionalPeers": ["typescript", "zod"] }, "sha512-Ofer5QUnuUdTFsBRwARMoWKOH1ND5ehwYhJ3OJ/BQO+StkwQjHw0XyVh4vDttzHB7QOFhPHa/o413PJ82gU/Tg=="],
 
     "eventemitter3": ["eventemitter3@5.0.1", "", {}, "sha512-GWkBvjiSZK87ELrYOSESUYeVIc9mvLLf/nXalMOS5dYrgZq9o5OVkbZAVM06CVxYsCwH9BDZFPlQTlPA1j4ahA=="],
@@ -56,6 +59,8 @@
     "preact": ["preact@10.24.2", "", {}, "sha512-1cSoF0aCC8uaARATfrlz4VCBqE8LwZwRfLgkxJOQwAlQt6ayTmi0D9OF7nXid1POI5SZidFuG9CnlXbDfLqY/Q=="],
 
     "typescript": ["typescript@5.4.5", "", { "bin": { "tsc": "bin/tsc", "tsserver": "bin/tsserver" } }, "sha512-vcI4UpRgg81oIRUFwR0WSIHKt11nJ7SAVlYNIu+QpqeyXP+gpQJy/Z4+F0aGxSE4MqwjyXvW/TzgkLAx2AGHwQ=="],
+
+    "undici-types": ["undici-types@5.26.5", "", {}, "sha512-JlCMO+ehdEIKqlFxk6IfVoAUVmgz7cU7zD/h9XZ0qzeosSHmUJVOzSQvvYSYWXkFXC+IfLKSIffhv0sVZup6pA=="],
 
     "viem": ["viem@2.48.4", "", { "dependencies": { "@noble/curves": "1.9.1", "@noble/hashes": "1.8.0", "@scure/bip32": "1.7.0", "@scure/bip39": "1.6.0", "abitype": "1.2.3", "isows": "1.0.7", "ox": "0.14.20", "ws": "8.18.3" }, "peerDependencies": { "typescript": ">=5.0.4" }, "optionalPeers": ["typescript"] }, "sha512-mReP/rgY2P+WeeRSG4sUvccCLKfyAW1C73Y3KkobAqgzYmVna9qyUMNE44xIUkDtfvRuC33r24UhF4baBYovsg=="],
 

--- a/package.json
+++ b/package.json
@@ -5,6 +5,7 @@
 	"packageManager": "bun@1.3.12",
 	"scripts": {
 		"test": "bun test",
+		"typecheck:test": "bun --bun tsc --project tsconfig-test.json --noEmit",
 		"install-chrome": "bash ./scripts/install-chrome.sh",
 		"setup-firefox": "bun run vendor && bun run inpage && bun run build-firefox",
 		"setup-chrome": "bun run vendor && bun run inpage && bun run build-chrome",
@@ -34,6 +35,7 @@
 	},
 	"devDependencies": {
 		"@types/firefox-webext-browser": "120.0.3",
+		"@types/node": "20.11.17",
 		"typescript": "5.4.5"
 	}
 }

--- a/test/bun-test.d.ts
+++ b/test/bun-test.d.ts
@@ -1,0 +1,7 @@
+declare module 'bun:test' {
+	export function describe(name: string, fn: () => void): void
+	export function test(name: string, fn: () => unknown | Promise<unknown>): void
+	export function test(name: string, options: { timeout?: number }, fn: () => unknown | Promise<unknown>): void
+	export function afterEach(fn: () => unknown | Promise<unknown>): void
+	export function afterAll(fn: () => unknown | Promise<unknown>): void
+}

--- a/test/tests/confirmTransactionRenderedTimestamp.test.ts
+++ b/test/tests/confirmTransactionRenderedTimestamp.test.ts
@@ -1,6 +1,4 @@
-// @ts-nocheck
 import * as assert from 'assert'
-import { encodeFunctionReturn } from '../../app/ts/utils/abiRuntime.js'
 import { h, render } from 'preact'
 import { act } from 'preact/test-utils'
 import { describe, test } from 'bun:test'
@@ -8,6 +6,34 @@ import { installDateMock, installDomMock } from './domMock.js'
 
 type RuntimeMessageListener = (message: unknown) => unknown
 const hexToBytes = (hex: string) => Uint8Array.from(Buffer.from(hex.slice(2), 'hex'))
+const defineGlobal = (name: PropertyKey, value: unknown) => Object.defineProperty(globalThis, name, { value, configurable: true, writable: true })
+const abiRuntimeModulePath = '../../app/ts/utils/abiRuntime.js'
+const interceptorMessagesModulePath = '../../app/ts/types/interceptor-messages.js'
+const wireTypesModulePath = '../../app/ts/types/wire-types.js'
+const confirmTransactionModulePath = '../../app/ts/components/pages/ConfirmTransaction.js'
+const ethereumClientServiceModulePath = '../../app/ts/simulation/services/EthereumClientService.js'
+const storageVariablesModulePath = '../../app/ts/background/storageVariables.js'
+const popupMessageHandlersModulePath = '../../app/ts/background/popupMessageHandlers.js'
+const storageUtilsModulePath = '../../app/ts/utils/storageUtils.js'
+const constantsModulePath = '../../app/ts/utils/constants.js'
+const ethSimulateTypesModulePath = '../../app/ts/types/ethSimulate-types.js'
+
+async function loadModules() {
+	return {
+		...await import(abiRuntimeModulePath),
+		...await import(interceptorMessagesModulePath),
+		...await import(wireTypesModulePath),
+		...await import(confirmTransactionModulePath),
+		...await import(ethereumClientServiceModulePath),
+		...await import(storageVariablesModulePath),
+		...await import(popupMessageHandlersModulePath),
+		...await import(storageUtilsModulePath),
+		...await import(constantsModulePath),
+		...await import(ethSimulateTypesModulePath),
+	}
+}
+
+const modulesPromise = loadModules()
 
 function createBrowserMock() {
 	const listeners: RuntimeMessageListener[] = []
@@ -20,8 +46,7 @@ function createBrowserMock() {
 		return Object.fromEntries(Object.entries(keys).map(([key, defaultValue]) => [key, key in storageState ? storageState[key] : defaultValue]))
 	}
 
-	// @ts-expect-error test shim intentionally overrides extension globals
-	globalThis.browser = {
+	const browserMock = {
 		runtime: {
 			lastError: null,
 			async sendMessage(message: any) {
@@ -83,11 +108,11 @@ function createBrowserMock() {
 			async setBadgeBackgroundColor() { return undefined },
 		},
 	}
-	// @ts-expect-error test shim intentionally overrides extension globals
-	globalThis.chrome = { runtime: { id: 'test-extension' } }
+	defineGlobal('browser', browserMock)
+	defineGlobal('chrome', { runtime: { id: 'test-extension' } })
 
 	return {
-		storage: globalThis.browser.storage,
+		storage: browserMock.storage,
 		dispatch(message: unknown) {
 			for (const listener of [...listeners]) listener(message)
 		},
@@ -163,11 +188,9 @@ function makePendingTransaction(simulationConductedTimestamp: Date) {
 	return pendingTransaction
 }
 
-const { UpdateConfirmTransactionDialogPendingTransactions } = await import('../../app/ts/types/interceptor-messages.js')
-const { serialize } = await import('../../app/ts/types/wire-types.js')
-const { ConfirmTransaction } = await import('../../app/ts/components/pages/ConfirmTransaction.js')
 describe('ConfirmTransaction', () => {
 	test('updates the simulation age when a refreshed pending transaction arrives', async () => {
+		const modules = await modulesPromise
 		const dom = installDomMock()
 		const clock = installDateMock('2024-01-01T00:00:10.000Z')
 		const browser = createBrowserMock()
@@ -175,13 +198,13 @@ describe('ConfirmTransaction', () => {
 		const newerPendingTransaction = makePendingTransaction(new Date('2024-01-01T00:00:09.000Z'))
 
 		await act(() => {
-			render(h(ConfirmTransaction, {}), dom.document.body)
+			render(h(modules.ConfirmTransaction, {}), dom.document.body)
 		})
 
 		await act(() => {
 			browser.dispatch({
 				role: 'all',
-				...serialize(UpdateConfirmTransactionDialogPendingTransactions, {
+				...modules.serialize(modules.UpdateConfirmTransactionDialogPendingTransactions, {
 				method: 'popup_update_confirm_transaction_dialog_pending_transactions',
 				data: {
 					pendingTransactionAndSignableMessages: [olderPendingTransaction],
@@ -195,7 +218,7 @@ describe('ConfirmTransaction', () => {
 		await act(() => {
 			browser.dispatch({
 				role: 'all',
-				...serialize(UpdateConfirmTransactionDialogPendingTransactions, {
+				...modules.serialize(modules.UpdateConfirmTransactionDialogPendingTransactions, {
 				method: 'popup_update_confirm_transaction_dialog_pending_transactions',
 				data: {
 					pendingTransactionAndSignableMessages: [newerPendingTransaction],
@@ -211,14 +234,11 @@ describe('ConfirmTransaction', () => {
 	})
 
 	test('updates the simulation age when the real refresh flow runs', { timeout: 15_000 }, async () => {
+		const modules = await modulesPromise
 		const dom = installDomMock()
 		const clock = installDateMock('2024-01-01T00:00:10.000Z')
 		const browser = createBrowserMock()
 		const olderPendingTransaction = makePendingTransaction(new Date('2024-01-01T00:00:05.000Z'))
-		const { EthereumClientService } = await import('../../app/ts/simulation/services/EthereumClientService.js')
-		const { updateInterceptorTransactionStack, getPendingTransactionsAndMessages } = await import('../../app/ts/background/storageVariables.js')
-		const { refreshPopupConfirmTransactionSimulation } = await import('../../app/ts/background/popupMessageHandlers.js')
-		const { browserStorageLocalSet2 } = await import('../../app/ts/utils/storageUtils.js')
 
 		const fakeRpcNetwork = {
 			name: 'Test Chain',
@@ -262,24 +282,26 @@ describe('ConfirmTransaction', () => {
 			async jsonRpcRequest(rpcRequest: { method: string, params?: readonly unknown[] }) {
 				switch (rpcRequest.method) {
 					case 'eth_getBlockByNumber':
-						return serialize((await import('../../app/ts/types/wire-types.js')).EthereumBlockHeader, fakeBlock)
+						return modules.serialize(modules.EthereumBlockHeader, fakeBlock)
 					case 'eth_getTransactionCount':
-						return serialize((await import('../../app/ts/types/wire-types.js')).EthereumQuantity, 0n)
+						return modules.serialize(modules.EthereumQuantity, 0n)
 					case 'eth_getBalance':
-						return serialize((await import('../../app/ts/types/wire-types.js')).EthereumQuantity, 0n)
+						return modules.serialize(modules.EthereumQuantity, 0n)
 					case 'eth_blockNumber':
-						return serialize((await import('../../app/ts/types/wire-types.js')).EthereumQuantity, 123n)
+						return modules.serialize(modules.EthereumQuantity, 123n)
 					case 'eth_getCode':
 						return '0x'
 					case 'eth_gasPrice':
-						return serialize((await import('../../app/ts/types/wire-types.js')).EthereumQuantity, 1n)
+						return modules.serialize(modules.EthereumQuantity, 1n)
 					case 'eth_simulateV1':
 						{
-							const multicallAbi = (await import('../../app/ts/utils/constants.js')).Multicall3ABI
-							const balanceResult = encodeFunctionReturn(multicallAbi, 'getEthBalance', [0n])
-							const aggregate3Result = encodeFunctionReturn(multicallAbi, 'aggregate3', [[{ success: true, returnData: balanceResult }]])
-							const blockStateCalls = Array.isArray(rpcRequest.params?.[0]?.blockStateCalls) ? rpcRequest.params[0].blockStateCalls : [{}]
-							return serialize((await import('../../app/ts/types/ethSimulate-types.js')).EthSimulateV1Result, blockStateCalls.map((blockStateCall) => ({
+							const balanceResult = modules.encodeFunctionReturn(modules.Multicall3ABI, 'getEthBalance', [0n])
+							const aggregate3Result = modules.encodeFunctionReturn(modules.Multicall3ABI, 'aggregate3', [[{ success: true, returnData: balanceResult }]])
+							const firstParam = rpcRequest.params === undefined ? undefined : rpcRequest.params[0]
+							const blockStateCalls = typeof firstParam === 'object' && firstParam !== null && 'blockStateCalls' in firstParam && Array.isArray(firstParam.blockStateCalls)
+								? firstParam.blockStateCalls
+								: [{}]
+							return modules.serialize(modules.EthSimulateV1Result, blockStateCalls.map((blockStateCall) => ({
 								number: 123n,
 								hash: 0x9876n,
 								timestamp: 0x65920080n,
@@ -299,7 +321,7 @@ describe('ConfirmTransaction', () => {
 				}
 			},
 		}
-		const ethereum = new EthereumClientService(fakeRequestHandler, async () => undefined, async () => undefined, fakeRpcNetwork)
+		const ethereum = new modules.EthereumClientService(fakeRequestHandler, async () => undefined, async () => undefined, fakeRpcNetwork)
 		const simulator = {
 			ethereum,
 			tokenPriceService: {
@@ -307,16 +329,16 @@ describe('ConfirmTransaction', () => {
 			},
 		}
 
-		await browserStorageLocalSet2({
+		await modules.browserStorageLocalSet2({
 			pendingTransactionsAndMessages: [olderPendingTransaction],
 		})
-		await updateInterceptorTransactionStack(() => ({ operations: [] }))
+		await modules.updateInterceptorTransactionStack(() => ({ operations: [] }))
 
 		await act(async () => {
-			await refreshPopupConfirmTransactionSimulation(simulator.ethereum, simulator.tokenPriceService as never)
+			await modules.refreshPopupConfirmTransactionSimulation(simulator.ethereum, simulator.tokenPriceService)
 		})
 
-		const [refreshedPendingTransaction] = await getPendingTransactionsAndMessages()
+		const [refreshedPendingTransaction] = await modules.getPendingTransactionsAndMessages()
 		if (refreshedPendingTransaction === undefined || refreshedPendingTransaction.type !== 'Transaction') throw new Error('missing refreshed pending transaction')
 		assert.ok(
 			refreshedPendingTransaction.popupVisualisation.data.simulationState.simulationConductedTimestamp.getTime() >
@@ -324,13 +346,13 @@ describe('ConfirmTransaction', () => {
 		)
 
 		await act(() => {
-			render(h(ConfirmTransaction, {}), dom.document.body)
+			render(h(modules.ConfirmTransaction, {}), dom.document.body)
 		})
 
 		await act(() => {
 			browser.dispatch({
 				role: 'all',
-				...serialize(UpdateConfirmTransactionDialogPendingTransactions, {
+				...modules.serialize(modules.UpdateConfirmTransactionDialogPendingTransactions, {
 					method: 'popup_update_confirm_transaction_dialog_pending_transactions',
 					data: {
 						pendingTransactionAndSignableMessages: [refreshedPendingTransaction],

--- a/test/tests/domMock.ts
+++ b/test/tests/domMock.ts
@@ -2,6 +2,7 @@ import { render } from 'preact'
 
 type AttributeMap = Record<string, string | undefined>
 type RenderContainer = Parameters<typeof render>[1]
+const defineGlobal = (name: PropertyKey, value: unknown) => Object.defineProperty(globalThis, name, { value, configurable: true, writable: true })
 
 class TestNode {
 	readonly nodeType: number = 0
@@ -177,28 +178,25 @@ export function installDomMock() {
 	const previousRequestAnimationFrame = globalThis.requestAnimationFrame
 	const previousCancelAnimationFrame = globalThis.cancelAnimationFrame
 
-	// @ts-expect-error test shim intentionally overrides the DOM globals
-	globalThis.document = document
-	// @ts-expect-error test shim intentionally overrides the DOM globals
-	globalThis.window = { document }
-	// @ts-expect-error test shim intentionally overrides the timer globals
-	globalThis.setInterval = () => 1
-	globalThis.clearInterval = () => undefined
-	globalThis.requestAnimationFrame = ((callback: FrameRequestCallback) => {
+	defineGlobal('document', document)
+	defineGlobal('window', { document })
+	defineGlobal('setInterval', () => 1)
+	defineGlobal('clearInterval', () => undefined)
+	defineGlobal('requestAnimationFrame', (callback: FrameRequestCallback) => {
 		callback(0)
 		return 1
 	})
-	globalThis.cancelAnimationFrame = () => undefined
+	defineGlobal('cancelAnimationFrame', () => undefined)
 
 	return {
 		document,
 		restore() {
-			globalThis.document = previousDocument
-			globalThis.window = previousWindow
-			globalThis.setInterval = previousSetInterval
-			globalThis.clearInterval = previousClearInterval
-			globalThis.requestAnimationFrame = previousRequestAnimationFrame
-			globalThis.cancelAnimationFrame = previousCancelAnimationFrame
+			defineGlobal('document', previousDocument)
+			defineGlobal('window', previousWindow)
+			defineGlobal('setInterval', previousSetInterval)
+			defineGlobal('clearInterval', previousClearInterval)
+			defineGlobal('requestAnimationFrame', previousRequestAnimationFrame)
+			defineGlobal('cancelAnimationFrame', previousCancelAnimationFrame)
 		},
 	}
 }
@@ -220,15 +218,14 @@ export function installDateMock(initialNow: Date | string | number) {
 		static UTC = RealDate.UTC
 	}
 
-	// @ts-expect-error test shim intentionally overrides the global Date constructor
-	globalThis.Date = MockDate
+	defineGlobal('Date', MockDate)
 
 	return {
 		setNow(nextNow: Date | string | number) {
 			currentNow = new RealDate(nextNow).getTime()
 		},
 		restore() {
-			globalThis.Date = RealDate
+			defineGlobal('Date', RealDate)
 		},
 	}
 }

--- a/test/tests/importSimulationStack.test.tsx
+++ b/test/tests/importSimulationStack.test.tsx
@@ -1,81 +1,81 @@
-// @ts-nocheck
 import * as assert from 'assert'
 import { describe, test } from 'bun:test'
 import { h, render } from 'preact'
 import { act } from 'preact/test-utils'
 import { signal } from '@preact/signals'
 import { installDomMock } from './domMock.js'
-import { InterceptorSimulationExport } from '../../app/ts/types/visualizer-types.js'
 
 const storageState: Record<string, unknown> = {}
-let runtimeSendMessage = async (_message: unknown) => undefined
+let runtimeSendMessage: (message: unknown) => Promise<unknown> = async (_message: unknown) => undefined
 let localSetBehavior = async (items: Record<string, unknown>) => {
 	Object.assign(storageState, items)
 }
+const defineGlobal = (name: PropertyKey, value: unknown) => Object.defineProperty(globalThis, name, { value, configurable: true, writable: true })
+const visualizerTypesModulePath = '../../app/ts/types/visualizer-types.js'
+const popupMessageHandlersModulePath = '../../app/ts/background/popupMessageHandlers.js'
+const importSimulationStackModulePath = '../../app/ts/components/pages/ImportSimulationStack.js'
+const { InterceptorSimulationExport } = await import(visualizerTypesModulePath)
 
 function installBrowser() {
-	Object.defineProperty(globalThis, 'browser', {
-		value: {
-			runtime: {
-				lastError: null,
-				getManifest: () => ({ manifest_version: 3 }),
-				sendMessage: async (message: unknown) => await runtimeSendMessage(message),
-				onMessage: { addListener: () => undefined, removeListener: () => undefined },
-				onConnect: { addListener: () => undefined, removeListener: () => undefined },
-			},
-			storage: {
-				local: {
-					async get(keys?: string | string[] | Record<string, unknown> | null) {
-						if (keys === undefined || keys === null) return { ...storageState }
-						if (Array.isArray(keys)) return Object.fromEntries(keys.filter((key) => key in storageState).map((key) => [key, storageState[key]]))
-						if (typeof keys === 'string') return keys in storageState ? { [keys]: storageState[keys] } : {}
-						return Object.fromEntries(Object.entries(keys).map(([key, defaultValue]) => [key, key in storageState ? storageState[key] : defaultValue]))
-					},
-					async set(items: Record<string, unknown>) {
-						await localSetBehavior(items)
-					},
-					async remove(keys: string | string[]) {
-						for (const key of Array.isArray(keys) ? keys : [keys]) delete storageState[key]
-					},
+	const browserMock = {
+		runtime: {
+			lastError: null,
+			getManifest: () => ({ manifest_version: 3 }),
+			sendMessage: async (message: unknown) => await runtimeSendMessage(message),
+			onMessage: { addListener: () => undefined, removeListener: () => undefined },
+			onConnect: { addListener: () => undefined, removeListener: () => undefined },
+		},
+		storage: {
+			local: {
+				async get(keys?: string | string[] | Record<string, unknown> | null) {
+					if (keys === undefined || keys === null) return { ...storageState }
+					if (Array.isArray(keys)) return Object.fromEntries(keys.filter((key) => key in storageState).map((key) => [key, storageState[key]]))
+					if (typeof keys === 'string') return keys in storageState ? { [keys]: storageState[keys] } : {}
+					return Object.fromEntries(Object.entries(keys).map(([key, defaultValue]) => [key, key in storageState ? storageState[key] : defaultValue]))
+				},
+				async set(items: Record<string, unknown>) {
+					await localSetBehavior(items)
+				},
+				async remove(keys: string | string[]) {
+					for (const key of Array.isArray(keys) ? keys : [keys]) delete storageState[key]
 				},
 			},
-			tabs: {
-				async query() { return [] },
-				async get() { return undefined },
-				async update() { return undefined },
-				onUpdated: { addListener: () => undefined, removeListener: () => undefined },
-				onRemoved: { addListener: () => undefined, removeListener: () => undefined },
-			},
-			windows: {
-				async get() { return undefined },
-				async update() { return undefined },
-			},
-			action: {
-				async setIcon() { return undefined },
-				async setTitle() { return undefined },
-				async setBadgeText() { return undefined },
-				async setBadgeBackgroundColor() { return undefined },
-			},
-			browserAction: {
-				async setIcon() { return undefined },
-				async setTitle() { return undefined },
-				async setBadgeText() { return undefined },
-				async setBadgeBackgroundColor() { return undefined },
-			},
 		},
-		configurable: true,
-		writable: true,
-	})
-	Object.defineProperty(globalThis, 'chrome', { value: { runtime: { id: 'test-extension' } }, configurable: true, writable: true })
-	Object.defineProperty(globalThis, 'indexedDB', { value: undefined, configurable: true, writable: true })
+		tabs: {
+			async query() { return [] },
+			async get() { return undefined },
+			async update() { return undefined },
+			onUpdated: { addListener: () => undefined, removeListener: () => undefined },
+			onRemoved: { addListener: () => undefined, removeListener: () => undefined },
+		},
+		windows: {
+			async get() { return undefined },
+			async update() { return undefined },
+		},
+		action: {
+			async setIcon() { return undefined },
+			async setTitle() { return undefined },
+			async setBadgeText() { return undefined },
+			async setBadgeBackgroundColor() { return undefined },
+		},
+		browserAction: {
+			async setIcon() { return undefined },
+			async setTitle() { return undefined },
+			async setBadgeText() { return undefined },
+			async setBadgeBackgroundColor() { return undefined },
+		},
+	}
+	defineGlobal('browser', browserMock)
+	defineGlobal('chrome', { runtime: { id: 'test-extension' } })
+	defineGlobal('indexedDB', undefined)
 }
 
 installBrowser()
 
 async function loadModules() {
 	return {
-		...await import('../../app/ts/background/popupMessageHandlers.js'),
-		...await import('../../app/ts/components/pages/ImportSimulationStack.js'),
+		...await import(popupMessageHandlersModulePath),
+		...await import(importSimulationStackModulePath),
 	}
 }
 
@@ -108,16 +108,19 @@ function resetEnvironment() {
 	localSetBehavior = async (items: Record<string, unknown>) => {
 		Object.assign(storageState, items)
 	}
-	Object.defineProperty(globalThis, 'indexedDB', { value: undefined, configurable: true, writable: true })
+	defineGlobal('indexedDB', undefined)
 }
 
-function collectElements(node: any, tagName: string, results: any[] = []) {
+type ClickableElement = { l?: Record<string, (event: { currentTarget: ClickableElement }) => unknown> }
+type ElementTreeNode = ClickableElement & { tagName?: string, childNodes?: readonly ElementTreeNode[], textContent?: string }
+
+function collectElements(node: ElementTreeNode | undefined, tagName: string, results: ElementTreeNode[] = []) {
 	if (node?.tagName === tagName.toUpperCase()) results.push(node)
 	for (const child of node?.childNodes ?? []) collectElements(child, tagName, results)
 	return results
 }
 
-async function clickElement(element: { l?: Record<string, (event: unknown) => unknown> }) {
+async function clickElement(element: ClickableElement) {
 	const clickHandler = element.l === undefined ? undefined : Object.entries(element.l).find(([key]) => key.startsWith('Click'))?.[1]
 	if (clickHandler === undefined) throw new Error('Expected click handler')
 	await clickHandler({ currentTarget: element })
@@ -132,7 +135,7 @@ describe('import simulation stack', () => {
 			Object.assign(storageState, items)
 		}
 
-		const reply = await modules.importSimulationStack({} as never, {} as never, { method: 'popup_importSimulationStack', data: exportPayload })
+		const reply = await modules.importSimulationStack(undefined, undefined, { method: 'popup_importSimulationStack', data: exportPayload })
 
 		assert.equal(reply.type, 'ImportSimulationStackReply')
 		assert.equal(reply.ok, false)

--- a/tsconfig-test.json
+++ b/tsconfig-test.json
@@ -1,12 +1,24 @@
 {
-	"extends": "./tsconfig.json",
 	"compilerOptions": {
+		"target": "ES2022",
+		"module": "ESNext",
+		"moduleResolution": "Bundler",
 		"rootDir": ".",
-		"outDir": "test/js",
+		"jsx": "react-jsx",
+		"jsxImportSource": "preact",
+		"lib": ["ES2022", "DOM", "DOM.Iterable"],
+		"types": ["node", "firefox-webext-browser"],
+		"strict": true,
+		"skipLibCheck": true,
+		"noEmit": true
 	},
 	"include": [
-		"./app/ts/**/*.ts",
-		"./app/ts/**/*.tsx",
-		"./test/**/*.ts",
+		"./test/tests/confirmTransactionRenderedTimestamp.test.ts",
+		"./test/tests/importSimulationStack.test.tsx",
+		"./test/tests/domMock.ts",
+		"./test/bun-test.d.ts"
+	],
+	"exclude": [
+		"./test/benchmarks/**/*"
 	]
 }


### PR DESCRIPTION
## Summary
- replace the inherited app tsconfig with a focused Bun/Node test tsconfig
- remove the ts-nocheck escapes from the cited tests and type the DOM/global shims directly
- add the minimal Bun test module declaration and Node types needed for the test surface

## Validation
- bun run typecheck:test
- bun test
- bun run setup-chrome