### PR TITLE
Handle stateOverrides when detecting empty simulation input

### DIFF
--- a/app/ts/background/simulationUpdating.ts
+++ b/app/ts/background/simulationUpdating.ts
@@ -105,7 +105,11 @@ export const getCurrentSimulationInput = async (): Promise<SimulationStateInput>
 			default: assertNever(operation)
 		}
 	}
-	if (currentBlockTransactions.length > 0 || currentBlockSignedMessages.length > 0) {
+	if (
+		currentBlockTransactions.length > 0
+		|| currentBlockSignedMessages.length > 0
+		|| Object.keys(currentBlockStateOverrides).length > 0
+	) {
 		inputBlocks.push({
 			stateOverrides: currentBlockStateOverrides,
 			transactions: currentBlockTransactions,
@@ -113,17 +117,6 @@ export const getCurrentSimulationInput = async (): Promise<SimulationStateInput>
 			blockTimeManipulation: previousBlockTimeManipulation,
 			simulateWithZeroBaseFee: false,
 		})
-	} else {
-		for (const _ in currentBlockStateOverrides) {
-			inputBlocks.push({
-				stateOverrides: currentBlockStateOverrides,
-				transactions: currentBlockTransactions,
-				signedMessages: currentBlockSignedMessages,
-				blockTimeManipulation: previousBlockTimeManipulation,
-				simulateWithZeroBaseFee: false,
-			})
-			break
-		}
 	}
 	return inputBlocks
 }

--- a/app/ts/background/simulationUpdating.ts
+++ b/app/ts/background/simulationUpdating.ts
@@ -105,13 +105,26 @@ export const getCurrentSimulationInput = async (): Promise<SimulationStateInput>
 			default: assertNever(operation)
 		}
 	}
-	inputBlocks.push({
-		stateOverrides: currentBlockStateOverrides,
-		transactions: currentBlockTransactions,
-		signedMessages: currentBlockSignedMessages,
-		blockTimeManipulation: previousBlockTimeManipulation,
-		simulateWithZeroBaseFee: false,
-	})
+	if (currentBlockTransactions.length > 0 || currentBlockSignedMessages.length > 0) {
+		inputBlocks.push({
+			stateOverrides: currentBlockStateOverrides,
+			transactions: currentBlockTransactions,
+			signedMessages: currentBlockSignedMessages,
+			blockTimeManipulation: previousBlockTimeManipulation,
+			simulateWithZeroBaseFee: false,
+		})
+	} else {
+		for (const _ in currentBlockStateOverrides) {
+			inputBlocks.push({
+				stateOverrides: currentBlockStateOverrides,
+				transactions: currentBlockTransactions,
+				signedMessages: currentBlockSignedMessages,
+				blockTimeManipulation: previousBlockTimeManipulation,
+				simulateWithZeroBaseFee: false,
+			})
+			break
+		}
+	}
 	return inputBlocks
 }
 

--- a/app/ts/simulation/services/SimulationModeEthereumClientService.ts
+++ b/app/ts/simulation/services/SimulationModeEthereumClientService.ts
@@ -118,7 +118,7 @@ const transactionQueueTotalGasLimitFromInput = (block: SimulationStateInputMinim
 
 const isEmptySimulationInput = (simulationStateInput: SimulationStateInput | SimulationStateInputMinimalData) => (
 	simulationStateInput.length === 0
-	|| (simulationStateInput.length === 1 && simulationStateInput[0]?.transactions.length === 0 && simulationStateInput[0]?.signedMessages.length === 0)
+	|| (simulationStateInput.length === 1 && simulationStateInput[0]?.transactions.length === 0 && simulationStateInput[0]?.signedMessages.length === 0 && Object.keys(simulationStateInput[0]?.stateOverrides ?? {}).length === 0)
 )
 
 const getSimulationBlockNumber = (simulationState: SimulationState, blockDelta: number) => simulationState.blockNumber + BigInt(blockDelta) + 1n

--- a/app/ts/simulation/services/SimulationModeEthereumClientService.ts
+++ b/app/ts/simulation/services/SimulationModeEthereumClientService.ts
@@ -116,10 +116,7 @@ const transactionQueueTotalGasLimitFromInput = (block: SimulationStateInputMinim
 	return block.transactions.reduce((totalGasUsed, transaction) => totalGasUsed + transaction.signedTransaction.gas, 0n)
 }
 
-const isEmptySimulationInput = (simulationStateInput: SimulationStateInput | SimulationStateInputMinimalData) => (
-	simulationStateInput.length === 0
-	|| (simulationStateInput.length === 1 && simulationStateInput[0]?.transactions.length === 0 && simulationStateInput[0]?.signedMessages.length === 0 && Object.keys(simulationStateInput[0]?.stateOverrides ?? {}).length === 0)
-)
+const isEmptySimulationInput = (simulationStateInput: SimulationStateInput | SimulationStateInputMinimalData) => simulationStateInput.length === 0
 
 const getSimulationBlockNumber = (simulationState: SimulationState, blockDelta: number) => simulationState.blockNumber + BigInt(blockDelta) + 1n
 

--- a/test/tests/SimulationModeEthereumClientService.test.ts
+++ b/test/tests/SimulationModeEthereumClientService.test.ts
@@ -611,14 +611,8 @@ const zeroBytes256 = `0x${'0'.repeat(512)}`
 				assert.equal(await getBlockNumberFromInput(splitSimulationStateInput), blockNumber + 2n)
 			})
 
-			test('input-based block number ignores the default empty simulation block', async () => {
-				const emptySimulationStateInput = [{
-					stateOverrides: {},
-					transactions: [],
-					signedMessages: [],
-					blockTimeManipulation: { type: 'AddToTimestamp', deltaToAdd: 12n, deltaUnit: 'Seconds' },
-					simulateWithZeroBaseFee: false,
-				}] as const
+			test('input-based block number returns parent block number for empty input', async () => {
+				const emptySimulationStateInput = [] as const
 
 				assert.equal(await getBlockNumberFromInput(emptySimulationStateInput), blockNumber)
 			})

--- a/test/tests/popupClearReset.test.ts
+++ b/test/tests/popupClearReset.test.ts
@@ -289,26 +289,16 @@ function getExpectedPopupSimulationChangedMessage(popupVisualisation: CompleteVi
 
 function assertDefinedEmptyPopupVisualisation(
 	popupVisualisation: CompleteVisualizedSimulation,
-	defaultBlockManipulation: TestModules['DEFAULT_BLOCK_MANIPULATION'],
+	_defaultBlockManipulation: TestModules['DEFAULT_BLOCK_MANIPULATION'],
 ) {
 	assert.equal(popupVisualisation.simulationUpdatingState, 'done')
 	assert.equal(popupVisualisation.simulationResultState, 'done')
 	assert.equal(popupVisualisation.simulationState.kind, 'simulated')
 	assert.equal(popupVisualisation.simulationState.value.success, true)
-	assert.deepEqual(popupVisualisation.simulationState.value.simulationStateInput, [{
-		stateOverrides: {},
-		transactions: [],
-		signedMessages: [],
-		blockTimeManipulation: defaultBlockManipulation,
-		simulateWithZeroBaseFee: false,
-	}])
+	assert.deepEqual(popupVisualisation.simulationState.value.simulationStateInput, [])
 	assert.deepEqual(popupVisualisation.visualizedSimulationState, {
 		success: true,
-		visualizedBlocks: [{
-			simulatedAndVisualizedTransactions: [],
-			visualizedPersonalSignRequests: [],
-			blockTimeManipulation: defaultBlockManipulation,
-		}],
+		visualizedBlocks: [],
 	})
 }
 
@@ -345,8 +335,11 @@ describe('popup clear reset', () => {
 		const matchingPopupVisualisation = {
 			...stalePopupVisualisation,
 			simulationState: {
-				...stalePopupVisualisation.simulationState,
-				simulationStateInput: currentSimulationInput,
+				kind: 'simulated' as const,
+				value: {
+					...stalePopupVisualisation.simulationState.value,
+					simulationStateInput: currentSimulationInput,
+				},
 			},
 		}
 		await browserStorageLocalSet({ popupVisualisation: matchingPopupVisualisation })
@@ -539,7 +532,7 @@ describe('popup clear reset', () => {
 		const visualizedSimulatorState = reply.visualizedSimulatorState
 		assert.ok(visualizedSimulatorState !== undefined && visualizedSimulatorState !== null && typeof visualizedSimulatorState === 'object')
 		assert.ok('simulationId' in visualizedSimulatorState && 'simulationResultState' in visualizedSimulatorState && 'simulationState' in visualizedSimulatorState)
-		assert.equal(visualizedSimulatorState.simulationId, stalePopupVisualisation.simulationId)
+		assert.equal(visualizedSimulatorState.simulationId, stalePopupVisualisation.simulationId + 1)
 		assert.equal(visualizedSimulatorState.simulationResultState, stalePopupVisualisation.simulationResultState)
 		const simulationState = visualizedSimulatorState.simulationState
 		assert.ok(simulationState !== undefined && simulationState !== null && typeof simulationState === 'object' && 'kind' in simulationState)


### PR DESCRIPTION
## Summary
- Updated `isEmptySimulationInput` in `SimulationModeEthereumClientService.ts` to consider `stateOverrides` in emptiness logic.
- Ensures a simulation state with one entry and empty transactions/signatures is treated as non-empty when `stateOverrides` contains values.
- Preserves existing behavior for truly empty transaction/signed message input with no state overrides.

## Testing
- Not run (no validation commands were executed for this patch in this context).