### PR TITLE
Compile Firefox extension build

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
 		"install-chrome": "bash ./scripts/install-chrome.sh",
 		"setup-firefox": "bun run vendor && bun run inpage && bun run build-firefox",
 		"setup-chrome": "bun run vendor && bun run inpage && bun run build-chrome",
-		"build-firefox": "bun run firefox",
+		"build-firefox": "bun run clean-js-output && bun --bun tsc --project tsconfig.json && bun run bundle && bun run firefox",
 		"build-chrome": "bun run clean-js-output && bun --bun tsc --project tsconfig.json && bun run bundle && bun run chrome",
 		"benchmark:popup-lifecycle": "bun ./test/benchmarks/popupLifecycleChrome.ts",
 		"vendor": "cd build && bun install --frozen-lockfile && bun run vendor",

--- a/test/tests/packageScripts.test.ts
+++ b/test/tests/packageScripts.test.ts
@@ -1,0 +1,38 @@
+import * as assert from 'assert'
+import * as fs from 'node:fs'
+import * as path from 'node:path'
+import { describe, test } from 'bun:test'
+
+const repositoryRoot = process.cwd()
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+	return typeof value === 'object' && value !== null && !Array.isArray(value)
+}
+
+function getPackageScripts() {
+	const packageJsonPath = path.join(repositoryRoot, 'package.json')
+	const packageJson = JSON.parse(fs.readFileSync(packageJsonPath, 'utf8'))
+	if (!isRecord(packageJson)) throw new Error('package.json root must be an object')
+	const scripts = packageJson.scripts
+	if (!isRecord(scripts)) throw new Error('package.json scripts must be an object')
+	return scripts
+}
+
+function getScript(scripts: Record<string, unknown>, scriptName: string) {
+	const script = scripts[scriptName]
+	if (typeof script !== 'string') throw new Error(`Missing package script: ${ scriptName }`)
+	return script
+}
+
+describe('package scripts', () => {
+	test('firefox build compiles app scripts before writing the manifest', () => {
+		const scripts = getPackageScripts()
+
+		assert.deepEqual(getScript(scripts, 'build-firefox').split(' && '), [
+			'bun run clean-js-output',
+			'bun --bun tsc --project tsconfig.json',
+			'bun run bundle',
+			'bun run firefox',
+		])
+	})
+})


### PR DESCRIPTION
## Summary
- make build-firefox compile app TypeScript and run the bundler before writing manifestV2
- add package-script regression coverage for the Firefox build pipeline

## Validation
- bun test
- bun run setup-firefox
- bun run setup-chrome
- bun run typecheck
- bun run lint (fails on existing main-branch lint errors in app/ts/background/background-startup.ts and build/bundler.mts; following up separately)