### PR TITLE
Cap default 1559 fees by sender balance

### DIFF
--- a/app/ts/background/simulationUpdating.ts
+++ b/app/ts/background/simulationUpdating.ts
@@ -365,9 +365,9 @@ export const updateSimulationMetadata = async (ethereum: EthereumClientService, 
 
 export const prepareSimulationInputForRpc = async (simulationInput: SimulationStateInput, ethereum: EthereumClientService) => {
 	const parentBlock = await ethereum.getBlock(undefined)
-	const baseFeeFixedInputStateBlocks = parentBlock === undefined ? simulationInput : simulationInput.map((block) => (
-		modifyObject(block, { transactions: getBaseFeeAdjustedTransactions(parentBlock, block.transactions) })
-	))
+	const baseFeeFixedInputStateBlocks = parentBlock === undefined ? simulationInput : await Promise.all(simulationInput.map(async (block) => (
+		modifyObject(block, { transactions: await getBaseFeeAdjustedTransactions(ethereum, undefined, parentBlock, block.transactions) })
+	)))
 	const nonceFixed = await getNonceFixedSimulationStateInput(ethereum, undefined, baseFeeFixedInputStateBlocks)
 	return nonceFixed.nonceFixed ? nonceFixed.simulationStateInput : baseFeeFixedInputStateBlocks
 }

--- a/app/ts/background/simulationUpdating.ts
+++ b/app/ts/background/simulationUpdating.ts
@@ -371,9 +371,16 @@ export const updateSimulationMetadata = async (ethereum: EthereumClientService, 
 
 export const prepareSimulationInputForRpc = async (simulationInput: SimulationStateInput, ethereum: EthereumClientService) => {
 	const parentBlock = await ethereum.getBlock(undefined)
-	const baseFeeFixedInputStateBlocks = parentBlock === undefined ? simulationInput : await Promise.all(simulationInput.map(async (block) => (
-		modifyObject(block, { transactions: await getBaseFeeAdjustedTransactions(ethereum, undefined, parentBlock, block.transactions) })
-	)))
+	const getBaseFeeFixedInputStateBlocks = async () => {
+		if (parentBlock === undefined) return simulationInput
+		const baseFeeFixedInputStateBlocks: SimulationStateInputBlock[] = []
+		for (const block of simulationInput) {
+			const transactions = await getBaseFeeAdjustedTransactions(ethereum, undefined, parentBlock, baseFeeFixedInputStateBlocks, block)
+			baseFeeFixedInputStateBlocks.push(modifyObject(block, { transactions }))
+		}
+		return baseFeeFixedInputStateBlocks
+	}
+	const baseFeeFixedInputStateBlocks = await getBaseFeeFixedInputStateBlocks()
 	const nonceFixed = await getNonceFixedSimulationStateInput(ethereum, undefined, baseFeeFixedInputStateBlocks)
 	return nonceFixed.nonceFixed ? nonceFixed.simulationStateInput : baseFeeFixedInputStateBlocks
 }

--- a/app/ts/background/simulationUpdating.ts
+++ b/app/ts/background/simulationUpdating.ts
@@ -1,5 +1,5 @@
 import type { EthereumClientService } from '../simulation/services/EthereumClientService.js'
-import { DEFAULT_BLOCK_MANIPULATION, appendTransactionToInputAndSimulate, calculateRealizedEffectiveGasPrice, createExecutionSimulationState, createSimulationState, getAddressToMakeRich, getBaseFeeAdjustedTransactions, getNonceFixedSimulationStateInput, getSimulatedCode, getTokenBalancesAfterForTransaction, getWebsiteCreatedEthereumUnsignedTransactions, mockSignTransaction, simulateEstimateGasFromInput, sliceSimulationState } from '../simulation/services/SimulationModeEthereumClientService.js'
+import { DEFAULT_BLOCK_MANIPULATION, appendTransactionToInputAndSimulate, calculateRealizedEffectiveGasPrice, createExecutionSimulationState, createSimulationState, getAddressToMakeRich, getBaseFeeAdjustedTransactions, getBaseFeeAdjustmentBalances, getNonceFixedSimulationStateInput, getSimulatedCode, getTokenBalancesAfterForTransaction, getWebsiteCreatedEthereumUnsignedTransactions, mockSignTransaction, simulateEstimateGasFromInput, sliceSimulationState } from '../simulation/services/SimulationModeEthereumClientService.js'
 import type { TokenPriceService } from '../simulation/services/priceEstimator.js'
 import { parseEvents, parseInputData } from '../simulation/parsing.js'
 import { runProtectorsForTransaction } from '../simulation/protectorRunner.js'
@@ -375,7 +375,8 @@ export const prepareSimulationInputForRpc = async (simulationInput: SimulationSt
 		if (parentBlock === undefined) return simulationInput
 		const baseFeeFixedInputStateBlocks: SimulationStateInputBlock[] = []
 		for (const block of simulationInput) {
-			const transactions = await getBaseFeeAdjustedTransactions(ethereum, undefined, parentBlock, baseFeeFixedInputStateBlocks, block)
+			const balances = await getBaseFeeAdjustmentBalances(ethereum, undefined, parentBlock, baseFeeFixedInputStateBlocks, block)
+			const transactions = getBaseFeeAdjustedTransactions(parentBlock, block, balances)
 			baseFeeFixedInputStateBlocks.push(modifyObject(block, { transactions }))
 		}
 		return baseFeeFixedInputStateBlocks

--- a/app/ts/background/windows/confirmTransaction.ts
+++ b/app/ts/background/windows/confirmTransaction.ts
@@ -58,10 +58,14 @@ const shouldReplacePopupVisualisation = (
 	return nextTimestamp.getTime() >= currentTimestamp.getTime()
 }
 
-const getAffordableMaxFeePerGas = (desiredMaxFeePerGas: bigint, balance: bigint, value: bigint, gasLimit: bigint) => {
-	if (gasLimit === 0n) return desiredMaxFeePerGas
+const getAffordableTransactionFees = (desiredMaxFeePerGas: bigint, desiredMaxPriorityFeePerGas: bigint, balance: bigint, value: bigint, gasLimit: bigint) => {
+	if (gasLimit === 0n) return { maxFeePerGas: desiredMaxFeePerGas, maxPriorityFeePerGas: desiredMaxPriorityFeePerGas }
 	const availableForGas = balance > value ? balance - value : 0n
-	return min(desiredMaxFeePerGas, availableForGas / gasLimit)
+	const maxFeePerGas = min(desiredMaxFeePerGas, availableForGas / gasLimit)
+	return {
+		maxFeePerGas,
+		maxPriorityFeePerGas: min(desiredMaxPriorityFeePerGas, maxFeePerGas),
+	}
 }
 
 export function toPopupPendingTransactionOrSignableMessage(pending: PendingTransactionOrSignableMessage): PopupPendingTransactionOrSignableMessage {
@@ -340,9 +344,12 @@ export const formEthSendTransaction = async(ethereumClientService: EthereumClien
 	const balancePromise = silenceChromeUnCaughtPromise(getSimulatedBalance(ethereumClientService, requestAbortController, simulationState, from))
 	const maxPriorityFeePerGas = transactionDetails.maxPriorityFeePerGas !== undefined && transactionDetails.maxPriorityFeePerGas !== null ? transactionDetails.maxPriorityFeePerGas : 10n**8n // 0.1 nanoEth/gas
 	const value = transactionDetails.value !== undefined  ? transactionDetails.value : 0n
-	const getMaxFeePerGas = async (gasLimit: bigint) => {
-		if (transactionDetails.maxFeePerGas !== undefined && transactionDetails.maxFeePerGas !== null) return transactionDetails.maxFeePerGas
-		return getAffordableMaxFeePerGas(parentBaseFeePerGas * 2n + maxPriorityFeePerGas, await balancePromise, value, gasLimit)
+	const getFeePerGas = async (gasLimit: bigint) => {
+		if (transactionDetails.maxFeePerGas !== undefined && transactionDetails.maxFeePerGas !== null) return {
+			maxFeePerGas: transactionDetails.maxFeePerGas,
+			maxPriorityFeePerGas,
+		}
+		return getAffordableTransactionFees(parentBaseFeePerGas * 2n + maxPriorityFeePerGas, maxPriorityFeePerGas, await balancePromise, value, gasLimit)
 	}
 	const transactionWithoutGas = {
 		type: '1559' as const,
@@ -367,7 +374,7 @@ export const formEthSendTransaction = async(ethereumClientService: EthereumClien
 		try {
 			const estimateGas = await simulateEstimateGas(ethereumClientService, requestAbortController, simulationState, transactionWithoutGas)
 			if ('error' in estimateGas) return { ...extraParams, ...estimateGas, success: false }
-			return { transaction: { ...transactionWithoutGas, maxFeePerGas: await getMaxFeePerGas(estimateGas.gas), gas: estimateGas.gas }, ...extraParams, success: true }
+			return { transaction: { ...transactionWithoutGas, ...await getFeePerGas(estimateGas.gas), gas: estimateGas.gas }, ...extraParams, success: true }
 		} catch(error: unknown) {
 			if (error instanceof JsonRpcResponseError) return { ...extraParams, error: { code: error.code, message: error.message, data: typeof error.data === 'string' ? error.data : '0x' }, success: false }
 			printError(error)
@@ -375,7 +382,7 @@ export const formEthSendTransaction = async(ethereumClientService: EthereumClien
 			return { ...extraParams, error: { code: 123456, message: 'Unknown Error', data: '0x' }, success: false }
 		}
 	}
-	return { transaction: { ...transactionWithoutGas, maxFeePerGas: await getMaxFeePerGas(transactionDetails.gas), gas: transactionDetails.gas }, ...extraParams, success: true }
+	return { transaction: { ...transactionWithoutGas, ...await getFeePerGas(transactionDetails.gas), gas: transactionDetails.gas }, ...extraParams, success: true }
 }
 
 const getPendingTransactionWindow = async (ethereum: EthereumClientService, tokenPriceService: TokenPriceService, websiteTabConnections: WebsiteTabConnections) => {

--- a/app/ts/background/windows/confirmTransaction.ts
+++ b/app/ts/background/windows/confirmTransaction.ts
@@ -1,5 +1,5 @@
 import type { EthereumClientService } from '../../simulation/services/EthereumClientService.js'
-import { getInputFieldFromDataOrInput, getSimulatedTransactionCount, mockSignTransaction, simulateEstimateGas, simulatePersonalSign } from '../../simulation/services/SimulationModeEthereumClientService.js'
+import { getInputFieldFromDataOrInput, getSimulatedBalance, getSimulatedTransactionCount, mockSignTransaction, simulateEstimateGas, simulatePersonalSign } from '../../simulation/services/SimulationModeEthereumClientService.js'
 import { CANNOT_SIMULATE_OFF_LEGACY_BLOCK, ERROR_INTERCEPTOR_NO_ACTIVE_ADDRESS, METAMASK_ERROR_BLANKET_ERROR, METAMASK_ERROR_FAILED_TO_PARSE_REQUEST, METAMASK_ERROR_USER_REJECTED_REQUEST } from '../../utils/constants.js'
 import { type TransactionConfirmation, UpdateConfirmTransactionDialog, UpdateConfirmTransactionDialogPendingTransactions } from '../../types/interceptor-messages.js'
 import { Semaphore } from '../../utils/semaphore.js'
@@ -333,11 +333,11 @@ export const formEthSendTransaction = async(ethereumClientService: EthereumClien
 	if (activeAddress === undefined) throw new Error('Access to active address is denied')
 	const from = simulationMode && transactionDetails.from !== undefined ? transactionDetails.from : activeAddress
 	const transactionCountPromise = silenceChromeUnCaughtPromise(getSimulatedTransactionCount(ethereumClientService, requestAbortController, simulationState, from))
-	const balancePromise = silenceChromeUnCaughtPromise(ethereumClientService.getBalance(from, 'latest', requestAbortController))
 	const parentBlock = await parentBlockPromise
 	if (parentBlock === null) throw new Error('The latest block is null')
 	if (parentBlock.baseFeePerGas === undefined) throw new Error(CANNOT_SIMULATE_OFF_LEGACY_BLOCK)
 	const parentBaseFeePerGas = parentBlock.baseFeePerGas
+	const balancePromise = silenceChromeUnCaughtPromise(getSimulatedBalance(ethereumClientService, requestAbortController, simulationState, from))
 	const maxPriorityFeePerGas = transactionDetails.maxPriorityFeePerGas !== undefined && transactionDetails.maxPriorityFeePerGas !== null ? transactionDetails.maxPriorityFeePerGas : 10n**8n // 0.1 nanoEth/gas
 	const value = transactionDetails.value !== undefined  ? transactionDetails.value : 0n
 	const getMaxFeePerGas = async (gasLimit: bigint) => {

--- a/app/ts/background/windows/confirmTransaction.ts
+++ b/app/ts/background/windows/confirmTransaction.ts
@@ -18,7 +18,7 @@ import {
 	parseTransaction as parseSerializedTransaction,
 	serializeTransaction,
 } from '../../utils/viem.js'
-import { dataStringWith0xStart, min, stringToUint8Array } from '../../utils/bigint.js'
+import { dataStringWith0xStart, stringToUint8Array } from '../../utils/bigint.js'
 import { EthereumAddress, EthereumBytes32, EthereumQuantity, serialize } from '../../types/wire-types.js'
 import type { PopupOrTabId, Website } from '../../types/websiteAccessTypes.js'
 import { JsonRpcResponseError, handleUnexpectedError, isFailedToFetchError, isNewBlockAbort, printError } from '../../utils/errors.js'
@@ -33,6 +33,7 @@ import { updatePopupVisualisationIfNeeded } from '../popupVisualisationUpdater.j
 import { POPUP_PERFORMANCE_MARKS, markPerformance } from '../../utils/popupPerformance.js'
 import type { TokenPriceService } from '../../simulation/services/priceEstimator.js'
 import { closePopupOrTabById, getPopupOrTabById, openPopupOrTab, tryFocusingTabOrWindow } from '../../utils/popupOrTab.js'
+import { getAffordableTransactionFees } from '../../utils/transactionFees.js'
 
 const pendingConfirmationSemaphore = new Semaphore(1)
 
@@ -56,16 +57,6 @@ const shouldReplacePopupVisualisation = (
 	const nextTimestamp = getSimulationStartedTimestamp(nextPopupVisualisation)
 	if (currentTimestamp === undefined || nextTimestamp === undefined) return true
 	return nextTimestamp.getTime() >= currentTimestamp.getTime()
-}
-
-const getAffordableTransactionFees = (desiredMaxFeePerGas: bigint, desiredMaxPriorityFeePerGas: bigint, balance: bigint, value: bigint, gasLimit: bigint) => {
-	if (gasLimit === 0n) return { maxFeePerGas: desiredMaxFeePerGas, maxPriorityFeePerGas: desiredMaxPriorityFeePerGas }
-	const availableForGas = balance > value ? balance - value : 0n
-	const maxFeePerGas = min(desiredMaxFeePerGas, availableForGas / gasLimit)
-	return {
-		maxFeePerGas,
-		maxPriorityFeePerGas: min(desiredMaxPriorityFeePerGas, maxFeePerGas),
-	}
 }
 
 export function toPopupPendingTransactionOrSignableMessage(pending: PendingTransactionOrSignableMessage): PopupPendingTransactionOrSignableMessage {

--- a/app/ts/background/windows/confirmTransaction.ts
+++ b/app/ts/background/windows/confirmTransaction.ts
@@ -18,7 +18,7 @@ import {
 	parseTransaction as parseSerializedTransaction,
 	serializeTransaction,
 } from '../../utils/viem.js'
-import { dataStringWith0xStart, stringToUint8Array } from '../../utils/bigint.js'
+import { dataStringWith0xStart, min, stringToUint8Array } from '../../utils/bigint.js'
 import { EthereumAddress, EthereumBytes32, EthereumQuantity, serialize } from '../../types/wire-types.js'
 import type { PopupOrTabId, Website } from '../../types/websiteAccessTypes.js'
 import { JsonRpcResponseError, handleUnexpectedError, isFailedToFetchError, isNewBlockAbort, printError } from '../../utils/errors.js'
@@ -56,6 +56,12 @@ const shouldReplacePopupVisualisation = (
 	const nextTimestamp = getSimulationStartedTimestamp(nextPopupVisualisation)
 	if (currentTimestamp === undefined || nextTimestamp === undefined) return true
 	return nextTimestamp.getTime() >= currentTimestamp.getTime()
+}
+
+const getAffordableMaxFeePerGas = (desiredMaxFeePerGas: bigint, balance: bigint, value: bigint, gasLimit: bigint) => {
+	if (gasLimit === 0n) return desiredMaxFeePerGas
+	const availableForGas = balance > value ? balance - value : 0n
+	return min(desiredMaxFeePerGas, availableForGas / gasLimit)
 }
 
 export function toPopupPendingTransactionOrSignableMessage(pending: PendingTransactionOrSignableMessage): PopupPendingTransactionOrSignableMessage {
@@ -327,19 +333,26 @@ export const formEthSendTransaction = async(ethereumClientService: EthereumClien
 	if (activeAddress === undefined) throw new Error('Access to active address is denied')
 	const from = simulationMode && transactionDetails.from !== undefined ? transactionDetails.from : activeAddress
 	const transactionCountPromise = silenceChromeUnCaughtPromise(getSimulatedTransactionCount(ethereumClientService, requestAbortController, simulationState, from))
+	const balancePromise = silenceChromeUnCaughtPromise(ethereumClientService.getBalance(from, 'latest', requestAbortController))
 	const parentBlock = await parentBlockPromise
 	if (parentBlock === null) throw new Error('The latest block is null')
 	if (parentBlock.baseFeePerGas === undefined) throw new Error(CANNOT_SIMULATE_OFF_LEGACY_BLOCK)
+	const parentBaseFeePerGas = parentBlock.baseFeePerGas
 	const maxPriorityFeePerGas = transactionDetails.maxPriorityFeePerGas !== undefined && transactionDetails.maxPriorityFeePerGas !== null ? transactionDetails.maxPriorityFeePerGas : 10n**8n // 0.1 nanoEth/gas
+	const value = transactionDetails.value !== undefined  ? transactionDetails.value : 0n
+	const getMaxFeePerGas = async (gasLimit: bigint) => {
+		if (transactionDetails.maxFeePerGas !== undefined && transactionDetails.maxFeePerGas !== null) return transactionDetails.maxFeePerGas
+		return getAffordableMaxFeePerGas(parentBaseFeePerGas * 2n + maxPriorityFeePerGas, await balancePromise, value, gasLimit)
+	}
 	const transactionWithoutGas = {
 		type: '1559' as const,
 		from,
 		chainId: ethereumClientService.getChainId(),
 		nonce: await transactionCountPromise,
-		maxFeePerGas: transactionDetails.maxFeePerGas !== undefined && transactionDetails.maxFeePerGas !== null ? transactionDetails.maxFeePerGas : parentBlock.baseFeePerGas * 2n + maxPriorityFeePerGas,
+		maxFeePerGas: transactionDetails.maxFeePerGas !== undefined && transactionDetails.maxFeePerGas !== null ? transactionDetails.maxFeePerGas : parentBaseFeePerGas * 2n + maxPriorityFeePerGas,
 		maxPriorityFeePerGas,
 		to: transactionDetails.to === undefined ? null : transactionDetails.to,
-		value: transactionDetails.value !== undefined  ? transactionDetails.value : 0n,
+		value,
 		input: getInputFieldFromDataOrInput(transactionDetails),
 		accessList: [],
 	}
@@ -354,7 +367,7 @@ export const formEthSendTransaction = async(ethereumClientService: EthereumClien
 		try {
 			const estimateGas = await simulateEstimateGas(ethereumClientService, requestAbortController, simulationState, transactionWithoutGas)
 			if ('error' in estimateGas) return { ...extraParams, ...estimateGas, success: false }
-			return { transaction: { ...transactionWithoutGas, gas: estimateGas.gas }, ...extraParams, success: true }
+			return { transaction: { ...transactionWithoutGas, maxFeePerGas: await getMaxFeePerGas(estimateGas.gas), gas: estimateGas.gas }, ...extraParams, success: true }
 		} catch(error: unknown) {
 			if (error instanceof JsonRpcResponseError) return { ...extraParams, error: { code: error.code, message: error.message, data: typeof error.data === 'string' ? error.data : '0x' }, success: false }
 			printError(error)
@@ -362,7 +375,7 @@ export const formEthSendTransaction = async(ethereumClientService: EthereumClien
 			return { ...extraParams, error: { code: 123456, message: 'Unknown Error', data: '0x' }, success: false }
 		}
 	}
-	return { transaction: { ...transactionWithoutGas, gas: transactionDetails.gas }, ...extraParams, success: true }
+	return { transaction: { ...transactionWithoutGas, maxFeePerGas: await getMaxFeePerGas(transactionDetails.gas), gas: transactionDetails.gas }, ...extraParams, success: true }
 }
 
 const getPendingTransactionWindow = async (ethereum: EthereumClientService, tokenPriceService: TokenPriceService, websiteTabConnections: WebsiteTabConnections) => {

--- a/app/ts/background/windows/confirmTransaction.ts
+++ b/app/ts/background/windows/confirmTransaction.ts
@@ -33,7 +33,7 @@ import { updatePopupVisualisationIfNeeded } from '../popupVisualisationUpdater.j
 import { POPUP_PERFORMANCE_MARKS, markPerformance } from '../../utils/popupPerformance.js'
 import type { TokenPriceService } from '../../simulation/services/priceEstimator.js'
 import { closePopupOrTabById, getPopupOrTabById, openPopupOrTab, tryFocusingTabOrWindow } from '../../utils/popupOrTab.js'
-import { getAffordableTransactionFees } from '../../utils/transactionFees.js'
+import { getDesiredMaxFeePerGasForBaseFee, getTransactionFeesForBaseFee, hasExplicitMaxFeePerGas } from '../../utils/transactionFees.js'
 
 const pendingConfirmationSemaphore = new Semaphore(1)
 
@@ -336,18 +336,14 @@ export const formEthSendTransaction = async(ethereumClientService: EthereumClien
 	const maxPriorityFeePerGas = transactionDetails.maxPriorityFeePerGas !== undefined && transactionDetails.maxPriorityFeePerGas !== null ? transactionDetails.maxPriorityFeePerGas : 10n**8n // 0.1 nanoEth/gas
 	const value = transactionDetails.value !== undefined  ? transactionDetails.value : 0n
 	const getFeePerGas = async (gasLimit: bigint) => {
-		if (transactionDetails.maxFeePerGas !== undefined && transactionDetails.maxFeePerGas !== null) return {
-			maxFeePerGas: transactionDetails.maxFeePerGas,
-			maxPriorityFeePerGas,
-		}
-		return getAffordableTransactionFees(parentBaseFeePerGas * 2n + maxPriorityFeePerGas, maxPriorityFeePerGas, await balancePromise, value, gasLimit)
+		return getTransactionFeesForBaseFee(parentBaseFeePerGas, maxPriorityFeePerGas, transactionDetails.maxFeePerGas, await balancePromise, value, gasLimit)
 	}
 	const transactionWithoutGas = {
 		type: '1559' as const,
 		from,
 		chainId: ethereumClientService.getChainId(),
 		nonce: await transactionCountPromise,
-		maxFeePerGas: transactionDetails.maxFeePerGas !== undefined && transactionDetails.maxFeePerGas !== null ? transactionDetails.maxFeePerGas : parentBaseFeePerGas * 2n + maxPriorityFeePerGas,
+		maxFeePerGas: hasExplicitMaxFeePerGas(transactionDetails.maxFeePerGas) ? transactionDetails.maxFeePerGas : getDesiredMaxFeePerGasForBaseFee(parentBaseFeePerGas, maxPriorityFeePerGas),
 		maxPriorityFeePerGas,
 		to: transactionDetails.to === undefined ? null : transactionDetails.to,
 		value,

--- a/app/ts/simulation/services/SimulationModeEthereumClientService.ts
+++ b/app/ts/simulation/services/SimulationModeEthereumClientService.ts
@@ -743,6 +743,18 @@ const getBalanceBeforeSimulationInputTransaction = async (
 	)
 }
 
+const getBaseFeeAdjustedTransactionWithBalances = (
+	parentBlock: NonNullable<EthereumBlockHeader>,
+	currentBlock: SimulationStateInput[number],
+	transaction: PreSimulationTransaction,
+	balances: ReadonlyMap<EthereumQuantity, bigint>,
+) => {
+	const adjustedTransactions = getBaseFeeAdjustedTransactions(parentBlock, modifyObject(currentBlock, { transactions: [transaction] }), balances)
+	const adjustedTransaction = adjustedTransactions[0]
+	if (adjustedTransaction === undefined) throw new Error('missing base fee adjusted transaction')
+	return adjustedTransaction
+}
+
 export const getBaseFeeAdjustmentBalances = async (
 	ethereumClientService: EthereumClientService,
 	requestAbortController: AbortController | undefined,
@@ -759,12 +771,12 @@ export const getBaseFeeAdjustmentBalances = async (
 	for (const transaction of currentBlock.transactions) {
 		if (transaction.originalRequestParameters.method !== 'eth_sendTransaction') {
 			conservativeBalances.delete(transaction.signedTransaction.from)
-			adjustedTransactions.push(transaction)
+			adjustedTransactions.push(getBaseFeeAdjustedTransactionWithBalances(parentBlock, currentBlock, transaction, balances))
 			continue
 		}
 		if (transaction.signedTransaction.type !== '1559') {
 			conservativeBalances.delete(transaction.signedTransaction.from)
-			adjustedTransactions.push(transaction)
+			adjustedTransactions.push(getBaseFeeAdjustedTransactionWithBalances(parentBlock, currentBlock, transaction, balances))
 			continue
 		}
 		if (hasExplicitMaxFeePerGas(transaction.originalRequestParameters.params[0].maxFeePerGas)) {
@@ -775,7 +787,7 @@ export const getBaseFeeAdjustmentBalances = async (
 					subtractMaxGasCost(conservativeBalance, transaction.signedTransaction.value, transaction.signedTransaction.gas, transaction.originalRequestParameters.params[0].maxFeePerGas),
 				)
 			}
-			adjustedTransactions.push(transaction)
+			adjustedTransactions.push(getBaseFeeAdjustedTransactionWithBalances(parentBlock, currentBlock, transaction, balances))
 			continue
 		}
 		const desiredMaxFeePerGas = getDesiredMaxFeePerGasForBaseFee(parentBaseFeePerGas, transaction.signedTransaction.maxPriorityFeePerGas)
@@ -783,9 +795,9 @@ export const getBaseFeeAdjustmentBalances = async (
 		const balance = conservativeBalance !== undefined && canAffordMaxGasCost(conservativeBalance, transaction.signedTransaction.value, transaction.signedTransaction.gas, desiredMaxFeePerGas)
 			? conservativeBalance
 			: await getBalanceBeforeSimulationInputTransaction(ethereumClientService, requestAbortController, parentBlock, simulationInputBeforeBlock, currentBlock, adjustedTransactions, transaction.signedTransaction.from)
-		const adjustedTransaction = getBaseFeeAdjustedTransaction(transaction, parentBaseFeePerGas, balance)
-		if (adjustedTransaction.signedTransaction.type !== '1559') throw new Error('Expected 1559 transaction after base fee adjustment')
 		balances.set(transaction.transactionIdentifier, balance)
+		const adjustedTransaction = getBaseFeeAdjustedTransactionWithBalances(parentBlock, currentBlock, transaction, balances)
+		if (adjustedTransaction.signedTransaction.type !== '1559') throw new Error('Expected 1559 transaction after base fee adjustment')
 		conservativeBalances.set(transaction.signedTransaction.from, subtractMaxGasCost(balance, transaction.signedTransaction.value, transaction.signedTransaction.gas, adjustedTransaction.signedTransaction.maxFeePerGas))
 		adjustedTransactions.push(adjustedTransaction)
 	}

--- a/app/ts/simulation/services/SimulationModeEthereumClientService.ts
+++ b/app/ts/simulation/services/SimulationModeEthereumClientService.ts
@@ -22,7 +22,7 @@ import type { ErrorWithCodeAndOptionalData } from '../../types/error.js'
 import { getSimulationInputHash } from '../../utils/simulationFingerprint.js'
 import { decodeCallDataLoose, decodeEventLoose, decodeFunctionOutput, encodeFunctionCall, type AbiLike } from '../../utils/abiRuntime.js'
 import { Erc20ABI, Erc1155ABI } from '../../utils/abi.js'
-import { getAffordableTransactionFees } from '../../utils/transactionFees.js'
+import { getDesiredMaxFeePerGasForBaseFee, getTransactionFeesForBaseFee, hasExplicitMaxFeePerGas } from '../../utils/transactionFees.js'
 
 type SuccessfulExecutionSimulationState = Extract<ExecutionSimulationState, { success: true }>
 
@@ -693,6 +693,30 @@ const subtractMaxGasCost = (balance: bigint, value: bigint, gasLimit: bigint, ma
 	return balance > maxCost ? balance - maxCost : 0n
 }
 
+const usesInterceptorFilledMaxFeePerGas = (transaction: PreSimulationTransaction) => {
+	return transaction.originalRequestParameters.method === 'eth_sendTransaction'
+		&& transaction.signedTransaction.type === '1559'
+		&& !hasExplicitMaxFeePerGas(transaction.originalRequestParameters.params[0].maxFeePerGas)
+}
+
+const getBaseFeeAdjustedTransaction = (
+	transaction: PreSimulationTransaction,
+	parentBaseFeePerGas: bigint,
+	balance: bigint,
+) => {
+	if (!usesInterceptorFilledMaxFeePerGas(transaction)) return transaction
+	if (transaction.signedTransaction.type !== '1559') return transaction
+	const feePerGas = getTransactionFeesForBaseFee(
+		parentBaseFeePerGas,
+		transaction.signedTransaction.maxPriorityFeePerGas,
+		undefined,
+		balance,
+		transaction.signedTransaction.value,
+		transaction.signedTransaction.gas,
+	)
+	return modifyObject(transaction, { signedTransaction: modifyObject(transaction.signedTransaction, feePerGas) })
+}
+
 const getBalanceBeforeSimulationInputTransaction = async (
 	ethereumClientService: EthereumClientService,
 	requestAbortController: AbortController | undefined,
@@ -719,25 +743,21 @@ const getBalanceBeforeSimulationInputTransaction = async (
 	)
 }
 
-export const getBaseFeeAdjustedTransactions = async (
+export const getBaseFeeAdjustmentBalances = async (
 	ethereumClientService: EthereumClientService,
 	requestAbortController: AbortController | undefined,
 	parentBlock: EthereumBlockHeader,
 	simulationInputBeforeBlock: SimulationStateInput,
 	currentBlock: SimulationStateInput[number],
-): Promise<readonly PreSimulationTransaction[]> => {
-	if (parentBlock === null) return currentBlock.transactions
+): Promise<ReadonlyMap<EthereumQuantity, bigint>> => {
+	const balances = new Map<EthereumQuantity, bigint>()
+	if (parentBlock === null) return balances
 	const parentBaseFeePerGas = parentBlock.baseFeePerGas
-	if (parentBaseFeePerGas === undefined) return currentBlock.transactions
+	if (parentBaseFeePerGas === undefined) return balances
 	const adjustedTransactions: PreSimulationTransaction[] = []
 	const conservativeBalances = new Map<bigint, bigint>()
 	for (const transaction of currentBlock.transactions) {
 		if (transaction.originalRequestParameters.method !== 'eth_sendTransaction') {
-			conservativeBalances.delete(transaction.signedTransaction.from)
-			adjustedTransactions.push(transaction)
-			continue
-		}
-		if (transaction.originalRequestParameters.params[0].maxFeePerGas !== undefined && transaction.originalRequestParameters.params[0].maxFeePerGas !== null) {
 			conservativeBalances.delete(transaction.signedTransaction.from)
 			adjustedTransactions.push(transaction)
 			continue
@@ -747,16 +767,45 @@ export const getBaseFeeAdjustedTransactions = async (
 			adjustedTransactions.push(transaction)
 			continue
 		}
-		const desiredMaxFeePerGas = parentBaseFeePerGas * 2n + transaction.signedTransaction.maxPriorityFeePerGas
+		if (hasExplicitMaxFeePerGas(transaction.originalRequestParameters.params[0].maxFeePerGas)) {
+			const conservativeBalance = conservativeBalances.get(transaction.signedTransaction.from)
+			if (conservativeBalance !== undefined) {
+				conservativeBalances.set(
+					transaction.signedTransaction.from,
+					subtractMaxGasCost(conservativeBalance, transaction.signedTransaction.value, transaction.signedTransaction.gas, transaction.originalRequestParameters.params[0].maxFeePerGas),
+				)
+			}
+			adjustedTransactions.push(transaction)
+			continue
+		}
+		const desiredMaxFeePerGas = getDesiredMaxFeePerGasForBaseFee(parentBaseFeePerGas, transaction.signedTransaction.maxPriorityFeePerGas)
 		const conservativeBalance = conservativeBalances.get(transaction.signedTransaction.from)
 		const balance = conservativeBalance !== undefined && canAffordMaxGasCost(conservativeBalance, transaction.signedTransaction.value, transaction.signedTransaction.gas, desiredMaxFeePerGas)
 			? conservativeBalance
 			: await getBalanceBeforeSimulationInputTransaction(ethereumClientService, requestAbortController, parentBlock, simulationInputBeforeBlock, currentBlock, adjustedTransactions, transaction.signedTransaction.from)
-		const feePerGas = getAffordableTransactionFees(desiredMaxFeePerGas, transaction.signedTransaction.maxPriorityFeePerGas, balance, transaction.signedTransaction.value, transaction.signedTransaction.gas)
-		conservativeBalances.set(transaction.signedTransaction.from, subtractMaxGasCost(balance, transaction.signedTransaction.value, transaction.signedTransaction.gas, feePerGas.maxFeePerGas))
-		adjustedTransactions.push(modifyObject(transaction, { signedTransaction: modifyObject(transaction.signedTransaction, feePerGas) }))
+		const adjustedTransaction = getBaseFeeAdjustedTransaction(transaction, parentBaseFeePerGas, balance)
+		if (adjustedTransaction.signedTransaction.type !== '1559') throw new Error('Expected 1559 transaction after base fee adjustment')
+		balances.set(transaction.transactionIdentifier, balance)
+		conservativeBalances.set(transaction.signedTransaction.from, subtractMaxGasCost(balance, transaction.signedTransaction.value, transaction.signedTransaction.gas, adjustedTransaction.signedTransaction.maxFeePerGas))
+		adjustedTransactions.push(adjustedTransaction)
 	}
-	return adjustedTransactions
+	return balances
+}
+
+export const getBaseFeeAdjustedTransactions = (
+	parentBlock: EthereumBlockHeader,
+	currentBlock: SimulationStateInput[number],
+	balances: ReadonlyMap<EthereumQuantity, bigint>,
+): readonly PreSimulationTransaction[] => {
+	if (parentBlock === null) return currentBlock.transactions
+	const parentBaseFeePerGas = parentBlock.baseFeePerGas
+	if (parentBaseFeePerGas === undefined) return currentBlock.transactions
+	return currentBlock.transactions.map((transaction) => {
+		if (!usesInterceptorFilledMaxFeePerGas(transaction)) return transaction
+		const balance = balances.get(transaction.transactionIdentifier)
+		if (balance === undefined) throw new Error('missing balance for base fee adjusted transaction')
+		return getBaseFeeAdjustedTransaction(transaction, parentBaseFeePerGas, balance)
+	})
 }
 
 const canQueryNodeDirectly = async (simulationState: SimulationState, blockTag: EthereumBlockTag = 'latest') => {

--- a/app/ts/simulation/services/SimulationModeEthereumClientService.ts
+++ b/app/ts/simulation/services/SimulationModeEthereumClientService.ts
@@ -683,10 +683,23 @@ export const getNonceFixedSimulationStateInput = async(ethereumClientService: Et
 	return { nonceFixed: true, simulationStateInput: simulationInputBlocks }
 }
 
-const getAffordableMaxFeePerGas = (desiredMaxFeePerGas: bigint, balance: bigint, value: bigint, gasLimit: bigint) => {
-	if (gasLimit === 0n) return desiredMaxFeePerGas
+const getAffordableTransactionFees = (desiredMaxFeePerGas: bigint, desiredMaxPriorityFeePerGas: bigint, balance: bigint, value: bigint, gasLimit: bigint) => {
+	if (gasLimit === 0n) return { maxFeePerGas: desiredMaxFeePerGas, maxPriorityFeePerGas: desiredMaxPriorityFeePerGas }
 	const availableForGas = balance > value ? balance - value : 0n
-	return min(desiredMaxFeePerGas, availableForGas / gasLimit)
+	const maxFeePerGas = min(desiredMaxFeePerGas, availableForGas / gasLimit)
+	return {
+		maxFeePerGas,
+		maxPriorityFeePerGas: min(desiredMaxPriorityFeePerGas, maxFeePerGas),
+	}
+}
+
+const canAffordMaxGasCost = (balance: bigint, value: bigint, gasLimit: bigint, maxFeePerGas: bigint) => {
+	return balance >= value + gasLimit * maxFeePerGas
+}
+
+const subtractMaxGasCost = (balance: bigint, value: bigint, gasLimit: bigint, maxFeePerGas: bigint) => {
+	const maxCost = value + gasLimit * maxFeePerGas
+	return balance > maxCost ? balance - maxCost : 0n
 }
 
 const getBalanceBeforeSimulationInputTransaction = async (
@@ -726,22 +739,31 @@ export const getBaseFeeAdjustedTransactions = async (
 	const parentBaseFeePerGas = parentBlock.baseFeePerGas
 	if (parentBaseFeePerGas === undefined) return currentBlock.transactions
 	const adjustedTransactions: PreSimulationTransaction[] = []
+	const conservativeBalances = new Map<bigint, bigint>()
 	for (const transaction of currentBlock.transactions) {
 		if (transaction.originalRequestParameters.method !== 'eth_sendTransaction') {
+			conservativeBalances.delete(transaction.signedTransaction.from)
 			adjustedTransactions.push(transaction)
 			continue
 		}
 		if (transaction.originalRequestParameters.params[0].maxFeePerGas !== undefined && transaction.originalRequestParameters.params[0].maxFeePerGas !== null) {
+			conservativeBalances.delete(transaction.signedTransaction.from)
 			adjustedTransactions.push(transaction)
 			continue
 		}
 		if (transaction.signedTransaction.type !== '1559') {
+			conservativeBalances.delete(transaction.signedTransaction.from)
 			adjustedTransactions.push(transaction)
 			continue
 		}
-		const balance = await getBalanceBeforeSimulationInputTransaction(ethereumClientService, requestAbortController, parentBlock, simulationInputBeforeBlock, currentBlock, adjustedTransactions, transaction.signedTransaction.from)
-		const maxFeePerGas = getAffordableMaxFeePerGas(parentBaseFeePerGas * 2n + transaction.signedTransaction.maxPriorityFeePerGas, balance, transaction.signedTransaction.value, transaction.signedTransaction.gas)
-		adjustedTransactions.push(modifyObject(transaction, { signedTransaction: modifyObject(transaction.signedTransaction, { maxFeePerGas }) }))
+		const desiredMaxFeePerGas = parentBaseFeePerGas * 2n + transaction.signedTransaction.maxPriorityFeePerGas
+		const conservativeBalance = conservativeBalances.get(transaction.signedTransaction.from)
+		const balance = conservativeBalance !== undefined && canAffordMaxGasCost(conservativeBalance, transaction.signedTransaction.value, transaction.signedTransaction.gas, desiredMaxFeePerGas)
+			? conservativeBalance
+			: await getBalanceBeforeSimulationInputTransaction(ethereumClientService, requestAbortController, parentBlock, simulationInputBeforeBlock, currentBlock, adjustedTransactions, transaction.signedTransaction.from)
+		const feePerGas = getAffordableTransactionFees(desiredMaxFeePerGas, transaction.signedTransaction.maxPriorityFeePerGas, balance, transaction.signedTransaction.value, transaction.signedTransaction.gas)
+		conservativeBalances.set(transaction.signedTransaction.from, subtractMaxGasCost(balance, transaction.signedTransaction.value, transaction.signedTransaction.gas, feePerGas.maxFeePerGas))
+		adjustedTransactions.push(modifyObject(transaction, { signedTransaction: modifyObject(transaction.signedTransaction, feePerGas) }))
 	}
 	return adjustedTransactions
 }

--- a/app/ts/simulation/services/SimulationModeEthereumClientService.ts
+++ b/app/ts/simulation/services/SimulationModeEthereumClientService.ts
@@ -686,15 +686,28 @@ export const getNonceFixedSimulationStateInput = async(ethereumClientService: Et
 	return { nonceFixed: true, simulationStateInput: simulationInputBlocks }
 }
 
-export const getBaseFeeAdjustedTransactions = (parentBlock: EthereumBlockHeader, preSimulationTransactions: readonly PreSimulationTransaction[]): readonly PreSimulationTransaction[] => {
+const getAffordableMaxFeePerGas = (desiredMaxFeePerGas: bigint, balance: bigint, value: bigint, gasLimit: bigint) => {
+	if (gasLimit === 0n) return desiredMaxFeePerGas
+	const availableForGas = balance > value ? balance - value : 0n
+	return min(desiredMaxFeePerGas, availableForGas / gasLimit)
+}
+
+export const getBaseFeeAdjustedTransactions = async (ethereumClientService: EthereumClientService, requestAbortController: AbortController | undefined, parentBlock: EthereumBlockHeader, preSimulationTransactions: readonly PreSimulationTransaction[]): Promise<readonly PreSimulationTransaction[]> => {
 	if (parentBlock === null) return preSimulationTransactions
 	const parentBaseFeePerGas = parentBlock.baseFeePerGas
 	if (parentBaseFeePerGas === undefined) return preSimulationTransactions
-	return preSimulationTransactions.map((transaction) => {
+	return await Promise.all(preSimulationTransactions.map(async (transaction) => {
 		if (transaction.originalRequestParameters.method !== 'eth_sendTransaction') return transaction
+		if (transaction.originalRequestParameters.params[0].maxFeePerGas !== undefined && transaction.originalRequestParameters.params[0].maxFeePerGas !== null) return transaction
 		if (transaction.signedTransaction.type !== '1559') return transaction
-		return modifyObject(transaction, { signedTransaction: modifyObject(transaction.signedTransaction, { maxFeePerGas: parentBaseFeePerGas * 2n + transaction.signedTransaction.maxPriorityFeePerGas }) })
-	})
+		const maxFeePerGas = getAffordableMaxFeePerGas(
+			parentBaseFeePerGas * 2n + transaction.signedTransaction.maxPriorityFeePerGas,
+			await ethereumClientService.getBalance(transaction.signedTransaction.from, 'latest', requestAbortController),
+			transaction.signedTransaction.value,
+			transaction.signedTransaction.gas,
+		)
+		return modifyObject(transaction, { signedTransaction: modifyObject(transaction.signedTransaction, { maxFeePerGas }) })
+	}))
 }
 
 const canQueryNodeDirectly = async (simulationState: SimulationState, blockTag: EthereumBlockTag = 'latest') => {

--- a/app/ts/simulation/services/SimulationModeEthereumClientService.ts
+++ b/app/ts/simulation/services/SimulationModeEthereumClientService.ts
@@ -689,22 +689,61 @@ const getAffordableMaxFeePerGas = (desiredMaxFeePerGas: bigint, balance: bigint,
 	return min(desiredMaxFeePerGas, availableForGas / gasLimit)
 }
 
-export const getBaseFeeAdjustedTransactions = async (ethereumClientService: EthereumClientService, requestAbortController: AbortController | undefined, parentBlock: EthereumBlockHeader, preSimulationTransactions: readonly PreSimulationTransaction[]): Promise<readonly PreSimulationTransaction[]> => {
-	if (parentBlock === null) return preSimulationTransactions
+const getBalanceBeforeSimulationInputTransaction = async (
+	ethereumClientService: EthereumClientService,
+	requestAbortController: AbortController | undefined,
+	parentBlock: NonNullable<EthereumBlockHeader>,
+	simulationInputBeforeBlock: SimulationStateInput,
+	currentBlock: SimulationStateInput[number],
+	transactionsBefore: readonly PreSimulationTransaction[],
+	address: bigint,
+) => {
+	const overrideBalance = currentBlock.stateOverrides[addressString(address)]?.balance
+	if (transactionsBefore.length === 0 && overrideBalance !== undefined) return overrideBalance
+	if (simulationInputBeforeBlock.length === 0 && transactionsBefore.length === 0) return await ethereumClientService.getBalance(address, parentBlock.number, requestAbortController)
+	const simulationInputBeforeTransaction = [
+		...simulationInputBeforeBlock,
+		modifyObject(currentBlock, { transactions: transactionsBefore }),
+	]
+	return await getSimulatedBalanceFromInput(
+		ethereumClientService,
+		requestAbortController,
+		{ kind: 'simulated', value: simulationInputBeforeTransaction },
+		address,
+		'latest',
+		parentBlock.number,
+	)
+}
+
+export const getBaseFeeAdjustedTransactions = async (
+	ethereumClientService: EthereumClientService,
+	requestAbortController: AbortController | undefined,
+	parentBlock: EthereumBlockHeader,
+	simulationInputBeforeBlock: SimulationStateInput,
+	currentBlock: SimulationStateInput[number],
+): Promise<readonly PreSimulationTransaction[]> => {
+	if (parentBlock === null) return currentBlock.transactions
 	const parentBaseFeePerGas = parentBlock.baseFeePerGas
-	if (parentBaseFeePerGas === undefined) return preSimulationTransactions
-	return await Promise.all(preSimulationTransactions.map(async (transaction) => {
-		if (transaction.originalRequestParameters.method !== 'eth_sendTransaction') return transaction
-		if (transaction.originalRequestParameters.params[0].maxFeePerGas !== undefined && transaction.originalRequestParameters.params[0].maxFeePerGas !== null) return transaction
-		if (transaction.signedTransaction.type !== '1559') return transaction
-		const maxFeePerGas = getAffordableMaxFeePerGas(
-			parentBaseFeePerGas * 2n + transaction.signedTransaction.maxPriorityFeePerGas,
-			await ethereumClientService.getBalance(transaction.signedTransaction.from, 'latest', requestAbortController),
-			transaction.signedTransaction.value,
-			transaction.signedTransaction.gas,
-		)
-		return modifyObject(transaction, { signedTransaction: modifyObject(transaction.signedTransaction, { maxFeePerGas }) })
-	}))
+	if (parentBaseFeePerGas === undefined) return currentBlock.transactions
+	const adjustedTransactions: PreSimulationTransaction[] = []
+	for (const transaction of currentBlock.transactions) {
+		if (transaction.originalRequestParameters.method !== 'eth_sendTransaction') {
+			adjustedTransactions.push(transaction)
+			continue
+		}
+		if (transaction.originalRequestParameters.params[0].maxFeePerGas !== undefined && transaction.originalRequestParameters.params[0].maxFeePerGas !== null) {
+			adjustedTransactions.push(transaction)
+			continue
+		}
+		if (transaction.signedTransaction.type !== '1559') {
+			adjustedTransactions.push(transaction)
+			continue
+		}
+		const balance = await getBalanceBeforeSimulationInputTransaction(ethereumClientService, requestAbortController, parentBlock, simulationInputBeforeBlock, currentBlock, adjustedTransactions, transaction.signedTransaction.from)
+		const maxFeePerGas = getAffordableMaxFeePerGas(parentBaseFeePerGas * 2n + transaction.signedTransaction.maxPriorityFeePerGas, balance, transaction.signedTransaction.value, transaction.signedTransaction.gas)
+		adjustedTransactions.push(modifyObject(transaction, { signedTransaction: modifyObject(transaction.signedTransaction, { maxFeePerGas }) }))
+	}
+	return adjustedTransactions
 }
 
 const canQueryNodeDirectly = async (simulationState: SimulationState, blockTag: EthereumBlockTag = 'latest') => {
@@ -1089,9 +1128,14 @@ export const getSimulatedBalanceFromInput = async (
 	simulationStateInput: ResolvedSimulationInput,
 	address: bigint,
 	blockTag: EthereumBlockTag = 'latest',
+	baseBlockTag: EthereumBlockTag = 'latest',
 ): Promise<bigint> => {
-	const context = await createPreparedSimulationExecutionContext(ethereumClientService, requestAbortController, simulationStateInput)
-	if (context === undefined || canQueryNodeDirectlyFromInput(context.parentBlock.number, context.executionBlocks.length, blockTag)) {
+	const context = await createPreparedSimulationExecutionContext(ethereumClientService, requestAbortController, simulationStateInput, baseBlockTag)
+	if (context === undefined) {
+		const directBlockTag = blockTag === 'latest' || blockTag === 'pending' ? baseBlockTag : blockTag
+		return await ethereumClientService.getBalance(address, directBlockTag, requestAbortController)
+	}
+	if (canQueryNodeDirectlyFromInput(context.parentBlock.number, context.executionBlocks.length, blockTag)) {
 		return await ethereumClientService.getBalance(address, blockTag, requestAbortController)
 	}
 	const executionBlocksToApply = getExecutionBlocksUpToTag(context, blockTag)

--- a/app/ts/simulation/services/SimulationModeEthereumClientService.ts
+++ b/app/ts/simulation/services/SimulationModeEthereumClientService.ts
@@ -22,6 +22,7 @@ import type { ErrorWithCodeAndOptionalData } from '../../types/error.js'
 import { getSimulationInputHash } from '../../utils/simulationFingerprint.js'
 import { decodeCallDataLoose, decodeEventLoose, decodeFunctionOutput, encodeFunctionCall, type AbiLike } from '../../utils/abiRuntime.js'
 import { Erc20ABI, Erc1155ABI } from '../../utils/abi.js'
+import { getAffordableTransactionFees } from '../../utils/transactionFees.js'
 
 type SuccessfulExecutionSimulationState = Extract<ExecutionSimulationState, { success: true }>
 
@@ -681,16 +682,6 @@ export const getNonceFixedSimulationStateInput = async(ethereumClientService: Et
 		simulationInputBlocks.push({ ...oldBlock, transactions: processedTransactions })
 	}
 	return { nonceFixed: true, simulationStateInput: simulationInputBlocks }
-}
-
-const getAffordableTransactionFees = (desiredMaxFeePerGas: bigint, desiredMaxPriorityFeePerGas: bigint, balance: bigint, value: bigint, gasLimit: bigint) => {
-	if (gasLimit === 0n) return { maxFeePerGas: desiredMaxFeePerGas, maxPriorityFeePerGas: desiredMaxPriorityFeePerGas }
-	const availableForGas = balance > value ? balance - value : 0n
-	const maxFeePerGas = min(desiredMaxFeePerGas, availableForGas / gasLimit)
-	return {
-		maxFeePerGas,
-		maxPriorityFeePerGas: min(desiredMaxPriorityFeePerGas, maxFeePerGas),
-	}
 }
 
 const canAffordMaxGasCost = (balance: bigint, value: bigint, gasLimit: bigint, maxFeePerGas: bigint) => {

--- a/app/ts/utils/transactionFees.ts
+++ b/app/ts/utils/transactionFees.ts
@@ -1,0 +1,11 @@
+import { min } from './bigint.js'
+
+export const getAffordableTransactionFees = (desiredMaxFeePerGas: bigint, desiredMaxPriorityFeePerGas: bigint, balance: bigint, value: bigint, gasLimit: bigint) => {
+	if (gasLimit === 0n) return { maxFeePerGas: desiredMaxFeePerGas, maxPriorityFeePerGas: desiredMaxPriorityFeePerGas }
+	const availableForGas = balance > value ? balance - value : 0n
+	const maxFeePerGas = min(desiredMaxFeePerGas, availableForGas / gasLimit)
+	return {
+		maxFeePerGas,
+		maxPriorityFeePerGas: min(desiredMaxPriorityFeePerGas, maxFeePerGas),
+	}
+}

--- a/app/ts/utils/transactionFees.ts
+++ b/app/ts/utils/transactionFees.ts
@@ -9,3 +9,22 @@ export const getAffordableTransactionFees = (desiredMaxFeePerGas: bigint, desire
 		maxPriorityFeePerGas: min(desiredMaxPriorityFeePerGas, maxFeePerGas),
 	}
 }
+
+export const hasExplicitMaxFeePerGas = (maxFeePerGas: bigint | null | undefined): maxFeePerGas is bigint => maxFeePerGas !== undefined && maxFeePerGas !== null
+
+export const getDesiredMaxFeePerGasForBaseFee = (parentBaseFeePerGas: bigint, maxPriorityFeePerGas: bigint) => parentBaseFeePerGas * 2n + maxPriorityFeePerGas
+
+export const getTransactionFeesForBaseFee = (
+	parentBaseFeePerGas: bigint,
+	maxPriorityFeePerGas: bigint,
+	maxFeePerGas: bigint | null | undefined,
+	balance: bigint,
+	value: bigint,
+	gasLimit: bigint,
+) => {
+	if (hasExplicitMaxFeePerGas(maxFeePerGas)) return {
+		maxFeePerGas,
+		maxPriorityFeePerGas,
+	}
+	return getAffordableTransactionFees(getDesiredMaxFeePerGasForBaseFee(parentBaseFeePerGas, maxPriorityFeePerGas), maxPriorityFeePerGas, balance, value, gasLimit)
+}

--- a/test/tests/SimulationModeEthereumClientService.test.ts
+++ b/test/tests/SimulationModeEthereumClientService.test.ts
@@ -6,7 +6,7 @@ import { EthereumClientService } from '../../app/ts/simulation/services/Ethereum
 import { EthereumSignedTransactionToSignedTransaction, EthereumUnsignedTransactionToUnsignedTransaction, serializeSignedTransactionToBytes, serializeUnsignedTransactionToBytes } from '../../app/ts/utils/ethereum.js'
 import { bytes32String, dataStringWith0xStart } from '../../app/ts/utils/bigint.js'
 import { EthereumSignatureParity, EthereumSignedTransaction, EthereumSignedTransaction1559, EthereumSignedTransactionWithBlockData, EthereumUnsignedTransaction } from '../../app/ts/types/wire-types.js'
-import { createExecutionSimulationState, createSimulationState, getBaseFeeAdjustedTransactions, getSimulatedBlockByHashFromInput, getSimulatedBlockFromInput, getSimulatedBlockNumberFromInput, getSimulatedCodeFromInput, getSimulatedLogs, getSimulatedTransactionByHashFromInput, getSimulatedTransactionReceipt, groupEthSimulateV1ResultByInputBlocks, mockSignTransaction, simulateEstimateGasFromInput, simulatedCallFromInput } from '../../app/ts/simulation/services/SimulationModeEthereumClientService.js'
+import { createExecutionSimulationState, createSimulationState, getBaseFeeAdjustedTransactions, getBaseFeeAdjustmentBalances, getSimulatedBlockByHashFromInput, getSimulatedBlockFromInput, getSimulatedBlockNumberFromInput, getSimulatedCodeFromInput, getSimulatedLogs, getSimulatedTransactionByHashFromInput, getSimulatedTransactionReceipt, groupEthSimulateV1ResultByInputBlocks, mockSignTransaction, simulateEstimateGasFromInput, simulatedCallFromInput } from '../../app/ts/simulation/services/SimulationModeEthereumClientService.js'
 import { EthTransactionReceiptResponse, JsonRpcResponse, type EthereumJsonRpcRequest } from '../../app/ts/types/JsonRpc-types.js'
 import type { EthSimulateV1Result } from '../../app/ts/types/ethSimulate-types.js'
 import { toResolvedExecutionSimulationState, toResolvedSimulationInput } from '../../app/ts/types/visualizer-types.js'
@@ -524,7 +524,8 @@ const zeroBytes256 = `0x${'0'.repeat(512)}`
 				simulateWithZeroBaseFee: false,
 			} as const
 
-			const adjusted = await getBaseFeeAdjustedTransactions(ethereum, undefined, parentBlock, [], currentBlock)
+			const balances = await getBaseFeeAdjustmentBalances(ethereum, undefined, parentBlock, [], currentBlock)
+			const adjusted = getBaseFeeAdjustedTransactions(parentBlock, currentBlock, balances)
 			const adjustedTransaction = adjusted[0]?.signedTransaction
 			if (adjustedTransaction === undefined || adjustedTransaction.type !== '1559') throw new Error('missing adjusted 1559 transaction')
 			assert.equal(adjustedTransaction.maxFeePerGas, 5n)
@@ -560,13 +561,52 @@ const zeroBytes256 = `0x${'0'.repeat(512)}`
 				simulateWithZeroBaseFee: false,
 			} as const
 
-			const adjusted = await getBaseFeeAdjustedTransactions(ethereum, undefined, parentBlock, [], currentBlock)
+			const balances = await getBaseFeeAdjustmentBalances(ethereum, undefined, parentBlock, [], currentBlock)
+			const adjusted = getBaseFeeAdjustedTransactions(parentBlock, currentBlock, balances)
 			assert.equal(adjusted.length, 2)
 			for (const transaction of adjusted) {
 				if (transaction.signedTransaction.type !== '1559') throw new Error('wrong transaction type')
 				assert.equal(transaction.signedTransaction.maxFeePerGas, 284n)
 				assert.equal(transaction.signedTransaction.maxPriorityFeePerGas, 100n)
 			}
+			assert.equal(requestHandler.ethGetBalanceCalls.length, 1)
+			assert.equal(requestHandler.ethSimulateV1Calls.length, 0)
+		})
+
+		test('getBaseFeeAdjustmentBalances tracks explicit max fee in conservative balance', async () => {
+			requestHandler.balance = 100_000n
+			requestHandler.ethGetBalanceCalls.length = 0
+			requestHandler.ethSimulateV1Calls.length = 0
+			const parentBlock = await ethereum.getBlock(undefined)
+			const makeTransaction = (nonce: bigint, identifier: bigint, maxFeePerGas: bigint | undefined) => ({
+				signedTransaction: mockSignTransaction({
+					...exampleTransaction,
+					nonce,
+					maxFeePerGas: maxFeePerGas ?? 999n,
+					maxPriorityFeePerGas: 100n,
+					gas: 10n,
+					value: 0n,
+				}),
+				website: { websiteOrigin: 'test', icon: undefined, title: undefined },
+				created: new Date(),
+				originalRequestParameters: { method: 'eth_sendTransaction', params: maxFeePerGas === undefined ? [{}] : [{ maxFeePerGas }]},
+				transactionIdentifier: identifier,
+			} as const)
+			const currentBlock = {
+				stateOverrides: {},
+				transactions: [
+					makeTransaction(0n, 23n, undefined),
+					makeTransaction(1n, 24n, 200n),
+					makeTransaction(2n, 25n, undefined),
+				],
+				signedMessages: [],
+				blockTimeManipulation: { type: 'AddToTimestamp', deltaToAdd: 12n, deltaUnit: 'Seconds' },
+				simulateWithZeroBaseFee: false,
+			} as const
+
+			const balances = await getBaseFeeAdjustmentBalances(ethereum, undefined, parentBlock, [], currentBlock)
+			const adjusted = getBaseFeeAdjustedTransactions(parentBlock, currentBlock, balances)
+			assert.equal(adjusted.length, 3)
 			assert.equal(requestHandler.ethGetBalanceCalls.length, 1)
 			assert.equal(requestHandler.ethSimulateV1Calls.length, 0)
 		})

--- a/test/tests/SimulationModeEthereumClientService.test.ts
+++ b/test/tests/SimulationModeEthereumClientService.test.ts
@@ -6,7 +6,7 @@ import { EthereumClientService } from '../../app/ts/simulation/services/Ethereum
 import { EthereumSignedTransactionToSignedTransaction, EthereumUnsignedTransactionToUnsignedTransaction, serializeSignedTransactionToBytes, serializeUnsignedTransactionToBytes } from '../../app/ts/utils/ethereum.js'
 import { bytes32String, dataStringWith0xStart } from '../../app/ts/utils/bigint.js'
 import { EthereumSignatureParity, EthereumSignedTransaction, EthereumSignedTransaction1559, EthereumSignedTransactionWithBlockData, EthereumUnsignedTransaction } from '../../app/ts/types/wire-types.js'
-import { createExecutionSimulationState, createSimulationState, getSimulatedBlockByHashFromInput, getSimulatedBlockFromInput, getSimulatedBlockNumberFromInput, getSimulatedCodeFromInput, getSimulatedLogs, getSimulatedTransactionByHashFromInput, getSimulatedTransactionReceipt, groupEthSimulateV1ResultByInputBlocks, mockSignTransaction, simulateEstimateGasFromInput, simulatedCallFromInput } from '../../app/ts/simulation/services/SimulationModeEthereumClientService.js'
+import { createExecutionSimulationState, createSimulationState, getBaseFeeAdjustedTransactions, getSimulatedBlockByHashFromInput, getSimulatedBlockFromInput, getSimulatedBlockNumberFromInput, getSimulatedCodeFromInput, getSimulatedLogs, getSimulatedTransactionByHashFromInput, getSimulatedTransactionReceipt, groupEthSimulateV1ResultByInputBlocks, mockSignTransaction, simulateEstimateGasFromInput, simulatedCallFromInput } from '../../app/ts/simulation/services/SimulationModeEthereumClientService.js'
 import { EthTransactionReceiptResponse, JsonRpcResponse, type EthereumJsonRpcRequest } from '../../app/ts/types/JsonRpc-types.js'
 import type { EthSimulateV1Result } from '../../app/ts/types/ethSimulate-types.js'
 import { toResolvedExecutionSimulationState, toResolvedSimulationInput } from '../../app/ts/types/visualizer-types.js'
@@ -90,6 +90,8 @@ const zeroBytes256 = `0x${'0'.repeat(512)}`
 	class MockEthereumJSONRpcRequestHandler {
 		public rpcUrl = 'https://rpc.dark.florist/flipcardtrustone'
 		public rejectOmittedGas = false
+		public balance = 0n
+		public ethGetBalanceCalls: EthereumJsonRpcRequest[] = []
 		public readonly ethSimulateV1Calls: { blockStateCallCount: number, aggregate3BalanceQueryCount: number | undefined, lastCallGas: bigint | undefined }[] = []
 
 		public clearCache = () => undefined
@@ -100,6 +102,9 @@ const zeroBytes256 = `0x${'0'.repeat(512)}`
 			switch (rpcRequest.method) {
 				case 'eth_blockNumber': return `0x${ blockNumber.toString(16) }`
 				case 'eth_getTransactionCount': return '0x0'
+				case 'eth_getBalance':
+					this.ethGetBalanceCalls.push(rpcRequest)
+					return `0x${ this.balance.toString(16) }`
 				case 'eth_getBlockByNumber': {
 					if (rpcRequest.params[0] !== blockNumber && rpcRequest.params[0] !== 'latest') throw new Error('Unsupported block number')
 					if (rpcRequest.params[1] === true) return parseRequest(eth_getBlockByNumber_goerli_8443561_true)
@@ -490,6 +495,80 @@ const zeroBytes256 = `0x${'0'.repeat(512)}`
 			assert.equal(groupedBlock.calls.length, 2)
 			assert.equal(groupedBlock.calls[0]?.gasUsed, 0x5208n)
 			assert.equal(groupedBlock.calls[1]?.gasUsed, 0x6dd4n)
+		})
+
+		test('getBaseFeeAdjustedTransactions caps priority fee with affordable max fee', async () => {
+			requestHandler.balance = 50n
+			requestHandler.ethGetBalanceCalls.length = 0
+			requestHandler.ethSimulateV1Calls.length = 0
+			const parentBlock = await ethereum.getBlock(undefined)
+			const transaction = {
+				signedTransaction: mockSignTransaction({
+					...exampleTransaction,
+					nonce: 0n,
+					maxFeePerGas: 999n,
+					maxPriorityFeePerGas: 100n,
+					gas: 10n,
+					value: 0n,
+				}),
+				website: { websiteOrigin: 'test', icon: undefined, title: undefined },
+				created: new Date(),
+				originalRequestParameters: { method: 'eth_sendTransaction', params: [{}]},
+				transactionIdentifier: 20n,
+			} as const
+			const currentBlock = {
+				stateOverrides: {},
+				transactions: [transaction],
+				signedMessages: [],
+				blockTimeManipulation: { type: 'AddToTimestamp', deltaToAdd: 12n, deltaUnit: 'Seconds' },
+				simulateWithZeroBaseFee: false,
+			} as const
+
+			const adjusted = await getBaseFeeAdjustedTransactions(ethereum, undefined, parentBlock, [], currentBlock)
+			const adjustedTransaction = adjusted[0]?.signedTransaction
+			if (adjustedTransaction === undefined || adjustedTransaction.type !== '1559') throw new Error('missing adjusted 1559 transaction')
+			assert.equal(adjustedTransaction.maxFeePerGas, 5n)
+			assert.equal(adjustedTransaction.maxPriorityFeePerGas, 5n)
+			assert.equal(requestHandler.ethGetBalanceCalls.length, 1)
+			assert.equal(requestHandler.ethSimulateV1Calls.length, 0)
+		})
+
+		test('getBaseFeeAdjustedTransactions skips prefix simulation when conservative balance can afford desired fees', async () => {
+			requestHandler.balance = 100_000n
+			requestHandler.ethGetBalanceCalls.length = 0
+			requestHandler.ethSimulateV1Calls.length = 0
+			const parentBlock = await ethereum.getBlock(undefined)
+			const makeTransaction = (nonce: bigint, identifier: bigint) => ({
+				signedTransaction: mockSignTransaction({
+					...exampleTransaction,
+					nonce,
+					maxFeePerGas: 999n,
+					maxPriorityFeePerGas: 100n,
+					gas: 10n,
+					value: 0n,
+				}),
+				website: { websiteOrigin: 'test', icon: undefined, title: undefined },
+				created: new Date(),
+				originalRequestParameters: { method: 'eth_sendTransaction', params: [{}]},
+				transactionIdentifier: identifier,
+			} as const)
+			const currentBlock = {
+				stateOverrides: {},
+				transactions: [makeTransaction(0n, 21n), makeTransaction(1n, 22n)],
+				signedMessages: [],
+				blockTimeManipulation: { type: 'AddToTimestamp', deltaToAdd: 12n, deltaUnit: 'Seconds' },
+				simulateWithZeroBaseFee: false,
+			} as const
+
+			const adjusted = await getBaseFeeAdjustedTransactions(ethereum, undefined, parentBlock, [], currentBlock)
+			assert.equal(adjusted.length, 2)
+			for (const transaction of adjusted) {
+				if (transaction.signedTransaction.type !== '1559') throw new Error('wrong transaction type')
+				assert.equal(transaction.signedTransaction.maxFeePerGas, 284n)
+				assert.equal(transaction.signedTransaction.maxPriorityFeePerGas, 100n)
+			}
+			assert.equal(requestHandler.ethGetBalanceCalls.length, 1)
+			assert.equal(requestHandler.ethSimulateV1Calls.length, 0)
 		})
 
 		test('simulateEstimateGasFromInput omits gas when input gas is omitted', async () => {


### PR DESCRIPTION
## Summary
- Cap Interceptor-filled EIP-1559 `maxFeePerGas` and `maxPriorityFeePerGas` by the sender balance available before each transaction.
- Use simulated stack balances so prior pending Interceptor transactions are included when computing affordable default fees.
- Preserve dapp-supplied `maxFeePerGas` values while tracking their conservative balance impact for later transactions.
- Reuse the adjusted transaction list produced during base-fee balance collection, avoiding duplicate fee-adjustment work in simulation input preparation.

## Testing
- `bun test`
- `bun run setup-chrome`
- `bun run typecheck`
- `bun run lint`
