### PR TITLE
Use simulated gas for input block queries

### DIFF
--- a/app/ts/simulation/services/SimulationModeEthereumClientService.ts
+++ b/app/ts/simulation/services/SimulationModeEthereumClientService.ts
@@ -127,12 +127,9 @@ const getHashOfSimulatedBlockFromInput = (simulationStateInput: SimulationStateI
 	return BigInt(keccak256(stringToBytes(`${ getSimulationInputHash(simulationStateInput) }:${ blockDelta }`)))
 }
 
-const createPreparedSimulationExecutionContext = async (
-	ethereumClientService: EthereumClientService,
-	requestAbortController: AbortController | undefined,
+const resolvePreparedSimulationInput = (
 	simulationStateInput: ResolvedSimulationInput | SimulationStateInputMinimalData | undefined,
-	baseBlockTag: EthereumBlockTag = 'latest',
-): Promise<PreparedSimulationExecutionContext | undefined> => {
+) => {
 	if (simulationStateInput === undefined) return undefined
 	const resolvedSimulationInput = 'kind' in simulationStateInput
 		? simulationStateInput.kind === 'passthrough'
@@ -141,9 +138,15 @@ const createPreparedSimulationExecutionContext = async (
 		: simulationStateInput
 	if (resolvedSimulationInput === undefined) return undefined
 	if (isEmptySimulationInput(resolvedSimulationInput)) return undefined
-	const parentBlock = await ethereumClientService.getBlock(requestAbortController, baseBlockTag)
-	if (parentBlock === null) throw new Error('The latest block is null')
-	const prepared = await ethereumClientService.prepareEthSimulateV1Input(resolvedSimulationInput, parentBlock.number, requestAbortController)
+	return resolvedSimulationInput
+}
+
+const createSimulationExecutionContextFromPreparedInput = (
+	resolvedSimulationInput: SimulationStateInputMinimalData,
+	parentBlock: NonNullable<EthereumBlockHeader>,
+	prepared: PreparedEthSimulateV1Input,
+	simulatedResult: EthSimulateV1Result | undefined,
+): PreparedSimulationExecutionContext => {
 	let previousBlockHash = parentBlock.hash
 	let previousGasUsed = parentBlock.gasUsed
 	let previousBaseFeePerGas = parentBlock.baseFeePerGas
@@ -153,15 +156,18 @@ const createPreparedSimulationExecutionContext = async (
 		const blockOverride = prepared.blockOverrides[blockIndex]
 		if (blockOverride === undefined) throw new Error('missing block override for prepared simulation block')
 		if (blockOverride.time === undefined) throw new Error('missing timestamp for prepared simulation block')
-		const gasUsed = transactionQueueTotalGasLimitFromInput(inputBlock)
-		const baseFeePerGas = previousBaseFeePerGas === undefined ? undefined : getNextBaseFeePerGas(previousGasUsed, parentBlock.gasLimit, previousBaseFeePerGas)
+		const simulatedBlock = simulatedResult?.[blockIndex]
+		if (simulatedResult !== undefined && simulatedBlock === undefined) throw new Error('missing simulated result block for prepared simulation block')
+		const gasUsed = simulatedBlock?.gasUsed ?? transactionQueueTotalGasLimitFromInput(inputBlock)
+		const baseFeePerGas = simulatedBlock?.baseFeePerGas ?? (previousBaseFeePerGas === undefined ? undefined : getNextBaseFeePerGas(previousGasUsed, parentBlock.gasLimit, previousBaseFeePerGas))
 		const blockHash = getHashOfSimulatedBlockFromInput(resolvedSimulationInput, blockIndex)
+		const blockTimestamp = simulatedBlock === undefined ? blockOverride.time : bigintSecondsToDate(simulatedBlock.timestamp)
 		const executionBlock = {
 			inputBlock,
 			blockNumber: previousBlockNumber + 1n,
 			blockHash,
 			parentHash: previousBlockHash,
-			blockTimestamp: blockOverride.time,
+			blockTimestamp,
 			gasUsed,
 			baseFeePerGas,
 			totalDifficulty: previousTotalDifficulty + parentBlock.difficulty,
@@ -179,6 +185,34 @@ const createPreparedSimulationExecutionContext = async (
 		prepared,
 		executionBlocks,
 	}
+}
+
+const createPreparedSimulationExecutionContext = async (
+	ethereumClientService: EthereumClientService,
+	requestAbortController: AbortController | undefined,
+	simulationStateInput: ResolvedSimulationInput | SimulationStateInputMinimalData | undefined,
+	baseBlockTag: EthereumBlockTag = 'latest',
+): Promise<PreparedSimulationExecutionContext | undefined> => {
+	const resolvedSimulationInput = resolvePreparedSimulationInput(simulationStateInput)
+	if (resolvedSimulationInput === undefined) return undefined
+	const parentBlock = await ethereumClientService.getBlock(requestAbortController, baseBlockTag)
+	if (parentBlock === null) throw new Error('The latest block is null')
+	const prepared = await ethereumClientService.prepareEthSimulateV1Input(resolvedSimulationInput, parentBlock.number, requestAbortController)
+	return createSimulationExecutionContextFromPreparedInput(resolvedSimulationInput, parentBlock, prepared, undefined)
+}
+
+const createSimulatedPreparedSimulationExecutionContext = async (
+	ethereumClientService: EthereumClientService,
+	requestAbortController: AbortController | undefined,
+	simulationStateInput: ResolvedSimulationInput | SimulationStateInputMinimalData | undefined,
+	baseBlockTag: EthereumBlockTag = 'latest',
+): Promise<PreparedSimulationExecutionContext | undefined> => {
+	const resolvedSimulationInput = resolvePreparedSimulationInput(simulationStateInput)
+	if (resolvedSimulationInput === undefined) return undefined
+	const parentBlock = await ethereumClientService.getBlock(requestAbortController, baseBlockTag)
+	if (parentBlock === null) throw new Error('The latest block is null')
+	const { prepared, result } = await ethereumClientService.simulatePrepared(resolvedSimulationInput, parentBlock.number, requestAbortController)
+	return createSimulationExecutionContextFromPreparedInput(resolvedSimulationInput, parentBlock, prepared, result)
 }
 
 const resolveSimulationBlockTag = (
@@ -927,7 +961,9 @@ export async function getSimulatedBlockFromInput(ethereumClientService: Ethereum
 	}
 	const blockIndex = getExecutionBlockIndexForTag(context.parentBlock.number, context.executionBlocks.length, blockTag)
 	if (blockIndex === undefined) return null
-	const block = await getSimulatedMockBlockFromPreparedContext(context, blockIndex)
+	const simulatedContext = await createSimulatedPreparedSimulationExecutionContext(ethereumClientService, requestAbortController, simulationStateInput)
+	if (simulatedContext === undefined) return null
+	const block = await getSimulatedMockBlockFromPreparedContext(simulatedContext, blockIndex)
 	if (block === null) return null
 	if (fullObjects) return block
 	return { ...block, transactions: block.transactions.map((transaction) => transaction.hash) }
@@ -944,7 +980,9 @@ export const getSimulatedBlockByHashFromInput = async (
 	if (context === undefined) return await ethereumClientService.getBlockByHash(blockHash, requestAbortController, fullObjects)
 	const blockIndex = context.executionBlocks.findIndex((block) => block.blockHash === blockHash)
 	if (blockIndex < 0) return await ethereumClientService.getBlockByHash(blockHash, requestAbortController, fullObjects)
-	const block = await getSimulatedMockBlockFromPreparedContext(context, blockIndex)
+	const simulatedContext = await createSimulatedPreparedSimulationExecutionContext(ethereumClientService, requestAbortController, simulationStateInput)
+	if (simulatedContext === undefined) return null
+	const block = await getSimulatedMockBlockFromPreparedContext(simulatedContext, blockIndex)
 	if (block === null) return null
 	if (fullObjects) return block
 	return { ...block, transactions: block.transactions.map((transaction) => transaction.hash) }

--- a/test/tests/SimulationModeEthereumClientService.test.ts
+++ b/test/tests/SimulationModeEthereumClientService.test.ts
@@ -180,6 +180,55 @@ const zeroBytes256 = `0x${'0'.repeat(512)}`
 			simulateWithZeroBaseFee: false,
 		}] as const
 
+		const createSimulationStateInputWithGas = (gas: bigint): Parameters<typeof toResolvedSimulationInput>[0] => [{
+			stateOverrides: {},
+			transactions: [{
+				signedTransaction: mockSignTransaction({
+					...exampleTransaction,
+					nonce: 0n,
+					gas,
+				}),
+				website: { websiteOrigin: 'test', icon: undefined, title: undefined },
+				created: new Date(),
+				originalRequestParameters: { method: 'eth_sendTransaction', params: [{}]},
+				transactionIdentifier: 101n,
+			}],
+			signedMessages: [],
+			blockTimeManipulation: { type: 'AddToTimestamp', deltaToAdd: 12n, deltaUnit: 'Seconds' },
+			simulateWithZeroBaseFee: false,
+		}]
+
+		const createSplitSimulationStateInput = (): Parameters<typeof toResolvedSimulationInput>[0] => [{
+			stateOverrides: {},
+			transactions: [
+				{
+					signedTransaction: mockSignTransaction({
+						...exampleTransaction,
+						nonce: 0n,
+						gas: 20_000_000n,
+					}),
+					website: { websiteOrigin: 'test', icon: undefined, title: undefined },
+					created: new Date(),
+					originalRequestParameters: { method: 'eth_sendTransaction', params: [{}]},
+					transactionIdentifier: 102n,
+				},
+				{
+					signedTransaction: mockSignTransaction({
+						...exampleTransaction,
+						nonce: 1n,
+						gas: 20_000_000n,
+					}),
+					website: { websiteOrigin: 'test', icon: undefined, title: undefined },
+					created: new Date(),
+					originalRequestParameters: { method: 'eth_sendTransaction', params: [{}]},
+					transactionIdentifier: 103n,
+				},
+			],
+			signedMessages: [],
+			blockTimeManipulation: { type: 'AddToTimestamp', deltaToAdd: 12n, deltaUnit: 'Seconds' },
+			simulateWithZeroBaseFee: false,
+		}]
+
 		test('mockSignTransaction should have r=0, s=0 and yParity = "even"', async () => {
 			const signed = mockSignTransaction(exampleTransaction)
 			assert.equal(signed.type, '1559')
@@ -651,6 +700,43 @@ const zeroBytes256 = `0x${'0'.repeat(512)}`
 			assert.equal(latestBlock.hash, sameBlock.hash)
 				assert.equal(roundTripped.hash, latestBlock.hash)
 				assert.equal(roundTripped.number, latestBlock.number)
+			})
+
+			test('input-based simulated block gasUsed comes from eth_simulateV1 result', async () => {
+				requestHandler.ethSimulateV1Calls.length = 0
+				const simulationStateInput = createSimulationStateInputWithGas(100_000n)
+
+				const latestBlock = await getBlockFromInput(simulationStateInput, 'latest', true)
+				if (latestBlock === null) throw new Error('latest simulated block missing')
+
+				assert.equal(latestBlock.gasUsed, 0x5208n)
+				assert.equal(requestHandler.ethSimulateV1Calls.length, 1)
+			})
+
+			test('input-based getBlockByHash gasUsed comes from eth_simulateV1 result', async () => {
+				requestHandler.ethSimulateV1Calls.length = 0
+				const simulationStateInput = createSimulationStateInputWithGas(100_000n)
+
+				const latestBlock = await getBlockFromInput(simulationStateInput, 'latest', true)
+				if (latestBlock === null) throw new Error('latest simulated block missing')
+				const roundTripped = await getBlockByHashFromInput(simulationStateInput, latestBlock.hash, true)
+				if (roundTripped === null) throw new Error('round-tripped block missing')
+
+				assert.equal(roundTripped.gasUsed, 0x5208n)
+				assert.equal(requestHandler.ethSimulateV1Calls.length, 2)
+			})
+
+			test('input-based split execution block gasUsed comes from each eth_simulateV1 result block', async () => {
+				requestHandler.ethSimulateV1Calls.length = 0
+				const simulationStateInput = createSplitSimulationStateInput()
+
+				const firstExecutionBlock = await getBlockFromInput(simulationStateInput, blockNumber + 1n, true)
+				const secondExecutionBlock = await getBlockFromInput(simulationStateInput, blockNumber + 2n, true)
+				if (firstExecutionBlock === null || secondExecutionBlock === null) throw new Error('simulated split execution block missing')
+
+				assert.equal(firstExecutionBlock.gasUsed, 0x5208n)
+				assert.equal(secondExecutionBlock.gasUsed, 0x6dd4n)
+				assert.equal(requestHandler.ethSimulateV1Calls.length, 2)
 			})
 
 			test('input-based simulated block hash changes when transaction contents change', async () => {


### PR DESCRIPTION
## Summary
- build input-based block responses with gasUsed and baseFeePerGas from eth_simulateV1 result blocks
- keep deterministic synthetic block hashes while using actual simulated block gas metadata
- add regressions for block number lookup, block hash lookup, and split execution blocks

## Validation
- bun test
- bun run setup-chrome
- bun run typecheck
- bun run lint (fails on existing origin/main lint baseline; see PR #1452)