### PR TITLE
Handle locked compatibility properties and startup port invalidation

### DIFF
--- a/app/inpage/ts/inpage.ts
+++ b/app/inpage/ts/inpage.ts
@@ -329,8 +329,36 @@ function formatForwardedDiagnostics(source: 'inpage' | 'content-script' | 'docum
 
 function setCompatibilityProperty(target: object, property: PropertyKey, value: unknown, propertyLabel: string) {
 	try {
-		if (Reflect.set(target, property, value) === false) {
+		const ownDescriptor = Object.getOwnPropertyDescriptor(target, property)
+		if (ownDescriptor !== undefined) {
+			if ('value' in ownDescriptor && ownDescriptor.writable === false) {
+				if (ownDescriptor.configurable !== true) return
+				Object.defineProperty(target, property, {
+					configurable: ownDescriptor.configurable,
+					enumerable: ownDescriptor.enumerable,
+					value,
+					writable: true,
+				})
+				return
+			}
+			if ('set' in ownDescriptor && ownDescriptor.set === undefined) {
+				if (ownDescriptor.configurable !== true) return
+				Object.defineProperty(target, property, {
+					configurable: ownDescriptor.configurable,
+					enumerable: ownDescriptor.enumerable,
+					value,
+					writable: true,
+				})
+				return
+			}
+		}
+		if (Reflect.set(target, property, value) === true) return
+		if (!Object.isExtensible(target)) {
 			console.warn(`Interceptor compatibility assignment was rejected for ${ propertyLabel }.`)
+			return
+		}
+		if (Object.isExtensible(target)) {
+			Object.defineProperty(target, property, { configurable: true, enumerable: true, writable: true, value })
 		}
 	} catch (error: unknown) {
 		console.warn(`Interceptor compatibility assignment failed for ${ propertyLabel }.`, error)

--- a/test/tests/inpageSignerBridge.test.ts
+++ b/test/tests/inpageSignerBridge.test.ts
@@ -4,6 +4,9 @@ import { describe, test } from 'bun:test'
 type WindowEvent = { type: string, data?: unknown, detail?: unknown, ports?: readonly MessagePort[] }
 type Listener = (event: WindowEvent) => void
 type InpageRequest = { readonly method: string, readonly requestId: number, readonly params?: readonly unknown[], readonly internal?: true }
+type FakeWindowOptions = {
+	readonly onConnectedToSignerRequest?: () => void
+}
 
 const isRecord = (value: unknown): value is Record<string, unknown> => typeof value === 'object' && value !== null
 
@@ -22,7 +25,7 @@ function parseInpageRequest(value: unknown): InpageRequest | undefined {
 	}
 }
 
-function createFakeWindow() {
+function createFakeWindow({ onConnectedToSignerRequest }: FakeWindowOptions = {}) {
 	const listeners = new Map<string, Set<Listener>>()
 	const signerRequests: string[] = []
 	const backgroundEthAccountsReplies: unknown[] = []
@@ -94,6 +97,7 @@ function createFakeWindow() {
 		queueMicrotask(() => {
 			switch (request.method) {
 				case 'connected_to_signer':
+					onConnectedToSignerRequest?.()
 					sendBackgroundMessage({
 						interceptorApproved: true,
 						requestId: request.requestId,
@@ -137,6 +141,56 @@ function createFakeWindow() {
 		setBlockRequestAccounts: (value: boolean) => { blockRequestAccounts = value },
 		rejectPendingRequestAccounts: (error: { code: number, message: string }) => rejectPendingRequestAccounts?.(error),
 	}
+}
+
+function createLockedCompatibilitySigner() {
+	const baseSigner = {
+		isMetaMask: true,
+		isConnected: () => true,
+		request: async ({ method }: { method: string }) => {
+			switch (method) {
+				case 'eth_chainId':
+					return '0x1'
+				default:
+					throw new Error(`Unexpected signer request: ${ method }`)
+			}
+		},
+		on: () => baseSigner,
+		removeListener: () => baseSigner,
+	}
+
+	Object.defineProperty(baseSigner, 'selectedAddress', {
+		configurable: false,
+		enumerable: true,
+		get: () => undefined,
+	})
+
+	return baseSigner
+}
+
+function createConfigurableGetterOnlyCompatibilitySigner() {
+	const baseSigner = {
+		isMetaMask: true,
+		isConnected: () => true,
+		request: async ({ method }: { method: string }) => {
+			switch (method) {
+				case 'eth_chainId':
+					return '0x1'
+				default:
+					throw new Error(`Unexpected signer request: ${ method }`)
+			}
+		},
+		on: () => baseSigner,
+		removeListener: () => baseSigner,
+	}
+
+	Object.defineProperty(baseSigner, 'selectedAddress', {
+		configurable: true,
+		enumerable: true,
+		get: () => undefined,
+	})
+
+	return baseSigner
 }
 
 async function waitFor(condition: () => boolean, timeoutMs = 2000) {
@@ -293,6 +347,120 @@ describe('inpage signer bridge', () => {
 			assert.equal(signerRequests.length, signerRequestCountBeforeSpoof)
 			assert.equal(interceptorErrorPayloads.length, 0)
 		} finally {
+			;(globalThis as { window?: unknown }).window = previousWindow
+			if (previousCustomEvent === undefined) {
+				delete (globalThis as { CustomEvent?: typeof CustomEvent }).CustomEvent
+			} else {
+				;(globalThis as { CustomEvent: typeof CustomEvent }).CustomEvent = previousCustomEvent
+			}
+		}
+	})
+
+	test('skips readonly compatibility properties without warning', async () => {
+		const previousWindow = (globalThis as { window?: unknown }).window
+		const previousCustomEvent = (globalThis as { CustomEvent?: typeof CustomEvent }).CustomEvent
+		const previousWarn = console.warn
+		const { fakeWindow } = createFakeWindow()
+		const warnings: unknown[] = []
+		fakeWindow.ethereum = createLockedCompatibilitySigner()
+		console.warn = (...args: unknown[]) => { warnings.push(args) }
+		;(globalThis as unknown as { window: typeof fakeWindow }).window = fakeWindow
+		if (typeof (globalThis as { CustomEvent?: typeof CustomEvent }).CustomEvent !== 'function') {
+			;(globalThis as { CustomEvent: typeof CustomEvent }).CustomEvent = class CustomEvent<T = unknown> extends Event {
+				public detail: T
+				constructor(type: string, init?: CustomEventInit<T>) {
+					super(type)
+					this.detail = init?.detail as T
+				}
+				public initCustomEvent(): void { return undefined }
+			}
+		}
+
+		try {
+			await import('../../app/inpage/ts/inpage.js?locked-compatibility')
+			await waitFor(() => 'isInterceptor' in (fakeWindow.ethereum as Record<string, unknown>))
+			assert.equal((fakeWindow.ethereum as { selectedAddress?: unknown }).selectedAddress, undefined)
+			assert.deepEqual(warnings, [])
+		} finally {
+			console.warn = previousWarn
+			;(globalThis as { window?: unknown }).window = previousWindow
+			if (previousCustomEvent === undefined) {
+				delete (globalThis as { CustomEvent?: typeof CustomEvent }).CustomEvent
+			} else {
+				;(globalThis as { CustomEvent: typeof CustomEvent }).CustomEvent = previousCustomEvent
+			}
+		}
+	})
+
+	test('updates configurable getter-only compatibility properties without throwing', async () => {
+		const previousWindow = (globalThis as { window?: unknown }).window
+		const previousCustomEvent = (globalThis as { CustomEvent?: typeof CustomEvent }).CustomEvent
+		const previousWarn = console.warn
+		const { fakeWindow } = createFakeWindow()
+		const warnings: unknown[] = []
+		fakeWindow.ethereum = createConfigurableGetterOnlyCompatibilitySigner()
+		console.warn = (...args: unknown[]) => { warnings.push(args) }
+		;(globalThis as unknown as { window: typeof fakeWindow }).window = fakeWindow
+		if (typeof (globalThis as { CustomEvent?: typeof CustomEvent }).CustomEvent !== 'function') {
+			;(globalThis as { CustomEvent: typeof CustomEvent }).CustomEvent = class CustomEvent<T = unknown> extends Event {
+				public detail: T
+				constructor(type: string, init?: CustomEventInit<T>) {
+					super(type)
+					this.detail = init?.detail as T
+				}
+				public initCustomEvent(): void { return undefined }
+			}
+		}
+
+		try {
+			await import('../../app/inpage/ts/inpage.js?configurable-getter-compatibility')
+			await waitFor(() => (fakeWindow.ethereum as { selectedAddress?: unknown }).selectedAddress === '0x1111111111111111111111111111111111111111')
+			assert.deepEqual((fakeWindow.ethereum as { selectedAddress?: unknown }).selectedAddress, '0x1111111111111111111111111111111111111111')
+			assert.deepEqual(warnings, [])
+		} finally {
+			console.warn = previousWarn
+			;(globalThis as { window?: unknown }).window = previousWindow
+			if (previousCustomEvent === undefined) {
+				delete (globalThis as { CustomEvent?: typeof CustomEvent }).CustomEvent
+			} else {
+				;(globalThis as { CustomEvent: typeof CustomEvent }).CustomEvent = previousCustomEvent
+			}
+		}
+	})
+
+	test('warns when compatibility assignments cannot be made on non-extensible targets', async () => {
+		const previousWindow = (globalThis as { window?: unknown }).window
+		const previousCustomEvent = (globalThis as { CustomEvent?: typeof CustomEvent }).CustomEvent
+		const previousWarn = console.warn
+		let fakeWindowWithSigner: { ethereum: { isMetamask?: boolean, [key: string]: unknown } } | undefined
+		const { fakeWindow } = createFakeWindow({
+			onConnectedToSignerRequest: () => {
+				if (fakeWindowWithSigner === undefined) return
+				fakeWindowWithSigner.ethereum.isMetamask = true
+				Object.preventExtensions(fakeWindowWithSigner.ethereum)
+			},
+		})
+		fakeWindowWithSigner = fakeWindow
+		const warnings: string[] = []
+		console.warn = (...args: unknown[]) => { warnings.push(String(args[0])) }
+		;(globalThis as unknown as { window: typeof fakeWindow }).window = fakeWindow
+		if (typeof (globalThis as { CustomEvent?: typeof CustomEvent }).CustomEvent !== 'function') {
+			;(globalThis as { CustomEvent: typeof CustomEvent }).CustomEvent = class CustomEvent<T = unknown> extends Event {
+				public detail: T
+				constructor(type: string, init?: CustomEventInit<T>) {
+					super(type)
+					this.detail = init?.detail as T
+				}
+				public initCustomEvent(): void { return undefined }
+			}
+		}
+
+		try {
+			await import('../../app/inpage/ts/inpage.js?non-extensible-compatibility')
+			await waitFor(() => warnings.length > 0)
+			assert.ok(warnings.some((warning) => warning.includes('compatibility assignment was rejected for window.ethereum.selectedAddress')))
+		} finally {
+			console.warn = previousWarn
 			;(globalThis as { window?: unknown }).window = previousWindow
 			if (previousCustomEvent === undefined) {
 				delete (globalThis as { CustomEvent?: typeof CustomEvent }).CustomEvent


### PR DESCRIPTION
## Summary
- Make the inpage compatibility bridge tolerate locked or non-writable signer properties without emitting warnings.
- Harden background startup against invalidated or disconnected ports during early lifecycle events.
- Add regression coverage for both the inpage signer bridge and background startup connection handling.

## Testing
- `bun test`
- `bun run setup-chrome`
- `bun run typecheck`
- `bun run lint`