### PR TITLE
Improve delegated execution visualization and confirm popup bootstrap

### DIFF
--- a/app/css/interceptor.css
+++ b/app/css/interceptor.css
@@ -836,6 +836,177 @@ svg.spinner > circle {
 	color: var(--text-color)
 }
 
+.delegation-flow-banner {
+	display: grid;
+	gap: 10px;
+	margin-bottom: 10px;
+	padding: 10px 12px;
+	border-radius: 12px;
+	background-color: var(--alpha-005);
+	border: 1px solid var(--alpha-015);
+	min-width: 0;
+}
+
+.delegation-flow-header {
+	display: flex;
+	align-items: center;
+	gap: 8px;
+	flex-wrap: wrap;
+}
+
+.delegation-flow-badge {
+	background-color: var(--alpha-01);
+	color: var(--subtitle-text-color);
+	margin: 0;
+	font-size: 11px;
+	padding-inline: 0.45rem;
+}
+
+.delegation-flow-title {
+	font-size: 15px;
+	font-weight: 500;
+	margin: 0;
+}
+
+.delegation-flow-grid {
+	display: grid;
+	grid-template-columns: minmax(0, 1fr) auto minmax(0, 1fr);
+	align-items: start;
+	gap: 10px;
+}
+
+.delegation-flow-row {
+	display: grid;
+	grid-template-columns: repeat(4, max-content);
+	align-items: center;
+	column-gap: 8px;
+	row-gap: 6px;
+	width: fit-content;
+	max-width: 100%;
+	min-width: 0;
+}
+
+.delegation-flow-column {
+	display: grid;
+	gap: 6px;
+	min-width: 0;
+}
+
+.delegation-flow-label {
+	color: var(--subtitle-text-color);
+	margin: 0;
+	font-size: 12px;
+	line-height: 1.2;
+	text-align: center;
+	justify-self: center;
+}
+
+.delegation-flow-arrow {
+	display: inline-flex;
+	justify-content: center;
+	align-items: center;
+	color: var(--subtitle-text-color);
+	align-self: center;
+}
+
+.delegation-flow-targets {
+	display: inline-grid;
+	gap: 6px;
+	min-width: 0;
+	justify-items: start;
+}
+
+.delegation-flow-address-button {
+	display: inline-block;
+	width: fit-content;
+	max-width: 100%;
+	padding: 0;
+	margin: 0;
+	border: 0;
+	background: none;
+	text-align: left;
+	cursor: pointer;
+}
+
+.delegation-flow-address {
+	display: grid;
+	grid-template-columns: auto minmax(0, 1fr);
+	align-items: center;
+	column-gap: 8px;
+	padding: 6px 8px;
+	border-radius: 8px;
+	background-color: var(--alpha-005);
+	min-width: 0;
+	width: fit-content;
+	max-width: 100%;
+}
+
+.delegation-flow-address-icon {
+	display: inline-flex;
+	font-size: 18px;
+	line-height: 1;
+}
+
+.delegation-flow-address-icon svg,
+.delegation-flow-address-icon img {
+	display: block;
+	width: 18px;
+	height: 18px;
+}
+
+.delegation-flow-address-text {
+	display: grid;
+	min-width: 0;
+}
+
+.delegation-flow-address-primary {
+	font-size: 13px;
+	line-height: 1.2;
+	color: var(--text-color);
+	white-space: nowrap;
+	overflow: hidden;
+	text-overflow: ellipsis;
+}
+
+.delegation-flow-address-secondary {
+	font-size: 11px;
+	line-height: 1.2;
+	color: var(--subtitle-text-color);
+	overflow-wrap: anywhere;
+}
+
+@media screen and (max-width: 480px) {
+	.delegation-flow-arrow {
+		justify-self: center;
+		transform: rotate(90deg);
+	}
+
+	.delegation-flow-row {
+		grid-template-columns: minmax(0, 1fr);
+		justify-items: stretch;
+		width: 100%;
+	}
+
+	.delegation-flow-targets {
+		display: grid;
+		justify-items: stretch;
+	}
+
+	.delegation-flow-label {
+		justify-self: center;
+	}
+
+	.delegation-flow-address-button,
+	.delegation-flow-address {
+		width: 100%;
+	}
+
+	.delegation-flow-address-primary {
+		white-space: normal;
+		overflow-wrap: anywhere;
+	}
+}
+
 .swap-box {
 	background-color: var(--alpha-005);
 	box-shadow: unset;

--- a/app/css/interceptor.css
+++ b/app/css/interceptor.css
@@ -876,12 +876,11 @@ svg.spinner > circle {
 }
 
 .delegation-flow-row {
-	display: grid;
-	grid-template-columns: repeat(4, max-content);
+	display: flex;
+	flex-wrap: wrap;
 	align-items: center;
-	column-gap: 8px;
-	row-gap: 6px;
-	width: fit-content;
+	gap: 6px 8px;
+	width: 100%;
 	max-width: 100%;
 	min-width: 0;
 }
@@ -898,7 +897,14 @@ svg.spinner > circle {
 	font-size: 12px;
 	line-height: 1.2;
 	text-align: center;
-	justify-self: center;
+	white-space: nowrap;
+}
+
+.delegation-flow-connector {
+	display: inline-flex;
+	align-items: center;
+	gap: 8px;
+	flex: 0 0 auto;
 }
 
 .delegation-flow-arrow {
@@ -910,15 +916,17 @@ svg.spinner > circle {
 }
 
 .delegation-flow-targets {
-	display: inline-grid;
+	display: inline-flex;
+	flex-wrap: wrap;
 	gap: 6px;
 	min-width: 0;
-	justify-items: start;
+	max-width: 100%;
 }
 
 .delegation-flow-address-button {
-	display: inline-block;
-	width: fit-content;
+	display: inline-flex;
+	flex: 0 1 auto;
+	min-width: 0;
 	max-width: 100%;
 	padding: 0;
 	margin: 0;
@@ -973,38 +981,6 @@ svg.spinner > circle {
 	line-height: 1.2;
 	color: var(--subtitle-text-color);
 	overflow-wrap: anywhere;
-}
-
-@media screen and (max-width: 480px) {
-	.delegation-flow-arrow {
-		justify-self: center;
-		transform: rotate(90deg);
-	}
-
-	.delegation-flow-row {
-		grid-template-columns: minmax(0, 1fr);
-		justify-items: stretch;
-		width: 100%;
-	}
-
-	.delegation-flow-targets {
-		display: grid;
-		justify-items: stretch;
-	}
-
-	.delegation-flow-label {
-		justify-self: center;
-	}
-
-	.delegation-flow-address-button,
-	.delegation-flow-address {
-		width: 100%;
-	}
-
-	.delegation-flow-address-primary {
-		white-space: normal;
-		overflow-wrap: anywhere;
-	}
 }
 
 .swap-box {

--- a/app/ts/background/background.ts
+++ b/app/ts/background/background.ts
@@ -587,7 +587,7 @@ export async function popupMessageHandler(
 				case 'popup_requestSimulationMode': return await requestSimulationMode()
 				case 'popup_requestLatestUnexpectedError': return await requestLatestUnexpectedError()
 				case 'popup_fetchSimulationStackRequestConfirmation': return await fetchSimulationStackRequestConfirmation(ethereum, websiteTabConnections, parsedRequest)
-				case 'popup_readyAndListening': return await popupReadyAndListening(ethereum, tokenPriceService, parsedRequest.data.page)
+				case 'popup_readyAndListening': return await popupReadyAndListening(ethereum, parsedRequest.data.page)
 				case 'popup_UnexpectedErrorOccured': return await handleUnexpectedErrorInWindow(parsedRequest)
 				case 'popup_requestInterceptorSimulationInput': return await requestInterceptorSimulationInput(ethereum)
 				case 'popup_importSimulationStack': return await importSimulationStack(ethereum, tokenPriceService, parsedRequest)

--- a/app/ts/background/popupMessageHandlers.ts
+++ b/app/ts/background/popupMessageHandlers.ts
@@ -12,7 +12,7 @@ import { findEntryWithSymbolOrName, getMetadataForAddressBookData } from './meda
 import { getActiveAddressEntry, getActiveAddresses, identifyAddress } from './metadataUtils.js'
 import type { TabState, WebsiteTabConnections } from '../types/user-interface-types.js'
 import type { EthereumClientService } from '../simulation/services/EthereumClientService.js'
-import { CompleteVisualizedSimulation, InterceptorSimulationExport, type InterceptorStackOperation, InterceptorTransactionStack, type ModifyAddressWindowState, createPassthroughCompleteVisualizedSimulation } from '../types/visualizer-types.js'
+import { CompleteVisualizedSimulation, InterceptorSimulationExport, type InterceptorStackOperation, InterceptorTransactionStack, type ModifyAddressWindowState } from '../types/visualizer-types.js'
 import { ExportedSettings } from '../types/exportedSettingsTypes.js'
 import { isJSON } from '../utils/json.js'
 import type { IncompleteAddressBookEntry } from '../types/addressBookTypes.js'
@@ -92,7 +92,7 @@ export async function getLastKnownCurrentTabId() {
 	return tabs[0].id
 }
 
-export async function popupReadyAndListening(ethereum: EthereumClientService, tokenPriceService: TokenPriceService, page: PopupReadyAndListeningPage) {
+export async function popupReadyAndListening(ethereum: EthereumClientService, _tokenPriceService: TokenPriceService, page: PopupReadyAndListeningPage) {
 	switch (page) {
 		case 'changeChain': {
 			const promise = await getChainChangeConfirmationPromise()
@@ -110,13 +110,9 @@ export async function popupReadyAndListening(ethereum: EthereumClientService, to
 			const pendingTransactions = await getPendingTransactionsAndMessages()
 			const firstPendingTransaction = pendingTransactions[0]
 			if (firstPendingTransaction === undefined) return undefined
-			const settings = await getSettings()
 			const currentBlockNumber = await ethereum.getBlockNumber(undefined)
 			const rpcConnectionStatus = await getRpcConnectionStatus()
-			const visualizedSimulatorState = settings.simulationMode
-				? await updatePopupVisualisationIfNeeded(ethereum, tokenPriceService, false, false)
-				: createPassthroughCompleteVisualizedSimulation()
-			await updateConfirmTransactionView(ethereum, tokenPriceService)
+			const visualizedSimulatorState = await getPopupVisualisationState()
 			return {
 				method: 'popup_readyAndListening' as const,
 				data: {

--- a/app/ts/background/popupMessageHandlers.ts
+++ b/app/ts/background/popupMessageHandlers.ts
@@ -92,7 +92,7 @@ export async function getLastKnownCurrentTabId() {
 	return tabs[0].id
 }
 
-export async function popupReadyAndListening(ethereum: EthereumClientService, _tokenPriceService: TokenPriceService, page: PopupReadyAndListeningPage) {
+export async function popupReadyAndListening(ethereum: EthereumClientService, page: PopupReadyAndListeningPage) {
 	switch (page) {
 		case 'changeChain': {
 			const promise = await getChainChangeConfirmationPromise()

--- a/app/ts/background/popupMessageHandlers.ts
+++ b/app/ts/background/popupMessageHandlers.ts
@@ -12,7 +12,7 @@ import { findEntryWithSymbolOrName, getMetadataForAddressBookData } from './meda
 import { getActiveAddressEntry, getActiveAddresses, identifyAddress } from './metadataUtils.js'
 import type { TabState, WebsiteTabConnections } from '../types/user-interface-types.js'
 import type { EthereumClientService } from '../simulation/services/EthereumClientService.js'
-import { CompleteVisualizedSimulation, InterceptorSimulationExport, type InterceptorStackOperation, InterceptorTransactionStack, type ModifyAddressWindowState } from '../types/visualizer-types.js'
+import { CompleteVisualizedSimulation, InterceptorSimulationExport, type InterceptorStackOperation, InterceptorTransactionStack, type ModifyAddressWindowState, createPassthroughCompleteVisualizedSimulation } from '../types/visualizer-types.js'
 import { ExportedSettings } from '../types/exportedSettingsTypes.js'
 import { isJSON } from '../utils/json.js'
 import type { IncompleteAddressBookEntry } from '../types/addressBookTypes.js'
@@ -102,6 +102,7 @@ export async function popupReadyAndListening(ethereum: EthereumClientService, to
 				method: 'popup_readyAndListening' as const,
 				data: {
 					popupOrTabId: promise.popupOrTabId,
+					confirmTransactionBootstrap: undefined,
 				},
 			}
 		}
@@ -109,11 +110,23 @@ export async function popupReadyAndListening(ethereum: EthereumClientService, to
 			const pendingTransactions = await getPendingTransactionsAndMessages()
 			const firstPendingTransaction = pendingTransactions[0]
 			if (firstPendingTransaction === undefined) return undefined
+			const settings = await getSettings()
+			const currentBlockNumber = await ethereum.getBlockNumber(undefined)
+			const rpcConnectionStatus = await getRpcConnectionStatus()
+			const visualizedSimulatorState = settings.simulationMode
+				? await updatePopupVisualisationIfNeeded(ethereum, tokenPriceService, false, false)
+				: createPassthroughCompleteVisualizedSimulation()
 			await updateConfirmTransactionView(ethereum, tokenPriceService)
 			return {
 				method: 'popup_readyAndListening' as const,
 				data: {
 					popupOrTabId: firstPendingTransaction.popupOrTabId,
+					confirmTransactionBootstrap: {
+						pendingTransactionAndSignableMessages: pendingTransactions.map(toPopupPendingTransactionOrSignableMessage),
+						currentBlockNumber,
+						rpcConnectionStatus,
+						visualizedSimulatorState,
+					},
 				},
 			}
 		}
@@ -126,6 +139,7 @@ export async function popupReadyAndListening(ethereum: EthereumClientService, to
 				method: 'popup_readyAndListening' as const,
 				data: {
 					popupOrTabId: firstPendingAccessRequest.popupOrTabId,
+					confirmTransactionBootstrap: undefined,
 				},
 			}
 		}
@@ -137,6 +151,7 @@ export async function popupReadyAndListening(ethereum: EthereumClientService, to
 				method: 'popup_readyAndListening' as const,
 				data: {
 					popupOrTabId: promise.popupOrTabId,
+					confirmTransactionBootstrap: undefined,
 				},
 			}
 		}

--- a/app/ts/background/simulationUpdating.ts
+++ b/app/ts/background/simulationUpdating.ts
@@ -141,6 +141,29 @@ export async function getMetadataForSimulation(
 	}
 }
 
+async function getDelegationAddressesForSimulation(
+	simulationStateInput: SimulationStateInput,
+	ethereum: EthereumClientService,
+	requestAbortController: AbortController | undefined,
+) {
+	const uniqueSenders = Array.from(new Set(simulationStateInput.flatMap((block) => block.transactions.map((transaction) => transaction.signedTransaction.from))))
+	const resolvedDelegations = await promiseAllMapAbortSafe(uniqueSenders, async (senderAddress) => {
+		try {
+			const delegationAddress = await ethereum.getDelegation(senderAddress, 'latest', requestAbortController)
+			if (delegationAddress === undefined) return undefined
+			return {
+				senderAddress,
+				delegationEntry: await identifyAddress(ethereum, requestAbortController, delegationAddress),
+			}
+		} catch {
+			return undefined
+		}
+	})
+	return new Map(resolvedDelegations
+		.filter((entry): entry is { senderAddress: bigint, delegationEntry: AddressBookEntry } => entry !== undefined)
+		.map((entry) => [addressString(entry.senderAddress), entry.delegationEntry] as const))
+}
+
 export const getGovernanceExecutionSimulationInput = (
 	simulationInput: SimulationStateInput,
 	executionTransaction: PreSimulationTransaction,
@@ -400,6 +423,7 @@ export async function visualizeSimulatorState(simulationState: SimulationState, 
 	}
 	const weth = await getWeth()
 	const settings = await getSettings()
+	const delegationAddressBySender = await getDelegationAddressesForSimulation(simulationState.simulationStateInput, ethereum, requestAbortController)
 
 	const parsedInputDataForEachBlockAndTransactionPromise = promiseAllMapAbortSafe(
 		simulationState.simulationStateInput, async (block) => {
@@ -433,7 +457,12 @@ export async function visualizeSimulatorState(simulationState: SimulationState, 
 						transactionStatus: 'Failed To Simulate',
 						error: { code: -1000000, message: 'Could not simulate transaction', decodedErrorMessage: 'Could not simulate transaction' },
 						parsedInputData,
-						transaction: { ...getFromAndToMetadata(transaction.signedTransaction, updatedMetadata.addressBookEntries), rpcNetwork: settings.activeRpcNetwork, ...otherFields },
+						transaction: {
+							...getFromAndToMetadata(transaction.signedTransaction, updatedMetadata.addressBookEntries),
+							...(delegationAddressBySender.get(addressString(transaction.signedTransaction.from)) !== undefined ? { delegationAddress: delegationAddressBySender.get(addressString(transaction.signedTransaction.from)) } : {}),
+							rpcNetwork: settings.activeRpcNetwork,
+							...otherFields,
+						},
 					}
 				}),
 				blockTimeManipulation: block.blockTimeManipulation,
@@ -488,7 +517,7 @@ export async function visualizeSimulatorState(simulationState: SimulationState, 
 		if (eventsForEachTransaction === undefined || parsedInputDataForBlock === undefined || protectorsForBlock === undefined) throw new Error('Block index overflow')
 		return {
 			visualizedPersonalSignRequests: await promiseAllMapAbortSafe(block.signedMessages, (signedMessage) => silenceChromeUnCaughtPromise(craftPersonalSignPopupMessage(ethereum, requestAbortController, signedMessage, settings.activeRpcNetwork))),
-			simulatedAndVisualizedTransactions: formSimulatedAndVisualizedTransactions(block.simulatedTransactions, eventsForEachTransaction, simulationState.rpcNetwork, parsedInputDataForBlock, protectorsForBlock, updatedMetadata.addressBookEntries, updatedMetadata.namedTokenIds, updatedMetadata.ens, tokenPriceEstimates, weth),
+			simulatedAndVisualizedTransactions: formSimulatedAndVisualizedTransactions(block.simulatedTransactions, eventsForEachTransaction, simulationState.rpcNetwork, parsedInputDataForBlock, protectorsForBlock, updatedMetadata.addressBookEntries, updatedMetadata.namedTokenIds, updatedMetadata.ens, tokenPriceEstimates, weth, delegationAddressBySender),
 			blockTimeManipulation: block.blockTimeManipulation,
 		}
 	})

--- a/app/ts/background/simulationUpdating.ts
+++ b/app/ts/background/simulationUpdating.ts
@@ -19,7 +19,7 @@ import { CompoundGovernanceAbi } from '../utils/abi.js'
 import type { VisualizedPersonalSignRequestSafeTx } from '../types/personal-message-definitions.js'
 import { getGnosisSafeProxyProxy } from '../utils/ethereumByteCodes.js'
 import { getInterceptorTransactionStack, updatePopupVisualisationWithCallBack } from './storageVariables.js'
-import { JsonRpcResponseError, handleUnexpectedError, isFailedToFetchError, isNewBlockAbort } from '../utils/errors.js'
+import { JsonRpcResponseError, handleUnexpectedError, isFailedToFetchError, isNewBlockAbort, printError } from '../utils/errors.js'
 import { craftPersonalSignPopupMessage } from './windows/personalSign.js'
 import { formSimulatedAndVisualizedTransactions, getFromAndToMetadata } from '../components/formVisualizerResults.js'
 import { promiseAllMapAbortSafe, silenceChromeUnCaughtPromise } from '../utils/requests.js'
@@ -155,7 +155,9 @@ async function getDelegationAddressesForSimulation(
 				senderAddress,
 				delegationEntry: await identifyAddress(ethereum, requestAbortController, delegationAddress),
 			}
-		} catch {
+		} catch(error: unknown) {
+			console.warn(`Failed to retrieve EIP-7702 delegation for ${ addressString(senderAddress) }`)
+			printError(error)
 			return undefined
 		}
 	})

--- a/app/ts/background/simulationUpdating.ts
+++ b/app/ts/background/simulationUpdating.ts
@@ -19,7 +19,7 @@ import { CompoundGovernanceAbi } from '../utils/abi.js'
 import type { VisualizedPersonalSignRequestSafeTx } from '../types/personal-message-definitions.js'
 import { getGnosisSafeProxyProxy } from '../utils/ethereumByteCodes.js'
 import { getInterceptorTransactionStack, updatePopupVisualisationWithCallBack } from './storageVariables.js'
-import { JsonRpcResponseError, handleUnexpectedError, isFailedToFetchError, isNewBlockAbort, printError } from '../utils/errors.js'
+import { JsonRpcResponseError, handleUnexpectedError, isFailedToFetchError, isNewBlockAbort } from '../utils/errors.js'
 import { craftPersonalSignPopupMessage } from './windows/personalSign.js'
 import { formSimulatedAndVisualizedTransactions, getFromAndToMetadata } from '../components/formVisualizerResults.js'
 import { promiseAllMapAbortSafe, silenceChromeUnCaughtPromise } from '../utils/requests.js'
@@ -156,8 +156,10 @@ async function getDelegationAddressesForSimulation(
 				delegationEntry: await identifyAddress(ethereum, requestAbortController, delegationAddress),
 			}
 		} catch(error: unknown) {
-			console.warn(`Failed to retrieve EIP-7702 delegation for ${ addressString(senderAddress) }`)
-			printError(error)
+			const errorMessage = error instanceof Error ? error.message : 'Unknown error'
+			await handleUnexpectedError(new Error(`Failed to retrieve EIP-7702 delegation for ${ addressString(senderAddress) }: ${ errorMessage }`), {
+				code: 'delegation_lookup_failed',
+			})
 			return undefined
 		}
 	})

--- a/app/ts/components/formVisualizerResults.ts
+++ b/app/ts/components/formVisualizerResults.ts
@@ -80,7 +80,7 @@ export const getFromAndToMetadata = (transaction: { from: bigint, to: bigint | n
 	return { from: enrichedFrom, to: enrichedTo }
 }
 
-export function formSimulatedAndVisualizedTransactions(simulatedTransactions: readonly SimulatedTransaction[], eventsForEachTransaction: readonly EnrichedEthereumEvents[], rpcNetwork: RpcNetwork, parsedInputData: readonly EnrichedEthereumInputData[], protectorResults: readonly ProtectorResults[], addressBookEntries: readonly AddressBookEntry[], namedTokenIds: readonly NamedTokenId[], ens: { ensNameHashes: MaybeENSNameHashes, ensLabelHashes: MaybeENSLabelHashes }, tokenPriceEstimates: readonly TokenPriceEstimate[], tokenPriceQuoteToken: Erc20TokenEntry | undefined): readonly SimulatedAndVisualizedTransaction[] {
+export function formSimulatedAndVisualizedTransactions(simulatedTransactions: readonly SimulatedTransaction[], eventsForEachTransaction: readonly EnrichedEthereumEvents[], rpcNetwork: RpcNetwork, parsedInputData: readonly EnrichedEthereumInputData[], protectorResults: readonly ProtectorResults[], addressBookEntries: readonly AddressBookEntry[], namedTokenIds: readonly NamedTokenId[], ens: { ensNameHashes: MaybeENSNameHashes, ensLabelHashes: MaybeENSLabelHashes }, tokenPriceEstimates: readonly TokenPriceEstimate[], tokenPriceQuoteToken: Erc20TokenEntry | undefined, delegationAddressBySender: ReadonlyMap<string, AddressBookEntry | undefined>): readonly SimulatedAndVisualizedTransaction[] {
 	const addressMetaData = new Map(addressBookEntries.map((x) => [addressString(x.address), x]))
 	return simulatedTransactions.map((simulatedTx, index) => {
 		const transactionEvents = eventsForEachTransaction[index]
@@ -132,8 +132,9 @@ export function formSimulatedAndVisualizedTransactions(simulatedTransactions: re
 			.map((entry) => 'abi' in entry && entry.abi !== undefined && entry.abi !== '' ? entry.abi : undefined)
 			.filter((abiOrUndefined): abiOrUndefined is string => abiOrUndefined !== undefined)
 		const toFrom = getFromAndToMetadata(simulatedTx.preSimulationTransaction.signedTransaction, addressBookEntries)
+		const delegationAddress = delegationAddressBySender.get(addressString(simulatedTx.preSimulationTransaction.signedTransaction.from))
 		return {
-			transaction: { ...toFrom, rpcNetwork, ...otherFields },
+			transaction: { ...toFrom, ...(delegationAddress !== undefined ? { delegationAddress } : {}), rpcNetwork, ...otherFields },
 			...(toFrom.to !== undefined ? { to: toFrom.to } : {}),
 			realizedGasPrice: simulatedTx.realizedGasPrice,
 			events: modifiedTransactionEvents,

--- a/app/ts/components/pages/ConfirmTransaction.tsx
+++ b/app/ts/components/pages/ConfirmTransaction.tsx
@@ -43,6 +43,11 @@ type UnderTransactionsParams = {
 
 export const CONFIRM_TRANSACTION_BOOTSTRAP_RETRY_DELAY_MS = 150
 export const CONFIRM_TRANSACTION_BOOTSTRAP_MAX_ATTEMPTS = 10
+const CONFIRM_TRANSACTION_DATA_PRIORITY = {
+	storage: 1,
+	bootstrap: 2,
+	push: 3,
+} as const
 
 const waitForDelay = async (delayMs: number) => await new Promise((resolve) => globalThis.setTimeout(resolve, delayMs))
 
@@ -555,11 +560,40 @@ export function ConfirmTransaction() {
 	const pendingTransactionAddedNotification = useSignal<boolean>(false)
 	const unexpectedError = useSignal<CaughtError | undefined>(undefined)
 	const rpcEntries = useSignal<RpcEntries>([])
+	const pendingTransactionsDataPriority = useSignal(0)
+	const simulationDataPriority = useSignal(0)
+	const networkDataPriority = useSignal(0)
+
+	const applyPendingTransactions = (pendingTransactions: readonly PendingTransactionOrSignableMessage[], priority: number) => {
+		if (priority < pendingTransactionsDataPriority.value) return
+		pendingTransactionsDataPriority.value = priority
+		pendingTransactionsAndSignableMessages.value = pendingTransactions
+		const firstMessage = pendingTransactions[0]
+		if (firstMessage === undefined) return
+		currentPendingTransactionOrSignableMessage.value = firstMessage
+		if (firstMessage.type === 'Transaction' && firstMessage.transactionOrMessageCreationStatus === 'Simulating') {
+			markPerformanceOnce(POPUP_PERFORMANCE_MARKS.confirmTransactionSimulationStarted)
+		}
+		if (firstMessage.type === 'Transaction' && (firstMessage.transactionOrMessageCreationStatus === 'Simulated' || firstMessage.transactionOrMessageCreationStatus === 'FailedToSimulate')) {
+			markPerformance(POPUP_PERFORMANCE_MARKS.confirmTransactionSimulationReady)
+		}
+		if (firstMessage.type === 'Transaction' && (firstMessage.transactionOrMessageCreationStatus === 'Simulated' || firstMessage.transactionOrMessageCreationStatus === 'FailedToSimulate') && firstMessage.popupVisualisation !== undefined && firstMessage.popupVisualisation.statusCode === 'success' && (currentBlockNumber.value === undefined || firstMessage.popupVisualisation.data.simulationState.blockNumber > currentBlockNumber.value)) {
+			currentBlockNumber.value = firstMessage.popupVisualisation.data.simulationState.blockNumber
+		}
+	}
+
+	const applyNetworkData = (blockNumber: bigint | undefined, status: RpcConnectionStatus, priority: number) => {
+		if (priority < networkDataPriority.value) return
+		networkDataPriority.value = priority
+		currentBlockNumber.value = blockNumber
+		rpcConnectionStatus.value = status
+	}
 
 	const updatePendingTransactionsAndSignableMessages = (message: UpdateConfirmTransactionDialog) => {
+		if (CONFIRM_TRANSACTION_DATA_PRIORITY.push < simulationDataPriority.value) return
+		simulationDataPriority.value = CONFIRM_TRANSACTION_DATA_PRIORITY.push
 		completeVisualizedSimulation.value = message.data.visualizedSimulatorState
-		currentBlockNumber.value = message.data.currentBlockNumber
-		rpcConnectionStatus.value = message.data.rpcConnectionStatus
+		applyNetworkData(message.data.currentBlockNumber, message.data.rpcConnectionStatus, CONFIRM_TRANSACTION_DATA_PRIORITY.push)
 	}
 	useEffect(() => {
 		function popupMessageListener(msg: unknown): false {
@@ -584,13 +618,12 @@ export function ConfirmTransaction() {
 				return false
 			}
 			if (parsed.method === 'popup_new_block_arrived') {
-				rpcConnectionStatus.value = parsed.data.rpcConnectionStatus
+				applyNetworkData(parsed.data.rpcConnectionStatus?.latestBlock?.number, parsed.data.rpcConnectionStatus, CONFIRM_TRANSACTION_DATA_PRIORITY.push)
 				refreshPopupVisualisationIfNeeded()
-				currentBlockNumber.value = parsed.data.rpcConnectionStatus?.latestBlock?.number
 				return false
 			}
 			if (parsed.method === 'popup_failed_to_get_block') {
-				rpcConnectionStatus.value = parsed.data.rpcConnectionStatus
+				applyNetworkData(parsed.data.rpcConnectionStatus?.latestBlock?.number, parsed.data.rpcConnectionStatus, CONFIRM_TRANSACTION_DATA_PRIORITY.push)
 				return false
 			}
 			if (parsed.method === 'popup_confirm_transaction_simulation_started') {
@@ -605,20 +638,10 @@ export function ConfirmTransaction() {
 			if (parsed.method === 'popup_update_confirm_transaction_dialog_pending_transactions') {
 				const { role: _role, ...popupUpdateConfirmTransactionDialogPendingTransactions } = parsed
 				const updateConfirmTransactionDialogPendingTransactions = UpdateConfirmTransactionDialogPendingTransactions.parse(popupUpdateConfirmTransactionDialogPendingTransactions)
-				rpcConnectionStatus.value = updateConfirmTransactionDialogPendingTransactions.data.rpcConnectionStatus
-				pendingTransactionsAndSignableMessages.value = updateConfirmTransactionDialogPendingTransactions.data.pendingTransactionAndSignableMessages
+				applyNetworkData(updateConfirmTransactionDialogPendingTransactions.data.currentBlockNumber, updateConfirmTransactionDialogPendingTransactions.data.rpcConnectionStatus, CONFIRM_TRANSACTION_DATA_PRIORITY.push)
 				const firstMessage = updateConfirmTransactionDialogPendingTransactions.data.pendingTransactionAndSignableMessages[0]
 				if (firstMessage === undefined) throw new Error('message data was undefined')
-				currentPendingTransactionOrSignableMessage.value = firstMessage
-				if (firstMessage.type === 'Transaction' && firstMessage.transactionOrMessageCreationStatus === 'Simulating') {
-					markPerformanceOnce(POPUP_PERFORMANCE_MARKS.confirmTransactionSimulationStarted)
-				}
-				if (firstMessage.type === 'Transaction' && (firstMessage.transactionOrMessageCreationStatus === 'Simulated' || firstMessage.transactionOrMessageCreationStatus === 'FailedToSimulate')) {
-					markPerformance(POPUP_PERFORMANCE_MARKS.confirmTransactionSimulationReady)
-				}
-				if (firstMessage.type === 'Transaction' && (firstMessage.transactionOrMessageCreationStatus === 'Simulated' || firstMessage.transactionOrMessageCreationStatus === 'FailedToSimulate') && firstMessage.popupVisualisation !== undefined && firstMessage.popupVisualisation.statusCode === 'success' && (currentBlockNumber.value === undefined || firstMessage.popupVisualisation.data.simulationState.blockNumber > currentBlockNumber.value)) {
-					currentBlockNumber.value = firstMessage.popupVisualisation.data.simulationState.blockNumber
-				}
+				applyPendingTransactions(updateConfirmTransactionDialogPendingTransactions.data.pendingTransactionAndSignableMessages, CONFIRM_TRANSACTION_DATA_PRIORITY.push)
 			}
 			return false
 		}
@@ -630,16 +653,16 @@ export function ConfirmTransaction() {
 		let cancelled = false
 		const applyBootstrapData = (bootstrapData: ConfirmTransactionBootstrapData) => {
 			if (cancelled) return
-			pendingTransactionsAndSignableMessages.value = bootstrapData.pendingTransactionAndSignableMessages
-			currentPendingTransactionOrSignableMessage.value = bootstrapData.pendingTransactionAndSignableMessages[0]
-			completeVisualizedSimulation.value = bootstrapData.visualizedSimulatorState
-			currentBlockNumber.value = bootstrapData.currentBlockNumber
-			rpcConnectionStatus.value = bootstrapData.rpcConnectionStatus
+			applyPendingTransactions(bootstrapData.pendingTransactionAndSignableMessages, CONFIRM_TRANSACTION_DATA_PRIORITY.bootstrap)
+			if (CONFIRM_TRANSACTION_DATA_PRIORITY.bootstrap >= simulationDataPriority.value) {
+				simulationDataPriority.value = CONFIRM_TRANSACTION_DATA_PRIORITY.bootstrap
+				completeVisualizedSimulation.value = bootstrapData.visualizedSimulatorState
+			}
+			applyNetworkData(bootstrapData.currentBlockNumber, bootstrapData.rpcConnectionStatus, CONFIRM_TRANSACTION_DATA_PRIORITY.bootstrap)
 		}
 		void hydratePendingTransactionsFromStorage().then((pendingTransactions) => {
 			if (cancelled || pendingTransactions.length === 0) return
-			pendingTransactionsAndSignableMessages.value = pendingTransactions
-			currentPendingTransactionOrSignableMessage.value = pendingTransactions[0]
+			applyPendingTransactions(pendingTransactions, CONFIRM_TRANSACTION_DATA_PRIORITY.storage)
 		})
 		void sendPopupMessageWithReply({ method: 'popup_readyAndListening', data: { page: 'confirmTransaction' } }).then((reply) => {
 			if (cancelled || reply?.method !== 'popup_readyAndListening') return

--- a/app/ts/components/pages/ConfirmTransaction.tsx
+++ b/app/ts/components/pages/ConfirmTransaction.tsx
@@ -6,7 +6,7 @@ import { GasLimitEditor, RawTransactionDetailsCard, GasFee, TokenLogAnalysisCard
 import { CenterToPageTextSpinner, Spinner } from '../subcomponents/Spinner.js'
 import { AddNewAddress } from './AddNewAddress.js'
 import type { RenameAddressCallBack, RpcConnectionStatus } from '../../types/user-interface-types.js'
-import { sendPopupMessageToBackgroundPage, sendPopupMessageWithReply, sendPopupReadyAndListening } from '../../background/backgroundUtils.js'
+import { sendPopupMessageToBackgroundPage, sendPopupMessageWithReply } from '../../background/backgroundUtils.js'
 import { SignerLogoText, SignersLogoName } from '../subcomponents/signers.js'
 import { type CaughtError, ErrorCheckBox, UnexpectedError } from '../subcomponents/Error.js'
 import { QuarantineReasons, SenderReceiver, TransactionImportanceBlock } from '../simulationExplaining/Transactions.js'
@@ -46,10 +46,23 @@ export const CONFIRM_TRANSACTION_BOOTSTRAP_MAX_ATTEMPTS = 10
 
 const waitForDelay = async (delayMs: number) => await new Promise((resolve) => globalThis.setTimeout(resolve, delayMs))
 
-export async function bootstrapConfirmTransactionDialog(hasLoadedPendingTransaction: () => boolean) {
+type ConfirmTransactionBootstrapData = {
+	pendingTransactionAndSignableMessages: readonly PendingTransactionOrSignableMessage[]
+	currentBlockNumber: bigint
+	rpcConnectionStatus: RpcConnectionStatus
+	visualizedSimulatorState: CompleteVisualizedSimulation
+}
+
+export async function bootstrapConfirmTransactionDialog(
+	hasLoadedPendingTransaction: () => boolean,
+	applyBootstrapData: (bootstrapData: ConfirmTransactionBootstrapData) => void,
+) {
 	for (let attempt = 0; attempt < CONFIRM_TRANSACTION_BOOTSTRAP_MAX_ATTEMPTS; attempt++) {
 		if (hasLoadedPendingTransaction()) return
-		await sendPopupReadyAndListening('confirmTransaction')
+		const reply = await sendPopupMessageWithReply({ method: 'popup_readyAndListening', data: { page: 'confirmTransaction' } })
+		if (reply?.method === 'popup_readyAndListening' && reply.data.confirmTransactionBootstrap !== undefined) {
+			applyBootstrapData(reply.data.confirmTransactionBootstrap)
+		}
 		if (hasLoadedPendingTransaction()) return
 		await waitForDelay(CONFIRM_TRANSACTION_BOOTSTRAP_RETRY_DELAY_MS)
 	}
@@ -615,6 +628,14 @@ export function ConfirmTransaction() {
 
 	useEffect(() => {
 		let cancelled = false
+		const applyBootstrapData = (bootstrapData: ConfirmTransactionBootstrapData) => {
+			if (cancelled) return
+			pendingTransactionsAndSignableMessages.value = bootstrapData.pendingTransactionAndSignableMessages
+			currentPendingTransactionOrSignableMessage.value = bootstrapData.pendingTransactionAndSignableMessages[0]
+			completeVisualizedSimulation.value = bootstrapData.visualizedSimulatorState
+			currentBlockNumber.value = bootstrapData.currentBlockNumber
+			rpcConnectionStatus.value = bootstrapData.rpcConnectionStatus
+		}
 		void hydratePendingTransactionsFromStorage().then((pendingTransactions) => {
 			if (cancelled || pendingTransactions.length === 0) return
 			pendingTransactionsAndSignableMessages.value = pendingTransactions
@@ -624,13 +645,9 @@ export function ConfirmTransaction() {
 			if (cancelled || reply?.method !== 'popup_readyAndListening') return
 			const bootstrapData = reply.data.confirmTransactionBootstrap
 			if (bootstrapData === undefined) return
-			pendingTransactionsAndSignableMessages.value = bootstrapData.pendingTransactionAndSignableMessages
-			currentPendingTransactionOrSignableMessage.value = bootstrapData.pendingTransactionAndSignableMessages[0]
-			completeVisualizedSimulation.value = bootstrapData.visualizedSimulatorState
-			currentBlockNumber.value = bootstrapData.currentBlockNumber
-			rpcConnectionStatus.value = bootstrapData.rpcConnectionStatus
+			applyBootstrapData(bootstrapData)
 		})
-		void bootstrapConfirmTransactionDialog(() => cancelled || currentPendingTransactionOrSignableMessage.value !== undefined)
+		void bootstrapConfirmTransactionDialog(() => cancelled || currentPendingTransactionOrSignableMessage.value !== undefined, applyBootstrapData)
 		sendPopupMessageToBackgroundPage({ method: 'popup_requestSettings' })
 		return () => {
 			cancelled = true

--- a/app/ts/components/pages/ConfirmTransaction.tsx
+++ b/app/ts/components/pages/ConfirmTransaction.tsx
@@ -6,7 +6,7 @@ import { GasLimitEditor, RawTransactionDetailsCard, GasFee, TokenLogAnalysisCard
 import { CenterToPageTextSpinner, Spinner } from '../subcomponents/Spinner.js'
 import { AddNewAddress } from './AddNewAddress.js'
 import type { RenameAddressCallBack, RpcConnectionStatus } from '../../types/user-interface-types.js'
-import { sendPopupMessageToBackgroundPage, sendPopupReadyAndListening } from '../../background/backgroundUtils.js'
+import { sendPopupMessageToBackgroundPage, sendPopupMessageWithReply, sendPopupReadyAndListening } from '../../background/backgroundUtils.js'
 import { SignerLogoText, SignersLogoName } from '../subcomponents/signers.js'
 import { type CaughtError, ErrorCheckBox, UnexpectedError } from '../subcomponents/Error.js'
 import { QuarantineReasons, SenderReceiver, TransactionImportanceBlock } from '../simulationExplaining/Transactions.js'
@@ -35,9 +35,28 @@ import { POPUP_PERFORMANCE_MARKS, markPerformance, markPerformanceOnce } from '.
 import { getAddressBookEntryOrAFiller } from '../ui-utils.js'
 import type { Website } from '../../types/websiteAccessTypes.js'
 import { dataStringWith0xStart } from '../../utils/bigint.js'
+import { browserStorageLocalGet2 } from '../../utils/storageUtils.js'
 
 type UnderTransactionsParams = {
 	pendingTransactionsAndSignableMessages: ReadonlySignal<PendingTransactionOrSignableMessage[]>
+}
+
+export const CONFIRM_TRANSACTION_BOOTSTRAP_RETRY_DELAY_MS = 150
+export const CONFIRM_TRANSACTION_BOOTSTRAP_MAX_ATTEMPTS = 10
+
+const waitForDelay = async (delayMs: number) => await new Promise((resolve) => globalThis.setTimeout(resolve, delayMs))
+
+export async function bootstrapConfirmTransactionDialog(hasLoadedPendingTransaction: () => boolean) {
+	for (let attempt = 0; attempt < CONFIRM_TRANSACTION_BOOTSTRAP_MAX_ATTEMPTS; attempt++) {
+		if (hasLoadedPendingTransaction()) return
+		await sendPopupReadyAndListening('confirmTransaction')
+		if (hasLoadedPendingTransaction()) return
+		await waitForDelay(CONFIRM_TRANSACTION_BOOTSTRAP_RETRY_DELAY_MS)
+	}
+}
+
+async function hydratePendingTransactionsFromStorage() {
+	return (await browserStorageLocalGet2('pendingTransactionsAndMessages')).pendingTransactionsAndMessages ?? []
 }
 
 const getResultsForTransaction = (visualizedSimulationState: VisualizedSimulationState, transactionIdentifier: bigint) => {
@@ -595,8 +614,27 @@ export function ConfirmTransaction() {
 	}, [])
 
 	useEffect(() => {
-		void sendPopupReadyAndListening('confirmTransaction')
+		let cancelled = false
+		void hydratePendingTransactionsFromStorage().then((pendingTransactions) => {
+			if (cancelled || pendingTransactions.length === 0) return
+			pendingTransactionsAndSignableMessages.value = pendingTransactions
+			currentPendingTransactionOrSignableMessage.value = pendingTransactions[0]
+		})
+		void sendPopupMessageWithReply({ method: 'popup_readyAndListening', data: { page: 'confirmTransaction' } }).then((reply) => {
+			if (cancelled || reply?.method !== 'popup_readyAndListening') return
+			const bootstrapData = reply.data.confirmTransactionBootstrap
+			if (bootstrapData === undefined) return
+			pendingTransactionsAndSignableMessages.value = bootstrapData.pendingTransactionAndSignableMessages
+			currentPendingTransactionOrSignableMessage.value = bootstrapData.pendingTransactionAndSignableMessages[0]
+			completeVisualizedSimulation.value = bootstrapData.visualizedSimulatorState
+			currentBlockNumber.value = bootstrapData.currentBlockNumber
+			rpcConnectionStatus.value = bootstrapData.rpcConnectionStatus
+		})
+		void bootstrapConfirmTransactionDialog(() => cancelled || currentPendingTransactionOrSignableMessage.value !== undefined)
 		sendPopupMessageToBackgroundPage({ method: 'popup_requestSettings' })
+		return () => {
+			cancelled = true
+		}
 	}, [])
 
 	async function approve() {

--- a/app/ts/components/simulationExplaining/Transactions.tsx
+++ b/app/ts/components/simulationExplaining/Transactions.tsx
@@ -31,13 +31,15 @@ import { type ReadonlySignal, useComputed, useSignal } from '@preact/signals'
 import type { VisualizedPersonalSignRequest } from '../../types/personal-message-definitions.js'
 import { sendPopupMessageToBackgroundPage } from '../../background/backgroundUtils.js'
 import { useEffect } from 'preact/hooks'
+import type { ComponentChildren } from 'preact'
 import type { SignalOrValue } from '../../utils/signals.js'
 import { TransactionInput } from '../subcomponents/ParsedInputData.js'
-import { stringifyJSONWithBigInts } from '../../utils/bigint.js'
+import { checksummedAddress, stringifyJSONWithBigInts } from '../../utils/bigint.js'
 import { normalizeSimulationStackRows, type SimulationStackMessageRow, type SimulationStackTransactionRow } from './simulationStackRows.js'
 import type { OriginalSendRequestParameters } from '../../types/JsonRpc-types.js'
 import type { Website } from '../../types/websiteAccessTypes.js'
 import type { EthereumSendableSignedTransaction } from '../../types/wire-types.js'
+import { Blockie } from '../subcomponents/SVGBlockie.js'
 
 function isPositiveEvent(visResult: TokenVisualizerResultWithMetadata, ourAddressInReferenceFrame: bigint) {
 	if (visResult.type === 'ERC20') {
@@ -74,35 +76,123 @@ export type TransactionImportanceBlockParams = {
 	rpcNetwork: ReadonlySignal<RpcNetwork>
 }
 
+function DelegationFlowArrow() {
+	return <div aria-hidden = 'true' class = 'delegation-flow-arrow'>
+		<ArrowIcon color = 'var(--subtitle-text-color)' />
+	</div>
+}
+
+function CompactDelegationAddress({ addressBookEntry }: { addressBookEntry: AddressBookEntry }) {
+	const address = checksummedAddress(addressBookEntry.address)
+	const showSecondaryLine = addressBookEntry.name !== address
+	return <div class = 'delegation-flow-address' title = { address }>
+		<span class = 'delegation-flow-address-icon'>
+			<Blockie address = { addressBookEntry.address } />
+		</span>
+		<span class = 'delegation-flow-address-text'>
+			<span class = 'delegation-flow-address-primary'>{ addressBookEntry.name }</span>
+			{ showSecondaryLine ? <span class = 'delegation-flow-address-secondary'>{ address }</span> : <></> }
+		</span>
+	</div>
+}
+
+function DelegationNotice({ signer, authorizationList, addressMetadata, renameAddressCallBack }: {
+	signer: AddressBookEntry
+	authorizationList: readonly { address: bigint }[]
+	addressMetadata: ReadonlySignal<readonly AddressBookEntry[]>
+	renameAddressCallBack: RenameAddressCallBack
+}) {
+	return <div class = 'delegation-flow-banner'>
+		<div class = 'delegation-flow-header'>
+			<a
+				class = 'tag delegation-flow-badge'
+				href = 'https://eips.ethereum.org/EIPS/eip-7702'
+				target = '_blank'
+				rel = 'noreferrer'
+			>
+				7702
+			</a>
+			<p class = 'paragraph delegation-flow-title'>Delegated execution</p>
+		</div>
+		<div class = 'delegation-flow-row'>
+			<button type = 'button' class = 'delegation-flow-address-button' onClick = { () => renameAddressCallBack(signer) }>
+				<CompactDelegationAddress addressBookEntry = { signer } />
+			</button>
+			<p class = 'paragraph delegation-flow-label'>delegated to</p>
+			<DelegationFlowArrow />
+			<div class = 'delegation-flow-targets'>
+				{ authorizationList.map((authorization, index) => {
+					const entry = getAddressBookEntryOrAFiller(addressMetadata.value, authorization.address)
+					return <button type = 'button' class = 'delegation-flow-address-button' key = { `${ authorization.address.toString() }-${ index }` } onClick = { () => renameAddressCallBack(entry) }>
+						<CompactDelegationAddress addressBookEntry = { entry } />
+					</button>
+				}) }
+			</div>
+		</div>
+	</div>
+}
+
+function getDelegationNotice(
+	transaction: MaybeSimulatedTransaction['transaction'],
+	addressMetadata: ReadonlySignal<readonly AddressBookEntry[]>,
+	renameAddressCallBack: RenameAddressCallBack
+) {
+	if (transaction.type === '7702' && transaction.authorizationList.length > 0) return <DelegationNotice
+		signer = { transaction.from }
+		authorizationList = { transaction.authorizationList }
+		addressMetadata = { addressMetadata }
+		renameAddressCallBack = { renameAddressCallBack }
+	/>
+	if (transaction.delegationAddress === undefined) return undefined
+	return <DelegationNotice
+		signer = { transaction.from }
+		authorizationList = { [{ address: transaction.delegationAddress.address }] }
+		addressMetadata = { addressMetadata }
+		renameAddressCallBack = { renameAddressCallBack }
+	/>
+}
+
+function ConnectedDelegationStack({ delegationNotice, children }: { delegationNotice: ComponentChildren, children: ComponentChildren }) {
+	if (delegationNotice === undefined || delegationNotice === null) return <>{ children }</>
+	return <div style = 'display: grid; gap: 8px;'>
+		{ delegationNotice }
+		{ children }
+	</div>
+}
+
 // showcases the most important things the transaction does
 export function TransactionImportanceBlock(param: TransactionImportanceBlockParams) {
-	if (param.simTx.transactionStatus === 'Failed To Simulate') return <ErrorComponent text = { 'Failed to simulate this transaction.' } containerStyle = { { margin: '0px' } } />
-	if (param.simTx.transactionStatus === 'Transaction Failed') return <ErrorComponent text = { `The transaction fails with an error: '${ param.simTx.error.decodedErrorMessage }' ${ param.simTx.error.data !== undefined ? ` (data: '${ param.simTx.error.data }')` : '' }` } containerStyle = { { margin: '0px' } } />
-	const transactionIdentification = identifyTransaction(param.simTx)
-	switch (transactionIdentification.type) {
-		case 'SimpleTokenTransfer': return <SimpleTokenTransferVisualisation simTx = { transactionIdentification.identifiedTransaction } renameAddressCallBack = { param.renameAddressCallBack }/>
-		case 'SimpleTokenApproval': {
-			const approval = transactionIdentification.identifiedTransaction.events[0]
-			if (approval === undefined || approval.type !== 'TokenEvent') throw new Error('approval was undefined')
-			return <SimpleTokenApprovalVisualisation
-				approval = { approval.logInformation }
-				transactionGasses = { transactionIdentification.identifiedTransaction }
-				rpcNetwork = { transactionIdentification.identifiedTransaction.transaction.rpcNetwork }
-				renameAddressCallBack = { param.renameAddressCallBack }
-			/>
+	const delegationNotice = getDelegationNotice(param.simTx.transaction, param.addressMetadata, param.renameAddressCallBack)
+	const content = (() => {
+		if (param.simTx.transactionStatus === 'Failed To Simulate') return <ErrorComponent text = { 'Failed to simulate this transaction.' } containerStyle = { { margin: '0px' } } />
+		if (param.simTx.transactionStatus === 'Transaction Failed') return <ErrorComponent text = { `The transaction fails with an error: '${ param.simTx.error.decodedErrorMessage }' ${ param.simTx.error.data !== undefined ? ` (data: '${ param.simTx.error.data }')` : '' }` } containerStyle = { { margin: '0px' } } />
+		const transactionIdentification = identifyTransaction(param.simTx)
+		switch (transactionIdentification.type) {
+			case 'SimpleTokenTransfer': return <SimpleTokenTransferVisualisation simTx = { transactionIdentification.identifiedTransaction } renameAddressCallBack = { param.renameAddressCallBack }/>
+			case 'SimpleTokenApproval': {
+				const approval = transactionIdentification.identifiedTransaction.events[0]
+				if (approval === undefined || approval.type !== 'TokenEvent') throw new Error('approval was undefined')
+				return <SimpleTokenApprovalVisualisation
+					approval = { approval.logInformation }
+					transactionGasses = { transactionIdentification.identifiedTransaction }
+					rpcNetwork = { transactionIdentification.identifiedTransaction.transaction.rpcNetwork }
+					renameAddressCallBack = { param.renameAddressCallBack }
+				/>
+			}
+			case 'Swap': {
+				const identifiedSwap = identifySwap(param.simTx)
+				if (identifiedSwap === undefined) throw new Error('Not a swap!')
+				return <SwapVisualization identifiedSwap = { identifiedSwap } renameAddressCallBack = { param.renameAddressCallBack }/>
+			}
+			case 'ProxyTokenTransfer': return <ProxyTokenTransferVisualisation simTx = { transactionIdentification.identifiedTransaction } renameAddressCallBack = { param.renameAddressCallBack }/>
+			case 'ContractDeployment':
+			case 'ContractFallbackMethod':
+			case 'ArbitraryContractExecution': return <CatchAllVisualizer editEnsNamedHashCallBack = { param.editEnsNamedHashCallBack } simTx = { param.simTx } renameAddressCallBack = { param.renameAddressCallBack } addressMetadata = { param.addressMetadata } rpcNetwork = { param.rpcNetwork }/>
+			case 'GovernanceVote': return <GovernanceVoteVisualizer editEnsNamedHashCallBack = { param.editEnsNamedHashCallBack } activeAddress = { param.activeAddress } simTx = { param.simTx } governanceVoteInputParameters = { transactionIdentification.governanceVoteInputParameters } renameAddressCallBack = { param.renameAddressCallBack }/>
+			default: assertNever(transactionIdentification)
 		}
-		case 'Swap': {
-			const identifiedSwap = identifySwap(param.simTx)
-			if (identifiedSwap === undefined) throw new Error('Not a swap!')
-			return <SwapVisualization identifiedSwap = { identifiedSwap } renameAddressCallBack = { param.renameAddressCallBack }/>
-		}
-		case 'ProxyTokenTransfer': return <ProxyTokenTransferVisualisation simTx = { transactionIdentification.identifiedTransaction } renameAddressCallBack = { param.renameAddressCallBack }/>
-		case 'ContractDeployment':
-		case 'ContractFallbackMethod':
-		case 'ArbitraryContractExecution': return <CatchAllVisualizer editEnsNamedHashCallBack = { param.editEnsNamedHashCallBack } simTx = { param.simTx } renameAddressCallBack = { param.renameAddressCallBack } addressMetadata = { param.addressMetadata } rpcNetwork = { param.rpcNetwork }/>
-		case 'GovernanceVote': return <GovernanceVoteVisualizer editEnsNamedHashCallBack = { param.editEnsNamedHashCallBack } activeAddress = { param.activeAddress } simTx = { param.simTx } governanceVoteInputParameters = { transactionIdentification.governanceVoteInputParameters } renameAddressCallBack = { param.renameAddressCallBack }/>
-		default: assertNever(transactionIdentification)
-	}
+	})()
+	return <ConnectedDelegationStack delegationNotice = { delegationNotice }>{ content }</ConnectedDelegationStack>
 }
 
 export function SenderReceiver({ from, to, renameAddressCallBack }: { from: AddressBookEntry, to: AddressBookEntry | undefined, renameAddressCallBack: (entry: AddressBookEntry) => void, }) {

--- a/app/ts/components/simulationExplaining/Transactions.tsx
+++ b/app/ts/components/simulationExplaining/Transactions.tsx
@@ -118,8 +118,10 @@ function DelegationNotice({ signer, authorizationList, addressMetadata, renameAd
 			<button type = 'button' class = 'delegation-flow-address-button' onClick = { () => renameAddressCallBack(signer) }>
 				<CompactDelegationAddress addressBookEntry = { signer } />
 			</button>
-			<p class = 'paragraph delegation-flow-label'>delegated to</p>
-			<DelegationFlowArrow />
+			<div class = 'delegation-flow-connector'>
+				<p class = 'paragraph delegation-flow-label'>delegated to</p>
+				<DelegationFlowArrow />
+			</div>
 			<div class = 'delegation-flow-targets'>
 				{ authorizationList.map((authorization, index) => {
 					const entry = getAddressBookEntryOrAFiller(addressMetadata.value, authorization.address)

--- a/app/ts/components/simulationExplaining/customExplainers/ProxySendVisualisations.tsx
+++ b/app/ts/components/simulationExplaining/customExplainers/ProxySendVisualisations.tsx
@@ -1,13 +1,11 @@
 import type { RenameAddressCallBack } from '../../../types/user-interface-types.js'
 import type { SimulatedAndVisualizedProxyTokenTransferTransaction } from '../identifyTransaction.js'
 import { ETHEREUM_LOGS_LOGGER_ADDRESS } from '../../../utils/constants.js'
-import { AddressBeforeAfter, type BeforeAfterAddress, SimpleSend, getAsset } from './SimpleSendVisualisations.js'
+import { AddressBeforeAfter, type BeforeAfterAddress, ExecutionRouteNotice, SimpleSend, getAsset } from './SimpleSendVisualisations.js'
 import { GasFee, type TransactionGasses } from '../SimulationSummary.js'
 import { TokenOrEth, type TokenOrEtherParams } from '../../subcomponents/coins.js'
 import type { RpcNetwork } from '../../../types/rpc.js'
 import type { AddressBookEntry } from '../../../types/addressBookTypes.js'
-import { interleave } from '../../../utils/typed-arrays.js'
-import { SmallAddress } from '../../subcomponents/address.js'
 import { extractTokenEvents } from '../../../background/metadataUtils.js'
 
 type BeforeAfterAddressWithAmount = BeforeAfterAddress & { amount: bigint }
@@ -27,11 +25,12 @@ function ProxyMultiSend({ transaction, asset, sender, receivers, renameAddressCa
 			<p class = 'paragraph' style = 'font-size: 28px; font-weight: 500; justify-self: right;'> Send&nbsp;</p>
 			<TokenOrEth { ...asset } useFullTokenName = { false } style = { { 'font-weight': '500' } } fontSize = 'big' />
 		</span>
+		{ viaProxypath === undefined ? <></> : <ExecutionRouteNotice viaProxypath = { viaProxypath } renameAddressCallBack = { renameAddressCallBack } /> }
 		<p class = 'paragraph'> From </p>
 		<div class = 'box' style = 'background-color: var(--alpha-005); box-shadow: unset; margin-bottom: 0px;'>
 			<AddressBeforeAfter { ...sender } renameAddressCallBack = { renameAddressCallBack } tokenOrEtherDefinition = { asset } />
 		</div>
-		<p class = 'paragraph'> To </p>
+		<p class = 'paragraph'> Final recipients </p>
 		{ receivers.map((receiver) => <>
 			<span style = 'grid-template-columns: auto auto auto auto; justify-content: center; display: grid; align-items: baseline;'>
 				<p class = 'paragraph' style = 'justify-self: right;'> Receive&nbsp;</p>
@@ -44,10 +43,6 @@ function ProxyMultiSend({ transaction, asset, sender, receivers, renameAddressCa
 		<span class = 'log-table' style = { { display: 'inline-flex', marginTop: '5px' } }>
 			<GasFee tx = { transaction } rpcNetwork = { transaction.rpcNetwork } />
 		</span>
-		{ viaProxypath === undefined ? <></> : <span style = 'display: flex;'>
-			<p class = 'paragraph' style = { 'color: var(--subtitle-text-color)' }> Via proxy:&nbsp;</p>
-			<> { interleave(viaProxypath.map((addressBookEntry) => <SmallAddress key = { addressBookEntry.address.toString() } addressBookEntry = { addressBookEntry } renameAddressCallBack = { renameAddressCallBack }/>), <p class = 'paragraph' style = { 'color: var(--subtitle-text-color)' }>&nbsp;{ ','}&nbsp;</p>) } </>
-		</span> }
 	</div>
 }
 

--- a/app/ts/components/simulationExplaining/customExplainers/SimpleSendVisualisations.tsx
+++ b/app/ts/components/simulationExplaining/customExplainers/SimpleSendVisualisations.tsx
@@ -47,13 +47,34 @@ export function AddressBeforeAfter({ address, beforeAndAfter, renameAddressCallB
 type SimpleSendParams = {
 	transaction: TransactionGasses & { rpcNetwork: RpcNetwork }
 	viaProxypath?: readonly AddressBookEntry[]
+	receiverLabel?: string
 	asset: TokenOrEtherParams
 	sender: BeforeAfterAddress
 	receiver: BeforeAfterAddress
 	renameAddressCallBack: RenameAddressCallBack
 }
 
-export function SimpleSend({ transaction, asset, sender, receiver, renameAddressCallBack, viaProxypath } : SimpleSendParams) {
+export function getProxyRouteLabel(viaProxypath: readonly AddressBookEntry[]) {
+	if (viaProxypath.length <= 1) return 'via 1 address'
+	return `via ${ viaProxypath.length } addresses`
+}
+
+export function ExecutionRouteNotice({ viaProxypath, renameAddressCallBack }: { viaProxypath: readonly AddressBookEntry[], renameAddressCallBack: RenameAddressCallBack }) {
+	return <div class = 'box' style = 'background-color: var(--alpha-005); box-shadow: unset; margin-bottom: 12px;'>
+		<div style = 'display: flex; flex-wrap: wrap; align-items: center; gap: 8px; margin-bottom: 8px;'>
+			<span class = 'tag' style = 'background-color: var(--alpha-005); color: var(--subtitle-text-color);'>Routed</span>
+			<p class = 'paragraph' style = 'color: var(--subtitle-text-color); margin: 0;'>
+				{ getProxyRouteLabel(viaProxypath) }
+			</p>
+		</div>
+		<div style = 'display: flex; flex-wrap: wrap; align-items: center; gap: 6px;'>
+			<p class = 'paragraph' style = 'color: var(--subtitle-text-color); margin: 0;'>Route:</p>
+			<> { interleave(viaProxypath.map((addressBookEntry) => <SmallAddress key = { addressBookEntry.address.toString() } addressBookEntry = { addressBookEntry } renameAddressCallBack = { renameAddressCallBack }/>), <p class = 'paragraph' style = { 'color: var(--subtitle-text-color)' }>{ '->' }</p>) } </>
+		</div>
+	</div>
+}
+
+export function SimpleSend({ transaction, asset, sender, receiver, renameAddressCallBack, viaProxypath, receiverLabel } : SimpleSendParams) {
 	return <div class = 'notification transaction-importance-box'>
 		<span style = 'grid-template-columns: auto auto auto auto; justify-content: center; display: grid; align-items: baseline;'>
 			<p class = 'paragraph' style = 'font-size: 28px; font-weight: 500; justify-self: right;'> Send&nbsp;</p>
@@ -64,6 +85,7 @@ export function SimpleSend({ transaction, asset, sender, receiver, renameAddress
 				fontSize = 'big'
 			/>
 		</span>
+		{ viaProxypath === undefined ? <></> : <ExecutionRouteNotice viaProxypath = { viaProxypath } renameAddressCallBack = { renameAddressCallBack } /> }
 		<p class = 'paragraph'> From </p>
 		<div class = 'box' style = 'background-color: var(--alpha-005); box-shadow: unset; margin-bottom: 0px;'>
 			<AddressBeforeAfter
@@ -72,7 +94,7 @@ export function SimpleSend({ transaction, asset, sender, receiver, renameAddress
 				tokenOrEtherDefinition = { asset }
 			/>
 		</div>
-		<p class = 'paragraph'> To </p>
+		<p class = 'paragraph'>{ receiverLabel ?? (viaProxypath === undefined ? 'To' : 'Final recipient') } </p>
 		<div class = 'box' style = 'background-color: var(--alpha-005); box-shadow: unset; margin-bottom: 0px;'>
 			<AddressBeforeAfter
 				{ ...receiver }
@@ -83,10 +105,6 @@ export function SimpleSend({ transaction, asset, sender, receiver, renameAddress
 		<span class = 'log-table' style = { { display: 'inline-flex', marginTop: '5px' } }>
 			<GasFee tx = { transaction } rpcNetwork = { transaction.rpcNetwork } />
 		</span>
-		{ viaProxypath === undefined ? <></> : <div style = 'display: flex;'>
-			<p class = 'paragraph' style = { 'color: var(--subtitle-text-color)' }> Via proxy:&nbsp;</p>
-			<> { interleave(viaProxypath.map((addressBookEntry) => <SmallAddress key = { addressBookEntry.address.toString() } addressBookEntry = { addressBookEntry } renameAddressCallBack = { renameAddressCallBack }/>), <p class = 'paragraph' style = { 'color: var(--subtitle-text-color)' }>&nbsp;{ '-> '}&nbsp;</p>) } </>
-		</div> }
 	</div>
 }
 
@@ -109,10 +127,16 @@ export function SimpleTokenTransferVisualisation({ simTx, renameAddressCallBack 
 	const receiverAfter = simTx.tokenBalancesAfter.find((change) => change.owner === transfer.to.address && change.token === asset.tokenEntry.address && change.tokenId === asset.tokenId)?.balance
 	const senderGasFees = (asset.tokenEntry.address === ETHEREUM_LOGS_LOGGER_ADDRESS && asset.tokenEntry.type === 'ERC20' && transfer.from.address === simTx.transaction.from.address ? simTx.gasSpent * simTx.realizedGasPrice : 0n)
 	const receiverGasFees = (asset.tokenEntry.address === ETHEREUM_LOGS_LOGGER_ADDRESS && asset.tokenEntry.type === 'ERC20' && transfer.to.address === simTx.transaction.from.address ? simTx.gasSpent * simTx.realizedGasPrice : 0n)
+	const isDelegatedExecution = simTx.transaction.type === '7702' && simTx.transaction.authorizationList.length > 0 || simTx.transaction.delegationAddress !== undefined
+	const isDelegatedSelfCallSendingElsewhere = isDelegatedExecution
+		&& simTx.transaction.to !== undefined
+		&& simTx.transaction.to.address === simTx.transaction.from.address
+		&& transfer.to.address !== simTx.transaction.to.address
 
 	return <SimpleSend
 		transaction = { { ...simTx, rpcNetwork: simTx.transaction.rpcNetwork } }
 		asset = { { ...asset, useFullTokenName: false, fontSize: 'normal' } }
+		receiverLabel = { isDelegatedSelfCallSendingElsewhere ? 'Funds sent to' : undefined }
 		sender = { {
 			address: transfer.from,
 			beforeAndAfter : senderAfter === undefined || !('amount' in asset) ? undefined : { before: senderAfter + asset.amount + senderGasFees, after: senderAfter },

--- a/app/ts/simulation/services/EthereumClientService.ts
+++ b/app/ts/simulation/services/EthereumClientService.ts
@@ -3,7 +3,7 @@ import type { IUnsignedTransaction1559 } from '../../utils/ethereum.js'
 import { MAX_BLOCK_CACHE, TIME_BETWEEN_BLOCKS } from '../../utils/constants.js'
 import { keccak256 } from '../../utils/viem.js'
 import type { IEthereumJSONRpcRequestHandler } from './EthereumJSONRpcRequestHandler.js'
-import { addressString, bigintSecondsToDate, bytes32String, dateToBigintSeconds, max } from '../../utils/bigint.js'
+import { addressString, bigintSecondsToDate, bytes32String, dataString, dateToBigintSeconds, max } from '../../utils/bigint.js'
 import { type BlockCalls, type BlockOverrides, EthSimulateV1Result, type EthSimulateV1Params } from '../../types/ethSimulate-types.js'
 import { EthGetStorageAtResponse, EthTransactionReceiptResponse, type EthGetLogsRequest, EthGetLogsResponse, type PartialEthereumTransaction } from '../../types/JsonRpc-types.js'
 import { DEFAULT_BLOCK_MANIPULATION, getBlockTimeManipulationSeconds, simulatePersonalSign } from './SimulationModeEthereumClientService.js'
@@ -149,6 +149,12 @@ export class EthereumClientService {
 	public readonly getCode = async (address: bigint, blockTag: EthereumBlockTag, requestAbortController: AbortController | undefined) => {
 		const response = await this.requestHandler.jsonRpcRequest({ method: 'eth_getCode', params: [address, blockTag] }, requestAbortController)
 		return EthereumData.parse(response)
+	}
+
+	public readonly getDelegation = async (address: bigint, blockTag: EthereumBlockTag, requestAbortController: AbortController | undefined) => {
+		const code = await this.getCode(address, blockTag, requestAbortController)
+		if (code.length !== 23 || code[0] !== 0xef || code[1] !== 0x01 || code[2] !== 0x00) return undefined
+		return BigInt(`0x${ dataString(code.slice(3)) }`)
 	}
 
 	public async getBlock(requestAbortController: AbortController | undefined, blockTag?: EthereumBlockTag, fullObjects?: true): Promise<EthereumBlockHeader>

--- a/app/ts/types/interceptor-reply-messages.ts
+++ b/app/ts/types/interceptor-reply-messages.ts
@@ -4,6 +4,8 @@ import { AddressBookEntry, ChainIdWithUniversal } from '../types/addressBookType
 import { PopupOrTabId } from './websiteAccessTypes.js'
 import { CompleteVisualizedSimulation, InterceptorSimulationExport, NamedTokenId } from './visualizer-types.js'
 import { EthereumAddress, EthereumQuantity, EthereumTimestamp } from './wire-types.js'
+import { PopupPendingTransactionOrSignableMessage } from './accessRequest.js'
+import { RpcConnectionStatus } from './user-interface-types.js'
 
 export type UnexpectedErrorOccured = funtypes.Static<typeof UnexpectedErrorOccured>
 export const UnexpectedErrorOccured = funtypes.ReadonlyObject({
@@ -136,15 +138,39 @@ const RequestIsMainWindowOpen = funtypes.ReadonlyObject({
 	})
 }).asReadonly()
 
+type ConfirmTransactionBootstrapReply = funtypes.Static<typeof ConfirmTransactionBootstrapReply>
+const ConfirmTransactionBootstrapReply = funtypes.ReadonlyObject({
+	pendingTransactionAndSignableMessages: funtypes.ReadonlyArray(PopupPendingTransactionOrSignableMessage),
+	currentBlockNumber: EthereumQuantity,
+	rpcConnectionStatus: funtypes.Union(RpcConnectionStatus, funtypes.Undefined),
+	visualizedSimulatorState: CompleteVisualizedSimulation,
+}).asReadonly()
+
 type PopupReadyAndListeningReply = funtypes.Static<typeof PopupReadyAndListeningReply>
 const PopupReadyAndListeningReply = funtypes.ReadonlyObject({
 	method: funtypes.Literal('popup_readyAndListening'),
 	data: funtypes.ReadonlyObject({
 		popupOrTabId: PopupOrTabId,
+		confirmTransactionBootstrap: funtypes.Union(ConfirmTransactionBootstrapReply, funtypes.Undefined),
 	}),
 }).asReadonly()
 
-export const PopupRequestsReplies = {
+type PopupRequestsRepliesMap = {
+	popup_requestMakeMeRichData: typeof RequestMakeMeRichDataReply
+	popup_requestActiveAddresses: typeof RequestActiveAddressesReply
+	popup_requestSimulationMode: typeof RequestSimulationModeReply
+	popup_requestLatestUnexpectedError: typeof RequestLatestUnexpectedErrorReply
+	popup_requestInterceptorSimulationInput: typeof RequestInterceptorSimulationInputReply
+	popup_importSimulationStack: typeof ImportSimulationStackReply
+	popup_requestCompleteVisualizedSimulation: typeof RequestCompleteVisualizedSimulationReply
+	popup_requestSimulationMetadata: typeof RequestSimulationMetadataReply
+	popup_requestAbiAndNameFromBlockExplorer: typeof RequestAbiAndNameFromBlockExplorerReply
+	popup_requestIdentifyAddress: typeof RequestIdentifyAddressReply
+	popup_isMainPopupWindowOpen: typeof RequestIsMainWindowOpen
+	popup_readyAndListening: typeof PopupReadyAndListeningReply
+}
+
+export const PopupRequestsReplies: PopupRequestsRepliesMap = {
 	popup_requestMakeMeRichData: RequestMakeMeRichDataReply,
 	popup_requestActiveAddresses: RequestActiveAddressesReply,
 	popup_requestSimulationMode: RequestSimulationModeReply,
@@ -197,8 +223,22 @@ export const PopupMessageReplyRequests = funtypes.Union(
 export type PopupRequests = funtypes.Static<typeof PopupMessageReplyRequests>
 export type PopupRequestsReplyReturn<Request extends PopupRequests> = Request['method'] extends keyof typeof PopupRequestsReplies ? funtypes.Static<(typeof PopupRequestsReplies)[Request['method']]> : undefined
 
-export type PopupReplyOption = funtypes.Static<typeof PopupReplyOption>
-export const PopupReplyOption = funtypes.Union(
+export type PopupReplyOption =
+	| RequestMakeMeRichDataReply
+	| RequestActiveAddressesReply
+	| RequestSimulationModeReply
+	| RequestLatestUnexpectedErrorReply
+	| RequestInterceptorSimulationInputReply
+	| ImportSimulationStackReply
+	| RequestCompleteVisualizedSimulationReply
+	| RequestSimulationMetadataReply
+	| RequestAbiAndNameFromBlockExplorerReply
+	| RequestIdentifyAddressReply
+	| RequestIsMainWindowOpen
+	| PopupReadyAndListeningReply
+	| undefined
+
+export const PopupReplyOption: funtypes.Codec<PopupReplyOption> = funtypes.Union(
 	RequestMakeMeRichDataReply,
 	RequestActiveAddressesReply,
 	RequestSimulationModeReply,

--- a/app/ts/types/visualizer-types.ts
+++ b/app/ts/types/visualizer-types.ts
@@ -286,12 +286,27 @@ export const TransactionWithAddressBookEntries = funtypes.Intersect(
 		hash: EthereumQuantity,
 		gas: EthereumQuantity,
 		nonce: EthereumQuantity,
-	}),
+	}).And(funtypes.Partial({
+		delegationAddress: AddressBookEntry,
+	})),
 	funtypes.Union(
 		funtypes.ReadonlyObject({
-			type: funtypes.Union(funtypes.Literal('1559'), funtypes.Literal('7702')),
+			type: funtypes.Literal('1559'),
 			maxFeePerGas: EthereumQuantity,
 			maxPriorityFeePerGas: EthereumQuantity,
+		}),
+		funtypes.ReadonlyObject({
+			type: funtypes.Literal('7702'),
+			maxFeePerGas: EthereumQuantity,
+			maxPriorityFeePerGas: EthereumQuantity,
+			authorizationList: funtypes.ReadonlyArray(funtypes.ReadonlyObject({
+				chainId: EthereumQuantity,
+				address: EthereumAddress,
+				nonce: EthereumQuantity,
+				r: EthereumQuantity,
+				s: EthereumQuantity,
+				yParity: funtypes.Union(funtypes.Literal('even'), funtypes.Literal('odd')),
+			})),
 		}),
 		funtypes.ReadonlyObject({
 			type: funtypes.Literal('4844'),

--- a/test/tests/confirmTransactionRenderedTimestamp.test.ts
+++ b/test/tests/confirmTransactionRenderedTimestamp.test.ts
@@ -94,6 +94,12 @@ function createBrowserMock() {
 
 createBrowserMock()
 
+async function unmountConfirmTransaction(dom: ReturnType<typeof installDomMock>) {
+	await act(() => {
+		render(null, dom.document.body)
+	})
+}
+
 function makePendingTransaction(simulationConductedTimestamp: Date) {
 	const activeAddress = 0x1111111111111111111111111111111111111111n
 	const recipientAddress = 0x2222222222222222222222222222222222222222n
@@ -206,6 +212,7 @@ describe('ConfirmTransaction', () => {
 		})
 		assert.equal(dom.document.body.textContent?.includes('Simulated 1s ago'), true)
 
+		await unmountConfirmTransaction(dom)
 		clock.restore()
 		dom.restore()
 	})
@@ -240,6 +247,7 @@ describe('ConfirmTransaction', () => {
 		assert.equal(dom.document.body.textContent?.includes('Gas limit'), true)
 		assert.equal(dom.document.body.textContent?.includes('Change'), true)
 
+		await unmountConfirmTransaction(dom)
 		clock.restore()
 		dom.restore()
 	})
@@ -377,6 +385,7 @@ describe('ConfirmTransaction', () => {
 
 		assert.equal(dom.document.body.textContent?.includes('Simulated 0s ago'), true)
 
+		await unmountConfirmTransaction(dom)
 		clock.restore()
 		dom.restore()
 	})

--- a/test/tests/confirmTransactionRpcStatus.test.ts
+++ b/test/tests/confirmTransactionRpcStatus.test.ts
@@ -6,7 +6,7 @@ import { installDomMock } from './domMock.js'
 
 type RuntimeMessageListener = (message: unknown) => unknown
 
-function installBrowserMock() {
+function installBrowserMock(sendMessageOverride?: (message: unknown, sentMessages: unknown[]) => unknown) {
 	const listeners: RuntimeMessageListener[] = []
 	const storageState: Record<string, unknown> = {}
 	const sentMessages: unknown[] = []
@@ -19,6 +19,7 @@ function installBrowserMock() {
 				lastError: null,
 				async sendMessage(message: unknown) {
 					sentMessages.push(message)
+					if (sendMessageOverride !== undefined) return await sendMessageOverride(message, sentMessages)
 					if (typeof message === 'object' && message !== null && 'method' in message) {
 						const typedMessage = message as { method?: string }
 						if (typedMessage.method === 'popup_isMainPopupWindowOpen') {
@@ -97,10 +98,19 @@ function installBrowserMock() {
 
 	return {
 		sentMessages,
+		getSentMessages() {
+			return [...sentMessages]
+		},
 		dispatch(message: unknown) {
 			for (const listener of [...listeners]) listener(message)
 		},
 	}
+}
+
+async function unmountConfirmTransaction(dom: ReturnType<typeof installDomMock>) {
+	await act(() => {
+		render(null, dom.document.body)
+	})
 }
 
 function makePendingTransaction() {
@@ -257,6 +267,101 @@ describe('confirm transaction rpc status bootstrap', () => {
 		})
 
 		assert.equal(dom.document.body.textContent?.includes('Retrying resumes when the extension becomes active.'), true)
+		await unmountConfirmTransaction(dom)
+		dom.restore()
+	})
+
+	test('retries bootstrap when the first ready handshake happens before pending data exists', async () => {
+		const dom = installDomMock()
+		const browser = installBrowserMock((message) => {
+			if (typeof message !== 'object' || message === null || !('method' in message)) return undefined
+			const typedMessage = message as { method?: string }
+			if (typedMessage.method === 'popup_readyAndListening') {
+				const readyCalls = browser.getSentMessages().filter((sentMessage) =>
+					typeof sentMessage === 'object'
+					&& sentMessage !== null
+					&& 'method' in sentMessage
+					&& sentMessage.method === 'popup_readyAndListening'
+				).length
+				if (readyCalls === 1) return undefined
+				return { method: 'popup_readyAndListening', data: { popupOrTabId: { type: 'popup', id: 1 } } }
+			}
+			if (typedMessage.method === 'popup_requestSettings') return undefined
+			return undefined
+		})
+		const [
+			{ serialize },
+			{ UpdateConfirmTransactionDialogPendingTransactions },
+			{ ConfirmTransaction, CONFIRM_TRANSACTION_BOOTSTRAP_RETRY_DELAY_MS },
+		] = await Promise.all([
+			import('../../app/ts/types/wire-types.js'),
+			import('../../app/ts/types/interceptor-messages.js'),
+			import('../../app/ts/components/pages/ConfirmTransaction.js'),
+		])
+
+		await act(() => {
+			render(h(ConfirmTransaction, {}), dom.document.body)
+		})
+
+		await new Promise((resolve) => setTimeout(resolve, CONFIRM_TRANSACTION_BOOTSTRAP_RETRY_DELAY_MS + 50))
+
+		const readyCalls = browser.getSentMessages().filter((message) =>
+			typeof message === 'object'
+			&& message !== null
+			&& 'method' in message
+			&& message.method === 'popup_readyAndListening'
+		).length
+		assert.equal(readyCalls >= 2, true)
+
+		await act(() => {
+			browser.dispatch({
+				role: 'all',
+				...serialize(UpdateConfirmTransactionDialogPendingTransactions, {
+					method: 'popup_update_confirm_transaction_dialog_pending_transactions',
+					data: {
+						pendingTransactionAndSignableMessages: [makePendingTransaction()],
+						currentBlockNumber: 123n,
+						rpcConnectionStatus: undefined,
+					},
+				}),
+			})
+		})
+
+		assert.equal(dom.document.body.textContent?.includes('simulation failed'), true)
+		assert.equal(dom.document.body.textContent?.includes('Initializing...'), false)
+		await unmountConfirmTransaction(dom)
+		dom.restore()
+	})
+
+	test('hydrates pending transaction details from storage when the initial popup push is missed', async () => {
+		const dom = installDomMock()
+		installBrowserMock((message) => {
+			if (typeof message !== 'object' || message === null || !('method' in message)) return undefined
+			const typedMessage = message as { method?: string }
+			if (typedMessage.method === 'popup_readyAndListening') return undefined
+			if (typedMessage.method === 'popup_requestSettings') return undefined
+			return undefined
+		})
+		const [
+			{ browserStorageLocalSet2 },
+			{ ConfirmTransaction },
+		] = await Promise.all([
+			import('../../app/ts/utils/storageUtils.js'),
+			import('../../app/ts/components/pages/ConfirmTransaction.js'),
+		])
+
+		await browserStorageLocalSet2({
+			pendingTransactionsAndMessages: [makePendingTransaction()],
+		})
+
+		await act(() => {
+			render(h(ConfirmTransaction, {}), dom.document.body)
+		})
+		await new Promise((resolve) => setTimeout(resolve, 25))
+
+		assert.equal(dom.document.body.textContent?.includes('simulation failed'), true)
+		assert.equal(dom.document.body.textContent?.includes('Initializing...'), false)
+		await unmountConfirmTransaction(dom)
 		dom.restore()
 	})
 })

--- a/test/tests/confirmTransactionRpcStatus.test.ts
+++ b/test/tests/confirmTransactionRpcStatus.test.ts
@@ -113,7 +113,7 @@ async function unmountConfirmTransaction(dom: ReturnType<typeof installDomMock>)
 	})
 }
 
-function makePendingTransaction() {
+function makePendingTransaction(errorMessage = 'simulation failed') {
 	const activeAddress = 0x1111111111111111111111111111111111111111n
 	const recipientAddress = 0x2222222222222222222222222222222222222222n
 	const transactionIdentifier = 1n
@@ -139,7 +139,7 @@ function makePendingTransaction() {
 		success: false as const,
 		error: {
 			code: -32000,
-			message: 'simulation failed',
+			message: errorMessage,
 		},
 	}
 
@@ -167,8 +167,8 @@ function makePendingTransaction() {
 				signerName: 'NoSignerDetected' as const,
 				error: {
 					code: -32000,
-					message: 'simulation failed',
-					decodedErrorMessage: 'simulation failed',
+					message: errorMessage,
+					decodedErrorMessage: errorMessage,
 				},
 				simulationState: {
 					blockNumber: 123n,
@@ -322,6 +322,62 @@ describe('confirm transaction rpc status bootstrap', () => {
 
 		assert.equal(dom.document.body.textContent?.includes('simulation failed'), true)
 		assert.equal(dom.document.body.textContent?.includes('Initializing...'), false)
+		await unmountConfirmTransaction(dom)
+		dom.restore()
+	})
+
+	test('does not let a late bootstrap reply overwrite pushed pending transaction data', async () => {
+		const dom = installDomMock()
+		const stalePendingTransaction = makePendingTransaction('stale bootstrap transaction')
+		const freshPendingTransaction = makePendingTransaction('fresh pushed transaction')
+		const { createPassthroughCompleteVisualizedSimulation } = await import('../../app/ts/types/visualizer-types.js')
+		const { serialize } = await import('../../app/ts/types/wire-types.js')
+		const { UpdateConfirmTransactionDialogPendingTransactions } = await import('../../app/ts/types/interceptor-messages.js')
+		const { PopupRequestsReplies } = await import('../../app/ts/types/interceptor-reply-messages.js')
+		const browser = installBrowserMock(async (message) => {
+			if (typeof message !== 'object' || message === null || !('method' in message)) return undefined
+			const typedMessage = message as { method?: string }
+			if (typedMessage.method === 'popup_readyAndListening') {
+				await new Promise((resolve) => setTimeout(resolve, 25))
+				return serialize(PopupRequestsReplies.popup_readyAndListening, {
+					method: 'popup_readyAndListening',
+					data: {
+						popupOrTabId: { type: 'popup', id: 1 },
+						confirmTransactionBootstrap: {
+							pendingTransactionAndSignableMessages: [stalePendingTransaction],
+							currentBlockNumber: 123n,
+							rpcConnectionStatus: undefined,
+							visualizedSimulatorState: createPassthroughCompleteVisualizedSimulation(),
+						},
+					},
+				})
+			}
+			if (typedMessage.method === 'popup_requestSettings') return undefined
+			return undefined
+		})
+		const { ConfirmTransaction } = await import('../../app/ts/components/pages/ConfirmTransaction.js')
+
+		await act(() => {
+			render(h(ConfirmTransaction, {}), dom.document.body)
+		})
+
+		await act(() => {
+			browser.dispatch({
+				role: 'all',
+				...serialize(UpdateConfirmTransactionDialogPendingTransactions, {
+					method: 'popup_update_confirm_transaction_dialog_pending_transactions',
+					data: {
+						pendingTransactionAndSignableMessages: [freshPendingTransaction],
+						currentBlockNumber: 124n,
+						rpcConnectionStatus: undefined,
+					},
+				}),
+			})
+		})
+		await new Promise((resolve) => setTimeout(resolve, 50))
+
+		assert.equal(dom.document.body.textContent?.includes('fresh pushed transaction'), true)
+		assert.equal(dom.document.body.textContent?.includes('stale bootstrap transaction'), false)
 		await unmountConfirmTransaction(dom)
 		dom.restore()
 	})

--- a/test/tests/confirmTransactionRpcStatus.test.ts
+++ b/test/tests/confirmTransactionRpcStatus.test.ts
@@ -271,8 +271,12 @@ describe('confirm transaction rpc status bootstrap', () => {
 		dom.restore()
 	})
 
-	test('retries bootstrap when the first ready handshake happens before pending data exists', async () => {
+	test('hydrates from a later bootstrap reply when the first ready handshake happens before pending data exists', async () => {
 		const dom = installDomMock()
+		const pendingTransaction = makePendingTransaction()
+		const { createPassthroughCompleteVisualizedSimulation } = await import('../../app/ts/types/visualizer-types.js')
+		const { serialize } = await import('../../app/ts/types/wire-types.js')
+		const { PopupRequestsReplies } = await import('../../app/ts/types/interceptor-reply-messages.js')
 		const browser = installBrowserMock((message) => {
 			if (typeof message !== 'object' || message === null || !('method' in message)) return undefined
 			const typedMessage = message as { method?: string }
@@ -284,20 +288,23 @@ describe('confirm transaction rpc status bootstrap', () => {
 					&& sentMessage.method === 'popup_readyAndListening'
 				).length
 				if (readyCalls === 1) return undefined
-				return { method: 'popup_readyAndListening', data: { popupOrTabId: { type: 'popup', id: 1 } } }
+				return serialize(PopupRequestsReplies.popup_readyAndListening, {
+					method: 'popup_readyAndListening',
+					data: {
+						popupOrTabId: { type: 'popup', id: 1 },
+						confirmTransactionBootstrap: {
+							pendingTransactionAndSignableMessages: [pendingTransaction],
+							currentBlockNumber: 123n,
+							rpcConnectionStatus: undefined,
+							visualizedSimulatorState: createPassthroughCompleteVisualizedSimulation(),
+						},
+					},
+				})
 			}
 			if (typedMessage.method === 'popup_requestSettings') return undefined
 			return undefined
 		})
-		const [
-			{ serialize },
-			{ UpdateConfirmTransactionDialogPendingTransactions },
-			{ ConfirmTransaction, CONFIRM_TRANSACTION_BOOTSTRAP_RETRY_DELAY_MS },
-		] = await Promise.all([
-			import('../../app/ts/types/wire-types.js'),
-			import('../../app/ts/types/interceptor-messages.js'),
-			import('../../app/ts/components/pages/ConfirmTransaction.js'),
-		])
+		const { ConfirmTransaction, CONFIRM_TRANSACTION_BOOTSTRAP_RETRY_DELAY_MS } = await import('../../app/ts/components/pages/ConfirmTransaction.js')
 
 		await act(() => {
 			render(h(ConfirmTransaction, {}), dom.document.body)
@@ -312,20 +319,6 @@ describe('confirm transaction rpc status bootstrap', () => {
 			&& message.method === 'popup_readyAndListening'
 		).length
 		assert.equal(readyCalls >= 2, true)
-
-		await act(() => {
-			browser.dispatch({
-				role: 'all',
-				...serialize(UpdateConfirmTransactionDialogPendingTransactions, {
-					method: 'popup_update_confirm_transaction_dialog_pending_transactions',
-					data: {
-						pendingTransactionAndSignableMessages: [makePendingTransaction()],
-						currentBlockNumber: 123n,
-						rpcConnectionStatus: undefined,
-					},
-				}),
-			})
-		})
 
 		assert.equal(dom.document.body.textContent?.includes('simulation failed'), true)
 		assert.equal(dom.document.body.textContent?.includes('Initializing...'), false)

--- a/test/tests/delegationFlowLayoutCss.test.ts
+++ b/test/tests/delegationFlowLayoutCss.test.ts
@@ -2,33 +2,36 @@ import * as assert from 'assert'
 import { describe, test } from 'bun:test'
 
 describe('delegation flow layout CSS', () => {
-	async function getDelegationFlowMobileCss() {
+	async function getDelegationFlowCss() {
 		const css = await Bun.file('app/css/interceptor.css').text()
-		const start = css.indexOf('@media screen and (max-width: 480px) {')
-		assert.notEqual(start, -1)
-		const end = css.indexOf('\n}\n\n.swap-box', start)
-		assert.notEqual(end, -1)
-		return { css, mobileCss: css.slice(start, end) }
+		const rowMatch = css.match(/\.delegation-flow-row\s*\{([\s\S]*?)\n\}/)
+		const connectorMatch = css.match(/\.delegation-flow-connector\s*\{([\s\S]*?)\n\}/)
+		const targetsMatch = css.match(/\.delegation-flow-targets\s*\{([\s\S]*?)\n\}/)
+		const buttonMatch = css.match(/\.delegation-flow-address-button\s*\{([\s\S]*?)\n\}/)
+		assert.ok(rowMatch)
+		assert.ok(connectorMatch)
+		assert.ok(targetsMatch)
+		assert.ok(buttonMatch)
+		return {
+			css,
+			rowCss: rowMatch[1],
+			connectorCss: connectorMatch[1],
+			targetsCss: targetsMatch[1],
+			buttonCss: buttonMatch[1],
+		}
 	}
 
-	test('keeps the delegated execution row horizontal at extension popup width', async () => {
-		const { css } = await getDelegationFlowMobileCss()
-		const delegationFlowRowMediaQueries = Array.from(css.matchAll(
-			/@media screen and \(max-width: ([0-9]+)px\) \{[\s\S]*?\.delegation-flow-row[\s\S]*?\n\}/g,
-		))
-		assert.ok(delegationFlowRowMediaQueries.length > 0)
-		for (const mediaQuery of delegationFlowRowMediaQueries) {
-			const breakpoint = Number(mediaQuery[1])
-			assert.ok(breakpoint < 600, `delegation flow should remain horizontal at popup width, found ${ breakpoint }px breakpoint`)
-		}
-	})
-
-	test('allows the delegated execution row to shrink in the narrow layout', async () => {
-		const { mobileCss } = await getDelegationFlowMobileCss()
-		assert.match(mobileCss, /\.delegation-flow-row\s*\{[\s\S]*grid-template-columns: minmax\(0, 1fr\);/)
-		assert.match(mobileCss, /\.delegation-flow-row\s*\{[\s\S]*width: 100%;/)
-		assert.match(mobileCss, /\.delegation-flow-address-button,\n\t\.delegation-flow-address\s*\{[\s\S]*width: 100%;/)
-		assert.match(mobileCss, /\.delegation-flow-address-primary\s*\{[\s\S]*white-space: normal;/)
-		assert.match(mobileCss, /\.delegation-flow-address-primary\s*\{[\s\S]*overflow-wrap: anywhere;/)
+	test('uses content-driven wrapping instead of a viewport breakpoint', async () => {
+		const { css, rowCss, connectorCss, targetsCss, buttonCss } = await getDelegationFlowCss()
+		assert.doesNotMatch(css, /@media[^{]*\{[\s\S]*?\.delegation-flow-row/)
+		assert.match(rowCss, /display: flex;/)
+		assert.match(rowCss, /flex-wrap: wrap;/)
+		assert.match(rowCss, /width: 100%;/)
+		assert.match(connectorCss, /display: inline-flex;/)
+		assert.match(connectorCss, /flex: 0 0 auto;/)
+		assert.match(targetsCss, /display: inline-flex;/)
+		assert.match(targetsCss, /flex-wrap: wrap;/)
+		assert.match(buttonCss, /flex: 0 1 auto;/)
+		assert.match(buttonCss, /min-width: 0;/)
 	})
 })

--- a/test/tests/delegationFlowLayoutCss.test.ts
+++ b/test/tests/delegationFlowLayoutCss.test.ts
@@ -1,0 +1,34 @@
+import * as assert from 'assert'
+import { describe, test } from 'bun:test'
+
+describe('delegation flow layout CSS', () => {
+	async function getDelegationFlowMobileCss() {
+		const css = await Bun.file('app/css/interceptor.css').text()
+		const start = css.indexOf('@media screen and (max-width: 480px) {')
+		assert.notEqual(start, -1)
+		const end = css.indexOf('\n}\n\n.swap-box', start)
+		assert.notEqual(end, -1)
+		return { css, mobileCss: css.slice(start, end) }
+	}
+
+	test('keeps the delegated execution row horizontal at extension popup width', async () => {
+		const { css } = await getDelegationFlowMobileCss()
+		const delegationFlowRowMediaQueries = Array.from(css.matchAll(
+			/@media screen and \(max-width: ([0-9]+)px\) \{[\s\S]*?\.delegation-flow-row[\s\S]*?\n\}/g,
+		))
+		assert.ok(delegationFlowRowMediaQueries.length > 0)
+		for (const mediaQuery of delegationFlowRowMediaQueries) {
+			const breakpoint = Number(mediaQuery[1])
+			assert.ok(breakpoint < 600, `delegation flow should remain horizontal at popup width, found ${ breakpoint }px breakpoint`)
+		}
+	})
+
+	test('allows the delegated execution row to shrink in the narrow layout', async () => {
+		const { mobileCss } = await getDelegationFlowMobileCss()
+		assert.match(mobileCss, /\.delegation-flow-row\s*\{[\s\S]*grid-template-columns: minmax\(0, 1fr\);/)
+		assert.match(mobileCss, /\.delegation-flow-row\s*\{[\s\S]*width: 100%;/)
+		assert.match(mobileCss, /\.delegation-flow-address-button,\n\t\.delegation-flow-address\s*\{[\s\S]*width: 100%;/)
+		assert.match(mobileCss, /\.delegation-flow-address-primary\s*\{[\s\S]*white-space: normal;/)
+		assert.match(mobileCss, /\.delegation-flow-address-primary\s*\{[\s\S]*overflow-wrap: anywhere;/)
+	})
+})

--- a/test/tests/proxyExecutionText.test.ts
+++ b/test/tests/proxyExecutionText.test.ts
@@ -1,0 +1,34 @@
+import * as assert from 'assert'
+import { describe, test } from 'bun:test'
+import { getProxyRouteLabel } from '../../app/ts/components/simulationExplaining/customExplainers/SimpleSendVisualisations.js'
+
+describe('proxy execution messaging', () => {
+	test('shows a compact single-hop route label', () => {
+		assert.equal(
+			getProxyRouteLabel([{
+				address: 1n,
+				name: 'Proxy',
+				type: 'contract',
+				entrySource: 'User',
+			}]),
+			'via 1 address',
+		)
+	})
+
+	test('shows a compact multi-hop route label', () => {
+		assert.equal(
+			getProxyRouteLabel([{
+				address: 1n,
+				name: 'Proxy 1',
+				type: 'contract',
+				entrySource: 'User',
+			}, {
+				address: 2n,
+				name: 'Proxy 2',
+				type: 'contract',
+				entrySource: 'User',
+			}]),
+			'via 2 addresses',
+		)
+	})
+})

--- a/test/tests/transactionImportanceBlockDelegation.test.tsx
+++ b/test/tests/transactionImportanceBlockDelegation.test.tsx
@@ -1,0 +1,341 @@
+import * as assert from 'assert'
+import { Signal } from '@preact/signals'
+import { h, render } from 'preact'
+import { act } from 'preact/test-utils'
+import { describe, test } from 'bun:test'
+import { TransactionImportanceBlock } from '../../app/ts/components/simulationExplaining/Transactions.js'
+import { installDomMock } from './domMock.js'
+import type { AddressBookEntry, Erc20TokenEntry } from '../../app/ts/types/addressBookTypes.js'
+import type { TokenEvent } from '../../app/ts/types/EnrichedEthereumData.js'
+import type { RpcNetwork } from '../../app/ts/types/rpc.js'
+import type { MaybeSimulatedTransaction } from '../../app/ts/types/visualizer-types.js'
+import { ETHEREUM_LOGS_LOGGER_ADDRESS } from '../../app/ts/utils/constants.js'
+
+const senderEntry: AddressBookEntry = {
+	type: 'contact',
+	name: 'Public private key',
+	address: 0x1111111111111111111111111111111111111111n,
+	entrySource: 'User',
+}
+
+const delegateEntry: AddressBookEntry = {
+	type: 'contract',
+	name: 'Delegated Executor',
+	address: 0x2222222222222222222222222222222222222222n,
+	entrySource: 'OnChain',
+}
+
+const secondDelegateEntry: AddressBookEntry = {
+	type: 'contract',
+	name: 'Delegated Executor 2',
+	address: 0x3333333333333333333333333333333333333333n,
+	entrySource: 'OnChain',
+}
+
+const recipientEntry: AddressBookEntry = {
+	type: 'contact',
+	name: 'Actual recipient',
+	address: 0x4444444444444444444444444444444444444444n,
+	entrySource: 'User',
+}
+
+const nativeTokenEntry: Erc20TokenEntry = {
+	type: 'ERC20',
+	name: 'Ether',
+	symbol: 'ETH',
+	decimals: 18n,
+	address: ETHEREUM_LOGS_LOGGER_ADDRESS,
+	entrySource: 'Interceptor',
+}
+
+const rpcNetwork: RpcNetwork = {
+	name: 'Ethereum',
+	chainId: 1n,
+	httpsRpc: 'https://example.invalid',
+	currencyName: 'Ether',
+	currencyTicker: 'ETH',
+	primary: true,
+	minimized: false,
+}
+
+function createAuthorization(address: bigint, nonce: bigint) {
+	return {
+		chainId: 1n,
+		address,
+		nonce,
+		r: 1n,
+		s: 2n,
+		yParity: 'even' as const,
+	}
+}
+
+function create7702Transaction({
+	status,
+	authorizationAddresses,
+	events = [],
+}: {
+	status: MaybeSimulatedTransaction['transactionStatus']
+	authorizationAddresses: readonly bigint[]
+	events?: readonly TokenEvent[]
+}): MaybeSimulatedTransaction {
+	const base = {
+		website: { websiteOrigin: 'https://example.com', icon: undefined, title: 'Example' },
+		created: new Date('2024-01-01T00:00:00.000Z'),
+		parsedInputData: { type: 'NonParsed' as const, input: new Uint8Array() },
+		transactionIdentifier: 1n,
+		originalRequestParameters: {
+			method: 'eth_sendTransaction' as const,
+			params: [{
+				from: senderEntry.address,
+				to: senderEntry.address,
+				value: 0n,
+				input: new Uint8Array(),
+				gas: 21_000n,
+				maxFeePerGas: 1n,
+				maxPriorityFeePerGas: 1n,
+				type: '0x4' as const,
+				authorizationList: authorizationAddresses.map((address, index) => createAuthorization(address, BigInt(index + 1))),
+			}],
+		},
+		transaction: {
+			from: senderEntry,
+			to: senderEntry,
+			value: 0n,
+			input: new Uint8Array(),
+			rpcNetwork,
+			hash: 0x1234n,
+			gas: 21_000n,
+			nonce: 7n,
+			type: '7702' as const,
+			maxFeePerGas: 1n,
+			maxPriorityFeePerGas: 1n,
+			authorizationList: authorizationAddresses.map((address, index) => createAuthorization(address, BigInt(index + 1))),
+		},
+	}
+
+	switch (status) {
+		case 'Failed To Simulate':
+			return {
+				...base,
+				transactionStatus: 'Failed To Simulate',
+				error: {
+					code: -32000,
+					message: 'Failed to simulate',
+					data: undefined,
+					decodedErrorMessage: 'Failed to simulate',
+				},
+			}
+		case 'Transaction Failed':
+			return {
+				...base,
+				transactionStatus: 'Transaction Failed',
+				tokenBalancesAfter: [],
+				tokenPriceEstimates: [],
+				tokenPriceQuoteToken: undefined,
+				gasSpent: 0n,
+				realizedGasPrice: 1n,
+				quarantine: false,
+				quarantineReasons: [],
+				events: [],
+				error: {
+					code: -32000,
+					message: 'execution reverted',
+					data: undefined,
+					decodedErrorMessage: 'execution reverted',
+				},
+			}
+		case 'Transaction Succeeded':
+			return {
+				...base,
+				transactionStatus: 'Transaction Succeeded',
+				tokenBalancesAfter: [],
+				tokenPriceEstimates: [],
+				tokenPriceQuoteToken: undefined,
+				gasSpent: 0n,
+				realizedGasPrice: 1n,
+				quarantine: false,
+				quarantineReasons: [],
+				events,
+			}
+	}
+}
+
+function createDelegatedSelfCallTransaction({
+	events = [],
+}: {
+	events?: readonly TokenEvent[]
+}): MaybeSimulatedTransaction {
+	return {
+		website: { websiteOrigin: 'https://example.com', icon: undefined, title: 'Example' },
+		created: new Date('2024-01-01T00:00:00.000Z'),
+		parsedInputData: { type: 'NonParsed', input: new Uint8Array() },
+		transactionIdentifier: 2n,
+		originalRequestParameters: {
+			method: 'eth_sendTransaction',
+			params: [{
+				from: senderEntry.address,
+				to: senderEntry.address,
+				value: 1n,
+				input: new Uint8Array(),
+				gas: 21_000n,
+				maxFeePerGas: 1n,
+				maxPriorityFeePerGas: 1n,
+				type: '0x2',
+			}],
+		},
+		transaction: {
+			from: senderEntry,
+			to: senderEntry,
+			delegationAddress: delegateEntry,
+			value: 1n,
+			input: new Uint8Array(),
+			rpcNetwork,
+			hash: 0x1235n,
+			gas: 21_000n,
+			nonce: 8n,
+			type: '1559',
+			maxFeePerGas: 1n,
+			maxPriorityFeePerGas: 1n,
+		},
+		transactionStatus: 'Transaction Succeeded',
+		tokenBalancesAfter: [],
+		tokenPriceEstimates: [],
+		tokenPriceQuoteToken: undefined,
+		gasSpent: 0n,
+		realizedGasPrice: 1n,
+		quarantine: false,
+		quarantineReasons: [],
+		events,
+	}
+}
+
+function createNativeTransferEvent(): TokenEvent {
+	return {
+		type: 'TokenEvent',
+		isParsed: 'Parsed',
+		name: 'Transfer',
+		signature: 'Transfer(address,address,uint256)',
+		args: [],
+		address: nativeTokenEntry.address,
+		loggersAddressBookEntry: nativeTokenEntry,
+		data: new Uint8Array(),
+		topics: [],
+		logInformation: {
+			type: 'ERC20',
+			logObject: undefined,
+			from: senderEntry,
+			to: recipientEntry,
+			token: nativeTokenEntry,
+			amount: 1n,
+			isApproval: false,
+		},
+	}
+}
+
+async function renderImportanceBlock(simTx: MaybeSimulatedTransaction, addressMetadata: readonly AddressBookEntry[]) {
+	const dom = installDomMock()
+
+	await act(() => {
+		render(h(TransactionImportanceBlock, {
+			simTx,
+			activeAddress: new Signal<bigint | undefined>(senderEntry.address),
+			renameAddressCallBack: () => undefined,
+			editEnsNamedHashCallBack: () => undefined,
+			addressMetadata: new Signal(addressMetadata),
+			rpcNetwork: new Signal(rpcNetwork),
+		}), dom.document.body)
+	})
+
+	return dom
+}
+
+describe('TransactionImportanceBlock delegation notice', () => {
+	test('shows authorization flow details for failed-to-simulate 7702 transactions', async () => {
+		const dom = await renderImportanceBlock(
+			create7702Transaction({ status: 'Failed To Simulate', authorizationAddresses: [delegateEntry.address] }),
+			[senderEntry, delegateEntry],
+		)
+
+		assert.equal(dom.document.body.textContent?.includes('Delegated execution'), true)
+		assert.equal(dom.document.body.textContent?.includes('delegated to'), true)
+		assert.equal(dom.document.body.textContent?.includes('Delegated Executor'), true)
+		assert.equal(dom.document.body.textContent?.includes('Failed to simulate this transaction.'), true)
+
+		dom.restore()
+	})
+
+	test('shows authorization flow details for failed 7702 transactions', async () => {
+		const dom = await renderImportanceBlock(
+			create7702Transaction({ status: 'Transaction Failed', authorizationAddresses: [delegateEntry.address] }),
+			[senderEntry, delegateEntry],
+		)
+
+		assert.equal(dom.document.body.textContent?.includes('Delegated execution'), true)
+		assert.equal(dom.document.body.textContent?.includes('delegated to'), true)
+		assert.equal(dom.document.body.textContent?.includes('execution reverted'), true)
+
+		dom.restore()
+	})
+
+	test('shows authorization flow details for successful 7702 self-calls', async () => {
+		const dom = await renderImportanceBlock(
+			create7702Transaction({ status: 'Transaction Succeeded', authorizationAddresses: [delegateEntry.address] }),
+			[senderEntry, delegateEntry],
+		)
+
+		assert.equal(dom.document.body.textContent?.includes('Delegated execution'), true)
+		assert.equal(dom.document.body.textContent?.includes('delegated to'), true)
+		assert.equal(dom.document.body.textContent?.includes('The transaction does no visible important changes to your accounts.'), true)
+
+		dom.restore()
+	})
+
+	test('shows multiple authorization targets when present', async () => {
+		const dom = await renderImportanceBlock(
+			create7702Transaction({ status: 'Transaction Succeeded', authorizationAddresses: [delegateEntry.address, secondDelegateEntry.address] }),
+			[senderEntry, delegateEntry, secondDelegateEntry],
+		)
+
+		assert.equal(dom.document.body.textContent?.includes('delegated to'), true)
+		assert.equal(dom.document.body.textContent?.includes('Delegated Executor'), true)
+		assert.equal(dom.document.body.textContent?.includes('Delegated Executor 2'), true)
+
+		dom.restore()
+	})
+
+	test('shows the delegated transfer flow together with the executed send outcome', async () => {
+		const dom = await renderImportanceBlock(
+			create7702Transaction({
+				status: 'Transaction Succeeded',
+				authorizationAddresses: [delegateEntry.address],
+				events: [createNativeTransferEvent()],
+			}),
+			[senderEntry, delegateEntry, recipientEntry, nativeTokenEntry],
+		)
+
+		assert.equal(dom.document.body.textContent?.includes('Delegated execution'), true)
+		assert.equal(dom.document.body.textContent?.includes('delegated to'), true)
+		assert.equal(dom.document.body.textContent?.includes('Send'), true)
+		assert.equal(dom.document.body.textContent?.includes('Funds sent to'), true)
+		assert.equal(dom.document.body.textContent?.includes('Actual recipient'), true)
+
+		dom.restore()
+	})
+
+	test('shows delegation flow for a regular self-call from an already delegated sender', async () => {
+		const dom = await renderImportanceBlock(
+			createDelegatedSelfCallTransaction({
+				events: [createNativeTransferEvent()],
+			}),
+			[senderEntry, delegateEntry, recipientEntry, nativeTokenEntry],
+		)
+
+		assert.equal(dom.document.body.textContent?.includes('Delegated execution'), true)
+		assert.equal(dom.document.body.textContent?.includes('Funds sent to'), true)
+		assert.equal(dom.document.body.textContent?.includes('Delegated Executor'), true)
+		assert.equal(dom.document.body.textContent?.includes('Actual recipient'), true)
+		assert.equal(dom.document.body.textContent?.includes('Send'), true)
+
+		dom.restore()
+	})
+})


### PR DESCRIPTION
## Summary
- Adds EIP-7702/delegated execution handling to the transaction explanation UI, including active delegated sender flows and 7702 authorization flows.
- Shows the delegation path visually as `[sender] delegated to -> [delegate]`, using compact address chips and a wrapping layout that adapts to narrow popup widths without viewport breakpoints.
- Clarifies delegated/proxy transfer outcomes so self-transfers that execute through a delegate can show the actual send result instead of implying the sender simply received the funds.
- Hardens confirm transaction popup startup by returning bootstrap data from the ready/listening handshake and applying bootstrap data from retry replies when the initial popup update is missed.
- Keeps proxy execution route wording/rendering consistent across simple and multi-send visualizations.

## Testing
- `bun test`
- `bun run setup-chrome`
- `bun run typecheck`
- `bun run lint`

## Notes
- The confirm popup can still initially render a loading state while pending data is being created, but it now hydrates from storage, broadcast updates, the initial ready reply, and later ready retry replies.
