### PR TITLE
Harden background lifecycle and popup synchronization

### DIFF
--- a/app/ts/background/accessManagement.ts
+++ b/app/ts/background/accessManagement.ts
@@ -211,9 +211,9 @@ function addIconRefreshTarget(iconRefreshTargets: Map<string, { tabId: number, w
 }
 
 async function updateTabConnections(
-	ethereum: EthereumClientService,
-	tokenPriceService: TokenPriceService,
-	resetSimulationServices: ResetSimulationServices,
+	ethereum: EthereumClientService | undefined,
+	tokenPriceService: TokenPriceService | undefined,
+	resetSimulationServices: ResetSimulationServices | undefined,
 	websiteTabConnections: WebsiteTabConnections,
 	tabConnection: TabConnection,
 	promptForAccessesIfNeeded: boolean,
@@ -233,7 +233,7 @@ async function updateTabConnections(
 			connectToPort(websiteTabConnections, connection.socket, settings, currentActiveAddress?.address)
 		}
 
-		if (access === 'notFound' && connection.wantsToConnect && promptForAccessesIfNeeded) {
+		if (access === 'notFound' && connection.wantsToConnect && promptForAccessesIfNeeded && ethereum !== undefined && tokenPriceService !== undefined && resetSimulationServices !== undefined) {
 			const activeAddress = currentActiveAddress !== undefined ? currentActiveAddress : undefined
 			askUserForAccessOnConnectionUpdate(ethereum, tokenPriceService, resetSimulationServices, websiteTabConnections, connection.socket, connection.websiteOrigin, activeAddress, settings)
 		}
@@ -333,21 +333,13 @@ export const areWeBlocking = async (websiteTabConnections: WebsiteTabConnections
 }
 
 export async function updateWebsiteApprovalAccesses(
-	ethereum: EthereumClientService,
-	tokenPriceServiceOrWebsiteTabConnections: TokenPriceService | WebsiteTabConnections,
-	resetSimulationServicesOrSettings: ResetSimulationServices | Settings,
-	websiteTabConnectionsOrPrompt: WebsiteTabConnections | boolean,
-	settingsOrPrompt: Settings | boolean,
+	ethereum: EthereumClientService | undefined,
+	tokenPriceService: TokenPriceService | undefined,
+	resetSimulationServices: ResetSimulationServices | undefined,
+	websiteTabConnections: WebsiteTabConnections,
+	settings: Settings,
 	promptForAccessesIfNeeded: boolean,
 ): Promise<number> {
-	const usingLegacySignature = tokenPriceServiceOrWebsiteTabConnections instanceof Map
-	const tokenPriceService = usingLegacySignature ? undefined as never : tokenPriceServiceOrWebsiteTabConnections
-	const resetSimulationServices = usingLegacySignature ? undefined as never : resetSimulationServicesOrSettings as ResetSimulationServices
-	const websiteTabConnections = usingLegacySignature ? tokenPriceServiceOrWebsiteTabConnections : websiteTabConnectionsOrPrompt as WebsiteTabConnections
-	const settings = usingLegacySignature ? resetSimulationServicesOrSettings as Settings : settingsOrPrompt as Settings
-	const promptForAccesses = typeof (usingLegacySignature ? websiteTabConnectionsOrPrompt : promptForAccessesIfNeeded) === 'boolean'
-		? usingLegacySignature ? websiteTabConnectionsOrPrompt as boolean : promptForAccessesIfNeeded
-		: promptForAccessesIfNeeded
 	const popupRefreshGeneration = bumpPopupRefreshGeneration()
 	const allTabStates = await getAllTabStates()
 	const iconRefreshTargets = new Map<string, { tabId: number, websiteOrigin: string }>()
@@ -359,7 +351,7 @@ export async function updateWebsiteApprovalAccesses(
 	}
 	// update port connections and disconnect from ports that should not have access anymore
 	const updatePromises = [...websiteTabConnections.entries()].map(async ([_tab, tabConnection]) => {
-		const tabIconRefreshTargets = await updateTabConnections(ethereum, tokenPriceService, resetSimulationServices, websiteTabConnections, tabConnection, promptForAccesses, settings)
+		const tabIconRefreshTargets = await updateTabConnections(ethereum, tokenPriceService, resetSimulationServices, websiteTabConnections, tabConnection, promptForAccessesIfNeeded, settings)
 		for (const iconRefreshTarget of tabIconRefreshTargets.values()) addIconRefreshTarget(iconRefreshTargets, iconRefreshTarget.tabId, iconRefreshTarget.websiteOrigin)
 	})
 	for (const tabState of allTabStates) {

--- a/app/ts/background/accessManagement.ts
+++ b/app/ts/background/accessManagement.ts
@@ -7,6 +7,7 @@ import type { InpageScriptCallBack, Settings } from '../types/interceptor-messag
 import { getSettings, getWebsiteAccess, updateWebsiteAccess } from './settings.js'
 import { sendSubscriptionReplyOrCallBack } from './messageSending.js'
 import { type WebsiteSocket, getHostWithPort } from '../utils/requests.js'
+import { getAllTabStates } from './storageVariables.js'
 import type { Website, WebsiteAccessArray, WebsiteAddressAccess } from '../types/websiteAccessTypes.js'
 import { getUniqueItemsByProperties, replaceElementInReadonlyArray } from '../utils/typed-arrays.js'
 import { modifyObject } from '../utils/typescript.js'
@@ -16,6 +17,8 @@ import type { EthereumClientService } from '../simulation/services/EthereumClien
 import type { TokenPriceService } from '../simulation/services/priceEstimator.js'
 import type { ResetSimulationServices } from '../simulation/serviceLifecycle.js'
 import { mergeStoredWebsiteMetadata } from '../utils/websiteIcons.js'
+import { handleUnexpectedError } from '../utils/errors.js'
+import { bumpPopupRefreshGeneration } from './popupRefreshGeneration.js'
 
 function getConnectionDetails(websiteTabConnections: WebsiteTabConnections, socket: WebsiteSocket) {
 	const identifier = websiteSocketToString(socket)
@@ -36,7 +39,16 @@ export function verifyAccess(websiteTabConnections: WebsiteTabConnections, socke
 	const connection = getConnectionDetails(websiteTabConnections, socket)
 	if (connection?.approved) return 'hasAccess'
 	const access = requestAccessForAddress !== undefined ? hasAddressAccess(settings.websiteAccess, websiteOrigin, requestAccessForAddress) : hasAccess(settings.websiteAccess, websiteOrigin)
-	if (access === 'hasAccess') return connectToPort(websiteTabConnections, socket, websiteOrigin, settings, requestAccessForAddress?.address) ? 'hasAccess' : 'noAccess'
+	if (access === 'hasAccess') {
+		return connectToPort(
+			websiteTabConnections,
+			socket,
+			websiteOrigin,
+			settings,
+			requestAccessForAddress?.address,
+			bumpPopupRefreshGeneration(),
+		) ? 'hasAccess' : 'noAccess'
+	}
 	if (access === 'noAccess' || access === 'interceptorDisabled') return access
 	return askAccessIfUnknown ? 'askAccess' : 'noAccess'
 }
@@ -150,9 +162,16 @@ async function getActiveAddressForDomain(websiteOrigin: string, settings: Settin
 	return undefined
 }
 
-function connectToPort(websiteTabConnections: WebsiteTabConnections, socket: WebsiteSocket, websiteOrigin: string, settings: Settings, connectWithActiveAddress: bigint | undefined): true {
+function connectToPort(
+	websiteTabConnections: WebsiteTabConnections,
+	socket: WebsiteSocket,
+	websiteOrigin: string,
+	settings: Settings,
+	connectWithActiveAddress: bigint | undefined,
+	popupRefreshGeneration: number,
+): true {
 	setWebsitePortApproval(websiteTabConnections, socket, true)
-	updateExtensionIcon(websiteTabConnections, socket.tabId, websiteOrigin)
+	updateExtensionIcon(websiteTabConnections, socket.tabId, websiteOrigin, popupRefreshGeneration)
 
 	sendSubscriptionReplyOrCallBack(websiteTabConnections, socket, { type: 'result' as const, method: 'connect', result: [settings.activeRpcNetwork.chainId] })
 
@@ -163,9 +182,14 @@ function connectToPort(websiteTabConnections: WebsiteTabConnections, socket: Web
 	return true
 }
 
-function disconnectFromPort(websiteTabConnections: WebsiteTabConnections, socket: WebsiteSocket, websiteOrigin: string): false {
+function disconnectFromPort(
+	websiteTabConnections: WebsiteTabConnections,
+	socket: WebsiteSocket,
+	websiteOrigin: string,
+	popupRefreshGeneration: number,
+): false {
 	setWebsitePortApproval(websiteTabConnections, socket, false)
-	updateExtensionIcon(websiteTabConnections, socket.tabId, websiteOrigin)
+	updateExtensionIcon(websiteTabConnections, socket.tabId, websiteOrigin, popupRefreshGeneration)
 	sendSubscriptionReplyOrCallBack(websiteTabConnections, socket, { type: 'result' as const, method: 'disconnect', result: [] })
 	return false
 }
@@ -191,7 +215,16 @@ function addIconRefreshTarget(iconRefreshTargets: Map<string, { tabId: number, w
 	iconRefreshTargets.set(key, { tabId, websiteOrigin })
 }
 
-async function updateTabConnections(ethereum: EthereumClientService, tokenPriceService: TokenPriceService, resetSimulationServices: ResetSimulationServices, websiteTabConnections: WebsiteTabConnections, tabConnection: TabConnection, promptForAccessesIfNeeded: boolean, settings: Settings) {
+async function updateTabConnections(
+	ethereum: EthereumClientService,
+	tokenPriceService: TokenPriceService,
+	resetSimulationServices: ResetSimulationServices,
+	websiteTabConnections: WebsiteTabConnections,
+	tabConnection: TabConnection,
+	promptForAccessesIfNeeded: boolean,
+	settings: Settings,
+	popupRefreshGeneration: number,
+) {
 	const iconRefreshTargets = new Map<string, { tabId: number, websiteOrigin: string }>()
 	for (const key in tabConnection.connections) {
 		const connection = tabConnection.connections[key]
@@ -201,9 +234,9 @@ async function updateTabConnections(ethereum: EthereumClientService, tokenPriceS
 		const access = currentActiveAddress ? hasAddressAccess(settings.websiteAccess, connection.websiteOrigin, currentActiveAddress) : hasAccess(settings.websiteAccess, connection.websiteOrigin)
 
 		if (access !== 'hasAccess' && connection.approved) {
-			disconnectFromPort(websiteTabConnections, connection.socket, connection.websiteOrigin)
+			disconnectFromPort(websiteTabConnections, connection.socket, connection.websiteOrigin, popupRefreshGeneration)
 		} else if (access === 'hasAccess' && !connection.approved) {
-			connectToPort(websiteTabConnections, connection.socket, connection.websiteOrigin, settings, currentActiveAddress?.address)
+			connectToPort(websiteTabConnections, connection.socket, connection.websiteOrigin, settings, currentActiveAddress?.address, popupRefreshGeneration)
 		}
 
 		if (access === 'notFound' && connection.wantsToConnect && promptForAccessesIfNeeded) {
@@ -212,13 +245,13 @@ async function updateTabConnections(ethereum: EthereumClientService, tokenPriceS
 		}
 	}
 	for (const { tabId, websiteOrigin } of iconRefreshTargets.values()) {
-		await updateExtensionIcon(websiteTabConnections, tabId, websiteOrigin)
+		await updateExtensionIcon(websiteTabConnections, tabId, websiteOrigin, popupRefreshGeneration)
 	}
 }
 
 const getApprovedTabs = (websiteTabConnections: WebsiteTabConnections) => {
 	const approvedTabs = new Set<number>()
-	for (const [tab, tabConnection] of websiteTabConnections.entries() ) {
+	for (const [tab, tabConnection] of websiteTabConnections.entries()) {
 		for (const key in tabConnection.connections) {
 			const connection = tabConnection.connections[key]
 			if (connection?.approved) {
@@ -307,16 +340,15 @@ export const areWeBlocking = async (websiteTabConnections: WebsiteTabConnections
 	return false
 }
 
-export function updateWebsiteApprovalAccesses(ethereum: EthereumClientService, websiteTabConnections: WebsiteTabConnections, settings: Settings, promptForAccessesIfNeeded?: boolean): void
-export function updateWebsiteApprovalAccesses(ethereum: EthereumClientService, tokenPriceService: TokenPriceService, resetSimulationServices: ResetSimulationServices, websiteTabConnections: WebsiteTabConnections, settings: Settings, promptForAccessesIfNeeded?: boolean): void
-export function updateWebsiteApprovalAccesses(
+export async function updateWebsiteApprovalAccesses(
 	ethereum: EthereumClientService,
 	tokenPriceServiceOrWebsiteTabConnections: TokenPriceService | WebsiteTabConnections,
 	resetSimulationServicesOrSettings: ResetSimulationServices | Settings,
-	websiteTabConnectionsOrPrompt?: WebsiteTabConnections | boolean,
-	settingsOrPrompt?: Settings | boolean,
-	promptForAccessesIfNeeded = true
-) {
+	websiteTabConnectionsOrPrompt: WebsiteTabConnections | boolean,
+	settingsOrPrompt: Settings | boolean,
+	promptForAccessesIfNeeded: boolean,
+	popupRefreshGeneration: number,
+): Promise<void> {
 	const usingLegacySignature = tokenPriceServiceOrWebsiteTabConnections instanceof Map
 	const tokenPriceService = usingLegacySignature ? undefined as never : tokenPriceServiceOrWebsiteTabConnections
 	const resetSimulationServices = usingLegacySignature ? undefined as never : resetSimulationServicesOrSettings as ResetSimulationServices
@@ -325,10 +357,25 @@ export function updateWebsiteApprovalAccesses(
 	const promptForAccesses = typeof (usingLegacySignature ? websiteTabConnectionsOrPrompt : promptForAccessesIfNeeded) === 'boolean'
 		? usingLegacySignature ? websiteTabConnectionsOrPrompt as boolean : promptForAccessesIfNeeded
 		: promptForAccessesIfNeeded
+	const allTabStates = await getAllTabStates()
 
-	updateDeclarativeNetRequestBlocks(websiteTabConnections)
+	try {
+		await updateDeclarativeNetRequestBlocks(websiteTabConnections)
+	} catch (error) {
+		await handleUnexpectedError(error)
+	}
 	// update port connections and disconnect from ports that should not have access anymore
-	for (const [_tab, tabConnection] of websiteTabConnections.entries()) {
-		updateTabConnections(ethereum, tokenPriceService, resetSimulationServices, websiteTabConnections, tabConnection, promptForAccesses, settings)
+	const updatePromises = [...websiteTabConnections.entries()].map(async ([_tab, tabConnection]) => {
+		await updateTabConnections(ethereum, tokenPriceService, resetSimulationServices, websiteTabConnections, tabConnection, promptForAccesses, settings, popupRefreshGeneration)
+	})
+	for (const tabState of allTabStates) {
+		if (websiteTabConnections.has(tabState.tabId)) continue
+		if (tabState.website?.websiteOrigin === undefined) continue
+		updatePromises.push(updateExtensionIcon(websiteTabConnections, tabState.tabId, tabState.website.websiteOrigin, popupRefreshGeneration))
+	}
+	try {
+		await Promise.all(updatePromises)
+	} catch (error) {
+		await handleUnexpectedError(error)
 	}
 }

--- a/app/ts/background/accessManagement.ts
+++ b/app/ts/background/accessManagement.ts
@@ -40,14 +40,15 @@ export function verifyAccess(websiteTabConnections: WebsiteTabConnections, socke
 	if (connection?.approved) return 'hasAccess'
 	const access = requestAccessForAddress !== undefined ? hasAddressAccess(settings.websiteAccess, websiteOrigin, requestAccessForAddress) : hasAccess(settings.websiteAccess, websiteOrigin)
 	if (access === 'hasAccess') {
-		return connectToPort(
+		const popupRefreshGeneration = bumpPopupRefreshGeneration()
+		connectToPort(
 			websiteTabConnections,
 			socket,
-			websiteOrigin,
 			settings,
 			requestAccessForAddress?.address,
-			bumpPopupRefreshGeneration(),
-		) ? 'hasAccess' : 'noAccess'
+		)
+		void updateExtensionIcon(websiteTabConnections, socket.tabId, websiteOrigin, popupRefreshGeneration)
+		return 'hasAccess'
 	}
 	if (access === 'noAccess' || access === 'interceptorDisabled') return access
 	return askAccessIfUnknown ? 'askAccess' : 'noAccess'
@@ -165,13 +166,10 @@ async function getActiveAddressForDomain(websiteOrigin: string, settings: Settin
 function connectToPort(
 	websiteTabConnections: WebsiteTabConnections,
 	socket: WebsiteSocket,
-	websiteOrigin: string,
 	settings: Settings,
 	connectWithActiveAddress: bigint | undefined,
-	popupRefreshGeneration: number,
 ): true {
 	setWebsitePortApproval(websiteTabConnections, socket, true)
-	updateExtensionIcon(websiteTabConnections, socket.tabId, websiteOrigin, popupRefreshGeneration)
 
 	sendSubscriptionReplyOrCallBack(websiteTabConnections, socket, { type: 'result' as const, method: 'connect', result: [settings.activeRpcNetwork.chainId] })
 
@@ -185,11 +183,8 @@ function connectToPort(
 function disconnectFromPort(
 	websiteTabConnections: WebsiteTabConnections,
 	socket: WebsiteSocket,
-	websiteOrigin: string,
-	popupRefreshGeneration: number,
 ): false {
 	setWebsitePortApproval(websiteTabConnections, socket, false)
-	updateExtensionIcon(websiteTabConnections, socket.tabId, websiteOrigin, popupRefreshGeneration)
 	sendSubscriptionReplyOrCallBack(websiteTabConnections, socket, { type: 'result' as const, method: 'disconnect', result: [] })
 	return false
 }
@@ -223,8 +218,7 @@ async function updateTabConnections(
 	tabConnection: TabConnection,
 	promptForAccessesIfNeeded: boolean,
 	settings: Settings,
-	popupRefreshGeneration: number,
-) {
+): Promise<Map<string, { tabId: number, websiteOrigin: string }>> {
 	const iconRefreshTargets = new Map<string, { tabId: number, websiteOrigin: string }>()
 	for (const key in tabConnection.connections) {
 		const connection = tabConnection.connections[key]
@@ -234,9 +228,9 @@ async function updateTabConnections(
 		const access = currentActiveAddress ? hasAddressAccess(settings.websiteAccess, connection.websiteOrigin, currentActiveAddress) : hasAccess(settings.websiteAccess, connection.websiteOrigin)
 
 		if (access !== 'hasAccess' && connection.approved) {
-			disconnectFromPort(websiteTabConnections, connection.socket, connection.websiteOrigin, popupRefreshGeneration)
+			disconnectFromPort(websiteTabConnections, connection.socket)
 		} else if (access === 'hasAccess' && !connection.approved) {
-			connectToPort(websiteTabConnections, connection.socket, connection.websiteOrigin, settings, currentActiveAddress?.address, popupRefreshGeneration)
+			connectToPort(websiteTabConnections, connection.socket, settings, currentActiveAddress?.address)
 		}
 
 		if (access === 'notFound' && connection.wantsToConnect && promptForAccessesIfNeeded) {
@@ -244,9 +238,7 @@ async function updateTabConnections(
 			askUserForAccessOnConnectionUpdate(ethereum, tokenPriceService, resetSimulationServices, websiteTabConnections, connection.socket, connection.websiteOrigin, activeAddress, settings)
 		}
 	}
-	for (const { tabId, websiteOrigin } of iconRefreshTargets.values()) {
-		await updateExtensionIcon(websiteTabConnections, tabId, websiteOrigin, popupRefreshGeneration)
-	}
+	return iconRefreshTargets
 }
 
 const getApprovedTabs = (websiteTabConnections: WebsiteTabConnections) => {
@@ -347,8 +339,7 @@ export async function updateWebsiteApprovalAccesses(
 	websiteTabConnectionsOrPrompt: WebsiteTabConnections | boolean,
 	settingsOrPrompt: Settings | boolean,
 	promptForAccessesIfNeeded: boolean,
-	popupRefreshGeneration: number,
-): Promise<void> {
+): Promise<number> {
 	const usingLegacySignature = tokenPriceServiceOrWebsiteTabConnections instanceof Map
 	const tokenPriceService = usingLegacySignature ? undefined as never : tokenPriceServiceOrWebsiteTabConnections
 	const resetSimulationServices = usingLegacySignature ? undefined as never : resetSimulationServicesOrSettings as ResetSimulationServices
@@ -357,7 +348,9 @@ export async function updateWebsiteApprovalAccesses(
 	const promptForAccesses = typeof (usingLegacySignature ? websiteTabConnectionsOrPrompt : promptForAccessesIfNeeded) === 'boolean'
 		? usingLegacySignature ? websiteTabConnectionsOrPrompt as boolean : promptForAccessesIfNeeded
 		: promptForAccessesIfNeeded
+	const popupRefreshGeneration = bumpPopupRefreshGeneration()
 	const allTabStates = await getAllTabStates()
+	const iconRefreshTargets = new Map<string, { tabId: number, websiteOrigin: string }>()
 
 	try {
 		await updateDeclarativeNetRequestBlocks(websiteTabConnections)
@@ -366,16 +359,26 @@ export async function updateWebsiteApprovalAccesses(
 	}
 	// update port connections and disconnect from ports that should not have access anymore
 	const updatePromises = [...websiteTabConnections.entries()].map(async ([_tab, tabConnection]) => {
-		await updateTabConnections(ethereum, tokenPriceService, resetSimulationServices, websiteTabConnections, tabConnection, promptForAccesses, settings, popupRefreshGeneration)
+		const tabIconRefreshTargets = await updateTabConnections(ethereum, tokenPriceService, resetSimulationServices, websiteTabConnections, tabConnection, promptForAccesses, settings)
+		for (const iconRefreshTarget of tabIconRefreshTargets.values()) addIconRefreshTarget(iconRefreshTargets, iconRefreshTarget.tabId, iconRefreshTarget.websiteOrigin)
 	})
 	for (const tabState of allTabStates) {
 		if (websiteTabConnections.has(tabState.tabId)) continue
 		if (tabState.website?.websiteOrigin === undefined) continue
-		updatePromises.push(updateExtensionIcon(websiteTabConnections, tabState.tabId, tabState.website.websiteOrigin, popupRefreshGeneration))
+		addIconRefreshTarget(iconRefreshTargets, tabState.tabId, tabState.website.websiteOrigin)
 	}
 	try {
 		await Promise.all(updatePromises)
 	} catch (error) {
 		await handleUnexpectedError(error)
 	}
+	const iconRefreshPromises = [...iconRefreshTargets.values()].map(({ tabId, websiteOrigin }) =>
+		updateExtensionIcon(websiteTabConnections, tabId, websiteOrigin, popupRefreshGeneration)
+	)
+	try {
+		await Promise.all(iconRefreshPromises)
+	} catch (error) {
+		await handleUnexpectedError(error)
+	}
+	return popupRefreshGeneration
 }

--- a/app/ts/background/background-startup.ts
+++ b/app/ts/background/background-startup.ts
@@ -25,6 +25,7 @@ import { addWindowTabListeners } from '../utils/popupOrTab.js'
 import { migrateAddressBook } from './addressBookMigration.js'
 import { migrateWebsiteAccess } from './websiteAccessMigration.js'
 import { isIgnorablePortLifecycleError, tryRegisterContentScriptPortListeners } from './contentScriptPortLifecycle.js'
+import { bumpPopupRefreshGeneration, initializePopupRefreshGeneration } from './popupRefreshGeneration.js'
 
 const websiteTabConnections = new Map<number, TabConnection>()
 let simulationServices: SimulationServices | undefined
@@ -132,7 +133,7 @@ async function onContentScriptConnected(waitForStartup: () => Promise<{ resetAct
 				tabIconDetails: { icon: ICON_NOT_ACTIVE, iconReason: 'No active address selected.' },
 			})
 		})
-		updateExtensionIcon(websiteTabConnections, socket.tabId, websiteOrigin)
+		updateExtensionIcon(websiteTabConnections, socket.tabId, websiteOrigin, bumpPopupRefreshGeneration())
 	} else {
 		tabConnection.connections[identifier] = newConnection
 	}
@@ -200,6 +201,8 @@ async function onErrorBlockCallback(ethereumClientService: EthereumClientService
 async function startup() {
 	await migrateAddressBook()
 	await migrateWebsiteAccess()
+	await initializePopupRefreshGeneration()
+	bumpPopupRefreshGeneration()
 	const settings = await getSettings()
 	const userSpecifiedSimulatorNetwork = settings.activeRpcNetwork.httpsRpc === undefined ? await getPrimaryRpcForChain(1n) : settings.activeRpcNetwork
 	const simulatorNetwork = userSpecifiedSimulatorNetwork === undefined ? defaultRpcs[0] : userSpecifiedSimulatorNetwork
@@ -240,7 +243,7 @@ const onTabUpdated = async (tabId: number, changeInfo: browser.tabs._OnUpdatedCh
 	await updateKnownWebsiteMetadata(website)
 	await updateTabState(tabId, (previousState: TabState) => modifyObject(previousState, { website, tabIconDetails: DEFAULT_TAB_CONNECTION }))
 	await updateDeclarativeNetRequestBlocks(websiteTabConnections)
-	await updateExtensionIcon(websiteTabConnections, tabId, websiteOrigin)
+	await updateExtensionIcon(websiteTabConnections, tabId, websiteOrigin, bumpPopupRefreshGeneration())
 })
 
 const onCloseWindow = async (id: number) => await catchAllErrorsAndCall(async () => {

--- a/app/ts/background/background.ts
+++ b/app/ts/background/background.ts
@@ -18,6 +18,7 @@ import { Semaphore } from '../utils/semaphore.js'
 import { JsonRpcResponseError, handleUnexpectedError, isFailedToFetchError, isNewBlockAbort, printError } from '../utils/errors.js'
 import { InterceptedRequest, type UniqueRequestIdentifier, type WebsiteSocket } from '../utils/requests.js'
 import { replyToInterceptedRequest } from './messageSending.js'
+import { bumpPopupRefreshGeneration } from './popupRefreshGeneration.js'
 import { type EthGetStorageAtParams, EthereumJsonRpcRequest, type SendRawTransactionParams, type SendTransactionParams, SupportedEthereumJsonRpcRequestMethods, type WalletAddEthereumChain } from '../types/JsonRpc-types.js'
 import type { Website } from '../types/websiteAccessTypes.js'
 import type { ConfirmTransactionTransactionSingleVisualization } from '../types/accessRequest.js'
@@ -320,8 +321,9 @@ export async function changeActiveAddressAndChain(
 	}
 
 	const updatedSettings = await getSettings()
-	sendPopupMessageToOpenWindows({ method: 'popup_settingsUpdated', data: updatedSettings })
-	updateWebsiteApprovalAccesses(ethereum, tokenPriceService, resetSimulationServices, websiteTabConnections, updatedSettings)
+	const popupRefreshGeneration = bumpPopupRefreshGeneration()
+	await updateWebsiteApprovalAccesses(ethereum, tokenPriceService, resetSimulationServices, websiteTabConnections, updatedSettings, true, popupRefreshGeneration)
+	sendPopupMessageToOpenWindows({ method: 'popup_settingsUpdated', data: updatedSettings, popupRefreshGeneration })
 	sendPopupMessageToOpenWindows({ method: 'popup_accounts_update' })
 	await changeActiveAddressAndChainSemaphore.execute(async () => {
 		if (change.rpcNetwork !== undefined) {
@@ -346,7 +348,9 @@ export async function changeActiveRpc(ethereum: EthereumClientService, tokenPric
 	// allow switching RPC only if we are in simulation mode, or that chain id would not change
 	if (simulationMode || rpcNetwork.chainId === (await getSettings()).activeRpcNetwork.chainId) return await changeActiveAddressAndChain(ethereum, tokenPriceService, resetSimulationServices, websiteTabConnections, { simulationMode, rpcNetwork })
 	sendMessageToApprovedWebsitePorts(websiteTabConnections, { method: 'request_signer_to_wallet_switchEthereumChain', result: rpcNetwork.chainId })
-	await sendPopupMessageToOpenWindows({ method: 'popup_settingsUpdated', data: await getSettings() })
+	const settings = await getSettings()
+	const popupRefreshGeneration = bumpPopupRefreshGeneration()
+	await sendPopupMessageToOpenWindows({ method: 'popup_settingsUpdated', data: settings, popupRefreshGeneration })
 	await promoteRpcAsPrimary(rpcNetwork)
 }
 
@@ -543,15 +547,24 @@ export async function popupMessageHandler(
 				case 'popup_getAddressBookData': return await getAddressBookData(parsedRequest)
 				case 'popup_removeAddressBookEntry': return await removeAddressBookEntry(ethereum, tokenPriceService, resetSimulationServices, websiteTabConnections, parsedRequest)
 				case 'popup_openAddressBook': return await openNewTab('addressBook')
-				case 'popup_requestNewHomeData': return await requestNewHomeData(ethereum, websiteTabConnections, true, simulationAbortController)
-				case 'popup_refreshHomeData': return await refreshHomeData(ethereum, tokenPriceService, websiteTabConnections, true)
+				case 'popup_requestNewHomeData': return await requestNewHomeData(ethereum, websiteTabConnections, true, simulationAbortController, bumpPopupRefreshGeneration())
+				case 'popup_refreshHomeData': return await refreshHomeData(ethereum, tokenPriceService, websiteTabConnections, true, bumpPopupRefreshGeneration())
 				case 'popup_requestSettings': return await settingsOpened()
 				case 'popup_refreshInterceptorAccessMetadata': return await interceptorAccessMetadataRefresh()
 				case 'popup_interceptorAccessChangeAddress': return await interceptorAccessChangeAddressOrRefresh(websiteTabConnections, parsedRequest)
 				case 'popup_interceptorAccessRefresh': return await interceptorAccessChangeAddressOrRefresh(websiteTabConnections, parsedRequest)
 				case 'popup_ChangeSettings': return await changeSettings(ethereum, tokenPriceService, resetSimulationServices, parsedRequest, simulationAbortController)
 				case 'popup_openSettings': return await openNewTab('settingsView')
-				case 'popup_import_settings': return await importSettings(parsedRequest)
+				case 'popup_import_settings': {
+					const importSettingsReply = await importSettings(parsedRequest)
+					await sendPopupMessageToOpenWindows(importSettingsReply)
+					if (!importSettingsReply.data.success) return
+					const settings = await getSettings()
+					const popupRefreshGeneration = bumpPopupRefreshGeneration()
+					await updateWebsiteApprovalAccesses(ethereum, tokenPriceService, resetSimulationServices, websiteTabConnections, settings, true, popupRefreshGeneration)
+					await sendPopupMessageToOpenWindows({ method: 'popup_settingsUpdated', data: settings, popupRefreshGeneration })
+					return
+				}
 				case 'popup_get_export_settings': return await exportSettings()
 				case 'popup_set_rpc_list': return await setNewRpcList(resetSimulationServices, parsedRequest, settings)
 				case 'popup_simulateGovernanceContractExecution': return await simulateGovernanceContractExecutionOnPass(ethereum, tokenPriceService, parsedRequest)

--- a/app/ts/background/background.ts
+++ b/app/ts/background/background.ts
@@ -321,8 +321,7 @@ export async function changeActiveAddressAndChain(
 	}
 
 	const updatedSettings = await getSettings()
-	const popupRefreshGeneration = bumpPopupRefreshGeneration()
-	await updateWebsiteApprovalAccesses(ethereum, tokenPriceService, resetSimulationServices, websiteTabConnections, updatedSettings, true, popupRefreshGeneration)
+	const popupRefreshGeneration = await updateWebsiteApprovalAccesses(ethereum, tokenPriceService, resetSimulationServices, websiteTabConnections, updatedSettings, true)
 	sendPopupMessageToOpenWindows({ method: 'popup_settingsUpdated', data: updatedSettings, popupRefreshGeneration })
 	sendPopupMessageToOpenWindows({ method: 'popup_accounts_update' })
 	await changeActiveAddressAndChainSemaphore.execute(async () => {
@@ -560,8 +559,7 @@ export async function popupMessageHandler(
 					await sendPopupMessageToOpenWindows(importSettingsReply)
 					if (!importSettingsReply.data.success) return
 					const settings = await getSettings()
-					const popupRefreshGeneration = bumpPopupRefreshGeneration()
-					await updateWebsiteApprovalAccesses(ethereum, tokenPriceService, resetSimulationServices, websiteTabConnections, settings, true, popupRefreshGeneration)
+					const popupRefreshGeneration = await updateWebsiteApprovalAccesses(ethereum, tokenPriceService, resetSimulationServices, websiteTabConnections, settings, true)
 					await sendPopupMessageToOpenWindows({ method: 'popup_settingsUpdated', data: settings, popupRefreshGeneration })
 					return
 				}

--- a/app/ts/background/iconHandler.ts
+++ b/app/ts/background/iconHandler.ts
@@ -27,7 +27,7 @@ async function getCachedWebsiteIcon(tabId: number, websiteOrigin: string) {
 	return { cachedIcon: sanitizeStoredWebsiteIcon(storedWebsite.website.icon), hasStoredWebsiteAccess: true as const }
 }
 
-async function setInterceptorIcon(tabId: number, icon: TabIcon, iconReason: string) {
+async function setInterceptorIcon(tabId: number, icon: TabIcon, iconReason: string, popupRefreshGeneration: number) {
 	const tabIconDetails = { icon, iconReason }
 	if (!(await doesTabExist(tabId))) return
 	const { previousState, newState } = await updateTabState(tabId, (previousState: TabState) => {
@@ -38,7 +38,14 @@ async function setInterceptorIcon(tabId: number, icon: TabIcon, iconReason: stri
 	if (previousState === newState) return
 	const iconChanged = previousState.tabIconDetails.icon !== icon
 	const titleChanged = previousState.tabIconDetails.iconReason !== iconReason
-	if (await getLastKnownCurrentTabId() === tabId) await sendPopupMessageToOpenWindows({ method: 'popup_websiteIconChanged', data: tabIconDetails })
+	if (await getLastKnownCurrentTabId() === tabId) {
+		await sendPopupMessageToOpenWindows({
+			method: 'popup_websiteIconChanged',
+			tabId,
+			popupRefreshGeneration,
+			data: tabIconDetails
+		})
+	}
 	try {
 		if (iconChanged) await setExtensionIcon({ path: { 128: icon }, tabId })
 		if (titleChanged) await setExtensionTitle({ title: iconReason, tabId })
@@ -78,7 +85,7 @@ async function waitForLoadedTab(tabId: number) {
 	}
 }
 
-export async function updateExtensionIcon(websiteTabConnections: WebsiteTabConnections, tabId: number, websiteOrigin: string) {
+export async function updateExtensionIcon(websiteTabConnections: WebsiteTabConnections, tabId: number, websiteOrigin: string, popupRefreshGeneration: number) {
 	if (!(await doesTabExist(tabId))) {
 		await removeTabState(tabId)
 		return
@@ -86,7 +93,7 @@ export async function updateExtensionIcon(websiteTabConnections: WebsiteTabConne
 	const blockingWebsitePromise = areWeBlocking(websiteTabConnections, tabId, websiteOrigin)
 	silenceChromeUnCaughtPromise(blockingWebsitePromise)
 	const addShieldIfNeeded = async (icon: TabIcon): Promise<TabIcon> => await blockingWebsitePromise && icon !== ICON_INTERCEPTOR_DISABLED ? TabIcon.parse(icon.replace('.png', '-shield.png')) : icon
-	const setIcon = async (icon: TabIcon, iconReason: string) => setInterceptorIcon(tabId, await addShieldIfNeeded(icon), await blockingWebsitePromise ? `${ iconReason } The Interceptor is blocking external requests made by the website.` : iconReason)
+	const setIcon = async (icon: TabIcon, iconReason: string) => setInterceptorIcon(tabId, await addShieldIfNeeded(icon), await blockingWebsitePromise ? `${ iconReason } The Interceptor is blocking external requests made by the website.` : iconReason, popupRefreshGeneration)
 
 	const settings = await getSettings()
 	if (hasAccess(settings.websiteAccess, websiteOrigin) === 'interceptorDisabled') return setIcon(ICON_INTERCEPTOR_DISABLED, `The Interceptor is disabled for ${ websiteOrigin } by user request.`)

--- a/app/ts/background/popupMessageHandlers.ts
+++ b/app/ts/background/popupMessageHandlers.ts
@@ -2,7 +2,7 @@ import { changeActiveAddressAndChain, changeActiveRpc, getUpdatedSimulationState
 import { getSettings, setUseTabsInsteadOfPopup, setPage, setUseSignersAddressAsActiveAddress, updateWebsiteAccess, exportSettingsAndAddressBook, importSettingsAndAddressBook, getMakeCurrentAddressRich, getUseTabsInsteadOfPopup, getMetamaskCompatibilityMode, setMetamaskCompatibilityMode, getPage, setPreSimulationBlockTimeManipulation, getPreSimulationBlockTimeManipulation, getFixedAddressRichList, getWebsiteAccess, setMakeCurrentAddressRich, setFixedMakeMeRichList } from './settings.js'
 import { getPendingTransactionsAndMessages, getCurrentTabId, getTabState, saveCurrentTabId, setRpcList, getRpcList, getPrimaryRpcForChain, getRpcConnectionStatus, updateUserAddressBookEntries, getPopupVisualisationState, setIdsOfOpenedTabs, getIdsOfOpenedTabs, updatePendingTransactionOrMessage, addEnsLabelHash, addEnsNodeHash, updateInterceptorTransactionStack, getLatestUnexpectedError, getInterceptorTransactionStack, getChainChangeConfirmationPromise, getFetchSimulationStackRequestPromise, getPendingAccessRequests } from './storageVariables.js'
 import { parseEvents, parseInputData } from '../simulation/parsing.js'
-import { type ChangeActiveAddress, type ModifyMakeMeRich, type ChangePage, type RemoveTransaction, type RequestAccountsFromSigner, type TransactionConfirmation, type InterceptorAccess, type ChangeInterceptorAccess, type ChainChangeConfirmation, type EnableSimulationMode, type ChangeActiveChain, type AddOrEditAddressBookEntry, type GetAddressBookData, type RemoveAddressBookEntry, type InterceptorAccessRefresh, type InterceptorAccessChangeAddress, type Settings, type ChangeSettings, type ImportSettings, type SetRpcList, UpdateHomePage, type SimulateGovernanceContractExecution, type ChangeAddOrModifyAddressWindowState, type OpenWebPage, type DisableInterceptor, type SetEnsNameForHash, UpdateConfirmTransactionDialog, UpdateConfirmTransactionDialogPendingTransactions, SimulateExecutionReply, type BlockOrAllowExternalRequests, type RemoveWebsiteAccess, type AllowOrPreventAddressAccessForWebsite, type RemoveWebsiteAddressAccess, type ForceSetGasLimitForTransaction, type RetrieveWebsiteAccess, type ChangePreSimulationBlockTimeManipulation, type SetTransactionOrMessageBlockTimeManipulator, type FetchSimulationStackRequestConfirmation, type ImportSimulationStack, type PopupReadyAndListeningPage } from '../types/interceptor-messages.js'
+import { type ChangeActiveAddress, type ModifyMakeMeRich, type ChangePage, type RemoveTransaction, type RequestAccountsFromSigner, type TransactionConfirmation, type InterceptorAccess, type ChangeInterceptorAccess, type ChainChangeConfirmation, type EnableSimulationMode, type ChangeActiveChain, type AddOrEditAddressBookEntry, type GetAddressBookData, type RemoveAddressBookEntry, type InterceptorAccessRefresh, type InterceptorAccessChangeAddress, type Settings, type ChangeSettings, type ImportSettings, type ImportSettingsReply, type SetRpcList, type UpdateHomePage, type SimulateGovernanceContractExecution, type ChangeAddOrModifyAddressWindowState, type OpenWebPage, type DisableInterceptor, type SetEnsNameForHash, UpdateConfirmTransactionDialog, UpdateConfirmTransactionDialogPendingTransactions, SimulateExecutionReply, type BlockOrAllowExternalRequests, type RemoveWebsiteAccess, type AllowOrPreventAddressAccessForWebsite, type RemoveWebsiteAddressAccess, type ForceSetGasLimitForTransaction, type RetrieveWebsiteAccess, type ChangePreSimulationBlockTimeManipulation, type SetTransactionOrMessageBlockTimeManipulator, type FetchSimulationStackRequestConfirmation, type ImportSimulationStack, type PopupReadyAndListeningPage } from '../types/interceptor-messages.js'
 import { formEthSendTransaction, formSendRawTransaction, resolvePendingTransactionOrMessage, updateConfirmTransactionView, setGasLimitForTransaction, toPopupPendingTransactionOrSignableMessage } from './windows/confirmTransaction.js'
 import { askForSignerAccountsFromSignerIfNotAvailable, getAddressMetadataForAccess, requestAddressChange, resolveInterceptorAccess } from './windows/interceptorAccess.js'
 import { resolveChainChange } from './windows/changeChain.js'
@@ -42,6 +42,7 @@ import type { ResetSimulationServices } from '../simulation/serviceLifecycle.js'
 import { updateFetchSimulationStackRequestWithPendingRequest } from './windows/fetchSimulationStack.js'
 import { estimateSerializedStateBytes, formatEstimatedBytes } from '../utils/largeStateStore.js'
 import { POPUP_PERFORMANCE_MARKS, markPerformance } from '../utils/popupPerformance.js'
+import { bumpPopupRefreshGeneration } from './popupRefreshGeneration.js'
 
 type TimestampedPopupVisualisation = {
 	data: {
@@ -194,7 +195,7 @@ export async function removeAddressBookEntry(ethereum: EthereumClientService, to
 		!(contact.address === removeAddressBookEntry.data.address
 		&& (contact.chainId === removeAddressBookEntry.data.chainId || (contact.chainId === undefined && removeAddressBookEntry.data.chainId === 1n))))
 	)
-	if (removeAddressBookEntry.data.addressBookCategory === 'My Active Addresses') updateWebsiteApprovalAccesses(ethereum, tokenPriceService, resetSimulationServices, websiteTabConnections, await getSettings())
+	if (removeAddressBookEntry.data.addressBookCategory === 'My Active Addresses') await updateWebsiteApprovalAccesses(ethereum, tokenPriceService, resetSimulationServices, websiteTabConnections, await getSettings(), true, bumpPopupRefreshGeneration())
 	await sendPopupMessageToOpenWindows({ method: 'popup_addressBookEntriesChanged' })
 }
 
@@ -205,7 +206,7 @@ export async function addOrModifyAddressBookEntry(ethereum: EthereumClientServic
 		}
 		return previousContacts.concat([entry.data])
 	})
-	if (entry.data.useAsActiveAddress) updateWebsiteApprovalAccesses(ethereum, tokenPriceService, resetSimulationServices, websiteTabConnections, await getSettings())
+	if (entry.data.useAsActiveAddress) await updateWebsiteApprovalAccesses(ethereum, tokenPriceService, resetSimulationServices, websiteTabConnections, await getSettings(), true, bumpPopupRefreshGeneration())
 	await sendPopupMessageToOpenWindows({ method: 'popup_addressBookEntriesChanged' })
 }
 
@@ -225,7 +226,7 @@ export async function changeInterceptorAccess(ethereum: EthereumClientService, t
 		return await disableInterceptorForPage(websiteTabConnections, disable.newEntry.website, disable.newEntry.interceptorDisabled)
 	}))
 
-	updateWebsiteApprovalAccesses(ethereum, tokenPriceService, resetSimulationServices, websiteTabConnections, await getSettings())
+	await updateWebsiteApprovalAccesses(ethereum, tokenPriceService, resetSimulationServices, websiteTabConnections, await getSettings(), true, bumpPopupRefreshGeneration())
 	await sendPopupMessageToOpenWindows({ method: 'popup_interceptor_access_changed' })
 }
 
@@ -478,12 +479,28 @@ export async function requestNewHomeData(
 	websiteTabConnections: WebsiteTabConnections,
 	shouldRefreshSignerAccounts: boolean,
 	requestAbortController: AbortController | undefined,
+	popupRefreshGeneration: number,
 ) {
-	const updatedPage = await buildHomePageUpdate(ethereum, websiteTabConnections, { requestAbortController, richDataSource: 'cached', shouldRefreshSignerAccounts })
-	await sendPopupMessageToOpenWindows(serialize(UpdateHomePage, updatedPage))
+	const newPopupRefreshGeneration = popupRefreshGeneration
+	const updatedPage = await buildHomePageUpdate(ethereum, websiteTabConnections, {
+		requestAbortController,
+		richDataSource: 'cached',
+		shouldRefreshSignerAccounts,
+		popupRefreshGeneration: newPopupRefreshGeneration,
+	})
+	await sendPopupMessageToOpenWindows(updatedPage)
 }
 
-export async function refreshHomeData(ethereum: EthereumClientService, tokenPriceService: TokenPriceService, websiteTabConnections: WebsiteTabConnections, shouldRefreshSignerAccounts: boolean, refreshSimulation = true, requestAbortController: AbortController | undefined = undefined) {
+export async function refreshHomeData(
+	ethereum: EthereumClientService,
+	tokenPriceService: TokenPriceService,
+	websiteTabConnections: WebsiteTabConnections,
+	shouldRefreshSignerAccounts: boolean,
+	popupRefreshGeneration: number,
+	refreshSimulation = true,
+	requestAbortController: AbortController | undefined = undefined,
+) {
+	const newPopupRefreshGeneration = popupRefreshGeneration
 	markPerformance(POPUP_PERFORMANCE_MARKS.backgroundRefreshStart)
 	try {
 		const currentSettings = await getSettings()
@@ -491,8 +508,13 @@ export async function refreshHomeData(ethereum: EthereumClientService, tokenPric
 		if (refreshSimulation) await updatePopupVisualisationIfNeeded(ethereum, tokenPriceService, false, false, true)
 		const settings = await getSettings()
 		if (settings.activeRpcNetwork.httpsRpc !== undefined) await makeSureInterceptorIsNotSleeping(ethereum)
-		const updatedPage = await buildHomePageUpdate(ethereum, websiteTabConnections, { requestAbortController, richDataSource: 'fresh', shouldRefreshSignerAccounts })
-		await sendPopupMessageToOpenWindows(serialize(UpdateHomePage, updatedPage))
+		const updatedPage = await buildHomePageUpdate(ethereum, websiteTabConnections, {
+			requestAbortController,
+			richDataSource: 'fresh',
+			shouldRefreshSignerAccounts,
+			popupRefreshGeneration: newPopupRefreshGeneration,
+		})
+		await sendPopupMessageToOpenWindows(updatedPage)
 	} finally {
 		markPerformance(POPUP_PERFORMANCE_MARKS.backgroundRefreshEnd)
 	}
@@ -522,30 +544,19 @@ export async function interceptorAccessChangeAddressOrRefresh(websiteTabConnecti
 export async function changeSettings(ethereum: EthereumClientService, _tokenPriceService: TokenPriceService, _resetSimulationServices: ResetSimulationServices, parsedRequest: ChangeSettings, requestAbortController: AbortController | undefined) {
 	if (parsedRequest.data.useTabsInsteadOfPopup !== undefined) await setUseTabsInsteadOfPopup(parsedRequest.data.useTabsInsteadOfPopup)
 	if (parsedRequest.data.metamaskCompatibilityMode !== undefined) await setMetamaskCompatibilityMode(parsedRequest.data.metamaskCompatibilityMode)
-	return await requestNewHomeData(ethereum, new Map(), false, requestAbortController)
+	return await requestNewHomeData(ethereum, new Map(), false, requestAbortController, bumpPopupRefreshGeneration())
 }
 
-export async function importSettings(settingsData: ImportSettings) {
+export async function importSettings(settingsData: ImportSettings): Promise<ImportSettingsReply> {
 	if (!isJSON(settingsData.data.fileContents)) {
-		await sendPopupMessageToOpenWindows({
-			method: 'popup_initiate_export_settings_reply',
-			data: { success: false, errorMessage: 'Failed to read the file. It is not a valid JSON file.' }
-		})
-		return
+		return { method: 'popup_initiate_export_settings_reply', data: { success: false, errorMessage: 'Failed to read the file. It is not a valid JSON file.' } }
 	}
 	const parsed = ExportedSettings.safeParse(JSON.parse(settingsData.data.fileContents))
 	if (!parsed.success) {
-		await sendPopupMessageToOpenWindows({
-			method: 'popup_initiate_export_settings_reply',
-			data: { success: false, errorMessage: 'Failed to read the file. It is not a valid interceptor settings file' }
-		})
-		return
+		return { method: 'popup_initiate_export_settings_reply', data: { success: false, errorMessage: 'Failed to read the file. It is not a valid interceptor settings file' } }
 	}
 	await importSettingsAndAddressBook(parsed.value)
-	await sendPopupMessageToOpenWindows({
-		method: 'popup_initiate_export_settings_reply',
-		data: { success: true }
-	})
+	return { method: 'popup_initiate_export_settings_reply', data: { success: true } }
 }
 
 export async function exportSettings() {
@@ -699,7 +710,7 @@ async function disableInterceptorForPage(websiteTabConnections: WebsiteTabConnec
 
 export async function disableInterceptor(ethereum: EthereumClientService, tokenPriceService: TokenPriceService, resetSimulationServices: ResetSimulationServices, websiteTabConnections: WebsiteTabConnections, parsedRequest: DisableInterceptor) {
 	await disableInterceptorForPage(websiteTabConnections, parsedRequest.data.website, parsedRequest.data.interceptorDisabled)
-	updateWebsiteApprovalAccesses(ethereum, tokenPriceService, resetSimulationServices, websiteTabConnections, await getSettings())
+	await updateWebsiteApprovalAccesses(ethereum, tokenPriceService, resetSimulationServices, websiteTabConnections, await getSettings(), true, bumpPopupRefreshGeneration())
 	await sendPopupMessageToOpenWindows({ method: 'popup_setDisableInterceptorReply' as const, data: parsedRequest.data })
 }
 
@@ -739,7 +750,7 @@ async function blockOrAllowWebsiteExternalRequests(websiteTabConnections: Websit
 
 export async function blockOrAllowExternalRequests(ethereum: EthereumClientService, tokenPriceService: TokenPriceService, resetSimulationServices: ResetSimulationServices, websiteTabConnections: WebsiteTabConnections, parsedRequest: BlockOrAllowExternalRequests) {
 	await blockOrAllowWebsiteExternalRequests(websiteTabConnections, parsedRequest.data.website, parsedRequest.data.shouldBlock)
-	updateWebsiteApprovalAccesses(ethereum, tokenPriceService, resetSimulationServices, websiteTabConnections, await getSettings())
+	await updateWebsiteApprovalAccesses(ethereum, tokenPriceService, resetSimulationServices, websiteTabConnections, await getSettings(), true, bumpPopupRefreshGeneration())
 	await sendPopupMessageToOpenWindows({ method: 'popup_websiteAccess_changed' })
 }
 
@@ -756,7 +767,7 @@ async function removeAddressAccessByAddress(websiteOrigin: string, address: Ethe
 export async function removeWebsiteAddressAccess(ethereum: EthereumClientService, tokenPriceService: TokenPriceService, resetSimulationServices: ResetSimulationServices, websiteTabConnections: WebsiteTabConnections, parsedRequest: RemoveWebsiteAddressAccess) {
 	await removeAddressAccessByAddress(parsedRequest.data.websiteOrigin, parsedRequest.data.address)
 	await reloadConnectedTabs(websiteTabConnections)
-	updateWebsiteApprovalAccesses(ethereum, tokenPriceService, resetSimulationServices, websiteTabConnections, await getSettings())
+	await updateWebsiteApprovalAccesses(ethereum, tokenPriceService, resetSimulationServices, websiteTabConnections, await getSettings(), true, bumpPopupRefreshGeneration())
 	await sendPopupMessageToOpenWindows({ method: 'popup_websiteAccess_changed' })
 }
 
@@ -779,7 +790,7 @@ export async function allowOrPreventAddressAccessForWebsite(websiteTabConnection
 
 export async function removeWebsiteAccess(ethereum: EthereumClientService, tokenPriceService: TokenPriceService, resetSimulationServices: ResetSimulationServices, websiteTabConnections: WebsiteTabConnections, parsedRequest: RemoveWebsiteAccess) {
 	await updateWebsiteAccess((previousAccess) => previousAccess.filter(access => access.website.websiteOrigin !== parsedRequest.data.websiteOrigin))
-	updateWebsiteApprovalAccesses(ethereum, tokenPriceService, resetSimulationServices, websiteTabConnections, await getSettings())
+	await updateWebsiteApprovalAccesses(ethereum, tokenPriceService, resetSimulationServices, websiteTabConnections, await getSettings(), true, bumpPopupRefreshGeneration())
 	await sendPopupMessageToOpenWindows({ method: 'popup_websiteAccess_changed' })
 }
 export async function forceSetGasLimitForTransaction(ethereum: EthereumClientService, tokenPriceService: TokenPriceService, parsedRequest: ForceSetGasLimitForTransaction) {
@@ -886,10 +897,12 @@ async function buildHomePageUpdate(
 		requestAbortController,
 		richDataSource,
 		shouldRefreshSignerAccounts,
+		popupRefreshGeneration,
 	}: {
 		requestAbortController?: AbortController
 		richDataSource: 'cached' | 'fresh'
 		shouldRefreshSignerAccounts: boolean
+		popupRefreshGeneration: number
 	}
 ): Promise<UpdateHomePage> {
 	const settingsPromise = silenceChromeUnCaughtPromise(getSettings())
@@ -914,6 +927,7 @@ async function buildHomePageUpdate(
 	const richData = await richDataPromise
 	return {
 		method: 'popup_UpdateHomePage' as const,
+		popupRefreshGeneration: popupRefreshGeneration,
 		data: {
 			visualizedSimulatorState: await visualizedSimulatorStatePromise,
 			activeAddresses: await activeAddressesPromise,

--- a/app/ts/background/popupMessageHandlers.ts
+++ b/app/ts/background/popupMessageHandlers.ts
@@ -195,7 +195,7 @@ export async function removeAddressBookEntry(ethereum: EthereumClientService, to
 		!(contact.address === removeAddressBookEntry.data.address
 		&& (contact.chainId === removeAddressBookEntry.data.chainId || (contact.chainId === undefined && removeAddressBookEntry.data.chainId === 1n))))
 	)
-	if (removeAddressBookEntry.data.addressBookCategory === 'My Active Addresses') await updateWebsiteApprovalAccesses(ethereum, tokenPriceService, resetSimulationServices, websiteTabConnections, await getSettings(), true, bumpPopupRefreshGeneration())
+	if (removeAddressBookEntry.data.addressBookCategory === 'My Active Addresses') await updateWebsiteApprovalAccesses(ethereum, tokenPriceService, resetSimulationServices, websiteTabConnections, await getSettings(), true)
 	await sendPopupMessageToOpenWindows({ method: 'popup_addressBookEntriesChanged' })
 }
 
@@ -206,7 +206,7 @@ export async function addOrModifyAddressBookEntry(ethereum: EthereumClientServic
 		}
 		return previousContacts.concat([entry.data])
 	})
-	if (entry.data.useAsActiveAddress) await updateWebsiteApprovalAccesses(ethereum, tokenPriceService, resetSimulationServices, websiteTabConnections, await getSettings(), true, bumpPopupRefreshGeneration())
+	if (entry.data.useAsActiveAddress) await updateWebsiteApprovalAccesses(ethereum, tokenPriceService, resetSimulationServices, websiteTabConnections, await getSettings(), true)
 	await sendPopupMessageToOpenWindows({ method: 'popup_addressBookEntriesChanged' })
 }
 
@@ -226,7 +226,7 @@ export async function changeInterceptorAccess(ethereum: EthereumClientService, t
 		return await disableInterceptorForPage(websiteTabConnections, disable.newEntry.website, disable.newEntry.interceptorDisabled)
 	}))
 
-	await updateWebsiteApprovalAccesses(ethereum, tokenPriceService, resetSimulationServices, websiteTabConnections, await getSettings(), true, bumpPopupRefreshGeneration())
+	await updateWebsiteApprovalAccesses(ethereum, tokenPriceService, resetSimulationServices, websiteTabConnections, await getSettings(), true)
 	await sendPopupMessageToOpenWindows({ method: 'popup_interceptor_access_changed' })
 }
 
@@ -710,7 +710,7 @@ async function disableInterceptorForPage(websiteTabConnections: WebsiteTabConnec
 
 export async function disableInterceptor(ethereum: EthereumClientService, tokenPriceService: TokenPriceService, resetSimulationServices: ResetSimulationServices, websiteTabConnections: WebsiteTabConnections, parsedRequest: DisableInterceptor) {
 	await disableInterceptorForPage(websiteTabConnections, parsedRequest.data.website, parsedRequest.data.interceptorDisabled)
-	await updateWebsiteApprovalAccesses(ethereum, tokenPriceService, resetSimulationServices, websiteTabConnections, await getSettings(), true, bumpPopupRefreshGeneration())
+	await updateWebsiteApprovalAccesses(ethereum, tokenPriceService, resetSimulationServices, websiteTabConnections, await getSettings(), true)
 	await sendPopupMessageToOpenWindows({ method: 'popup_setDisableInterceptorReply' as const, data: parsedRequest.data })
 }
 
@@ -750,7 +750,7 @@ async function blockOrAllowWebsiteExternalRequests(websiteTabConnections: Websit
 
 export async function blockOrAllowExternalRequests(ethereum: EthereumClientService, tokenPriceService: TokenPriceService, resetSimulationServices: ResetSimulationServices, websiteTabConnections: WebsiteTabConnections, parsedRequest: BlockOrAllowExternalRequests) {
 	await blockOrAllowWebsiteExternalRequests(websiteTabConnections, parsedRequest.data.website, parsedRequest.data.shouldBlock)
-	await updateWebsiteApprovalAccesses(ethereum, tokenPriceService, resetSimulationServices, websiteTabConnections, await getSettings(), true, bumpPopupRefreshGeneration())
+	await updateWebsiteApprovalAccesses(ethereum, tokenPriceService, resetSimulationServices, websiteTabConnections, await getSettings(), true)
 	await sendPopupMessageToOpenWindows({ method: 'popup_websiteAccess_changed' })
 }
 
@@ -767,7 +767,7 @@ async function removeAddressAccessByAddress(websiteOrigin: string, address: Ethe
 export async function removeWebsiteAddressAccess(ethereum: EthereumClientService, tokenPriceService: TokenPriceService, resetSimulationServices: ResetSimulationServices, websiteTabConnections: WebsiteTabConnections, parsedRequest: RemoveWebsiteAddressAccess) {
 	await removeAddressAccessByAddress(parsedRequest.data.websiteOrigin, parsedRequest.data.address)
 	await reloadConnectedTabs(websiteTabConnections)
-	await updateWebsiteApprovalAccesses(ethereum, tokenPriceService, resetSimulationServices, websiteTabConnections, await getSettings(), true, bumpPopupRefreshGeneration())
+	await updateWebsiteApprovalAccesses(ethereum, tokenPriceService, resetSimulationServices, websiteTabConnections, await getSettings(), true)
 	await sendPopupMessageToOpenWindows({ method: 'popup_websiteAccess_changed' })
 }
 
@@ -790,7 +790,7 @@ export async function allowOrPreventAddressAccessForWebsite(websiteTabConnection
 
 export async function removeWebsiteAccess(ethereum: EthereumClientService, tokenPriceService: TokenPriceService, resetSimulationServices: ResetSimulationServices, websiteTabConnections: WebsiteTabConnections, parsedRequest: RemoveWebsiteAccess) {
 	await updateWebsiteAccess((previousAccess) => previousAccess.filter(access => access.website.websiteOrigin !== parsedRequest.data.websiteOrigin))
-	await updateWebsiteApprovalAccesses(ethereum, tokenPriceService, resetSimulationServices, websiteTabConnections, await getSettings(), true, bumpPopupRefreshGeneration())
+	await updateWebsiteApprovalAccesses(ethereum, tokenPriceService, resetSimulationServices, websiteTabConnections, await getSettings(), true)
 	await sendPopupMessageToOpenWindows({ method: 'popup_websiteAccess_changed' })
 }
 export async function forceSetGasLimitForTransaction(ethereum: EthereumClientService, tokenPriceService: TokenPriceService, parsedRequest: ForceSetGasLimitForTransaction) {

--- a/app/ts/background/popupRefreshGeneration.ts
+++ b/app/ts/background/popupRefreshGeneration.ts
@@ -1,0 +1,24 @@
+import { getPopupRefreshGeneration as getPopupRefreshGenerationFromStorage, setPopupRefreshGeneration } from './storageVariables.js'
+
+let popupRefreshGeneration = 0
+
+const persistPopupRefreshGeneration = (value: number) => {
+	void setPopupRefreshGeneration(value).catch((error) => {
+		console.warn('Could not persist popup refresh generation:')
+		console.warn(error)
+	})
+}
+
+export const initializePopupRefreshGeneration = async () => {
+	const storedGeneration = await getPopupRefreshGenerationFromStorage()
+	popupRefreshGeneration = Math.max(storedGeneration ?? 0, Date.now())
+	persistPopupRefreshGeneration(popupRefreshGeneration)
+	return popupRefreshGeneration
+}
+
+export const bumpPopupRefreshGeneration = () => {
+	popupRefreshGeneration = Math.max(popupRefreshGeneration + 1, Date.now())
+	persistPopupRefreshGeneration(popupRefreshGeneration)
+	return popupRefreshGeneration
+}
+export const getPopupRefreshGeneration = () => popupRefreshGeneration

--- a/app/ts/background/storageVariables.ts
+++ b/app/ts/background/storageVariables.ts
@@ -76,6 +76,9 @@ export async function setFetchSimulationStackRequestPromise(fetchSimulationStack
 	return await browserStorageLocalSet({ fetchSimulationStackRequestPromise })
 }
 
+export const getPopupRefreshGeneration = async () => (await browserStorageLocalGet('popupRefreshGeneration'))?.popupRefreshGeneration ?? 0
+export const setPopupRefreshGeneration = async (popupRefreshGeneration: number) => await browserStorageLocalSet({ popupRefreshGeneration })
+
 const simulationResultsSemaphore = new Semaphore(1)
 export async function getPopupVisualisationState() {
 	const emptyResults = createPassthroughCompleteVisualizedSimulation()

--- a/app/ts/background/windows/interceptorAccess.ts
+++ b/app/ts/background/windows/interceptorAccess.ts
@@ -7,7 +7,6 @@ import { getAssociatedAddresses, setAccess, updateWebsiteApprovalAccesses, verif
 import { changeActiveAddressAndChain, handleInterceptedRequest, refuseAccess } from '../background.js'
 import { INTERNAL_CHANNEL_NAME, createInternalMessageListener, getHtmlFile, sendPopupMessageToOpenWindows, websiteSocketToString } from '../backgroundUtils.js'
 import { getActiveAddressEntry, getActiveAddresses } from '../metadataUtils.js'
-import { bumpPopupRefreshGeneration } from '../popupRefreshGeneration.js'
 import { getSettings } from '../settings.js'
 import { getTabState, updatePendingAccessRequests, getPendingAccessRequests, clearPendingAccessRequests } from '../storageVariables.js'
 import type { InterceptedRequest, WebsiteSocket } from '../../utils/requests.js'
@@ -86,7 +85,6 @@ async function changeAccess(ethereum: EthereumClientService, tokenPriceService: 
 		websiteTabConnections,
 		await getSettings(),
 		promptForAccessesIfNeeded,
-		bumpPopupRefreshGeneration(),
 	)
 	await sendPopupMessageToOpenWindows({ method: 'popup_websiteAccess_changed' })
 }

--- a/app/ts/background/windows/interceptorAccess.ts
+++ b/app/ts/background/windows/interceptorAccess.ts
@@ -7,6 +7,7 @@ import { getAssociatedAddresses, setAccess, updateWebsiteApprovalAccesses, verif
 import { changeActiveAddressAndChain, handleInterceptedRequest, refuseAccess } from '../background.js'
 import { INTERNAL_CHANNEL_NAME, createInternalMessageListener, getHtmlFile, sendPopupMessageToOpenWindows, websiteSocketToString } from '../backgroundUtils.js'
 import { getActiveAddressEntry, getActiveAddresses } from '../metadataUtils.js'
+import { bumpPopupRefreshGeneration } from '../popupRefreshGeneration.js'
 import { getSettings } from '../settings.js'
 import { getTabState, updatePendingAccessRequests, getPendingAccessRequests, clearPendingAccessRequests } from '../storageVariables.js'
 import type { InterceptedRequest, WebsiteSocket } from '../../utils/requests.js'
@@ -78,7 +79,15 @@ export async function getAddressMetadataForAccess(websiteAccess: WebsiteAccessAr
 async function changeAccess(ethereum: EthereumClientService, tokenPriceService: TokenPriceService, resetSimulationServices: ResetSimulationServices, websiteTabConnections: WebsiteTabConnections, confirmation: InterceptorAccessReply, website: Website, promptForAccessesIfNeeded = true) {
 	if (confirmation.userReply === 'noResponse') return
 	await setAccess(website, confirmation.userReply === 'Approved', confirmation.requestAccessToAddress)
-	updateWebsiteApprovalAccesses(ethereum, tokenPriceService, resetSimulationServices, websiteTabConnections, await getSettings(), promptForAccessesIfNeeded)
+	await updateWebsiteApprovalAccesses(
+		ethereum,
+		tokenPriceService,
+		resetSimulationServices,
+		websiteTabConnections,
+		await getSettings(),
+		promptForAccessesIfNeeded,
+		bumpPopupRefreshGeneration(),
+	)
 	await sendPopupMessageToOpenWindows({ method: 'popup_websiteAccess_changed' })
 }
 

--- a/app/ts/components/App.tsx
+++ b/app/ts/components/App.tsx
@@ -155,6 +155,7 @@ export function App() {
 	const boundaryResetKey = useSignal(0)
 	const preSimulationBlockTimeManipulation = useSignal<BlockTimeManipulation | undefined>(undefined)
 	const popupRefreshAppliedGeneration = useSignal(0)
+	const popupRefreshGeneration = useSignal(0)
 
 	const fixedAddressRichList = useSignal<readonly EnrichedRichListElement[]>([])
 	const makeCurrentAddressRich = useSignal<boolean>(false)
@@ -244,8 +245,11 @@ export function App() {
 			simulationResultState.value = state.simulationResultState
 		}
 
-		const updateHomePage = ({ data }: UpdateHomePage) => {
+		const shouldIgnoreOutdatedPopupRefreshMessage = (refreshGeneration: number) => refreshGeneration < popupRefreshGeneration.value
+		const updateHomePage = ({ data, popupRefreshGeneration: updateGeneration }: UpdateHomePage) => {
 			if (data.tabId !== currentTabId.value && currentTabId.value !== undefined) return
+			if (shouldIgnoreOutdatedPopupRefreshMessage(updateGeneration)) return
+			popupRefreshGeneration.value = updateGeneration
 			const wasLoaded = isSettingsLoaded.value
 			isSettingsLoaded.value = true
 			rpcEntries.value = data.rpcEntries
@@ -293,12 +297,16 @@ export function App() {
 			if (!maybeParsed.success) return undefined // not a message we are interested in
 			const parsed = maybeParsed.value
 			if (parsed.role === 'confirmTransaction') return undefined
-				switch(parsed.method) {
+			switch(parsed.method) {
 					case 'popup_UnexpectedErrorOccured': {
 						unexpectedError.value = parsed
 						return undefined
 					}
 					case 'popup_settingsUpdated':
+						if (shouldIgnoreOutdatedPopupRefreshMessage(parsed.popupRefreshGeneration)) return undefined
+						popupRefreshGeneration.value = parsed.popupRefreshGeneration
+						requestCachedHomeData()
+						return undefined
 					case 'popup_accounts_update':
 					case 'popup_chain_update':
 					case 'popup_signer_name_changed':
@@ -315,6 +323,9 @@ export function App() {
 						return undefined
 					}
 					case 'popup_websiteIconChanged': {
+						if (currentTabId.value === undefined || parsed.tabId !== currentTabId.value) return undefined
+						if (shouldIgnoreOutdatedPopupRefreshMessage(parsed.popupRefreshGeneration)) return undefined
+						popupRefreshGeneration.value = parsed.popupRefreshGeneration
 						tabIconDetails.value = parsed.data
 						return undefined
 					}
@@ -336,8 +347,15 @@ export function App() {
 				if (parsed.method !== 'popup_UpdateHomePage') {
 					return undefined
 				}
-				const { role: _role, ...popupUpdateHomePage } = parsed
-				return updateHomePage(UpdateHomePage.parse(popupUpdateHomePage))
+				if (typeof msg !== 'object' || msg === null) {
+					return undefined
+				}
+				const { role: _role, ...popupUpdateHomePage } = msg as Record<string, unknown>
+				const parsedUpdateHomePage = UpdateHomePage.safeParse(popupUpdateHomePage)
+				if (!parsedUpdateHomePage.success) {
+					return undefined
+				}
+				return updateHomePage(parsedUpdateHomePage.value)
 			}
 
 		browser.runtime.onMessage.addListener(replyPopupMessageListener)

--- a/app/ts/components/App.tsx
+++ b/app/ts/components/App.tsx
@@ -156,6 +156,8 @@ export function App() {
 	const preSimulationBlockTimeManipulation = useSignal<BlockTimeManipulation | undefined>(undefined)
 	const popupRefreshAppliedGeneration = useSignal(0)
 	const popupRefreshGeneration = useSignal(0)
+	const pendingPopupRefreshGeneration = useSignal(0)
+	const popupIconRefreshGeneration = useSignal(0)
 
 	const fixedAddressRichList = useSignal<readonly EnrichedRichListElement[]>([])
 	const makeCurrentAddressRich = useSignal<boolean>(false)
@@ -245,11 +247,15 @@ export function App() {
 			simulationResultState.value = state.simulationResultState
 		}
 
-		const shouldIgnoreOutdatedPopupRefreshMessage = (refreshGeneration: number) => refreshGeneration < popupRefreshGeneration.value
+		const shouldIgnoreOutdatedPopupRefreshMessage = (refreshGeneration: number, minimumGeneration = popupRefreshGeneration.value) => refreshGeneration < minimumGeneration
 		const updateHomePage = ({ data, popupRefreshGeneration: updateGeneration }: UpdateHomePage) => {
 			if (data.tabId !== currentTabId.value && currentTabId.value !== undefined) return
-			if (shouldIgnoreOutdatedPopupRefreshMessage(updateGeneration)) return
+			const minimumValidGeneration = Math.max(popupRefreshGeneration.value, pendingPopupRefreshGeneration.value)
+			if (shouldIgnoreOutdatedPopupRefreshMessage(updateGeneration, minimumValidGeneration)) return
 			popupRefreshGeneration.value = updateGeneration
+			if (pendingPopupRefreshGeneration.value <= updateGeneration) {
+				pendingPopupRefreshGeneration.value = 0
+			}
 			const wasLoaded = isSettingsLoaded.value
 			isSettingsLoaded.value = true
 			rpcEntries.value = data.rpcEntries
@@ -261,7 +267,10 @@ export function App() {
 			fixedAddressRichList.value = data.richList
 			unexpectedError.value = data.latestUnexpectedError
 			updateHomePageSettings(data.settings, !wasLoaded)
-			tabIconDetails.value = data.tabState.tabIconDetails
+			if (popupIconRefreshGeneration.value <= updateGeneration) {
+				tabIconDetails.value = data.tabState.tabIconDetails
+				popupIconRefreshGeneration.value = updateGeneration
+			}
 			updateVisualizedState(data.visualizedSimulatorState)
 			tabState.value = data.tabState
 			currentBlockNumber.value = data.currentBlockNumber
@@ -302,11 +311,11 @@ export function App() {
 						unexpectedError.value = parsed
 						return undefined
 					}
-					case 'popup_settingsUpdated':
-						if (shouldIgnoreOutdatedPopupRefreshMessage(parsed.popupRefreshGeneration)) return undefined
-						popupRefreshGeneration.value = parsed.popupRefreshGeneration
-						requestCachedHomeData()
-						return undefined
+						case 'popup_settingsUpdated':
+							if (shouldIgnoreOutdatedPopupRefreshMessage(parsed.popupRefreshGeneration)) return undefined
+							pendingPopupRefreshGeneration.value = Math.max(pendingPopupRefreshGeneration.value, parsed.popupRefreshGeneration)
+							requestCachedHomeData()
+							return undefined
 					case 'popup_accounts_update':
 					case 'popup_chain_update':
 					case 'popup_signer_name_changed':
@@ -325,7 +334,8 @@ export function App() {
 					case 'popup_websiteIconChanged': {
 						if (currentTabId.value === undefined || parsed.tabId !== currentTabId.value) return undefined
 						if (shouldIgnoreOutdatedPopupRefreshMessage(parsed.popupRefreshGeneration)) return undefined
-						popupRefreshGeneration.value = parsed.popupRefreshGeneration
+						if (parsed.popupRefreshGeneration < popupIconRefreshGeneration.value) return undefined
+						popupIconRefreshGeneration.value = parsed.popupRefreshGeneration
 						tabIconDetails.value = parsed.data
 						return undefined
 					}

--- a/app/ts/components/App.tsx
+++ b/app/ts/components/App.tsx
@@ -329,11 +329,11 @@ export function App() {
 						tabIconDetails.value = parsed.data
 						return undefined
 					}
-				case 'popup_new_block_arrived': {
-					rpcConnectionStatus.value = parsed.data.rpcConnectionStatus
-					currentBlockNumber.value = parsed.data.rpcConnectionStatus?.latestBlock?.number
-					return undefined
-				}
+					case 'popup_new_block_arrived': {
+						rpcConnectionStatus.value = parsed.data.rpcConnectionStatus
+						currentBlockNumber.value = parsed.data.rpcConnectionStatus?.latestBlock?.number
+						return undefined
+					}
 					case 'popup_failed_to_get_block': {
 						rpcConnectionStatus.value = parsed.data.rpcConnectionStatus
 						currentBlockNumber.value = parsed.data.rpcConnectionStatus?.latestBlock?.number

--- a/app/ts/components/App.tsx
+++ b/app/ts/components/App.tsx
@@ -307,15 +307,15 @@ export function App() {
 			const parsed = maybeParsed.value
 			if (parsed.role === 'confirmTransaction') return undefined
 			switch(parsed.method) {
-					case 'popup_UnexpectedErrorOccured': {
+				case 'popup_UnexpectedErrorOccured': {
 						unexpectedError.value = parsed
 						return undefined
 					}
-						case 'popup_settingsUpdated':
-							if (shouldIgnoreOutdatedPopupRefreshMessage(parsed.popupRefreshGeneration)) return undefined
-							pendingPopupRefreshGeneration.value = Math.max(pendingPopupRefreshGeneration.value, parsed.popupRefreshGeneration)
-							requestCachedHomeData()
-							return undefined
+					case 'popup_settingsUpdated':
+						if (shouldIgnoreOutdatedPopupRefreshMessage(parsed.popupRefreshGeneration)) return undefined
+						pendingPopupRefreshGeneration.value = Math.max(pendingPopupRefreshGeneration.value, parsed.popupRefreshGeneration)
+						requestCachedHomeData()
+						return undefined
 					case 'popup_accounts_update':
 					case 'popup_chain_update':
 					case 'popup_signer_name_changed':

--- a/app/ts/components/pages/Home.tsx
+++ b/app/ts/components/pages/Home.tsx
@@ -61,7 +61,6 @@ function FirstCardHeader(param: FirstCardParams) {
 	const signerName = useComputed(() => param.tabState.value?.signerName ?? 'NoSignerDetected')
 
 	function enableSimulationMode(enabled: boolean ) {
-		param.simulationMode.value = enabled
 		sendPopupMessageToBackgroundPage( { method: 'popup_enableSimulationMode', data: enabled } )
 	}
 

--- a/app/ts/types/interceptor-messages.ts
+++ b/app/ts/types/interceptor-messages.ts
@@ -441,6 +441,9 @@ export const GetAddressBookDataReply = funtypes.ReadonlyObject({
 	}),
 }).asReadonly()
 
+const PopupRefreshGeneration = funtypes.Number
+type PopupRefreshGeneration = funtypes.Static<typeof PopupRefreshGeneration>
+
 type NewBlockArrivedOrFailedToArrive = funtypes.Static<typeof NewBlockArrivedOrFailedToArrive>
 const NewBlockArrivedOrFailedToArrive = funtypes.ReadonlyObject({
 	method: funtypes.Union(funtypes.Literal('popup_new_block_arrived'), funtypes.Literal('popup_failed_to_get_block')),
@@ -450,7 +453,9 @@ const NewBlockArrivedOrFailedToArrive = funtypes.ReadonlyObject({
 type WebsiteIconChanged = funtypes.Static<typeof WebsiteIconChanged>
 const WebsiteIconChanged = funtypes.ReadonlyObject({
 	method: funtypes.Literal('popup_websiteIconChanged'),
-	data: TabIconDetails
+	tabId: funtypes.Number,
+	data: TabIconDetails,
+	popupRefreshGeneration: PopupRefreshGeneration,
 })
 
 type SimulationUpdateStartedOrEnded = funtypes.Static<typeof SimulationUpdateStartedOrEnded>
@@ -557,15 +562,10 @@ export const Settings = funtypes.ReadonlyObject({
 	simulationMode: funtypes.Boolean,
 })
 
-type PartialUpdateHomePage = funtypes.Static<typeof PartialUpdateHomePage>
-const PartialUpdateHomePage = funtypes.ReadonlyObject({
-	method: funtypes.Literal('popup_UpdateHomePage'),
-	data: funtypes.Unknown,
-})
-
 export type UpdateHomePage = funtypes.Static<typeof UpdateHomePage>
 export const UpdateHomePage = funtypes.ReadonlyObject({
 	method: funtypes.Literal('popup_UpdateHomePage'),
+	popupRefreshGeneration: PopupRefreshGeneration,
 	data: funtypes.ReadonlyObject({
 		visualizedSimulatorState: CompleteVisualizedSimulation,
 		activeAddresses: AddressBookEntries,
@@ -682,7 +682,8 @@ export const PopupReadyAndListening = funtypes.ReadonlyObject({
 type SettingsUpdated = funtypes.Static<typeof SettingsUpdated>
 const SettingsUpdated = funtypes.ReadonlyObject({
 	method: funtypes.Literal('popup_settingsUpdated'),
-	data: Settings
+	data: Settings,
+	popupRefreshGeneration: PopupRefreshGeneration,
 })
 
 type PartiallyParsedSimulateExecutionReply = funtypes.Static<typeof PartiallyParsedSimulateExecutionReply>
@@ -883,8 +884,40 @@ export const ImportSimulationStack = funtypes.ReadonlyObject({
 	data: InterceptorSimulationExport,
 })
 
-export type MessageToPopupPayload = funtypes.Static<typeof MessageToPopupPayload>
-export const MessageToPopupPayload = funtypes.Union(
+const PopupInitiateExportSettings = funtypes.ReadonlyObject({
+	method: funtypes.Literal('popup_initiate_export_settings'),
+	data: funtypes.ReadonlyObject({ fileContents: funtypes.String }),
+}).asReadonly()
+
+const PopupIsMainPopupWindowOpen = funtypes.ReadonlyObject({
+	method: funtypes.Literal('popup_isMainPopupWindowOpen'),
+}).asReadonly()
+
+const messageToPopupPayloadCodecs: [
+	typeof MessageToPopupSimple,
+	typeof WebsiteIconChanged,
+	typeof GetAddressBookDataReply,
+	typeof ChangeChainRequest,
+	typeof InterceptorAccessDialog,
+	typeof NewBlockArrivedOrFailedToArrive,
+	typeof SettingsUpdated,
+	typeof UpdateConfirmTransactionDialogPartial,
+	typeof UpdateConfirmTransactionDialogPendingTransactionsPartial,
+	typeof PopupInitiateExportSettings,
+	typeof ImportSettingsReply,
+	typeof ActiveSigningAddressChanged,
+	typeof UpdateRPCList,
+	typeof SimulationUpdateStartedOrEnded,
+	typeof PartiallyParsedSimulateExecutionReply,
+	typeof SettingsOpenedReply,
+	typeof PopupAddOrModifyAddressWindowStateInfomation,
+	typeof DisableInterceptorReply,
+	typeof UnexpectedErrorOccured,
+	typeof RetrieveWebsiteAccessReply,
+	typeof UpdateHomePage,
+	typeof FetchSimulationStackRequest,
+	typeof PopupIsMainPopupWindowOpen,
+] = [
 	MessageToPopupSimple,
 	WebsiteIconChanged,
 	GetAddressBookDataReply,
@@ -894,24 +927,28 @@ export const MessageToPopupPayload = funtypes.Union(
 	SettingsUpdated,
 	UpdateConfirmTransactionDialogPartial,
 	UpdateConfirmTransactionDialogPendingTransactionsPartial,
-	funtypes.ReadonlyObject({ method: funtypes.Literal('popup_initiate_export_settings'), data: funtypes.ReadonlyObject({ fileContents: funtypes.String }) }),
+	PopupInitiateExportSettings,
 	ImportSettingsReply,
 	ActiveSigningAddressChanged,
 	UpdateRPCList,
 	SimulationUpdateStartedOrEnded,
-	PartialUpdateHomePage,
 	PartiallyParsedSimulateExecutionReply,
 	SettingsOpenedReply,
 	PopupAddOrModifyAddressWindowStateInfomation,
 	DisableInterceptorReply,
 	UnexpectedErrorOccured,
 	RetrieveWebsiteAccessReply,
+	UpdateHomePage,
 	FetchSimulationStackRequest,
-	funtypes.ReadonlyObject({ method: funtypes.Literal('popup_isMainPopupWindowOpen') })
-)
+	PopupIsMainPopupWindowOpen,
+]
 
-export type PopupMessage = funtypes.Static<typeof PopupMessage>
-export const PopupMessage = funtypes.Union(
+export type MessageToPopupPayload = funtypes.Static<(typeof messageToPopupPayloadCodecs)[number]>
+
+const MessageToPopupPayloadRuntype: funtypes.Codec<MessageToPopupPayload> = funtypes.Union(...messageToPopupPayloadCodecs)
+export const MessageToPopupPayload = MessageToPopupPayloadRuntype
+
+const PopupMessageRuntype = funtypes.Union(
 	PopupMessageReplyRequests,
 	TransactionConfirmation,
 	RemoveTransaction,
@@ -964,11 +1001,15 @@ export const PopupMessage = funtypes.Union(
 	UnexpectedErrorOccured,
 	ImportSimulationStack,
 )
+export type PopupMessage = funtypes.Static<typeof PopupMessageRuntype>
+export const PopupMessage = PopupMessageRuntype
 
-export type MessageToPopup = funtypes.Static<typeof MessageToPopup>
-export const MessageToPopup = funtypes.Union(
+type MessageToPopupType = MessageToPopupPayload & { role: MessageToPopupRole }
+export type MessageToPopup = MessageToPopupType
+const MessageToPopupRuntype: funtypes.Codec<MessageToPopup> = funtypes.Union(
 	funtypes.Intersect(
 		funtypes.ReadonlyObject({ role: MessageToPopupRole }),
 		MessageToPopupPayload
 	)
 )
+export const MessageToPopup = MessageToPopupRuntype

--- a/app/ts/utils/storageUtils.ts
+++ b/app/ts/utils/storageUtils.ts
@@ -72,6 +72,7 @@ const LocalStorageItemsRuntype = funtypes.ReadonlyPartial({
 	preSimulationBlockTimeManipulation: BlockTimeManipulation,
 	fixedAddressRichList: funtypes.ReadonlyArray(RichListElement),
 	fetchSimulationStackRequestPromise: funtypes.Union(funtypes.Undefined, PendingFetchSimulationStackRequestPromise),
+	popupRefreshGeneration: funtypes.Number,
 })
 type LocalStorageItems = funtypes.Static<typeof LocalStorageItemsRuntype>
 const LocalStorageItems: typeof LocalStorageItemsRuntype = LocalStorageItemsRuntype
@@ -108,6 +109,7 @@ const LocalStorageKey = funtypes.Union(
 	funtypes.Literal('preSimulationBlockTimeManipulation'),
 	funtypes.Literal('fixedAddressRichList'),
 	funtypes.Literal('fetchSimulationStackRequestPromise'),
+	funtypes.Literal('popupRefreshGeneration'),
 )
 
 const LocalStorageItems2Runtype: funtypes.Partial<{

--- a/test/tests/extensionIconDeduping.test.ts
+++ b/test/tests/extensionIconDeduping.test.ts
@@ -100,6 +100,7 @@ async function loadModules() {
 		...await import('../../app/ts/background/backgroundUtils.js'),
 		...await import('../../app/ts/background/iconHandler.js'),
 		...await import('../../app/ts/background/settings.js'),
+		...await import('../../app/ts/background/popupMessageHandlers.js'),
 		...await import('../../app/ts/background/storageVariables.js'),
 		...await import('../../app/ts/background/websiteTabConnections.js'),
 	}
@@ -203,11 +204,109 @@ describe('extension icon deduping', () => {
 			}],
 		])
 
-		updateWebsiteApprovalAccesses({} as never, websiteTabConnections, await getSettings())
+		await updateWebsiteApprovalAccesses(
+			{} as never,
+			undefined as never,
+			undefined as never,
+			websiteTabConnections,
+			await getSettings(),
+			true,
+			0,
+		)
 		await flushAsyncWork()
 
 		assert.equal(setIconCalls.length, 1)
 		assert.equal(setTitleCalls.length, 1)
+	})
+
+	test('access refresh updates stale icons for tabs without active connections', async () => {
+		const { setIconCalls, setTitleCalls } = installBrowserMock([{ id: 1, url: 'https://example.test', status: 'complete' }])
+		const { changeSimulationMode, getSettings, updateTabState, updateWebsiteApprovalAccesses } = await loadModules()
+
+		await changeSimulationMode({ simulationMode: false, activeSigningAddress: undefined })
+		await updateTabState(1, (previousState) => ({
+			...previousState,
+			website: { websiteOrigin: 'example.test', icon: undefined, title: 'Example' },
+			tabIconDetails: {
+				icon: ICON_SIMULATING,
+				iconReason: 'The Interceptor simulates your sent transactions.',
+			},
+		}))
+
+		await updateWebsiteApprovalAccesses(
+			{} as never,
+			undefined as never,
+			undefined as never,
+			new Map(),
+			await getSettings(),
+			true,
+			0,
+		)
+		await flushAsyncWork()
+
+		assert.equal(setIconCalls.length, 1)
+		assert.equal(setTitleCalls.length, 1)
+		assert.deepEqual(setIconCalls[0]?.path, { 128: ICON_NOT_ACTIVE })
+		assert.equal(setTitleCalls[0]?.title, 'No active address selected.')
+	})
+
+	test('imported mode change updates tabs without active connections', async () => {
+		const { changeSimulationMode, getSettings, importSettings, updateTabState, updateWebsiteApprovalAccesses } = await loadModules()
+		const { setIconCalls, setTitleCalls } = installBrowserMock([{ id: 1, url: 'https://example.test', status: 'complete' }])
+		const importedSettingsReply = JSON.stringify({
+			name: 'InterceptorSettingsAndAddressBook',
+			version: '1.4',
+			exportedDate: '2026-05-21',
+			settings: {
+				activeSimulationAddress: '0x0000000000000000000000000000000000000002',
+				rpcNetwork: {
+					name: 'Imported',
+					chainId: '0x1',
+					httpsRpc: 'https://example.test/rpc',
+					currencyName: 'Ether',
+					currencyTicker: 'ETH',
+					primary: true,
+					minimized: true,
+				},
+				openedPage: { page: 'Home' },
+				useSignersAddressAsActiveAddress: false,
+				websiteAccess: [],
+				simulationMode: false,
+				addressBookEntries: [],
+				useTabsInsteadOfPopup: false,
+				metamaskCompatibilityMode: false,
+			},
+		})
+
+		await changeSimulationMode({ simulationMode: true, activeSimulationAddress: 0x1n, activeSigningAddress: undefined })
+		await updateTabState(1, (previousState) => ({
+			...previousState,
+			website: { websiteOrigin: 'example.test', icon: undefined, title: 'Example' },
+			tabIconDetails: {
+				icon: ICON_SIMULATING,
+				iconReason: 'The Interceptor simulates your sent transactions.',
+			},
+		}))
+
+		const importSettingsReply = await importSettings({ method: 'popup_import_settings', data: { fileContents: importedSettingsReply } })
+		assert.equal(importSettingsReply.data.success, true)
+		await updateWebsiteApprovalAccesses(
+			{} as never,
+			undefined as never,
+			undefined as never,
+			new Map(),
+			await getSettings(),
+			true,
+			0,
+		)
+		await flushAsyncWork()
+
+		const settings = await getSettings()
+		assert.equal(settings.activeRpcNetwork.httpsRpc, 'https://example.test/rpc')
+		assert.equal(settings.simulationMode, false)
+
+		assert.deepEqual(setIconCalls[0]?.path, { 128: ICON_NOT_ACTIVE })
+		assert.equal(setTitleCalls[0]?.title, 'No active address selected.')
 	})
 
 	test('last-port disconnect removes the tab entry', async () => {

--- a/test/tests/extensionIconDeduping.test.ts
+++ b/test/tests/extensionIconDeduping.test.ts
@@ -205,9 +205,9 @@ describe('extension icon deduping', () => {
 		])
 
 		await updateWebsiteApprovalAccesses(
-			{} as never,
-			undefined as never,
-			undefined as never,
+			undefined,
+			undefined,
+			undefined,
 			websiteTabConnections,
 			await getSettings(),
 			true,
@@ -234,9 +234,9 @@ describe('extension icon deduping', () => {
 		}))
 
 		await updateWebsiteApprovalAccesses(
-			{} as never,
-			undefined as never,
-			undefined as never,
+			undefined,
+			undefined,
+			undefined,
 			new Map(),
 			await getSettings(),
 			true,
@@ -291,9 +291,9 @@ describe('extension icon deduping', () => {
 		const importSettingsReply = await importSettings({ method: 'popup_import_settings', data: { fileContents: importedSettingsReply } })
 		assert.equal(importSettingsReply.data.success, true)
 		await updateWebsiteApprovalAccesses(
-			{} as never,
-			undefined as never,
-			undefined as never,
+			undefined,
+			undefined,
+			undefined,
 			new Map(),
 			await getSettings(),
 			true,

--- a/test/tests/popupClearReset.test.ts
+++ b/test/tests/popupClearReset.test.ts
@@ -401,7 +401,7 @@ describe('popup clear reset', () => {
 		await browserStorageLocalSet({ popupVisualisation: matchingPopupVisualisation })
 
 		const { refreshHomeData } = modules
-		await refreshHomeData(fakeEthereum, fakeTokenPriceService, new Map(), true, false, undefined)
+		await refreshHomeData(fakeEthereum, fakeTokenPriceService, new Map(), true, 1, false)
 
 		const popupVisualisation = (await browserStorageLocalGet('popupVisualisation')).popupVisualisation
 		assert.ok(popupVisualisation)

--- a/test/tests/popupIconResync.test.ts
+++ b/test/tests/popupIconResync.test.ts
@@ -1,0 +1,436 @@
+import * as assert from 'assert'
+import { describe, test } from 'bun:test'
+import { act } from 'preact/test-utils'
+import { h, render } from 'preact'
+import { App } from '../../app/ts/components/App.js'
+import { createPassthroughCompleteVisualizedSimulation } from '../../app/ts/types/visualizer-types.js'
+import type { UpdateHomePage as UpdateHomePageData } from '../../app/ts/types/interceptor-messages.js'
+import type { Settings } from '../../app/ts/types/interceptor-messages.js'
+import { installDomMock } from './domMock.js'
+import { ICON_SIGNING, ICON_SIMULATING } from '../../app/ts/utils/constants.js'
+
+type RuntimeMessageListener = (message: unknown, sender: unknown, sendResponse: (response?: unknown) => void) => void
+
+function installBrowserMock() {
+	const sentMessages: unknown[] = []
+	let messageListener: RuntimeMessageListener | undefined
+
+	Object.defineProperty(globalThis, 'browser', { value: {
+		runtime: {
+			lastError: null,
+			async sendMessage(message: unknown) {
+				sentMessages.push(message)
+				return undefined
+			},
+			getManifest: () => ({ manifest_version: 3 }),
+			onMessage: {
+				addListener: (listener: RuntimeMessageListener) => {
+					messageListener = listener
+				},
+				removeListener: () => undefined,
+			},
+			onConnect: { addListener: () => undefined, removeListener: () => undefined },
+		},
+		storage: {
+			local: {
+				async get(keys?: string | string[] | Record<string, unknown> | null) {
+					if (keys === undefined || keys === null) return {}
+					if (Array.isArray(keys)) return Object.fromEntries(keys.map((key) => [key, undefined]))
+					if (typeof keys === 'string') return { [keys]: undefined }
+					return Object.fromEntries(Object.entries(keys).map(([key]) => [key, undefined]))
+				},
+				async set() { return undefined },
+				async remove() { return undefined },
+			},
+		},
+		tabs: {
+			query: async () => [],
+			get: async () => undefined,
+			update: async () => undefined,
+			onUpdated: { addListener: () => undefined, removeListener: () => undefined },
+			onRemoved: { addListener: () => undefined, removeListener: () => undefined },
+		},
+		windows: {
+			get: async () => undefined,
+			update: async () => undefined,
+		},
+		action: {
+			async setIcon() { return undefined },
+			async setTitle() { return undefined },
+			async setBadgeText() { return undefined },
+			async setBadgeBackgroundColor() { return undefined },
+		},
+		browserAction: {
+			async setIcon() { return undefined },
+			async setTitle() { return undefined },
+			async setBadgeText() { return undefined },
+			async setBadgeBackgroundColor() { return undefined },
+		},
+		declarativeNetRequest: {
+			getDynamicRules: async () => [],
+			getSessionRules: async () => [],
+			updateDynamicRules: async () => undefined,
+			updateSessionRules: async () => undefined,
+		},
+	}, writable: true })
+
+	Object.defineProperty(globalThis, 'chrome', { value: { runtime: { id: 'test-extension' } }, writable: true })
+
+	return { messageListener: () => messageListener, sentMessages }
+}
+
+function collectImageSrcs(node: { nodeType: number; childNodes?: readonly { nodeType: number; childNodes: readonly unknown[] }[]; getAttribute?: (_name: string) => string | null; }): string[] {
+	if (node.nodeType === 1 && node.getAttribute !== undefined) {
+		const src = node.getAttribute('src')
+		if (src !== null) return [src]
+	}
+	if (node.childNodes === undefined) return []
+	return node.childNodes.flatMap((child) => collectImageSrcs(child as { nodeType: number; childNodes: readonly { nodeType: number; childNodes: readonly unknown[] }[]; getAttribute?: (_name: string) => string | null }))
+}
+
+const defaultSettings: Settings = {
+	activeSimulationAddress: undefined,
+	activeRpcNetwork: {
+		name: 'Ethereum',
+		chainId: '0x1',
+		httpsRpc: 'https://example.invalid',
+		currencyName: 'Ether?',
+		currencyTicker: 'ETH?',
+		primary: false,
+		minimized: true,
+	},
+	openedPage: { page: 'Home' },
+	useSignersAddressAsActiveAddress: false,
+	websiteAccess: [],
+	simulationMode: false,
+}
+
+const defaultRpcEntries = [{ name: 'Ethereum', chainId: '0x1', httpsRpc: 'https://example.invalid', currencyName: 'Ether', currencyTicker: 'ETH', primary: true, minimized: false }]
+	const defaultHomePage = (tabId: number, icon: { icon: string; iconReason: string }, popupRefreshGeneration: number): UpdateHomePageData => ({
+	method: 'popup_UpdateHomePage',
+	popupRefreshGeneration,
+	data: {
+		visualizedSimulatorState: createPassthroughCompleteVisualizedSimulation(),
+		activeAddresses: [],
+		richList: [],
+		makeCurrentAddressRich: false,
+		latestUnexpectedError: undefined,
+		websiteAccessAddressMetadata: [],
+		tabState: {
+			tabId,
+			website: { websiteOrigin: `tab-${ tabId }.invalid`, icon: undefined, title: `Tab ${ tabId }` },
+			signerConnected: false,
+			signerName: 'NoSigner',
+			signerAccounts: [],
+			signerAccountError: undefined,
+			signerChain: undefined,
+			tabIconDetails: icon,
+			activeSigningAddress: undefined,
+		},
+		currentBlockNumber: undefined,
+		settings: defaultSettings,
+		rpcConnectionStatus: undefined,
+		activeSigningAddressInThisTab: undefined,
+		tabId,
+		rpcEntries: defaultRpcEntries,
+		interceptorDisabled: false,
+		preSimulationBlockTimeManipulation: { type: 'AddToTimestamp', deltaToAdd: '0xc', deltaUnit: 'Seconds' },
+	},
+})
+
+describe('popup icon sync', () => {
+	test('ignores icon updates for a different tab id', async () => {
+		const dom = installDomMock()
+		const { messageListener, sentMessages } = installBrowserMock()
+		try {
+			Object.defineProperty(globalThis, 'window', {
+				value: {
+					document: dom.document,
+					addEventListener: () => undefined,
+					removeEventListener: () => undefined,
+				},
+				configurable: true,
+				writable: true,
+			})
+
+			await act(() => {
+				render(h(App, {}), dom.document.body)
+			})
+			const listener = messageListener()
+			assert.equal(typeof listener, 'function')
+			const initialMessage = defaultHomePage(1, { icon: ICON_SIGNING, iconReason: 'Signing' }, 1)
+
+			await act(() => {
+				// first message should establish the active tab id
+				listener?.({ role: 'all', ...initialMessage }, undefined, () => undefined)
+			})
+			assert.equal(sentMessages.length > 0, true)
+
+			const iconSrcAfterHomePage = collectImageSrcs(dom.document.body).find((src) => src.includes('head-'))
+			assert.equal(iconSrcAfterHomePage?.endsWith('head-signing.png'), true)
+
+			await act(() => {
+				// stale icon update for another tab must not override current tab icon
+				listener?.({
+					role: 'all',
+					method: 'popup_websiteIconChanged',
+					popupRefreshGeneration: 2,
+					tabId: 2,
+					data: { icon: ICON_SIMULATING, iconReason: 'Simulating' },
+				}, undefined, () => undefined)
+			})
+			const iconSrcAfterWrongTabUpdate = collectImageSrcs(dom.document.body).find((src) => src.includes('head-'))
+			assert.equal(iconSrcAfterWrongTabUpdate?.endsWith('head-signing.png'), true)
+		} finally {
+			dom.restore()
+		}
+	})
+
+	test('does not apply icon updates while tab id is unknown', async () => {
+		const dom = installDomMock()
+		const { messageListener } = installBrowserMock()
+		try {
+			Object.defineProperty(globalThis, 'window', {
+				value: {
+					document: dom.document,
+					addEventListener: () => undefined,
+					removeEventListener: () => undefined,
+				},
+				configurable: true,
+				writable: true,
+			})
+
+			await act(() => {
+				render(h(App, {}), dom.document.body)
+			})
+			const listener = messageListener()
+			assert.equal(typeof listener, 'function')
+
+			await act(() => {
+				listener?.({
+					role: 'all',
+					method: 'popup_websiteIconChanged',
+					popupRefreshGeneration: 2,
+					tabId: 2,
+					data: { icon: ICON_SIMULATING, iconReason: 'Simulating' },
+				}, undefined, () => undefined)
+			})
+
+			const iconSrcAfterUnknownTabUpdate = collectImageSrcs(dom.document.body).find((src) => src.includes('head-'))
+			assert.equal(iconSrcAfterUnknownTabUpdate, undefined)
+		} finally {
+			dom.restore()
+		}
+	})
+
+	test('ignores stale popup home updates', async () => {
+		const dom = installDomMock()
+		const { messageListener } = installBrowserMock()
+		try {
+			Object.defineProperty(globalThis, 'window', {
+				value: {
+					document: dom.document,
+					addEventListener: () => undefined,
+					removeEventListener: () => undefined,
+				},
+				configurable: true,
+				writable: true,
+			})
+
+			await act(() => {
+				render(h(App, {}), dom.document.body)
+			})
+			const listener = messageListener()
+			assert.equal(typeof listener, 'function')
+
+			await act(() => {
+				listener?.({
+					role: 'all',
+					...defaultHomePage(1, { icon: ICON_SIGNING, iconReason: 'Signing' }, 10),
+				}, undefined, () => undefined)
+			})
+			const iconAfterCurrentTabUpdate = collectImageSrcs(dom.document.body).find((src) => src.includes('head-'))
+			assert.equal(iconAfterCurrentTabUpdate?.endsWith('head-signing.png'), true)
+
+			await act(() => {
+				listener?.({
+					role: 'all',
+					...defaultHomePage(1, { icon: ICON_SIMULATING, iconReason: 'Simulating' }, 5),
+				}, undefined, () => undefined)
+			})
+			const iconAfterStaleUpdate = collectImageSrcs(dom.document.body).find((src) => src.includes('head-'))
+			assert.equal(iconAfterStaleUpdate?.endsWith('head-signing.png'), true)
+
+			await act(() => {
+				listener?.({
+					role: 'all',
+					...defaultHomePage(1, { icon: ICON_SIMULATING, iconReason: 'Simulating' }, 20),
+					method: 'popup_UpdateHomePage',
+				}, undefined, () => undefined)
+			})
+			const iconAfterFreshUpdate = collectImageSrcs(dom.document.body).find((src) => src.includes('head-'))
+			assert.equal(iconAfterFreshUpdate?.endsWith('head-simulating.png'), true)
+		} finally {
+			dom.restore()
+		}
+	})
+
+	test('does not apply higher-generation updates for a non-current tab', async () => {
+		const dom = installDomMock()
+		const { messageListener } = installBrowserMock()
+		try {
+			Object.defineProperty(globalThis, 'window', {
+				value: {
+					document: dom.document,
+					addEventListener: () => undefined,
+					removeEventListener: () => undefined,
+				},
+				configurable: true,
+				writable: true,
+			})
+
+			await act(() => {
+				render(h(App, {}), dom.document.body)
+			})
+			const listener = messageListener()
+			assert.equal(typeof listener, 'function')
+
+			await act(() => {
+				listener?.({
+					role: 'all',
+					...defaultHomePage(1, { icon: ICON_SIGNING, iconReason: 'Signing' }, 10),
+				}, undefined, () => undefined)
+			})
+			const iconAfterCurrentTabUpdate = collectImageSrcs(dom.document.body).find((src) => src.includes('head-'))
+			assert.equal(iconAfterCurrentTabUpdate?.endsWith('head-signing.png'), true)
+
+			await act(() => {
+				listener?.({
+					role: 'all',
+					...defaultHomePage(2, { icon: ICON_SIMULATING, iconReason: 'Simulating' }, 20),
+				}, undefined, () => undefined)
+			})
+			const iconAfterWrongTabUpdate = collectImageSrcs(dom.document.body).find((src) => src.includes('head-'))
+			assert.equal(iconAfterWrongTabUpdate?.endsWith('head-signing.png'), true)
+
+			await act(() => {
+				listener?.({
+					role: 'all',
+					...defaultHomePage(1, { icon: ICON_SIMULATING, iconReason: 'Simulating' }, 11),
+					method: 'popup_UpdateHomePage',
+				}, undefined, () => undefined)
+			})
+			const iconAfterCurrentTabFreshUpdate = collectImageSrcs(dom.document.body).find((src) => src.includes('head-'))
+			assert.equal(iconAfterCurrentTabFreshUpdate?.endsWith('head-simulating.png'), true)
+		} finally {
+			dom.restore()
+		}
+	})
+
+	test('non-current icon updates do not block later current tab icon updates', async () => {
+		const dom = installDomMock()
+		const { messageListener } = installBrowserMock()
+		try {
+			Object.defineProperty(globalThis, 'window', {
+				value: {
+					document: dom.document,
+					addEventListener: () => undefined,
+					removeEventListener: () => undefined,
+				},
+				configurable: true,
+				writable: true,
+			})
+
+			await act(() => {
+				render(h(App, {}), dom.document.body)
+			})
+			const listener = messageListener()
+			assert.equal(typeof listener, 'function')
+
+			await act(() => {
+				listener?.({
+					role: 'all',
+					...defaultHomePage(1, { icon: ICON_SIGNING, iconReason: 'Signing' }, 10),
+				}, undefined, () => undefined)
+			})
+			const iconAfterCurrentTabUpdate = collectImageSrcs(dom.document.body).find((src) => src.includes('head-'))
+			assert.equal(iconAfterCurrentTabUpdate?.endsWith('head-signing.png'), true)
+
+			await act(() => {
+				listener?.({
+					role: 'all',
+					method: 'popup_websiteIconChanged',
+					popupRefreshGeneration: 20,
+					tabId: 2,
+					data: { icon: ICON_SIMULATING, iconReason: 'Simulating' },
+				}, undefined, () => undefined)
+			})
+			const iconAfterWrongTabIconUpdate = collectImageSrcs(dom.document.body).find((src) => src.includes('head-'))
+			assert.equal(iconAfterWrongTabIconUpdate?.endsWith('head-signing.png'), true)
+
+			await act(() => {
+				listener?.({
+					role: 'all',
+					method: 'popup_websiteIconChanged',
+					popupRefreshGeneration: 11,
+					tabId: 1,
+					data: { icon: ICON_SIMULATING, iconReason: 'Simulating' },
+				}, undefined, () => undefined)
+			})
+			const iconAfterCurrentTabIconUpdate = collectImageSrcs(dom.document.body).find((src) => src.includes('head-'))
+			assert.equal(iconAfterCurrentTabIconUpdate?.endsWith('head-simulating.png'), true)
+		} finally {
+			dom.restore()
+		}
+	})
+
+	test('same-tab icon updates update refresh generation to protect stale home payloads', async () => {
+		const dom = installDomMock()
+		const { messageListener } = installBrowserMock()
+		try {
+			Object.defineProperty(globalThis, 'window', {
+				value: {
+					document: dom.document,
+					addEventListener: () => undefined,
+					removeEventListener: () => undefined,
+				},
+				configurable: true,
+				writable: true,
+			})
+
+			await act(() => {
+				render(h(App, {}), dom.document.body)
+			})
+			const listener = messageListener()
+			assert.equal(typeof listener, 'function')
+
+			await act(() => {
+				listener?.({
+					role: 'all',
+					...defaultHomePage(1, { icon: ICON_SIGNING, iconReason: 'Signing' }, 10),
+				}, undefined, () => undefined)
+			})
+
+			await act(() => {
+				listener?.({
+					role: 'all',
+					method: 'popup_websiteIconChanged',
+					popupRefreshGeneration: 20,
+					tabId: 1,
+					data: { icon: ICON_SIMULATING, iconReason: 'Simulating' },
+				}, undefined, () => undefined)
+			})
+
+			await act(() => {
+				listener?.({
+					role: 'all',
+					...defaultHomePage(1, { icon: ICON_SIGNING, iconReason: 'Signing' }, 15),
+				}, undefined, () => undefined)
+			})
+			const iconAfterStaleHomeUpdate = collectImageSrcs(dom.document.body).find((src) => src.includes('head-'))
+			assert.equal(iconAfterStaleHomeUpdate?.endsWith('head-simulating.png'), true)
+		} finally {
+			dom.restore()
+		}
+	})
+})

--- a/test/tests/popupIconResync.test.ts
+++ b/test/tests/popupIconResync.test.ts
@@ -433,4 +433,55 @@ describe('popup icon sync', () => {
 			dom.restore()
 		}
 	})
+
+	test('settings update blocks stale home updates with lower generation', async () => {
+		const dom = installDomMock()
+		const { messageListener } = installBrowserMock()
+		try {
+			Object.defineProperty(globalThis, 'window', {
+				value: {
+					document: dom.document,
+					addEventListener: () => undefined,
+					removeEventListener: () => undefined,
+				},
+				configurable: true,
+				writable: true,
+			})
+
+			await act(() => {
+				render(h(App, {}), dom.document.body)
+			})
+			const listener = messageListener()
+			assert.equal(typeof listener, 'function')
+
+			await act(() => {
+				listener?.({
+					role: 'all',
+					...defaultHomePage(1, { icon: ICON_SIGNING, iconReason: 'Signing' }, 10),
+				}, undefined, () => undefined)
+			})
+			const iconAfterCurrentTabUpdate = collectImageSrcs(dom.document.body).find((src) => src.includes('head-'))
+			assert.equal(iconAfterCurrentTabUpdate?.endsWith('head-signing.png'), true)
+
+			await act(() => {
+				listener?.({
+					role: 'all',
+					method: 'popup_settingsUpdated',
+					popupRefreshGeneration: 20,
+					data: defaultSettings,
+				}, undefined, () => undefined)
+			})
+
+			await act(() => {
+				listener?.({
+					role: 'all',
+					...defaultHomePage(1, { icon: ICON_SIMULATING, iconReason: 'Simulating' }, 5),
+				}, undefined, () => undefined)
+			})
+			const iconAfterStaleHomeAfterSettingsUpdate = collectImageSrcs(dom.document.body).find((src) => src.includes('head-'))
+			assert.equal(iconAfterStaleHomeAfterSettingsUpdate?.endsWith('head-signing.png'), true)
+		} finally {
+			dom.restore()
+		}
+	})
 })

--- a/test/tests/popupRefreshGeneration.test.ts
+++ b/test/tests/popupRefreshGeneration.test.ts
@@ -1,0 +1,74 @@
+import * as assert from 'assert'
+import { describe, test } from 'bun:test'
+
+function installBrowserMock() {
+	const storageState: Record<string, unknown> = {}
+	globalThis.browser = {
+		runtime: {
+			lastError: null,
+			getManifest: () => ({ manifest_version: 3 }),
+			onMessage: { addListener: () => undefined, removeListener: () => undefined },
+			onConnect: { addListener: () => undefined, removeListener: () => undefined },
+		},
+		storage: {
+			local: {
+				async get(keys?: string | string[] | Record<string, unknown> | null) {
+					if (keys === undefined || keys === null) return { ...storageState }
+					if (Array.isArray(keys)) return Object.fromEntries(keys.map((key) => [key, storageState[key]]))
+					if (typeof keys === 'string') return { [keys]: storageState[keys] }
+					return Object.fromEntries(Object.entries(keys).map(([key, defaultValue]) => [key, key in storageState ? storageState[key] : defaultValue]))
+				},
+				async set(items: Record<string, unknown>) {
+					Object.assign(storageState, items)
+				},
+				async remove(keys: string | string[]) {
+					for (const key of Array.isArray(keys) ? keys : [keys]) delete storageState[key]
+				},
+			},
+		},
+		tabs: {
+			query: async () => [],
+			get: async () => undefined,
+			update: async () => undefined,
+			onUpdated: { addListener: () => undefined, removeListener: () => undefined },
+			onRemoved: { addListener: () => undefined, removeListener: () => undefined },
+		},
+		windows: {
+			get: async () => undefined,
+			update: async () => undefined,
+		},
+		action: {
+			async setIcon() { return undefined },
+			async setTitle() { return undefined },
+			async setBadgeText() { return undefined },
+			async setBadgeBackgroundColor() { return undefined },
+		},
+		browserAction: {
+			async setIcon() { return undefined },
+			async setTitle() { return undefined },
+			async setBadgeText() { return undefined },
+			async setBadgeBackgroundColor() { return undefined },
+		},
+	} as unknown as typeof globalThis.browser
+
+	return { storageState }
+}
+
+describe('popup refresh generation persistence', () => {
+	test('keeps in-memory generation above persisted restart value', async () => {
+		const { storageState } = installBrowserMock()
+		const previousGeneration = 10_000_000_000_000
+		storageState.popupRefreshGeneration = previousGeneration
+
+		const { initializePopupRefreshGeneration, bumpPopupRefreshGeneration, getPopupRefreshGeneration } = await import('../../app/ts/background/popupRefreshGeneration.js')
+		await initializePopupRefreshGeneration()
+		const afterInitialize = getPopupRefreshGeneration()
+		assert.equal(afterInitialize >= previousGeneration, true)
+
+		const afterBump = bumpPopupRefreshGeneration()
+		assert.equal(afterBump > previousGeneration, true)
+		await new Promise((resolve) => setTimeout(resolve, 0))
+		assert.equal(storageState.popupRefreshGeneration, afterBump)
+	})
+})
+

--- a/test/tests/refreshHomeDataRpcStatus.test.ts
+++ b/test/tests/refreshHomeDataRpcStatus.test.ts
@@ -163,7 +163,7 @@ describe('refreshHomeData', () => {
 		const tokenPriceService = new TokenPriceService(ethereum, 0)
 
 		try {
-			await refreshHomeData(ethereum, tokenPriceService, new Map(), true, false)
+			await refreshHomeData(ethereum, tokenPriceService, new Map(), true, 1, false)
 		} finally {
 			ethereum.cleanup()
 		}
@@ -247,7 +247,7 @@ describe('refreshHomeData', () => {
 		const tokenPriceService = new TokenPriceService(ethereum, 0)
 
 		try {
-			await refreshHomeData(ethereum, tokenPriceService, websiteTabConnections, true, false)
+			await refreshHomeData(ethereum, tokenPriceService, websiteTabConnections, true, 1, false)
 		} finally {
 			ethereum.cleanup()
 		}
@@ -304,7 +304,7 @@ describe('refreshHomeData', () => {
 		const tokenPriceService = new TokenPriceService(ethereum, 0)
 
 		try {
-			await refreshHomeData(ethereum, tokenPriceService, new Map(), true, false)
+			await refreshHomeData(ethereum, tokenPriceService, new Map(), true, 1, false)
 		} finally {
 			ethereum.cleanup()
 		}


### PR DESCRIPTION
## Summary
- Fixes popup/icon staleness by introducing a popup refresh generation token flow across background startup, access updates, connection state changes, and popup messaging.
- Extracts safer content-script port lifecycle management into dedicated helpers and adds ignorable lifecycle error handling for disconnected ports and invalidated contexts.
- Refactors website/icon handling to reuse stored metadata, sanitize favicon inputs, validate origin/protocol, and update known website metadata during startup/tab updates.
- Adds migration support for address book/version upgrades and website access migration hooks into startup.
- Improves extension icon updates with loaded-tab waiting and deduplicated/safer icon resolution, while broadening regression coverage around background startup, popup icon resync, image conversion, and migration paths.

## Testing
- Not run (no local test execution was requested in this task).
- Suggested concrete checks to run before merge:
  - `bun test`
  - `bun run setup-chrome`
  - `bun run typecheck`
  - `bun run lint`
  - `bun run test:chrome-communication` (after Chromium/Chrome available)
  - `bun run benchmark:popup-lifecycle` (if validating popup refresh behavior)