### PR TITLE
Harden website metadata handling and migrate legacy storage

### DIFF
--- a/build/vendor.mts
+++ b/build/vendor.mts
@@ -196,8 +196,21 @@ async function vendorDependencies() {
 		}
 		await recursiveDirectoryCopy(sourceDirectoryPath, destinationDirectoryPath, inclusionPredicate, rewriteSourceMapSourcePath.bind(undefined, packageRoot))
 		await rewriteNestedNodeModulesDirectory(destinationDirectoryPath)
+		if (packageRoot === '@darkflorist/address-metadata') await exposeAddressMetadataImagesAtPackageRoot(destinationDirectoryPath)
 	}
 	await writeVendorTypeShims()
+}
+
+async function exposeAddressMetadataImagesAtPackageRoot(packageDirectoryPath: string) {
+	const sourceDirectoryPath = path.join(packageDirectoryPath, 'lib', 'images')
+	const destinationDirectoryPath = path.join(packageDirectoryPath, 'images')
+	try {
+		const sourceStats = await fs.stat(sourceDirectoryPath)
+		if (!sourceStats.isDirectory()) return
+	} catch {
+		return
+	}
+	await recursiveDirectoryCopy(sourceDirectoryPath, destinationDirectoryPath)
 }
 
 async function rewriteNestedNodeModulesDirectory(packageDirectoryPath: string) {

--- a/build/vendor.mts
+++ b/build/vendor.mts
@@ -204,12 +204,8 @@ async function vendorDependencies() {
 async function exposeAddressMetadataImagesAtPackageRoot(packageDirectoryPath: string) {
 	const sourceDirectoryPath = path.join(packageDirectoryPath, 'lib', 'images')
 	const destinationDirectoryPath = path.join(packageDirectoryPath, 'images')
-	try {
-		const sourceStats = await fs.stat(sourceDirectoryPath)
-		if (!sourceStats.isDirectory()) return
-	} catch {
-		return
-	}
+	const sourceStats = await fs.stat(sourceDirectoryPath)
+	if (!sourceStats.isDirectory()) return
 	await recursiveDirectoryCopy(sourceDirectoryPath, destinationDirectoryPath)
 }
 


### PR DESCRIPTION
## Summary
- Expose `@darkflorist/address-metadata` images at the package root during vendoring in addition to `lib/images`.
- Keep the built extension aligned with metadata `logoUri` values like `/images/tokens/...`, which fixes token logos such as USDC resolving to missing assets.

## Testing
- `bun test`
- `bun run setup-chrome`
- `bun run typecheck`
- `bun run lint`