### PR TITLE
Await website access refresh work

### DIFF
--- a/app/ts/background/accessManagement.ts
+++ b/app/ts/background/accessManagement.ts
@@ -194,7 +194,7 @@ function addIconRefreshTarget(iconRefreshTargets: Map<string, { tabId: number, w
 	iconRefreshTargets.set(key, { tabId, websiteOrigin })
 }
 
-async function updateTabConnections(ethereum: EthereumClientService, tokenPriceService: TokenPriceService, resetSimulationServices: ResetSimulationServices, websiteTabConnections: WebsiteTabConnections, tabConnection: TabConnection, promptForAccessesIfNeeded: boolean, settings: Settings) {
+async function updateTabConnections(ethereum: EthereumClientService | undefined, tokenPriceService: TokenPriceService | undefined, resetSimulationServices: ResetSimulationServices | undefined, websiteTabConnections: WebsiteTabConnections, tabConnection: TabConnection, promptForAccessesIfNeeded: boolean, settings: Settings) {
 	const iconRefreshTargets = new Map<string, { tabId: number, websiteOrigin: string }>()
 	for (const key in tabConnection.connections) {
 		const connection = tabConnection.connections[key]
@@ -210,8 +210,9 @@ async function updateTabConnections(ethereum: EthereumClientService, tokenPriceS
 		}
 
 		if (access === 'notFound' && connection.wantsToConnect && promptForAccessesIfNeeded) {
+			if (ethereum === undefined || tokenPriceService === undefined || resetSimulationServices === undefined) throw new Error('Cannot prompt for access without simulation services')
 			const activeAddress = currentActiveAddress !== undefined ? currentActiveAddress : undefined
-			askUserForAccessOnConnectionUpdate(ethereum, tokenPriceService, resetSimulationServices, websiteTabConnections, connection.socket, connection.websiteOrigin, activeAddress, settings)
+			await askUserForAccessOnConnectionUpdate(ethereum, tokenPriceService, resetSimulationServices, websiteTabConnections, connection.socket, connection.websiteOrigin, activeAddress, settings)
 		}
 	}
 	for (const { tabId, websiteOrigin } of iconRefreshTargets.values()) {
@@ -310,10 +311,10 @@ export const areWeBlocking = async (websiteTabConnections: WebsiteTabConnections
 	return false
 }
 
-export function updateWebsiteApprovalAccesses(ethereum: EthereumClientService, websiteTabConnections: WebsiteTabConnections, settings: Settings, promptForAccessesIfNeeded?: boolean): void
-export function updateWebsiteApprovalAccesses(ethereum: EthereumClientService, tokenPriceService: TokenPriceService, resetSimulationServices: ResetSimulationServices, websiteTabConnections: WebsiteTabConnections, settings: Settings, promptForAccessesIfNeeded?: boolean): void
-export function updateWebsiteApprovalAccesses(
-	ethereum: EthereumClientService,
+export function updateWebsiteApprovalAccesses(ethereum: EthereumClientService | undefined, websiteTabConnections: WebsiteTabConnections, settings: Settings, promptForAccessesIfNeeded?: boolean): Promise<void>
+export function updateWebsiteApprovalAccesses(ethereum: EthereumClientService, tokenPriceService: TokenPriceService, resetSimulationServices: ResetSimulationServices, websiteTabConnections: WebsiteTabConnections, settings: Settings, promptForAccessesIfNeeded?: boolean): Promise<void>
+export async function updateWebsiteApprovalAccesses(
+	ethereum: EthereumClientService | undefined,
 	tokenPriceServiceOrWebsiteTabConnections: TokenPriceService | WebsiteTabConnections,
 	resetSimulationServicesOrSettings: ResetSimulationServices | Settings,
 	websiteTabConnectionsOrPrompt?: WebsiteTabConnections | boolean,
@@ -321,17 +322,18 @@ export function updateWebsiteApprovalAccesses(
 	promptForAccessesIfNeeded = true
 ) {
 	const usingLegacySignature = tokenPriceServiceOrWebsiteTabConnections instanceof Map
-	const tokenPriceService = usingLegacySignature ? undefined as never : tokenPriceServiceOrWebsiteTabConnections
-	const resetSimulationServices = usingLegacySignature ? undefined as never : resetSimulationServicesOrSettings as ResetSimulationServices
-	const websiteTabConnections = usingLegacySignature ? tokenPriceServiceOrWebsiteTabConnections : websiteTabConnectionsOrPrompt as WebsiteTabConnections
-	const settings = usingLegacySignature ? resetSimulationServicesOrSettings as Settings : settingsOrPrompt as Settings
-	const promptForAccesses = typeof (usingLegacySignature ? websiteTabConnectionsOrPrompt : promptForAccessesIfNeeded) === 'boolean'
-		? usingLegacySignature ? websiteTabConnectionsOrPrompt as boolean : promptForAccessesIfNeeded
-		: promptForAccessesIfNeeded
+	const tokenPriceService = usingLegacySignature ? undefined : tokenPriceServiceOrWebsiteTabConnections
+	const resetSimulationServices = typeof resetSimulationServicesOrSettings === 'function' ? resetSimulationServicesOrSettings : undefined
+	const websiteTabConnections = usingLegacySignature ? tokenPriceServiceOrWebsiteTabConnections : websiteTabConnectionsOrPrompt
+	const settings = usingLegacySignature ? resetSimulationServicesOrSettings : settingsOrPrompt
+	if (!(websiteTabConnections instanceof Map)) throw new Error('Website tab connections missing')
+	if (settings === undefined || typeof settings === 'boolean' || typeof settings === 'function') throw new Error('Settings missing')
+	const requestedPromptForAccesses = usingLegacySignature ? websiteTabConnectionsOrPrompt : promptForAccessesIfNeeded
+	const promptForAccesses = typeof requestedPromptForAccesses === 'boolean' ? requestedPromptForAccesses : promptForAccessesIfNeeded
 
-	updateDeclarativeNetRequestBlocks(websiteTabConnections)
+	await updateDeclarativeNetRequestBlocks(websiteTabConnections)
 	// update port connections and disconnect from ports that should not have access anymore
-	for (const [_tab, tabConnection] of websiteTabConnections.entries()) {
-		updateTabConnections(ethereum, tokenPriceService, resetSimulationServices, websiteTabConnections, tabConnection, promptForAccesses, settings)
-	}
+	await Promise.all(Array.from(websiteTabConnections.values()).map(async (tabConnection) =>
+		await updateTabConnections(ethereum, tokenPriceService, resetSimulationServices, websiteTabConnections, tabConnection, promptForAccesses, settings)
+	))
 }

--- a/app/ts/background/background.ts
+++ b/app/ts/background/background.ts
@@ -310,7 +310,7 @@ export async function changeActiveAddressAndChain(
 
 	const updatedSettings = await getSettings()
 	sendPopupMessageToOpenWindows({ method: 'popup_settingsUpdated', data: updatedSettings })
-	updateWebsiteApprovalAccesses(ethereum, tokenPriceService, resetSimulationServices, websiteTabConnections, updatedSettings)
+	await updateWebsiteApprovalAccesses(ethereum, tokenPriceService, resetSimulationServices, websiteTabConnections, updatedSettings)
 	sendPopupMessageToOpenWindows({ method: 'popup_accounts_update' })
 	await changeActiveAddressAndChainSemaphore.execute(async () => {
 		if (change.rpcNetwork !== undefined) {
@@ -327,7 +327,7 @@ export async function changeActiveAddressAndChain(
 			}
 		}
 		// inform website about this only after we have updated simulation, as they often query the balance right after
-		sendActiveAccountChangeToApprovedWebsitePorts(websiteTabConnections, await getSettings())
+		await sendActiveAccountChangeToApprovedWebsitePorts(websiteTabConnections, await getSettings())
 	})
 }
 

--- a/app/ts/background/popupMessageHandlers.ts
+++ b/app/ts/background/popupMessageHandlers.ts
@@ -180,7 +180,7 @@ export async function removeAddressBookEntry(ethereum: EthereumClientService, to
 		!(contact.address === removeAddressBookEntry.data.address
 		&& (contact.chainId === removeAddressBookEntry.data.chainId || (contact.chainId === undefined && removeAddressBookEntry.data.chainId === 1n))))
 	)
-	if (removeAddressBookEntry.data.addressBookCategory === 'My Active Addresses') updateWebsiteApprovalAccesses(ethereum, tokenPriceService, resetSimulationServices, websiteTabConnections, await getSettings())
+	if (removeAddressBookEntry.data.addressBookCategory === 'My Active Addresses') await updateWebsiteApprovalAccesses(ethereum, tokenPriceService, resetSimulationServices, websiteTabConnections, await getSettings())
 	await sendPopupMessageToOpenWindows({ method: 'popup_addressBookEntriesChanged' })
 }
 
@@ -191,7 +191,7 @@ export async function addOrModifyAddressBookEntry(ethereum: EthereumClientServic
 		}
 		return previousContacts.concat([entry.data])
 	})
-	if (entry.data.useAsActiveAddress) updateWebsiteApprovalAccesses(ethereum, tokenPriceService, resetSimulationServices, websiteTabConnections, await getSettings())
+	if (entry.data.useAsActiveAddress) await updateWebsiteApprovalAccesses(ethereum, tokenPriceService, resetSimulationServices, websiteTabConnections, await getSettings())
 	await sendPopupMessageToOpenWindows({ method: 'popup_addressBookEntriesChanged' })
 }
 
@@ -211,7 +211,7 @@ export async function changeInterceptorAccess(ethereum: EthereumClientService, t
 		return await disableInterceptorForPage(websiteTabConnections, disable.newEntry.website, disable.newEntry.interceptorDisabled)
 	}))
 
-	updateWebsiteApprovalAccesses(ethereum, tokenPriceService, resetSimulationServices, websiteTabConnections, await getSettings())
+	await updateWebsiteApprovalAccesses(ethereum, tokenPriceService, resetSimulationServices, websiteTabConnections, await getSettings())
 	await sendPopupMessageToOpenWindows({ method: 'popup_interceptor_access_changed' })
 }
 
@@ -676,7 +676,7 @@ async function disableInterceptorForPage(websiteTabConnections: WebsiteTabConnec
 
 export async function disableInterceptor(ethereum: EthereumClientService, tokenPriceService: TokenPriceService, resetSimulationServices: ResetSimulationServices, websiteTabConnections: WebsiteTabConnections, parsedRequest: DisableInterceptor) {
 	await disableInterceptorForPage(websiteTabConnections, parsedRequest.data.website, parsedRequest.data.interceptorDisabled)
-	updateWebsiteApprovalAccesses(ethereum, tokenPriceService, resetSimulationServices, websiteTabConnections, await getSettings())
+	await updateWebsiteApprovalAccesses(ethereum, tokenPriceService, resetSimulationServices, websiteTabConnections, await getSettings())
 	await sendPopupMessageToOpenWindows({ method: 'popup_setDisableInterceptorReply' as const, data: parsedRequest.data })
 }
 
@@ -716,7 +716,7 @@ async function blockOrAllowWebsiteExternalRequests(websiteTabConnections: Websit
 
 export async function blockOrAllowExternalRequests(ethereum: EthereumClientService, tokenPriceService: TokenPriceService, resetSimulationServices: ResetSimulationServices, websiteTabConnections: WebsiteTabConnections, parsedRequest: BlockOrAllowExternalRequests) {
 	await blockOrAllowWebsiteExternalRequests(websiteTabConnections, parsedRequest.data.website, parsedRequest.data.shouldBlock)
-	updateWebsiteApprovalAccesses(ethereum, tokenPriceService, resetSimulationServices, websiteTabConnections, await getSettings())
+	await updateWebsiteApprovalAccesses(ethereum, tokenPriceService, resetSimulationServices, websiteTabConnections, await getSettings())
 	await sendPopupMessageToOpenWindows({ method: 'popup_websiteAccess_changed' })
 }
 
@@ -733,7 +733,7 @@ async function removeAddressAccessByAddress(websiteOrigin: string, address: Ethe
 export async function removeWebsiteAddressAccess(ethereum: EthereumClientService, tokenPriceService: TokenPriceService, resetSimulationServices: ResetSimulationServices, websiteTabConnections: WebsiteTabConnections, parsedRequest: RemoveWebsiteAddressAccess) {
 	await removeAddressAccessByAddress(parsedRequest.data.websiteOrigin, parsedRequest.data.address)
 	await reloadConnectedTabs(websiteTabConnections)
-	updateWebsiteApprovalAccesses(ethereum, tokenPriceService, resetSimulationServices, websiteTabConnections, await getSettings())
+	await updateWebsiteApprovalAccesses(ethereum, tokenPriceService, resetSimulationServices, websiteTabConnections, await getSettings())
 	await sendPopupMessageToOpenWindows({ method: 'popup_websiteAccess_changed' })
 }
 
@@ -756,7 +756,7 @@ export async function allowOrPreventAddressAccessForWebsite(websiteTabConnection
 
 export async function removeWebsiteAccess(ethereum: EthereumClientService, tokenPriceService: TokenPriceService, resetSimulationServices: ResetSimulationServices, websiteTabConnections: WebsiteTabConnections, parsedRequest: RemoveWebsiteAccess) {
 	await updateWebsiteAccess((previousAccess) => previousAccess.filter(access => access.website.websiteOrigin !== parsedRequest.data.websiteOrigin))
-	updateWebsiteApprovalAccesses(ethereum, tokenPriceService, resetSimulationServices, websiteTabConnections, await getSettings())
+	await updateWebsiteApprovalAccesses(ethereum, tokenPriceService, resetSimulationServices, websiteTabConnections, await getSettings())
 	await sendPopupMessageToOpenWindows({ method: 'popup_websiteAccess_changed' })
 }
 export async function forceSetGasLimitForTransaction(ethereum: EthereumClientService, tokenPriceService: TokenPriceService, parsedRequest: ForceSetGasLimitForTransaction) {

--- a/app/ts/background/windows/interceptorAccess.ts
+++ b/app/ts/background/windows/interceptorAccess.ts
@@ -78,7 +78,7 @@ export async function getAddressMetadataForAccess(websiteAccess: WebsiteAccessAr
 async function changeAccess(ethereum: EthereumClientService, tokenPriceService: TokenPriceService, resetSimulationServices: ResetSimulationServices, websiteTabConnections: WebsiteTabConnections, confirmation: InterceptorAccessReply, website: Website, promptForAccessesIfNeeded = true) {
 	if (confirmation.userReply === 'noResponse') return
 	await setAccess(website, confirmation.userReply === 'Approved', confirmation.requestAccessToAddress)
-	updateWebsiteApprovalAccesses(ethereum, tokenPriceService, resetSimulationServices, websiteTabConnections, await getSettings(), promptForAccessesIfNeeded)
+	await updateWebsiteApprovalAccesses(ethereum, tokenPriceService, resetSimulationServices, websiteTabConnections, await getSettings(), promptForAccessesIfNeeded)
 	await sendPopupMessageToOpenWindows({ method: 'popup_websiteAccess_changed' })
 }
 

--- a/test/tests/extensionIconDeduping.test.ts
+++ b/test/tests/extensionIconDeduping.test.ts
@@ -10,12 +10,22 @@ type MockTab = {
 	title?: string
 	favIconUrl?: string
 }
+type DeclarativeRuleUpdate = {
+	removeRuleIds: readonly number[]
+	addRules?: readonly unknown[]
+}
 
 function installBrowserMock(tabs: readonly MockTab[]) {
 	const storageState: BrowserStorageState = {}
 	const tabsById = new Map(tabs.map((tab) => [tab.id, tab]))
 	const setIconCalls: browser.action._SetIconDetails[] = []
 	const setTitleCalls: browser.action._SetTitleDetails[] = []
+	const dynamicRuleUpdates: DeclarativeRuleUpdate[] = []
+	const sessionRuleUpdates: DeclarativeRuleUpdate[] = []
+	const recordRuleUpdate = async (updates: DeclarativeRuleUpdate[], update: DeclarativeRuleUpdate) => {
+		await new Promise((resolve) => setTimeout(resolve, 0))
+		updates.push(update)
+	}
 
 	globalThis.browser = {
 		runtime: {
@@ -79,8 +89,8 @@ function installBrowserMock(tabs: readonly MockTab[]) {
 		declarativeNetRequest: {
 			async getDynamicRules() { return [] },
 			async getSessionRules() { return [] },
-			async updateDynamicRules() { return undefined },
-			async updateSessionRules() { return undefined },
+			async updateDynamicRules(update: DeclarativeRuleUpdate) { await recordRuleUpdate(dynamicRuleUpdates, update) },
+			async updateSessionRules(update: DeclarativeRuleUpdate) { await recordRuleUpdate(sessionRuleUpdates, update) },
 		},
 		webRequest: {
 			onBeforeRequest: {
@@ -91,7 +101,7 @@ function installBrowserMock(tabs: readonly MockTab[]) {
 	} as typeof globalThis.browser
 	globalThis.chrome = { runtime: { id: 'test-extension' } }
 
-	return { setIconCalls, setTitleCalls }
+	return { setIconCalls, setTitleCalls, dynamicRuleUpdates, sessionRuleUpdates }
 }
 
 async function loadModules() {
@@ -111,12 +121,6 @@ function createPort(tabId: number) {
 		sender: { tab: { id: tabId } },
 		postMessage: () => undefined,
 	} as browser.runtime.Port
-}
-
-async function flushAsyncWork() {
-	await Promise.resolve()
-	await Promise.resolve()
-	await new Promise((resolve) => setTimeout(resolve, 0))
 }
 
 describe('extension icon deduping', () => {
@@ -203,11 +207,26 @@ describe('extension icon deduping', () => {
 			}],
 		])
 
-		updateWebsiteApprovalAccesses({} as never, websiteTabConnections, await getSettings())
-		await flushAsyncWork()
+		await updateWebsiteApprovalAccesses(undefined, websiteTabConnections, await getSettings())
 
 		assert.equal(setIconCalls.length, 1)
 		assert.equal(setTitleCalls.length, 1)
+	})
+
+	test('access refresh waits for declarative net request updates', async () => {
+		const { dynamicRuleUpdates, sessionRuleUpdates } = installBrowserMock([{ id: 1, url: 'https://blocked.test', status: 'complete' }])
+		const { getSettings, updateWebsiteAccess, updateWebsiteApprovalAccesses } = await loadModules()
+		await updateWebsiteAccess(() => [{
+			website: { websiteOrigin: 'blocked.test', icon: undefined, title: undefined },
+			access: true,
+			addressAccess: undefined,
+			declarativeNetRequestBlockMode: 'block-all',
+		}])
+
+		await updateWebsiteApprovalAccesses(undefined, new Map(), await getSettings())
+
+		assert.equal(dynamicRuleUpdates.length, 1)
+		assert.equal(sessionRuleUpdates.length, 1)
 	})
 
 	test('last-port disconnect removes the tab entry', async () => {


### PR DESCRIPTION
## Summary
- make updateWebsiteApprovalAccesses return a real Promise and await DNR, tab connection, and prompt refresh work
- await access-refresh callers before sending follow-up popup replies/events
- add regression coverage that awaiting access refresh waits for delayed declarative net request updates

## Validation
- bun test
- bun run setup-chrome
- bun run typecheck
- bun run lint (fails on existing origin/main lint baseline; see PR #1452)