### PR TITLE
Harden inpage signer bridge messages

### DIFF
--- a/app/inpage/ts/document_start.ts
+++ b/app/inpage/ts/document_start.ts
@@ -8,6 +8,7 @@ function injectScript(_content: string) {
 	}
 
 	function listenContentScript(connectionName: string | undefined) {
+		const INTERCEPTOR_BRIDGE_PORT_MESSAGE = 'interceptor_bridge_port'
 		const checkAndThrowRuntimeLastError = () => {
 			const error: browser.runtime._LastError | undefined | null = browser.runtime.lastError // firefox return `null` on no errors
 			if (error !== null && error !== undefined && error.message !== undefined) throw new Error(error.message)
@@ -41,6 +42,7 @@ function injectScript(_content: string) {
 		const connectionNameNotUndefined = connectionName === undefined ? generateId(40) : connectionName
 		let pageHidden = false
 		let extensionPort: browser.runtime.Port | undefined 
+		let inpagePort: MessagePort | undefined
 
 		const isForwardedDiagnosticsRecord = (value: unknown): value is Record<string, unknown> => typeof value === 'object' && value !== null
 		const stringifyForwardedThrownValue = (value: unknown) => {
@@ -94,22 +96,15 @@ function injectScript(_content: string) {
 			}
 		}
 
-		// forward all page messages to the background script, which will then filter and process them
-		// anything reaching this boundary is untrusted page input unless the extension proves otherwise
-		globalThis.addEventListener('message', (messageEvent: MessageEvent<unknown>) => {
+		const forwardInpageMessageToBackground = (data: unknown) => {
 			if (extensionPort === undefined) return
 			if (
-				typeof messageEvent !== 'object'
-				|| messageEvent === null
-				|| !('data' in messageEvent)
-				|| typeof messageEvent.data !== 'object'
-				|| messageEvent.data === null
-				|| !('interceptorRequest' in messageEvent.data)
+				typeof data !== 'object'
+				|| data === null
+				|| !('interceptorRequest' in data)
 			) return
 			try {
-				// we only want the data element, if it exists, and postMessage will fail if it can't clone the object fully (and it cannot clone a MessageEvent)
-				if (!('data' in messageEvent) || !(typeof messageEvent.data === 'object' && messageEvent.data !== null) || !('interceptorRequest' in messageEvent.data)) return
-				extensionPort.postMessage({ data: messageEvent.data })
+				extensionPort.postMessage({ data })
 				checkAndThrowRuntimeLastError()
 			} catch (error) {
 				if (error instanceof Error) {
@@ -119,9 +114,26 @@ function injectScript(_content: string) {
 					}
 					if (error.message?.includes('User denied')) return // user denied signature
 				}
-				reportInterceptorError(serializeForwardedDiagnostics('document-start', 'forward page message', error, getForwardedDiagnosticsRequestContext(messageEvent.data)))
+				reportInterceptorError(serializeForwardedDiagnostics('document-start', 'forward page message', error, getForwardedDiagnosticsRequestContext(data)))
 				throw error
 			}
+		}
+
+		globalThis.addEventListener('message', (messageEvent: MessageEvent<unknown>) => {
+			if (
+				inpagePort !== undefined
+				|| typeof messageEvent.data !== 'object'
+				|| messageEvent.data === null
+				|| !('type' in messageEvent.data)
+				|| messageEvent.data.type !== INTERCEPTOR_BRIDGE_PORT_MESSAGE
+			) return
+			const port = messageEvent.ports[0]
+			if (port === undefined) {
+				reportInterceptorError(createForwardedDiagnosticsFromRaw('document-start', 'connect inpage bridge', 'Missing inpage MessagePort', messageEvent.data, getForwardedDiagnosticsRequestContext(messageEvent.data)))
+				return
+			}
+			inpagePort = port
+			inpagePort.onmessage = (portMessageEvent: MessageEvent<unknown>) => forwardInpageMessageToBackground(portMessageEvent.data)
 		})
 
 		const connect = () => {
@@ -137,7 +149,11 @@ function injectScript(_content: string) {
 					return
 				}
 				try {
-					globalThis.postMessage(messageEvent, '*')
+					if (inpagePort === undefined) {
+						reportInterceptorError(createForwardedDiagnosticsFromRaw('document-start', 'forward background message', 'Inpage MessagePort is not connected', messageEvent, getForwardedDiagnosticsRequestContext(messageEvent)))
+						return
+					}
+					inpagePort.postMessage(messageEvent)
 					checkAndThrowRuntimeLastError()
 				} catch (error) {
 					console.error(error)
@@ -170,13 +186,13 @@ function injectScript(_content: string) {
 	}
 
 	try {
+		listenContentScript(undefined)
 		const container = document.head || document.documentElement
 		const scriptTag = document.createElement('script')
 		scriptTag.setAttribute('async', 'false')
 		scriptTag.src = browser.runtime.getURL('inpage/js/inpage.js')
 		container.insertBefore(scriptTag, container.children[1])
 		container.removeChild(scriptTag)
-		listenContentScript(undefined)
 		checkAndThrowRuntimeLastError()
 	} catch (error) {
 	  	console.error('Interceptor: Provider injection failed.', error)

--- a/app/inpage/ts/inpage.ts
+++ b/app/inpage/ts/inpage.ts
@@ -85,6 +85,76 @@ type InterceptedRequestForwardToSigner = InterceptedRequestBase & { readonly typ
 
 type InterceptedRequestForward = InterceptedRequestForwardWithResult | InterceptedRequestForwardWithError | InterceptedRequestForwardToSigner
 
+const INTERCEPTOR_BRIDGE_PORT_MESSAGE = 'interceptor_bridge_port'
+
+type InterceptorApprovedMessageCandidate = {
+	readonly interceptorApproved?: unknown
+	readonly method?: unknown
+	readonly type?: unknown
+	readonly requestId?: unknown
+	readonly params?: unknown
+	readonly subscription?: unknown
+	readonly replyWithSignersReply?: unknown
+	readonly result?: unknown
+	readonly error?: unknown
+}
+
+type InterceptorErrorCandidate = {
+	readonly code?: unknown
+	readonly message?: unknown
+	readonly data?: unknown
+}
+
+const isMessageCandidate = (value: unknown): value is InterceptorApprovedMessageCandidate => typeof value === 'object' && value !== null
+const isErrorCandidate = (value: unknown): value is InterceptorErrorCandidate => typeof value === 'object' && value !== null
+
+function parseInterceptorApprovedMessage(data: unknown): InterceptedRequestForward | undefined {
+	if (!isMessageCandidate(data)) return undefined
+	if (data.interceptorApproved !== true) return undefined
+	const method = data.method
+	if (typeof method !== 'string') return undefined
+	const type = data.type
+	if (type !== 'result' && type !== 'forwardToSigner') return undefined
+	const requestId = data.requestId
+	const params = data.params
+	const subscription = data.subscription
+	const base = {
+		interceptorApproved: true as const,
+		method,
+		...(typeof requestId === 'number' ? { requestId } : {}),
+		...(Array.isArray(params) ? { params } : {}),
+		...(typeof subscription === 'string' ? { subscription } : {}),
+	}
+	if (type === 'forwardToSigner') return {
+		...base,
+		type: 'forwardToSigner',
+		...(data.replyWithSignersReply === true ? { replyWithSignersReply: true as const } : {}),
+	}
+	const hasResult = 'result' in data
+	const maybeError = data.error
+	if (hasResult && maybeError !== undefined) return undefined
+	if (isErrorCandidate(maybeError)) {
+		const { code, message } = maybeError
+		if (typeof code !== 'number' || typeof message !== 'string') return undefined
+		const errorData = maybeError.data
+		return {
+			...base,
+			type: 'result',
+			error: {
+				code,
+				message,
+				...(errorData !== undefined && typeof errorData === 'object' && errorData !== null ? { data: errorData } : {}),
+			},
+		}
+	}
+	if (!hasResult) return undefined
+	return {
+		...base,
+		type: 'result',
+		result: data.result,
+	}
+}
+
 interface ProviderConnectInfo {
 	readonly chainId: string
 }
@@ -254,6 +324,7 @@ class InterceptorMessageListener {
 	private requestId = 0
 	private metamaskCompatibilityMode = false
 	private signerWindowEthereumRequest: EthereumRequest | undefined = undefined
+	private extensionMessagePort: MessagePort | undefined = undefined
 
 	private readonly outstandingRequests: Map<number, InterceptorFuture<unknown> > = new Map()
 
@@ -271,11 +342,19 @@ class InterceptorMessageListener {
 	private pendingSignerAddressRequest: InterceptorFuture<SignerAccountsReply> | undefined = undefined
 
 	public constructor() {
+		this.connectToContentScript()
 		this.injectEthereumIntoWindow()
 		this.onPageLoad()
 	}
 
 	private readonly WindowEthereumIsConnected = () => this.connected
+
+	private readonly connectToContentScript = () => {
+		const channel = new MessageChannel()
+		this.extensionMessagePort = channel.port1
+		channel.port1.onmessage = (messageEvent: MessageEvent<unknown>) => { void this.onMessage(messageEvent) }
+		window.postMessage({ type: INTERCEPTOR_BRIDGE_PORT_MESSAGE }, '*', [channel.port2])
+	}
 
 	private readonly sendMessageToBackgroundPage = async (messageMethodAndParams: MessageMethodAndParams) => {
 		this.requestId++
@@ -283,13 +362,14 @@ class InterceptorMessageListener {
 		const future = new InterceptorFuture<unknown>()
 		this.outstandingRequests.set(pendingRequestId, future)
 		try {
-			window.postMessage({
+			if (this.extensionMessagePort === undefined) throw new Error('Interceptor content script bridge is not connected')
+			this.extensionMessagePort.postMessage({
 				interceptorRequest: true,
 				method: messageMethodAndParams.method,
 				params: messageMethodAndParams.params,
 				usingInterceptorWithoutSigner: this.signerWindowEthereumRequest === undefined,
 				requestId: pendingRequestId,
-			}, '*')
+			})
 			return await future
 		} finally {
 			this.outstandingRequests.delete(pendingRequestId)
@@ -298,13 +378,14 @@ class InterceptorMessageListener {
 
 	private readonly reportInterceptorError = (diagnostics: string) => {
 		try {
-			window.postMessage({
+			if (this.extensionMessagePort === undefined) return
+			this.extensionMessagePort.postMessage({
 				interceptorRequest: true,
 				method: 'InterceptorError',
 				params: [diagnostics],
 				usingInterceptorWithoutSigner: this.signerWindowEthereumRequest === undefined,
 				requestId: -1,
-			}, '*')
+			})
 		} catch(reportingError: unknown) {
 			console.error('Failed to report InterceptorError diagnostics')
 			console.error(reportingError)
@@ -630,21 +711,23 @@ class InterceptorMessageListener {
 		return new EthereumJsonRpcError(METAMASK_ERROR_BLANKET_ERROR, 'Unexpected thrown value.', maybeErrorObject )
 	}
 
-	public readonly onMessage = async (messageEvent: unknown) => {
+	public readonly onWindowMessage = (messageEvent: unknown) => {
 		this.checkIfCoinbaseInjectionMessageAndInject(messageEvent)
+	}
+
+	public readonly onMessage = async (messageEvent: unknown) => {
 		if (
 			typeof messageEvent !== 'object'
 			|| messageEvent === null
 			|| !('data' in messageEvent)
 			|| typeof messageEvent.data !== 'object'
 			|| messageEvent.data === null
-			|| !('interceptorApproved' in messageEvent.data)
 		) return
 		try {
 			if (!('ethereum' in inpageWindow) || !inpageWindow.ethereum) throw new Error('window.ethereum missing')
-			if (!('method' in messageEvent.data)) throw new Error('missing method field')
+			const forwardRequest = parseInterceptorApprovedMessage(messageEvent.data)
+			if (forwardRequest === undefined) throw new Error('Malformed message from content script')
 			if (!('type' in messageEvent)) throw new Error('missing type field')
-			const forwardRequest = messageEvent.data as InterceptedRequestForward //use 'as' here as we don't want to inject funtypes here
 			if (forwardRequest.type === 'result' && 'error' in forwardRequest) {
 				if (forwardRequest.requestId === undefined) throw new EthereumJsonRpcError(forwardRequest.error.code, forwardRequest.error.message, forwardRequest.error.data)
 				const pending = this.outstandingRequests.get(forwardRequest.requestId)
@@ -653,7 +736,7 @@ class InterceptorMessageListener {
 			}
 			if (forwardRequest.type === 'result' && 'result' in forwardRequest) {
 				if (this.metamaskCompatibilityMode && this.signerWindowEthereumRequest === undefined && inpageWindow.ethereum !== undefined) {
-					switch (messageEvent.data.method) {
+					switch (forwardRequest.method) {
 						case 'eth_requestAccounts':
 						case 'eth_accounts': {
 							if (!Array.isArray(forwardRequest.result) || forwardRequest.result === null) throw new Error('wrong type')
@@ -875,7 +958,7 @@ class InterceptorMessageListener {
 
 function injectInterceptor() {
 	const interceptorMessageListener = new InterceptorMessageListener()
-	window.addEventListener('message', interceptorMessageListener.onMessage)
+	window.addEventListener('message', interceptorMessageListener.onWindowMessage)
 	window.dispatchEvent(new Event('ethereum#initialized'))
 
 	// listen if Metamask injects (I think this method of injection is only supported by Metamask currently) their payload, and if so, reinject Interceptor

--- a/app/inpage/ts/listenContentScript.ts
+++ b/app/inpage/ts/listenContentScript.ts
@@ -1,4 +1,5 @@
 function listenContentScript(connectionName: string | undefined) {
+	const INTERCEPTOR_BRIDGE_PORT_MESSAGE = 'interceptor_bridge_port'
 	const checkAndThrowRuntimeLastError = () => {
 		const error: browser.runtime._LastError | undefined | null = browser.runtime.lastError // firefox return `null` on no errors
 		if (error !== null && error !== undefined && error.message !== undefined) throw new Error(error.message)
@@ -32,6 +33,7 @@ function listenContentScript(connectionName: string | undefined) {
 	const connectionNameNotUndefined = connectionName === undefined ? generateId(40) : connectionName
 	let pageHidden = false
 	let extensionPort: browser.runtime.Port | undefined 
+	let inpagePort: MessagePort | undefined
 
 	const isForwardedDiagnosticsRecord = (value: unknown): value is Record<string, unknown> => typeof value === 'object' && value !== null
 	const stringifyForwardedThrownValue = (value: unknown) => {
@@ -85,22 +87,15 @@ function listenContentScript(connectionName: string | undefined) {
 		}
 	}
 
-	// forward all page messages to the background script, which will then filter and process them
-	// anything reaching this boundary is untrusted page input unless the extension proves otherwise
-	globalThis.addEventListener('message', (messageEvent: MessageEvent<unknown>) => {
+	const forwardInpageMessageToBackground = (data: unknown) => {
 		if (extensionPort === undefined) return
 		if (
-			typeof messageEvent !== 'object'
-			|| messageEvent === null
-			|| !('data' in messageEvent)
-			|| typeof messageEvent.data !== 'object'
-			|| messageEvent.data === null
-			|| !('interceptorRequest' in messageEvent.data)
+			typeof data !== 'object'
+			|| data === null
+			|| !('interceptorRequest' in data)
 		) return
 		try {
-			// we only want the data element, if it exists, and postMessage will fail if it can't clone the object fully (and it cannot clone a MessageEvent)
-			if (!('data' in messageEvent) || !(typeof messageEvent.data === 'object' && messageEvent.data !== null) || !('interceptorRequest' in messageEvent.data)) return
-			extensionPort.postMessage({ data: messageEvent.data })
+			extensionPort.postMessage({ data })
 			checkAndThrowRuntimeLastError()
 		} catch (error) {
 			if (error instanceof Error) {
@@ -110,9 +105,26 @@ function listenContentScript(connectionName: string | undefined) {
 				}
 				if (error.message?.includes('User denied')) return // user denied signature
 			}
-			reportInterceptorError(serializeForwardedDiagnostics('content-script', 'forward page message', error, getForwardedDiagnosticsRequestContext(messageEvent.data)))
+			reportInterceptorError(serializeForwardedDiagnostics('content-script', 'forward page message', error, getForwardedDiagnosticsRequestContext(data)))
 			throw error
 		}
+	}
+
+	globalThis.addEventListener('message', (messageEvent: MessageEvent<unknown>) => {
+		if (
+			inpagePort !== undefined
+			|| typeof messageEvent.data !== 'object'
+			|| messageEvent.data === null
+			|| !('type' in messageEvent.data)
+			|| messageEvent.data.type !== INTERCEPTOR_BRIDGE_PORT_MESSAGE
+		) return
+		const port = messageEvent.ports[0]
+		if (port === undefined) {
+			reportInterceptorError(createForwardedDiagnosticsFromRaw('content-script', 'connect inpage bridge', 'Missing inpage MessagePort', messageEvent.data, getForwardedDiagnosticsRequestContext(messageEvent.data)))
+			return
+		}
+		inpagePort = port
+		inpagePort.onmessage = (portMessageEvent: MessageEvent<unknown>) => forwardInpageMessageToBackground(portMessageEvent.data)
 	})
 
 	const connect = () => {
@@ -128,7 +140,11 @@ function listenContentScript(connectionName: string | undefined) {
 				return
 			}
 			try {
-				globalThis.postMessage(messageEvent, '*')
+				if (inpagePort === undefined) {
+					reportInterceptorError(createForwardedDiagnosticsFromRaw('content-script', 'forward background message', 'Inpage MessagePort is not connected', messageEvent, getForwardedDiagnosticsRequestContext(messageEvent)))
+					return
+				}
+				inpagePort.postMessage(messageEvent)
 				checkAndThrowRuntimeLastError()
 			} catch (error) {
 				console.error(error)

--- a/test/tests/inpageSignerBridge.test.ts
+++ b/test/tests/inpageSignerBridge.test.ts
@@ -1,7 +1,23 @@
 import * as assert from 'assert'
 import { describe, test } from 'bun:test'
 
-type Listener = (event: { type: string, data?: unknown, detail?: unknown, ports?: readonly unknown[] }) => void
+type WindowEvent = { type: string, data?: unknown, detail?: unknown, ports?: readonly MessagePort[] }
+type Listener = (event: WindowEvent) => void
+type InpageRequest = { readonly method: string, readonly requestId: number, readonly params?: readonly unknown[] }
+
+const isRecord = (value: unknown): value is Record<string, unknown> => typeof value === 'object' && value !== null
+
+function parseInpageRequest(value: unknown): InpageRequest | undefined {
+	if (!isRecord(value)) return undefined
+	if (value.interceptorRequest !== true) return undefined
+	if (typeof value.method !== 'string') return undefined
+	if (typeof value.requestId !== 'number') return undefined
+	return {
+		method: value.method,
+		requestId: value.requestId,
+		...(Array.isArray(value.params) ? { params: value.params } : {}),
+	}
+}
 
 function createFakeWindow() {
 	const listeners = new Map<string, Set<Listener>>()
@@ -11,6 +27,7 @@ function createFakeWindow() {
 	const signerAccounts = ['0x1111111111111111111111111111111111111111']
 	let blockRequestAccounts = false
 	let rejectPendingRequestAccounts: ((error: { code: number, message: string }) => void) | undefined
+	let bridgePort: MessagePort | undefined
 
 	const fakeSigner = {
 		isMetaMask: true,
@@ -50,57 +67,62 @@ function createFakeWindow() {
 		removeEventListener: (type: string, listener: Listener) => {
 			listeners.get(type)?.delete(listener)
 		},
-		dispatchEvent: (event: { type: string, data?: unknown, detail?: unknown, ports?: readonly unknown[] }) => {
+		dispatchEvent: (event: WindowEvent) => {
 			for (const listener of listeners.get(event.type) ?? []) listener(event)
 			return true
 		},
-		postMessage: (data: unknown) => {
-			queueMicrotask(() => {
-				if (typeof data !== 'object' || data === null || !('interceptorRequest' in data) || (data as { interceptorRequest?: unknown }).interceptorRequest !== true) return
-				const request = data as unknown as { method: string, requestId: number, params?: readonly unknown[] }
-				switch (request.method) {
-					case 'connected_to_signer':
-						fakeWindow.dispatchEvent({
-							type: 'message',
-							data: {
-								interceptorApproved: true,
-								requestId: request.requestId,
-								type: 'result',
-								method: 'connected_to_signer',
-								result: { metamaskCompatibilityMode: true, activeAddress: signerAccounts[0] },
-							},
-						})
-						return
-					case 'InterceptorError':
-						interceptorErrorPayloads.push(request.params?.[0])
-						return
-					case 'eth_accounts_reply':
-						backgroundEthAccountsReplies.push((request.params?.[0] as { accounts?: unknown } | undefined) ?? {})
-						fakeWindow.dispatchEvent({
-							type: 'message',
-							data: {
-								interceptorApproved: true,
-								requestId: request.requestId,
-								type: 'result',
-								method: 'eth_accounts_reply',
-								result: undefined,
-							},
-						})
-						return
-					default:
-						fakeWindow.dispatchEvent({
-							type: 'message',
-							data: {
-								interceptorApproved: true,
-								requestId: request.requestId,
-								type: 'result',
-								method: request.method,
-								result: '0x',
-							},
-						})
-				}
-			})
+		postMessage: (data: unknown, _targetOrigin?: string, transfer?: readonly Transferable[]) => {
+			if (isRecord(data) && data.type === 'interceptor_bridge_port') {
+				const port = transfer?.find((item): item is MessagePort => item instanceof MessagePort)
+				if (port === undefined) throw new Error('missing bridge port')
+				bridgePort = port
+				bridgePort.onmessage = (event: MessageEvent<unknown>) => handleInpageRequest(event.data)
+			}
 		},
+	}
+
+	const sendBackgroundMessage = (data: unknown) => {
+		if (bridgePort === undefined) throw new Error('bridge port is not connected')
+		bridgePort.postMessage(data)
+	}
+
+	const handleInpageRequest = (data: unknown) => {
+		const request = parseInpageRequest(data)
+		if (request === undefined) return
+		queueMicrotask(() => {
+			switch (request.method) {
+				case 'connected_to_signer':
+					sendBackgroundMessage({
+						interceptorApproved: true,
+						requestId: request.requestId,
+						type: 'result',
+						method: 'connected_to_signer',
+						result: { metamaskCompatibilityMode: true, activeAddress: signerAccounts[0] },
+					})
+					return
+				case 'InterceptorError':
+					interceptorErrorPayloads.push(request.params?.[0])
+					return
+				case 'eth_accounts_reply':
+					backgroundEthAccountsReplies.push((request.params?.[0] as { accounts?: unknown } | undefined) ?? {})
+					sendBackgroundMessage({
+						interceptorApproved: true,
+						requestId: request.requestId,
+						type: 'result',
+						method: 'eth_accounts_reply',
+						result: undefined,
+					})
+					return
+				default:
+					sendBackgroundMessage({
+						interceptorApproved: true,
+						requestId: request.requestId,
+						type: 'result',
+						method: request.method,
+						result: '0x',
+					})
+			}
+		})
 	}
 
 	return {
@@ -109,6 +131,7 @@ function createFakeWindow() {
 		backgroundEthAccountsReplies,
 		signerAccounts,
 		interceptorErrorPayloads,
+		sendBackgroundMessage,
 		setBlockRequestAccounts: (value: boolean) => { blockRequestAccounts = value },
 		rejectPendingRequestAccounts: (error: { code: number, message: string }) => rejectPendingRequestAccounts?.(error),
 	}
@@ -132,6 +155,7 @@ describe('inpage signer bridge', () => {
 			backgroundEthAccountsReplies,
 			signerAccounts,
 			interceptorErrorPayloads,
+			sendBackgroundMessage,
 			setBlockRequestAccounts,
 			rejectPendingRequestAccounts,
 		} = createFakeWindow()
@@ -178,72 +202,54 @@ describe('inpage signer bridge', () => {
 			])
 			const connectEvents: unknown[] = []
 			provider.on('connect', (value) => connectEvents.push(value))
-			fakeWindow.dispatchEvent({
-				type: 'message',
-				data: {
-					interceptorApproved: true,
-					type: 'result',
-					method: 'disconnect',
-					result: [],
-				},
+			sendBackgroundMessage({
+				interceptorApproved: true,
+				type: 'result',
+				method: 'disconnect',
+				result: [],
 			})
-			fakeWindow.dispatchEvent({
-				type: 'message',
-				data: {
-					interceptorApproved: true,
-					type: 'result',
-					method: 'connect',
-					result: ['0x1'],
-				},
+			sendBackgroundMessage({
+				interceptorApproved: true,
+				type: 'result',
+				method: 'connect',
+				result: ['0x1'],
 			})
 			await waitFor(() => connectEvents.length === 1)
 			assert.deepEqual(connectEvents, [{ chainId: '0x1' }])
 
-			fakeWindow.dispatchEvent({
-				type: 'message',
-				data: {
-					interceptorApproved: true,
-					type: 'result',
-					method: 'request_signer_to_eth_accounts',
-					result: [],
-				},
+			sendBackgroundMessage({
+				interceptorApproved: true,
+				type: 'result',
+				method: 'request_signer_to_eth_accounts',
+				result: [],
 			})
 			await waitFor(() => signerRequests.includes('eth_accounts'))
 			assert.deepEqual(signerRequests, ['eth_chainId', 'eth_accounts'])
 			await waitFor(() => backgroundEthAccountsReplies.length === 1)
 			assert.deepEqual((backgroundEthAccountsReplies[0] as { accounts?: unknown }).accounts, signerAccounts)
 
-			fakeWindow.dispatchEvent({
-				type: 'message',
-				data: {
-					interceptorApproved: true,
-					type: 'result',
-					method: 'request_signer_to_eth_requestAccounts',
-					result: [],
-				},
+			sendBackgroundMessage({
+				interceptorApproved: true,
+				type: 'result',
+				method: 'request_signer_to_eth_requestAccounts',
+				result: [],
 			})
 			await waitFor(() => signerRequests.filter((method) => method === 'eth_requestAccounts').length === 1)
 			assert.deepEqual(signerRequests, ['eth_chainId', 'eth_accounts', 'eth_requestAccounts'])
 			await waitFor(() => backgroundEthAccountsReplies.length === 2)
 			assert.deepEqual((backgroundEthAccountsReplies[1] as { accounts?: unknown }).accounts, signerAccounts)
 			setBlockRequestAccounts(true)
-			fakeWindow.dispatchEvent({
-				type: 'message',
-				data: {
-					interceptorApproved: true,
-					type: 'result',
-					method: 'request_signer_to_eth_requestAccounts',
-					result: [],
-				},
+			sendBackgroundMessage({
+				interceptorApproved: true,
+				type: 'result',
+				method: 'request_signer_to_eth_requestAccounts',
+				result: [],
 			})
-			fakeWindow.dispatchEvent({
-				type: 'message',
-				data: {
-					interceptorApproved: true,
-					type: 'result',
-					method: 'request_signer_to_eth_requestAccounts',
-					result: [],
-				},
+			sendBackgroundMessage({
+				interceptorApproved: true,
+				type: 'result',
+				method: 'request_signer_to_eth_requestAccounts',
+				result: [],
 			})
 			await waitFor(() => signerRequests.filter((method) => method === 'eth_requestAccounts').length === 2)
 			rejectPendingRequestAccounts({ code: 4001, message: 'User rejected the request.' })
@@ -253,6 +259,7 @@ describe('inpage signer bridge', () => {
 				{ type: 'error', requestAccounts: true, error: { code: 4001, message: 'User rejected the request.' } },
 			])
 
+			const signerRequestCountBeforeSpoof = signerRequests.length
 			fakeWindow.dispatchEvent({
 				type: 'message',
 				data: {
@@ -263,14 +270,18 @@ describe('inpage signer bridge', () => {
 					params: [],
 				},
 			})
-			await waitFor(() => interceptorErrorPayloads.length === 1)
-			const diagnostics = interceptorErrorPayloads[0]
-			if (typeof diagnostics !== 'string') throw new Error('missing forwarded diagnostics string')
-			assert.equal(diagnostics.includes('inpage: Request did not exist anymore'), true)
-			assert.equal(diagnostics.includes('phase: handle background reply'), true)
-			assert.equal(diagnostics.includes('requestMethod: eth_accounts'), true)
-			assert.equal(diagnostics.includes('requestId: 999'), true)
-			assert.equal(diagnostics.includes('thrown:\nError: Request did not exist anymore'), true)
+			fakeWindow.dispatchEvent({
+				type: 'message',
+				data: {
+					interceptorApproved: true,
+					type: 'result',
+					method: 'request_signer_to_eth_requestAccounts',
+					result: [],
+				},
+			})
+			await new Promise((resolve) => setTimeout(resolve, 0))
+			assert.equal(signerRequests.length, signerRequestCountBeforeSpoof)
+			assert.equal(interceptorErrorPayloads.length, 0)
 		} finally {
 			;(globalThis as { window?: unknown }).window = previousWindow
 			if (previousCustomEvent === undefined) {


### PR DESCRIPTION
## Summary
- move inpage/content-script traffic onto a transferred MessagePort instead of trusting page-wide window.postMessage traffic
- stop forwarding page-originated interceptorRequest messages directly from the content-script boundary
- validate inpage-approved message shape before resolving requests or forwarding to the signer
- update signer bridge regression coverage to prove forged page messages no longer trigger signer requests or diagnostics

## Validation
- bun test
- bun run setup-chrome
- bun run typecheck
- bun run lint (fails on existing origin/main lint baseline; see PR #1452)