### PR TITLE
Fix lint baseline

### DIFF
--- a/app/ts/background/background-startup.ts
+++ b/app/ts/background/background-startup.ts
@@ -27,8 +27,8 @@ import { removeWebsiteTabConnection } from './websiteTabConnections.js'
 import { createSimulationServices, resetSimulationServices, type ResetSimulationServices, type SimulationServices } from '../simulation/serviceLifecycle.js'
 
 const websiteTabConnections = new Map<number, TabConnection>()
-let simulationServices: SimulationServices | undefined = undefined
-let resetActiveRpcNetwork: ResetSimulationServices | undefined = undefined
+let simulationServices: SimulationServices | undefined
+let resetActiveRpcNetwork: ResetSimulationServices | undefined
 
 function getSimulationServices() {
 	if (simulationServices === undefined) throw new Error('Simulation services are not initialized')

--- a/build/bundler.mts
+++ b/build/bundler.mts
@@ -502,7 +502,6 @@ if (import.meta.main) {
 		await replaceImportsInJSFiles()
 	} catch (error) {
 		console.error(error)
-		debugger
 		process.exit(1)
 	}
 }

--- a/build/vendor.mts
+++ b/build/vendor.mts
@@ -44,127 +44,127 @@ const extraPackageRoots = [
 const vendorTypeShims = [
 	{
 		pathParts: ['viem', '_esm', 'utils', 'index.d.ts'],
-		contents: "export * from 'viem/utils'\n",
+		contents: 'export * from \'viem/utils\'\n',
 	},
 	{
 		pathParts: ['viem', '_esm', 'ens', 'index.d.ts'],
-		contents: "export * from 'viem/ens'\n",
+		contents: 'export * from \'viem/ens\'\n',
 	},
 	{
 		pathParts: ['viem', '_esm', 'accounts', 'index.d.ts'],
-		contents: "export * from 'viem/accounts'\n",
+		contents: 'export * from \'viem/accounts\'\n',
 	},
 	{
 		pathParts: ['@noble', 'hashes', 'esm', 'sha3.d.ts'],
-		contents: "export * from '@noble/hashes/sha3'\n",
+		contents: 'export * from \'@noble/hashes/sha3\'\n',
 	},
 	{
 		pathParts: ['viem', '_esm', 'utils', 'abi', 'decodeAbiParameters.d.ts'],
-		contents: "export { decodeAbiParameters } from 'viem/utils'\n",
+		contents: 'export { decodeAbiParameters } from \'viem/utils\'\n',
 	},
 	{
 		pathParts: ['viem', '_esm', 'utils', 'abi', 'decodeEventLog.d.ts'],
-		contents: "export { decodeEventLog } from 'viem/utils'\n",
+		contents: 'export { decodeEventLog } from \'viem/utils\'\n',
 	},
 	{
 		pathParts: ['viem', '_esm', 'utils', 'abi', 'decodeFunctionData.d.ts'],
-		contents: "export { decodeFunctionData } from 'viem/utils'\n",
+		contents: 'export { decodeFunctionData } from \'viem/utils\'\n',
 	},
 	{
 		pathParts: ['viem', '_esm', 'utils', 'abi', 'encodeAbiParameters.d.ts'],
-		contents: "export { encodeAbiParameters } from 'viem/utils'\n",
+		contents: 'export { encodeAbiParameters } from \'viem/utils\'\n',
 	},
 	{
 		pathParts: ['viem', '_esm', 'utils', 'abi', 'encodePacked.d.ts'],
-		contents: "export { encodePacked } from 'viem/utils'\n",
+		contents: 'export { encodePacked } from \'viem/utils\'\n',
 	},
 	{
 		pathParts: ['viem', '_esm', 'utils', 'abi', 'formatAbiItem.d.ts'],
-		contents: "export { formatAbiItem } from 'viem/utils'\n",
+		contents: 'export { formatAbiItem } from \'viem/utils\'\n',
 	},
 	{
 		pathParts: ['viem', '_esm', 'utils', 'address', 'getAddress.d.ts'],
-		contents: "export { getAddress } from 'viem/utils'\n",
+		contents: 'export { getAddress } from \'viem/utils\'\n',
 	},
 	{
 		pathParts: ['viem', '_esm', 'utils', 'address', 'getContractAddress.d.ts'],
-		contents: "export { getCreate2Address } from 'viem/utils'\n",
+		contents: 'export { getCreate2Address } from \'viem/utils\'\n',
 	},
 	{
 		pathParts: ['viem', '_esm', 'utils', 'address', 'isAddress.d.ts'],
-		contents: "export { isAddress } from 'viem/utils'\n",
+		contents: 'export { isAddress } from \'viem/utils\'\n',
 	},
 	{
 		pathParts: ['viem', '_esm', 'utils', 'data', 'concat.d.ts'],
-		contents: "export { concat } from 'viem/utils'\n",
+		contents: 'export { concat } from \'viem/utils\'\n',
 	},
 	{
 		pathParts: ['viem', '_esm', 'utils', 'encoding', 'toHex.d.ts'],
-		contents: "export { bytesToHex } from 'viem/utils'\n",
+		contents: 'export { bytesToHex } from \'viem/utils\'\n',
 	},
 	{
 		pathParts: ['viem', '_esm', 'utils', 'encoding', 'toBytes.d.ts'],
-		contents: "export { stringToBytes } from 'viem/utils'\n",
+		contents: 'export { stringToBytes } from \'viem/utils\'\n',
 	},
 	{
 		pathParts: ['viem', '_esm', 'utils', 'encoding', 'toRlp.d.ts'],
-		contents: "export { toRlp } from 'viem/utils'\n",
+		contents: 'export { toRlp } from \'viem/utils\'\n',
 	},
 	{
 		pathParts: ['viem', '_esm', 'utils', 'ens', 'namehash.d.ts'],
-		contents: "export { namehash } from 'viem/ens'\n",
+		contents: 'export { namehash } from \'viem/ens\'\n',
 	},
 	{
 		pathParts: ['viem', '_esm', 'utils', 'hash', 'keccak256.d.ts'],
-		contents: "export { keccak256 } from 'viem/utils'\n",
+		contents: 'export { keccak256 } from \'viem/utils\'\n',
 	},
 	{
 		pathParts: ['viem', '_esm', 'utils', 'hash', 'toEventSelector.d.ts'],
-		contents: "export { toEventSelector } from 'viem/utils'\n",
+		contents: 'export { toEventSelector } from \'viem/utils\'\n',
 	},
 	{
 		pathParts: ['viem', '_esm', 'utils', 'hash', 'toFunctionSelector.d.ts'],
-		contents: "export { toFunctionSelector } from 'viem/utils'\n",
+		contents: 'export { toFunctionSelector } from \'viem/utils\'\n',
 	},
 	{
 		pathParts: ['viem', '_esm', 'utils', 'signature', 'recoverAddress.d.ts'],
-		contents: "export { recoverAddress } from 'viem/utils'\n",
+		contents: 'export { recoverAddress } from \'viem/utils\'\n',
 	},
 	{
 		pathParts: ['viem', '_esm', 'utils', 'signature', 'hashMessage.d.ts'],
-		contents: "export { hashMessage } from 'viem/utils'\n",
+		contents: 'export { hashMessage } from \'viem/utils\'\n',
 	},
 	{
 		pathParts: ['viem', '_esm', 'utils', 'signature', 'hashTypedData.d.ts'],
-		contents: "export { hashStruct, hashTypedData } from 'viem/utils'\n",
+		contents: 'export { hashStruct, hashTypedData } from \'viem/utils\'\n',
 	},
 	{
 		pathParts: ['viem', '_esm', 'utils', 'transaction', 'parseTransaction.d.ts'],
-		contents: "export { parseTransaction } from 'viem/utils'\n",
+		contents: 'export { parseTransaction } from \'viem/utils\'\n',
 	},
 	{
 		pathParts: ['viem', '_esm', 'utils', 'transaction', 'serializeTransaction.d.ts'],
-		contents: "export { serializeTransaction } from 'viem/utils'\n",
+		contents: 'export { serializeTransaction } from \'viem/utils\'\n',
 	},
 	{
 		pathParts: ['viem', '_esm', 'utils', 'unit', 'formatUnits.d.ts'],
-		contents: "export { formatUnits } from 'viem/utils'\n",
+		contents: 'export { formatUnits } from \'viem/utils\'\n',
 	},
 	{
 		pathParts: ['viem', '_esm', 'accounts', 'privateKeyToAccount.d.ts'],
-		contents: "export { privateKeyToAccount } from 'viem/accounts'\n",
+		contents: 'export { privateKeyToAccount } from \'viem/accounts\'\n',
 	},
 	{
 		pathParts: ['abitype', 'dist', 'esm', 'human-readable', 'parseAbiItem.d.ts'],
-		contents: "export { parseAbiItem } from 'abitype'\n",
+		contents: 'export { parseAbiItem } from \'abitype\'\n',
 	},
 	{
 		pathParts: ['abitype', 'dist', 'esm', 'human-readable', 'parseAbiParameters.d.ts'],
-		contents: "export { parseAbiParameters } from 'abitype'\n",
+		contents: 'export { parseAbiParameters } from \'abitype\'\n',
 	},
 	{
 		pathParts: ['@adraffy', 'ens-normalize', 'dist', 'index.d.ts'],
-		contents: "export { ens_normalize } from '@adraffy/ens-normalize'\n",
+		contents: 'export { ens_normalize } from \'@adraffy/ens-normalize\'\n',
 	},
 ] as const
 

--- a/test/tests/bundlerImportRewrite.test.ts
+++ b/test/tests/bundlerImportRewrite.test.ts
@@ -30,25 +30,25 @@ describe('bundler import rewriting', () => {
 
 	test('rewrites nested vendored package imports using the vendored dependency tree', () => {
 		const filePath = path.join(repositoryRoot, 'app', 'vendor', 'ox', '_esm', 'core', 'Hash.js')
-		const source = "import { keccak_256 as noble_keccak256 } from '@noble/hashes/sha3';"
+		const source = 'import { keccak_256 as noble_keccak256 } from \'@noble/hashes/sha3\';'
 
 		const rewritten = replaceImport(filePath, source)
 
-		assert.equal(rewritten, "import { keccak_256 as noble_keccak256 } from '../../__dependencies__/@noble/hashes/esm/sha3.js';")
+		assert.equal(rewritten, 'import { keccak_256 as noble_keccak256 } from \'../../__dependencies__/@noble/hashes/esm/sha3.js\';')
 	})
 
 	test('rewrites vendored relative node_modules imports away from node_modules paths', () => {
 		const filePath = path.join(repositoryRoot, 'app', 'vendor', 'viem', '_esm', 'utils', 'hash', 'keccak256.js')
-		const source = "import { keccak_256 } from '../../../node_modules/@noble/hashes/esm/sha3.js';"
+		const source = 'import { keccak_256 } from \'../../../node_modules/@noble/hashes/esm/sha3.js\';'
 
 		const rewritten = replaceImport(filePath, source)
 
-		assert.equal(rewritten, "import { keccak_256 } from '../../../__dependencies__/@noble/hashes/esm/sha3.js';")
+		assert.equal(rewritten, 'import { keccak_256 } from \'../../../__dependencies__/@noble/hashes/esm/sha3.js\';')
 	})
 
 	test('does not rewrite comment examples that are not real imports', () => {
 		const filePath = path.join(repositoryRoot, 'app', 'vendor', 'viem', '_esm', 'utils', 'hash', 'keccak256.js')
-		const source = "// import { keccak_256 } from '@noble/hashes/sha3';\nexport const ok = true;"
+		const source = '// import { keccak_256 } from \'@noble/hashes/sha3\';\nexport const ok = true;'
 
 		const rewritten = replaceImport(filePath, source)
 
@@ -70,7 +70,7 @@ describe('bundler import rewriting', () => {
 		const appJsDirectoryPath = path.join(repositoryRoot, 'app', 'js')
 		const staleFilePath = path.join(repositoryRoot, 'app', 'js', 'stale-build-output.js')
 		fs.mkdirSync(appJsDirectoryPath, { recursive: true })
-		fs.writeFileSync(staleFilePath, "import '../vendor/does-not-exist/index.js';\n")
+		fs.writeFileSync(staleFilePath, 'import \'../vendor/does-not-exist/index.js\';\n')
 
 		try {
 			const missingImports = findMissingRuntimeImportsInRuntimeFiles()


### PR DESCRIPTION
## Summary
- remove redundant undefined initializers flagged by Biome
- remove a stray debugger statement from the bundler CLI error path
- normalize existing double-quoted TypeScript string literals to satisfy the repo quote checker

## Validation
- bun test
- bun run setup-chrome
- bun run typecheck
- bun run lint