### PR TITLE
Preserve scheme in website access origins

### DIFF
--- a/app/ts/background/accessManagement.ts
+++ b/app/ts/background/accessManagement.ts
@@ -6,8 +6,8 @@ import type { TabConnection, WebsiteTabConnections } from '../types/user-interfa
 import type { InpageScriptCallBack, Settings } from '../types/interceptor-messages.js'
 import { getSettings, getWebsiteAccess, updateWebsiteAccess } from './settings.js'
 import { sendSubscriptionReplyOrCallBack } from './messageSending.js'
-import { type WebsiteSocket, getHostWithPort } from '../utils/requests.js'
-import type { Website, WebsiteAccessArray, WebsiteAddressAccess } from '../types/websiteAccessTypes.js'
+import { type WebsiteSocket, getHostWithPort, getHostWithPortFromOriginLike } from '../utils/requests.js'
+import type { Website, WebsiteAccess, WebsiteAccessArray, WebsiteAddressAccess } from '../types/websiteAccessTypes.js'
 import { getUniqueItemsByProperties, replaceElementInReadonlyArray } from '../utils/typed-arrays.js'
 import { modifyObject } from '../utils/typescript.js'
 import type { AddressBookEntries, AddressBookEntry } from '../types/addressBookTypes.js'
@@ -30,6 +30,13 @@ function setWebsitePortApproval(websiteTabConnections: WebsiteTabConnections, so
 }
 
 export type ApprovalState = 'hasAccess' | 'noAccess' | 'askAccess' | 'interceptorDisabled' | 'notFound'
+
+function findWebsiteAccess(websiteAccess: WebsiteAccessArray, websiteOrigin: string): WebsiteAccess | undefined {
+	const exactAccess = websiteAccess.find((web) => web.website.websiteOrigin === websiteOrigin)
+	if (exactAccess !== undefined) return exactAccess
+	const legacyWebsiteOrigin = getHostWithPortFromOriginLike(websiteOrigin)
+	return websiteAccess.find((web) => web.website.websiteOrigin === legacyWebsiteOrigin)
+}
 
 export function verifyAccess(websiteTabConnections: WebsiteTabConnections, socket: WebsiteSocket, askAccessIfUnknown: boolean, websiteOrigin: string, requestAccessForAddress: AddressBookEntry | undefined, settings: Settings) {
 	const connection = getConnectionDetails(websiteTabConnections, socket)
@@ -69,41 +76,31 @@ export async function sendActiveAccountChangeToApprovedWebsitePorts(websiteTabCo
 }
 
 export function hasAccess(websiteAccess: WebsiteAccessArray, websiteOrigin: string) : ApprovalState {
-	for (const web of websiteAccess) {
-		if (web.website.websiteOrigin === websiteOrigin) {
-			if (web.interceptorDisabled) return 'interceptorDisabled'
-			return web.access ? 'hasAccess' : 'noAccess'
-		}
-	}
-	return 'notFound'
+	const web = findWebsiteAccess(websiteAccess, websiteOrigin)
+	if (web === undefined) return 'notFound'
+	if (web.interceptorDisabled) return 'interceptorDisabled'
+	return web.access ? 'hasAccess' : 'noAccess'
 }
 
 export function hasAddressAccess(websiteAccess: WebsiteAccessArray, websiteOrigin: string, address: AddressBookEntry) : ApprovalState {
-	for (const web of websiteAccess) {
-		if (web.website.websiteOrigin === websiteOrigin) {
-			if (web.interceptorDisabled) return 'interceptorDisabled'
-			if (!web.access) return 'noAccess'
-			if (web.addressAccess !== undefined) {
-				for (const addressAccess of web.addressAccess) {
-					if (addressAccess.address === address.address) {
-						return addressAccess.access ? 'hasAccess' : 'noAccess'
-					}
-				}
+	const web = findWebsiteAccess(websiteAccess, websiteOrigin)
+	if (web === undefined) return 'notFound'
+	if (web.interceptorDisabled) return 'interceptorDisabled'
+	if (!web.access) return 'noAccess'
+	if (web.addressAccess !== undefined) {
+		for (const addressAccess of web.addressAccess) {
+			if (addressAccess.address === address.address) {
+				return addressAccess.access ? 'hasAccess' : 'noAccess'
 			}
-			if (address.askForAddressAccess === false) return 'hasAccess'
-			return 'notFound'
 		}
 	}
+	if (address.askForAddressAccess === false) return 'hasAccess'
 	return 'notFound'
 }
 
 function getAddressAccesses(websiteAccess: WebsiteAccessArray, websiteOrigin: string) : readonly WebsiteAddressAccess[] {
-	for (const web of websiteAccess) {
-		if (web.website.websiteOrigin === websiteOrigin) {
-			return web.addressAccess === undefined ? [] : web.addressAccess
-		}
-	}
-	return []
+	const web = findWebsiteAccess(websiteAccess, websiteOrigin)
+	return web?.addressAccess === undefined ? [] : web.addressAccess
 }
 function getAddressesThatDoNotNeedIndividualAccesses(activeAddressEntries: AddressBookEntries) : AddressBookEntries {
 	return activeAddressEntries.filter((x) => x.askForAddressAccess === false)
@@ -235,7 +232,10 @@ const getApprovedTabs = (websiteTabConnections: WebsiteTabConnections) => {
 const getTabsAndAddressesToBlock = async (websiteTabConnections: WebsiteTabConnections) => {
 	const approvedTabIds = getApprovedTabs(websiteTabConnections)
 	const tabIdsToBlock = (await getActiveAddressesForAllTabs(await getSettings())).filter((tabData) => approvedTabIds.has(tabData.tabId)).filter((tabData) => tabData.activeAddress?.declarativeNetRequestBlockMode === 'block-all').map((tabData) => tabData.tabId)
-	const sitesToBlock = (await getWebsiteAccess()).filter((access) => access.declarativeNetRequestBlockMode === 'block-all').map((acccess) => acccess.website.websiteOrigin)
+	const sitesToBlock = (await getWebsiteAccess())
+		.filter((access) => access.declarativeNetRequestBlockMode === 'block-all')
+		.map((acccess) => getHostWithPortFromOriginLike(acccess.website.websiteOrigin))
+		.filter((websiteOrigin) => websiteOrigin.length > 0)
 	return {
 		tabIdsToBlock,
 		sitesToBlock
@@ -305,7 +305,8 @@ export async function updateDeclarativeNetRequestBlocks(websiteTabConnections: W
 
 export const areWeBlocking = async (websiteTabConnections: WebsiteTabConnections, tabId: number, websiteOrigin: string) => {
 	const { tabIdsToBlock, sitesToBlock } = await getTabsAndAddressesToBlock(websiteTabConnections)
-	if (sitesToBlock.find((blockUrl) => blockUrl === websiteOrigin) !== undefined) return true
+	const websiteHost = getHostWithPortFromOriginLike(websiteOrigin)
+	if (sitesToBlock.find((blockUrl) => blockUrl === websiteHost) !== undefined) return true
 	if (tabIdsToBlock.find((blockTab) => blockTab === tabId) !== undefined) return true
 	return false
 }

--- a/app/ts/background/background-startup.ts
+++ b/app/ts/background/background-startup.ts
@@ -9,7 +9,7 @@ import type { EthereumClientService } from '../simulation/services/EthereumClien
 import { getSocketFromPort, sendPopupMessageToOpenWindows, websiteSocketToString } from './backgroundUtils.js'
 import { sendSubscriptionMessagesForNewBlock } from '../simulation/services/EthereumSubscriptionService.js'
 import { Semaphore } from '../utils/semaphore.js'
-import { RawInterceptedRequest, checkAndThrowRuntimeLastError, getHostWithPort, silenceChromeUnCaughtPromise } from '../utils/requests.js'
+import { RawInterceptedRequest, checkAndThrowRuntimeLastError, getOriginWithPort, silenceChromeUnCaughtPromise } from '../utils/requests.js'
 import { DEFAULT_TAB_CONNECTION, ICON_NOT_ACTIVE } from '../utils/constants.js'
 import { handleUnexpectedError, isNewBlockAbort, printError } from '../utils/errors.js'
 import { updateContentScriptInjectionStrategyManifestV2 } from '../utils/contentScriptsUpdating.js'
@@ -107,7 +107,7 @@ async function onContentScriptConnected(getCurrentSimulationServices: () => Simu
 		printError(`Could not connect to a port: ${ port.name}`)
 		return
 	}
-	const websiteOrigin = getHostWithPort(port.sender.url)
+	const websiteOrigin = getOriginWithPort(port.sender.url)
 	const identifier = websiteSocketToString(socket)
 	const websitePromise = (async () => ({ websiteOrigin, ...await retrieveWebsiteDetails(socket.tabId) }))()
 	silenceChromeUnCaughtPromise(websitePromise)
@@ -267,7 +267,7 @@ const onTabUpdated = async (tabId: number, changeInfo: browser.tabs._OnUpdatedCh
 	await waitForBackgroundStartup()
 	if (changeInfo.status !== 'complete') return
 	if (tab.url === undefined) return
-	const websiteOrigin = getHostWithPort(tab.url)
+	const websiteOrigin = getOriginWithPort(tab.url)
 	const website = { websiteOrigin, ...await retrieveWebsiteDetails(tabId) }
 	await updateTabState(tabId, (previousState: TabState) => modifyObject(previousState, { website, tabIconDetails: DEFAULT_TAB_CONNECTION }))
 	await updateDeclarativeNetRequestBlocks(websiteTabConnections)

--- a/app/ts/background/settings.ts
+++ b/app/ts/background/settings.ts
@@ -11,7 +11,7 @@ import { getUniqueItemsByProperties } from '../utils/typed-arrays.js'
 import type { AddressBookEntries, AddressBookEntry } from '../types/addressBookTypes.js'
 import type { BlockTimeManipulation } from '../types/visualizer-types.js'
 import { DEFAULT_BLOCK_MANIPULATION } from '../simulation/services/SimulationModeEthereumClientService.js'
-import { silenceChromeUnCaughtPromise } from '../utils/requests.js'
+import { getHostWithPortFromOriginLike, silenceChromeUnCaughtPromise } from '../utils/requests.js'
 
 export const defaultActiveAddresses: AddressBookEntries = [
 	{
@@ -140,7 +140,7 @@ export async function getSettings() : Promise<Settings> {
 }
 
 export function getInterceptorDisabledSites(settings: Settings): string[] {
-	return settings.websiteAccess.filter((site) => site.interceptorDisabled === true).map((site) => site.website.websiteOrigin)
+	return settings.websiteAccess.filter((site) => site.interceptorDisabled === true).map((site) => getHostWithPortFromOriginLike(site.website.websiteOrigin))
 }
 
 export const setPage = async (openedPageV2: Page) => await browserStorageLocalSet({ openedPageV2 })

--- a/app/ts/utils/requests.ts
+++ b/app/ts/utils/requests.ts
@@ -131,6 +131,21 @@ export const getHostWithPort = (urlString: string): string => {
 	return url.port ? `${ url.hostname }:${ url.port }` : url.hostname
 }
 
+export const getOriginWithPort = (urlString: string): string => {
+	const url = new URL(urlString)
+	if (url.protocol === 'http:' || url.protocol === 'https:') return url.origin
+	return getHostWithPort(urlString)
+}
+
+export const getHostWithPortFromOriginLike = (originLike: string): string => {
+	if (!originLike.includes('://')) return originLike
+	try {
+		return getHostWithPort(originLike)
+	} catch {
+		return originLike
+	}
+}
+
 export const silenceChromeUnCaughtPromise = async <ReturnValue>(maybeAwaitedFunction: Promise<ReturnValue>) => {
 	maybeAwaitedFunction.catch(() => undefined)
 	return maybeAwaitedFunction

--- a/test/tests/websiteOriginAccess.test.ts
+++ b/test/tests/websiteOriginAccess.test.ts
@@ -1,0 +1,103 @@
+import * as assert from 'assert'
+import { describe, test } from 'bun:test'
+import type { AddressBookEntry } from '../../app/ts/types/addressBookTypes.js'
+import type { WebsiteAccessArray } from '../../app/ts/types/websiteAccessTypes.js'
+
+type BrowserStorageState = Record<string, unknown>
+
+function installBrowserMock() {
+	const storageState: BrowserStorageState = {}
+	Object.defineProperty(globalThis, 'browser', { configurable: true, writable: true, value: {
+		storage: {
+			local: {
+				async get(keys?: string | string[] | Record<string, unknown> | null) {
+					if (keys === undefined || keys === null) return { ...storageState }
+					if (Array.isArray(keys)) return Object.fromEntries(keys.filter((key) => key in storageState).map((key) => [key, storageState[key]]))
+					if (typeof keys === 'string') return keys in storageState ? { [keys]: storageState[keys] } : {}
+					return Object.fromEntries(Object.entries(keys).map(([key, defaultValue]) => [key, key in storageState ? storageState[key] : defaultValue]))
+				},
+				async set(items: Record<string, unknown>) {
+					Object.assign(storageState, items)
+				},
+				async remove(keys: string | string[]) {
+					for (const key of Array.isArray(keys) ? keys : [keys]) delete storageState[key]
+				},
+			},
+		},
+	} })
+	Object.defineProperty(globalThis, 'chrome', { configurable: true, writable: true, value: { runtime: { id: 'test-extension' } } })
+	return storageState
+}
+
+async function loadModules() {
+	installBrowserMock()
+	return {
+		...await import('../../app/ts/background/accessManagement.js'),
+		...await import('../../app/ts/background/settings.js'),
+		...await import('../../app/ts/utils/requests.js'),
+	}
+}
+
+const address = 0x1111111111111111111111111111111111111111n
+const addressBookEntry: AddressBookEntry = {
+	type: 'contact',
+	name: 'Test Account',
+	address,
+	entrySource: 'User',
+	askForAddressAccess: true,
+	chainId: 'AllChains',
+}
+
+describe('website origin access', () => {
+	test('getOriginWithPort preserves http and https scheme', async () => {
+		const { getHostWithPortFromOriginLike, getOriginWithPort } = await loadModules()
+		assert.equal(getOriginWithPort('https://example.com/a'), 'https://example.com')
+		assert.equal(getOriginWithPort('http://example.com/a'), 'http://example.com')
+		assert.equal(getOriginWithPort('https://example.com:8443/a'), 'https://example.com:8443')
+		assert.equal(getOriginWithPort('http://example.com:8443/a'), 'http://example.com:8443')
+		assert.equal(getHostWithPortFromOriginLike('https://example.com:8443'), 'example.com:8443')
+	})
+
+	test('schemeful website access entries do not grant the opposite scheme', async () => {
+		const { hasAccess, hasAddressAccess } = await loadModules()
+		const websiteAccess: WebsiteAccessArray = [{
+			website: { websiteOrigin: 'https://example.com', icon: undefined, title: undefined },
+			access: true,
+			addressAccess: [{ address, access: true }],
+		}]
+
+		assert.equal(hasAccess(websiteAccess, 'https://example.com'), 'hasAccess')
+		assert.equal(hasAccess(websiteAccess, 'http://example.com'), 'notFound')
+		assert.equal(hasAddressAccess(websiteAccess, 'https://example.com', addressBookEntry), 'hasAccess')
+		assert.equal(hasAddressAccess(websiteAccess, 'http://example.com', addressBookEntry), 'notFound')
+	})
+
+	test('legacy host-only access remains a fallback and exact schemeful entries win', async () => {
+		const { hasAccess, hasAddressAccess } = await loadModules()
+		const websiteAccess: WebsiteAccessArray = [
+			{
+				website: { websiteOrigin: 'example.com', icon: undefined, title: undefined },
+				access: true,
+				addressAccess: [{ address, access: true }],
+			},
+			{
+				website: { websiteOrigin: 'https://example.com', icon: undefined, title: undefined },
+				access: false,
+				addressAccess: [{ address, access: false }],
+			},
+		]
+
+		assert.equal(hasAccess(websiteAccess, 'http://example.com'), 'hasAccess')
+		assert.equal(hasAddressAccess(websiteAccess, 'http://example.com', addressBookEntry), 'hasAccess')
+		assert.equal(hasAccess(websiteAccess, 'https://example.com'), 'noAccess')
+		assert.equal(hasAddressAccess(websiteAccess, 'https://example.com', addressBookEntry), 'noAccess')
+	})
+
+	test('new access writes keep schemeful website origins', async () => {
+		const { getWebsiteAccess, setAccess } = await loadModules()
+
+		await setAccess({ websiteOrigin: 'https://example.com', icon: undefined, title: undefined }, true, undefined)
+
+		assert.deepEqual((await getWebsiteAccess()).map((entry) => entry.website.websiteOrigin), ['https://example.com'])
+	})
+})


### PR DESCRIPTION
## Summary
- key new website access records by schemeful origin for http/https pages
- preserve legacy host-only website access entries as a fallback while exact schemeful entries take precedence
- keep browser API host/domain consumers on host-only values for disabled-site matching and external request blocking
- add origin/access regressions for scheme isolation, legacy fallback, and schemeful writes

## Validation
- bun test
- bun run setup-chrome
- bun run typecheck
- bun run lint (fails on existing origin/main lint baseline; see PR #1452)

## Notes
- Legacy host-only grants intentionally remain a fallback so existing installs keep working; exact schemeful entries override them.