### PR TITLE
Normalize DNR blocked site domains

### DIFF
--- a/app/ts/background/accessManagement.ts
+++ b/app/ts/background/accessManagement.ts
@@ -232,10 +232,49 @@ const getApprovedTabs = (websiteTabConnections: WebsiteTabConnections) => {
 	}
 	return approvedTabs
 }
+const parseWebsiteOriginLike = (websiteOrigin: string) => {
+	try {
+		const parsed = new URL(websiteOrigin.includes('://') ? websiteOrigin : `https://${ websiteOrigin }`)
+		if (parsed.hostname.length === 0) return undefined
+		return {
+			hostname: parsed.hostname,
+			hostWithPort: parsed.port ? `${ parsed.hostname }:${ parsed.port }` : parsed.hostname,
+			hasPort: parsed.port.length > 0,
+		}
+	} catch {
+		return undefined
+	}
+}
+
+const getWebsiteOriginHostWithPort = (websiteOrigin: string) => parseWebsiteOriginLike(websiteOrigin)?.hostWithPort
+
+export const getDeclarativeNetRequestInitiatorDomain = (websiteOrigin: string) => {
+	const parsed = parseWebsiteOriginLike(websiteOrigin)
+	if (parsed === undefined || parsed.hasPort) return undefined
+	return parsed.hostname
+}
+
+const getTabIdsForBlockedWebsiteOrigins = (websiteTabConnections: WebsiteTabConnections, blockedWebsiteOrigins: ReadonlySet<string>) => {
+	const tabIdsToBlock = new Set<number>()
+	for (const tabConnection of websiteTabConnections.values()) {
+		for (const connection of Object.values(tabConnection.connections)) {
+			if (connection === undefined) continue
+			if (blockedWebsiteOrigins.has(connection.websiteOrigin)) tabIdsToBlock.add(connection.socket.tabId)
+		}
+	}
+	return [...tabIdsToBlock]
+}
+
 const getTabsAndAddressesToBlock = async (websiteTabConnections: WebsiteTabConnections) => {
 	const approvedTabIds = getApprovedTabs(websiteTabConnections)
-	const tabIdsToBlock = (await getActiveAddressesForAllTabs(await getSettings())).filter((tabData) => approvedTabIds.has(tabData.tabId)).filter((tabData) => tabData.activeAddress?.declarativeNetRequestBlockMode === 'block-all').map((tabData) => tabData.tabId)
-	const sitesToBlock = (await getWebsiteAccess()).filter((access) => access.declarativeNetRequestBlockMode === 'block-all').map((acccess) => acccess.website.websiteOrigin)
+	const activeAddressTabIdsToBlock = (await getActiveAddressesForAllTabs(await getSettings())).filter((tabData) => approvedTabIds.has(tabData.tabId)).filter((tabData) => tabData.activeAddress?.declarativeNetRequestBlockMode === 'block-all').map((tabData) => tabData.tabId)
+	const websiteAccessesToBlock = (await getWebsiteAccess()).filter((access) => access.declarativeNetRequestBlockMode === 'block-all')
+	const sitesToBlock = websiteAccessesToBlock.map((acccess) => acccess.website.websiteOrigin)
+	const portScopedSitesToBlock = new Set(websiteAccessesToBlock
+		.filter((access) => getDeclarativeNetRequestInitiatorDomain(access.website.websiteOrigin) === undefined)
+		.map((access) => getWebsiteOriginHostWithPort(access.website.websiteOrigin))
+		.filter((websiteOrigin): websiteOrigin is string => websiteOrigin !== undefined))
+	const tabIdsToBlock = [...new Set([...activeAddressTabIdsToBlock, ...getTabIdsForBlockedWebsiteOrigins(websiteTabConnections, portScopedSitesToBlock)])]
 	return {
 		tabIdsToBlock,
 		sitesToBlock
@@ -248,6 +287,7 @@ const updateDeclarativeNetRequestBlocksSemaphore = new Semaphore(1)
 export async function updateDeclarativeNetRequestBlocks(websiteTabConnections: WebsiteTabConnections) {
 	return await updateDeclarativeNetRequestBlocksSemaphore.execute(async () => {
 		const { tabIdsToBlock, sitesToBlock } = await getTabsAndAddressesToBlock(websiteTabConnections)
+		const initiatorDomainsToBlock = [...new Set(sitesToBlock.map(getDeclarativeNetRequestInitiatorDomain).filter((domain): domain is string => domain !== undefined && domain.length > 0))]
 		// check if the rules would change, if not, just bail out
 		const decralativeNetRequestBlockIdentifier = `${ tabIdsToBlock.join('|') }|a|${ sitesToBlock.join('|') }`
 		if (decralativeNetRequestBlockIdentifier === previousDecralativeNetRequestBlockIdentifier) return
@@ -256,14 +296,14 @@ export async function updateDeclarativeNetRequestBlocks(websiteTabConnections: W
 		if (browser.runtime.getManifest().manifest_version === 3) {
 			const dynamicRuleIds = (await browser.declarativeNetRequest.getDynamicRules()).map((rule) => rule.id)
 			const sessionRuleIds = (await browser.declarativeNetRequest.getSessionRules()).map((rule) => rule.id)
-			if (sitesToBlock.length !== 0) {
+			if (initiatorDomainsToBlock.length !== 0) {
 				await browser.declarativeNetRequest.updateDynamicRules({
 					removeRuleIds: dynamicRuleIds,
 					addRules: [{
 						id: dynamicRuleIds.length === 0 ? 1 : Math.max.apply(null, dynamicRuleIds) + 1,
 						priority: 1,
 						action : { type: 'block' as const },
-						condition: { initiatorDomains: sitesToBlock, domainType: 'thirdParty' as const }
+						condition: { initiatorDomains: initiatorDomainsToBlock, domainType: 'thirdParty' as const }
 					}]
 				})
 			} else {

--- a/test/tests/declarativeNetRequestBlocks.test.ts
+++ b/test/tests/declarativeNetRequestBlocks.test.ts
@@ -1,0 +1,157 @@
+import * as assert from 'assert'
+import { describe, test } from 'bun:test'
+
+type BrowserStorageState = Record<string, unknown>
+type DeclarativeRule = {
+	condition?: {
+		initiatorDomains?: readonly string[]
+		tabIds?: readonly number[]
+	}
+}
+type DeclarativeRuleUpdate = {
+	removeRuleIds: readonly number[]
+	addRules?: readonly DeclarativeRule[]
+}
+
+function installBrowserMock() {
+	const storageState: BrowserStorageState = {}
+	const dynamicRuleUpdates: DeclarativeRuleUpdate[] = []
+	const sessionRuleUpdates: DeclarativeRuleUpdate[] = []
+
+	Object.defineProperty(globalThis, 'browser', { configurable: true, writable: true, value: {
+		runtime: {
+			lastError: null,
+			connect: () => ({ postMessage: () => undefined }),
+			async sendMessage() { return undefined },
+			getManifest: () => ({ manifest_version: 3 }),
+			onMessage: { addListener: () => undefined, removeListener: () => undefined },
+			onConnect: { addListener: () => undefined, removeListener: () => undefined },
+		},
+		storage: {
+			local: {
+				async get(keys?: string | string[] | Record<string, unknown> | null) {
+					if (keys === undefined || keys === null) return { ...storageState }
+					if (Array.isArray(keys)) return Object.fromEntries(keys.filter((key) => key in storageState).map((key) => [key, storageState[key]]))
+					if (typeof keys === 'string') return keys in storageState ? { [keys]: storageState[keys] } : {}
+					return Object.fromEntries(Object.entries(keys).map(([key, defaultValue]) => [key, key in storageState ? storageState[key] : defaultValue]))
+				},
+				async set(items: Record<string, unknown>) {
+					Object.assign(storageState, items)
+				},
+				async remove(keys: string | string[]) {
+					for (const key of Array.isArray(keys) ? keys : [keys]) delete storageState[key]
+				},
+			},
+		},
+		tabs: {
+			async query() { return [] },
+			async get() { return undefined },
+			async update() { return undefined },
+			onUpdated: { addListener: () => undefined, removeListener: () => undefined },
+			onRemoved: { addListener: () => undefined, removeListener: () => undefined },
+		},
+		windows: {
+			async get() { return undefined },
+			async update() { return undefined },
+		},
+		action: {
+			async setIcon() { return undefined },
+			async setTitle() { return undefined },
+			async setBadgeText() { return undefined },
+			async setBadgeBackgroundColor() { return undefined },
+		},
+		browserAction: {
+			async setIcon() { return undefined },
+			async setTitle() { return undefined },
+			async setBadgeText() { return undefined },
+			async setBadgeBackgroundColor() { return undefined },
+		},
+		declarativeNetRequest: {
+			async getDynamicRules() { return [{ id: 7 }] },
+			async getSessionRules() { return [{ id: 11 }] },
+			async updateDynamicRules(update: DeclarativeRuleUpdate) {
+				dynamicRuleUpdates.push(update)
+			},
+			async updateSessionRules(update: DeclarativeRuleUpdate) {
+				sessionRuleUpdates.push(update)
+			},
+		},
+		webRequest: {
+			onBeforeRequest: {
+				addListener: () => undefined,
+				removeListener: () => undefined,
+			},
+		},
+	} })
+	globalThis.chrome = { runtime: { id: 'test-extension' } }
+
+	return { dynamicRuleUpdates, sessionRuleUpdates }
+}
+
+async function loadModules() {
+	return {
+		...await import('../../app/ts/background/accessManagement.js'),
+		...await import('../../app/ts/background/settings.js'),
+	}
+}
+
+describe('declarative net request blocking', () => {
+	test('uses persistent initiatorDomains only for host-scoped website blocks', async () => {
+		const { dynamicRuleUpdates, sessionRuleUpdates } = installBrowserMock()
+		const { getDeclarativeNetRequestInitiatorDomain, updateDeclarativeNetRequestBlocks, updateWebsiteAccess } = await loadModules()
+		assert.equal(getDeclarativeNetRequestInitiatorDomain('localhost:5173'), undefined)
+		assert.equal(getDeclarativeNetRequestInitiatorDomain('https://app.example:8443'), undefined)
+		assert.equal(getDeclarativeNetRequestInitiatorDomain('https://app.example'), 'app.example')
+		assert.equal(getDeclarativeNetRequestInitiatorDomain('example.com'), 'example.com')
+		assert.equal(getDeclarativeNetRequestInitiatorDomain('http://[bad'), undefined)
+
+		await updateWebsiteAccess(() => [
+			{
+				website: { websiteOrigin: 'example.com', icon: undefined, title: undefined },
+				access: true,
+				addressAccess: undefined,
+				declarativeNetRequestBlockMode: 'block-all',
+			},
+			{
+				website: { websiteOrigin: 'localhost:5173', icon: undefined, title: undefined },
+				access: true,
+				addressAccess: undefined,
+				declarativeNetRequestBlockMode: 'block-all',
+			},
+			{
+				website: { websiteOrigin: 'https://app.example', icon: undefined, title: undefined },
+				access: true,
+				addressAccess: undefined,
+				declarativeNetRequestBlockMode: 'block-all',
+			},
+			{
+				website: { websiteOrigin: 'http://[bad', icon: undefined, title: undefined },
+				access: true,
+				addressAccess: undefined,
+				declarativeNetRequestBlockMode: 'block-all',
+			},
+		])
+
+		await updateDeclarativeNetRequestBlocks(new Map([[1, { connections: {
+			portScoped: {
+				port: browser.runtime.connect(),
+				socket: { tabId: 1, connectionName: 0n },
+				websiteOrigin: 'localhost:5173',
+				approved: false,
+				wantsToConnect: false,
+			},
+		} }]]))
+
+		const dynamicUpdate = dynamicRuleUpdates[0]
+		if (dynamicUpdate === undefined) throw new Error('missing dynamic DNR update')
+		const addedDynamicRule = dynamicUpdate.addRules?.[0]
+		if (addedDynamicRule === undefined) throw new Error('missing dynamic DNR add rule')
+		assert.deepEqual(dynamicUpdate.removeRuleIds, [7])
+		assert.deepEqual(addedDynamicRule.condition?.initiatorDomains, ['example.com', 'app.example'])
+
+		const sessionUpdate = sessionRuleUpdates[0]
+		if (sessionUpdate === undefined) throw new Error('missing session DNR update')
+		assert.deepEqual(sessionUpdate.removeRuleIds, [11])
+		assert.deepEqual(sessionUpdate.addRules?.[0]?.condition?.tabIds, [1])
+	})
+})


### PR DESCRIPTION
## Summary
- normalize website access entries before writing Chrome DNR initiatorDomains
- avoid broad host-level DNR rules for port-scoped sites; cover connected port-scoped tabs with session tab rules
- add DNR rule regression coverage for host, ported, scheme-bearing, and invalid website origins

## Validation
- bun test
- bun run setup-chrome
- bun run typecheck
- bun run lint (fails on existing origin/main lint baseline; see PR #1452)