### PR TITLE
Remove @zoltu/file-copier dependency, replace with native Node.js implementation

### DIFF
--- a/build/bun.lock
+++ b/build/bun.lock
@@ -5,15 +5,12 @@
     "": {
       "devDependencies": {
         "@types/node": "20.11.17",
-        "@zoltu/file-copier": "3.0.0",
         "typescript": "5.4.5",
       },
     },
   },
   "packages": {
     "@types/node": ["@types/node@20.11.17", "", { "dependencies": { "undici-types": "~5.26.4" } }, "sha512-QmgQZGWu1Yw9TDyAP9ZzpFJKynYNeOvwMJmaxABfieQoVoiVOS6MN1WSpqpRcbeA5+RW82kraAVxCCJg+780Qw=="],
-
-    "@zoltu/file-copier": ["@zoltu/file-copier@3.0.0", "", {}, "sha512-foCy+pdL3sHBL0yrv8KCYcHnidii4kbE1xS52xXevyHFBAhRZKeX9qcCfRLIDDeHSYKB94vDeastE7fo3lwQFw=="],
 
     "typescript": ["typescript@5.4.5", "", { "bin": { "tsc": "bin/tsc", "tsserver": "bin/tsserver" } }, "sha512-vcI4UpRgg81oIRUFwR0WSIHKt11nJ7SAVlYNIu+QpqeyXP+gpQJy/Z4+F0aGxSE4MqwjyXvW/TzgkLAx2AGHwQ=="],
 

--- a/build/package.json
+++ b/build/package.json
@@ -4,7 +4,6 @@
 	"packageManager": "bun@1.3.13",
 	"devDependencies": {
 		"@types/node": "20.11.17",
-		"@zoltu/file-copier": "3.0.0",
 		"typescript": "5.4.5"
 	},
 	"scripts": {

--- a/build/vendor.mts
+++ b/build/vendor.mts
@@ -174,20 +174,20 @@ const vendoredPackageRoots = [...new Set([
 	...extraPackageRoots,
 ])]
 
-async function recursiveDirectoryCopy(source: string, destination: string, include: (path: string, fileType: 'directory' | 'file') => Promise<boolean>, transform: (sourcePath: string, destinationPath: string) => Promise<void>) {
+async function recursiveDirectoryCopy(source: string, destination: string, include?: (path: string, fileType: 'directory' | 'file') => Promise<boolean>, transform?: (sourcePath: string, destinationPath: string) => Promise<void>) {
 	const entries = await fs.readdir(source, { withFileTypes: true })
 	await fs.mkdir(destination, { recursive: true })
 	for (const entry of entries) {
 		const sourcePath = path.join(source, entry.name)
 		const destinationPath = path.join(destination, entry.name)
 		if (entry.isDirectory()) {
-			if (!await include(sourcePath, 'directory')) continue
+			if (include && !await include(sourcePath, 'directory')) continue
 			await recursiveDirectoryCopy(sourcePath, destinationPath, include, transform)
 		} else {
-			if (!await include(sourcePath, 'file')) continue
+			if (include && !await include(sourcePath, 'file')) continue
 			await fs.copyFile(sourcePath, destinationPath)
 		}
-		await transform(sourcePath, destinationPath)
+		await transform?.(sourcePath, destinationPath)
 	}
 }
 

--- a/build/vendor.mts
+++ b/build/vendor.mts
@@ -1,7 +1,6 @@
 import * as path from 'node:path'
 import * as url from 'node:url'
 import { promises as fs } from 'node:fs'
-import { type FileType, recursiveDirectoryCopy } from '@zoltu/file-copier'
 
 const directoryOfThisFile = path.dirname(url.fileURLToPath(import.meta.url))
 const nodeModulesDirectory = path.join(directoryOfThisFile, '..', 'node_modules')
@@ -175,12 +174,29 @@ const vendoredPackageRoots = [...new Set([
 	...extraPackageRoots,
 ])]
 
+async function recursiveDirectoryCopy(source: string, destination: string, include: (path: string, fileType: 'directory' | 'file') => Promise<boolean>, transform: (sourcePath: string, destinationPath: string) => Promise<void>) {
+	const entries = await fs.readdir(source, { withFileTypes: true })
+	await fs.mkdir(destination, { recursive: true })
+	for (const entry of entries) {
+		const sourcePath = path.join(source, entry.name)
+		const destinationPath = path.join(destination, entry.name)
+		if (entry.isDirectory()) {
+			if (!await include(sourcePath, 'directory')) continue
+			await recursiveDirectoryCopy(sourcePath, destinationPath, include, transform)
+		} else {
+			if (!await include(sourcePath, 'file')) continue
+			await fs.copyFile(sourcePath, destinationPath)
+		}
+		await transform(sourcePath, destinationPath)
+	}
+}
+
 async function vendorDependencies() {
 	await fs.rm(path.join(directoryOfThisFile, '..', 'app', 'vendor'), { recursive: true, force: true })
 	for (const packageRoot of vendoredPackageRoots) {
 		const sourceDirectoryPath = path.join(nodeModulesDirectory, packageRoot)
 		const destinationDirectoryPath = path.join(directoryOfThisFile, '..', 'app', 'vendor', packageRoot)
-		async function inclusionPredicate(path: string, fileType: FileType) {
+		async function inclusionPredicate(path: string, fileType: 'directory' | 'file') {
 			if (/[.](?:spec|test|bench)[.][cm]?[jt]s$/.test(path)) return false
 			if (/(?:^|[\\/])(?:test|tests|__tests__|benchmark|benchmarks)(?:[\\/]|$)/.test(path)) return false
 			if (path.endsWith('.js')) return true


### PR DESCRIPTION
## Summary

- Removed `@zoltu/file-copier` dependency from `build/package.json`
- Replaced the single `recursiveDirectoryCopy` usage in `build/vendor.mts` with a native implementation using Node.js built-in `fs` and `path` APIs (`fs.readdir`, `fs.mkdir`, `fs.copyFile`)
- Updated lockfiles accordingly

`@zoltu/file-copier` was used in exactly one place for a recursive directory copy with filtering and source-map rewriting. Node.js 16.7+ provides `fs.cp` and the project already imports `node:fs` and `node:path`, making the external dependency unnecessary.

## Testing

- `bun run lint` — clean
- `bun test` — 262 pass, 0 fail
- `bun run vendor` — completes successfully