### PR TITLE
Fix address modal ABI and metadata refresh state

### DIFF
--- a/app/ts/background/popupMessageHandlers.ts
+++ b/app/ts/background/popupMessageHandlers.ts
@@ -341,17 +341,19 @@ export async function refreshPopupConfirmTransactionMetadata(ethereum: EthereumC
 			if (first.transactionOrMessageCreationStatus !== 'Simulated' || first.popupVisualisation.statusCode === 'failed') return
 			try {
 				const visualizedSimulationState = await visualizeSimulatorState(first.popupVisualisation.data.simulationState, ethereum, tokenPriceService, requestAbortController)
+				const updatedFirst = modifyObject(first,
+					{
+						popupVisualisation: {
+							statusCode: 'success',
+							data: modifyObject(first.popupVisualisation.data, { ...visualizedSimulationState })
+						}
+					})
+				await updatePendingTransactionOrMessage(first.uniqueRequestIdentifier, async () => updatedFirst)
 				const messagePendingTransactions: UpdateConfirmTransactionDialogPendingTransactions = {
 					method: 'popup_update_confirm_transaction_dialog_pending_transactions' as const,
 					data: {
 						pendingTransactionAndSignableMessages: [
-							modifyObject(first,
-								{
-									popupVisualisation: {
-										statusCode: 'success',
-										data: modifyObject(first.popupVisualisation.data, { ...visualizedSimulationState })
-									}
-								})
+							updatedFirst
 							, ...promises.slice(1)].map(toPopupPendingTransactionOrSignableMessage),
 						currentBlockNumber: await currentBlockNumberPromise,
 						rpcConnectionStatus: await rpcConnectionStatusPromise,

--- a/app/ts/components/pages/AddNewAddress.tsx
+++ b/app/ts/components/pages/AddNewAddress.tsx
@@ -19,6 +19,20 @@ import { noReplyExpectingBrowserRuntimeOnMessageListener } from '../../utils/bro
 import { DropDownMenu } from '../subcomponents/DropDownMenu.js'
 import { NonHexBigInt } from '../../types/wire-types.js'
 
+export function mergeAddressWindowErrorState(
+	currentErrorState: ModifyAddressWindowState['errorState'],
+	validationErrorState: ModifyAddressWindowState['errorState'],
+) {
+	if (validationErrorState !== undefined) return validationErrorState
+	if (currentErrorState?.blockEditing === false) return currentErrorState
+	return undefined
+}
+
+export function getAddressWindowStateSyncErrorMessage(error: unknown) {
+	if (error instanceof Error && error.message.length > 0) return `Failed to update address window state: ${ error.message }`
+	return 'Failed to update address window state.'
+}
+
 export async function saveAddressBookEntry(entryToAdd: AddressBookEntry | { type: 'error', error: string }, close: () => void, sendMessage = sendPopupMessageToBackgroundPage,
 ) {
 	if (entryToAdd.type === 'error') return
@@ -123,6 +137,26 @@ function AbiInput({ abiInput, setAbiInput, disabled }: AbiInputParams) {
 	/>
 }
 
+export async function updateModifyAddressWindowState(
+	modifyAddressWindowState: Signal<ModifyAddressWindowState>,
+	updateState: (previousState: ModifyAddressWindowState) => ModifyAddressWindowState,
+	sendMessage = sendPopupMessageToBackgroundPage,
+) {
+	const previousState = modifyAddressWindowState.peek()
+	const updatedState = updateState(previousState)
+	modifyAddressWindowState.value = updatedState
+	try {
+		await sendMessage({ method: 'popup_changeAddOrModifyAddressWindowState', data: { windowStateId: updatedState.windowStateId, newState: updatedState } })
+	} catch(error) {
+		modifyAddressWindowState.value = modifyObject(updatedState, {
+			errorState: {
+				blockEditing: false,
+				message: getAddressWindowStateSyncErrorMessage(error),
+			}
+		})
+	}
+}
+
 function RenderIncompleteAddressBookEntry({ modifyAddressWindowState, rpcEntries, canFetchFromEtherScan, fetchAbiAndNameFromBlockExplorer }: RenderinCompleteAddressBookParams) {
 	const Text = (param: { text: ComponentChildren }) => {
 		return <p class = 'paragraph' style = 'color: var(--subtitle-text-color); text-overflow: ellipsis; overflow: hidden; width: 100%'>
@@ -142,16 +176,13 @@ function RenderIncompleteAddressBookEntry({ modifyAddressWindowState, rpcEntries
 		updateIncompleteAddressBookEntry(previousEntry => modifyObject(previousEntry, { type }))
 	}
 
-	type ModifyEntry = typeof modifyAddressWindowState.peek extends () => infer State ? (State extends { incompleteAddressBookEntry: infer Entry } ? Entry : never) : never
-	const updateIncompleteAddressBookEntry = async (updateEntry: (previousEntry: ModifyEntry) => ModifyEntry) => {
-		const previousState = modifyAddressWindowState.peek()
-		modifyAddressWindowState.value = modifyObject(previousState, { incompleteAddressBookEntry: updateEntry(previousState.incompleteAddressBookEntry) })
-		try {
-			await sendPopupMessageToBackgroundPage({ method: 'popup_changeAddOrModifyAddressWindowState', data: { windowStateId: modifyAddressWindowState.value.windowStateId, newState: modifyAddressWindowState.value } })
-		} catch(e) {
-			console.error(e)
-		}
-	}
+	const updateIncompleteAddressBookEntry = async (updateEntry: (previousEntry: ModifyAddressWindowState['incompleteAddressBookEntry']) => ModifyAddressWindowState['incompleteAddressBookEntry']) => updateModifyAddressWindowState(
+		modifyAddressWindowState,
+		previousState => modifyObject(previousState, {
+			incompleteAddressBookEntry: updateEntry(previousState.incompleteAddressBookEntry),
+			errorState: previousState.errorState?.blockEditing === false ? undefined : previousState.errorState
+		})
+	)
 
 	const setAddress = async (address: string) => updateIncompleteAddressBookEntry(previousEntry => modifyObject(previousEntry, { address }))
 	const setName = async (name: string) => updateIncompleteAddressBookEntry(previousEntry => modifyObject(previousEntry, { name }))
@@ -239,7 +270,9 @@ export function AddNewAddress(param: AddAddressParam) {
 			const parsed = maybeParsed.value
 			if (parsed.method === 'popup_addOrModifyAddressWindowStateInformation') {
 				if (parsed.data.windowStateId !== param.modifyAddressWindowState.value.windowStateId) return false
-				param.modifyAddressWindowState.value = modifyObject(param.modifyAddressWindowState.value, { errorState: parsed.data.errorState })
+				param.modifyAddressWindowState.value = modifyObject(param.modifyAddressWindowState.value, {
+					errorState: mergeAddressWindowErrorState(param.modifyAddressWindowState.value.errorState, parsed.data.errorState)
+				})
 			}
 			return false
 		}
@@ -369,21 +402,27 @@ export function AddNewAddress(param: AddAddressParam) {
 			address,
 			chainId: param.modifyAddressWindowState.value.incompleteAddressBookEntry.chainId
 		})
-		if (reply === undefined) return
 		canFetchFromEtherScan.value = true
+		if (reply === undefined) return
 		if (!reply.data.success) {
-			param.modifyAddressWindowState.value = modifyObject(param.modifyAddressWindowState.value, {
-				errorState: { blockEditing: false, message: reply.data.error }
-			})
+			const error = reply.data.error
+			await updateModifyAddressWindowState(
+				param.modifyAddressWindowState,
+				previousState => modifyObject(previousState, { errorState: { blockEditing: false, message: error } })
+			)
 			return
 		}
-		param.modifyAddressWindowState.value = modifyObject(param.modifyAddressWindowState.value, {
-			incompleteAddressBookEntry: modifyObject(param.modifyAddressWindowState.value.incompleteAddressBookEntry, {
-				abi: reply.data.abi,
-				name: param.modifyAddressWindowState.value.incompleteAddressBookEntry.name === undefined ? reply.data.contractName : param.modifyAddressWindowState.value.incompleteAddressBookEntry.name
-			}),
-			errorState: undefined
-		} )
+		const { abi, contractName } = reply.data
+		await updateModifyAddressWindowState(
+			param.modifyAddressWindowState,
+			previousState => modifyObject(previousState, {
+				incompleteAddressBookEntry: modifyObject(previousState.incompleteAddressBookEntry, {
+					abi,
+					name: previousState.incompleteAddressBookEntry.name === undefined ? contractName : previousState.incompleteAddressBookEntry.name
+				}),
+				errorState: undefined
+			})
+		)
 	}
 
 	const showOnChainVerificationErrorBox = useComputed(() => {

--- a/app/ts/components/pages/ConfirmTransaction.tsx
+++ b/app/ts/components/pages/ConfirmTransaction.tsx
@@ -46,6 +46,14 @@ const getResultsForTransaction = (visualizedSimulationState: VisualizedSimulatio
 		.find((transaction) => transaction.transactionIdentifier === transactionIdentifier)
 }
 
+export function getAddressBookEntryForEdit(clickedEntry: AddressBookEntry, addressBookEntries: readonly AddressBookEntry[]) {
+	const exactChainEntry = addressBookEntries.find((entry) => entry.address === clickedEntry.address && entry.chainId === clickedEntry.chainId)
+	if (exactChainEntry !== undefined) return exactChainEntry
+	const mainnetFallbackEntry = addressBookEntries.find((entry) => entry.address === clickedEntry.address && entry.chainId === undefined && clickedEntry.chainId === 1n)
+	if (mainnetFallbackEntry !== undefined) return mainnetFallbackEntry
+	return addressBookEntries.find((entry) => entry.address === clickedEntry.address) ?? clickedEntry
+}
+
 const HALF_HEADER_HEIGHT = 48 / 2
 
 export function shouldDisableSignableMessageConfirm(params: {
@@ -247,10 +255,10 @@ function FailedTransactionPreviewDetails({
 }
 
 export function TransactionCard(param: TransactionCardParams) {
-	const currentPendingTransaction = param.currentPendingTransaction.value
-	if (currentPendingTransaction === undefined || currentPendingTransaction.type !== 'Transaction' || (currentPendingTransaction.transactionOrMessageCreationStatus !== 'Simulated' && currentPendingTransaction.transactionOrMessageCreationStatus !== 'FailedToSimulate')) return <></>
+	const renderablePendingTransaction = useComputed(() => getRenderableTransaction(param.currentPendingTransaction.value))
+	if (renderablePendingTransaction.value === undefined) return <></>
 	return <TransactionCardContent
-		currentPendingTransaction = { currentPendingTransaction }
+		currentPendingTransaction = { renderablePendingTransaction }
 		pendingTransactionsAndSignableMessages = { param.pendingTransactionsAndSignableMessages }
 		renameAddressCallBack = { param.renameAddressCallBack }
 		editEnsNamedHashCallBack = { param.editEnsNamedHashCallBack }
@@ -261,7 +269,7 @@ export function TransactionCard(param: TransactionCardParams) {
 }
 
 type TransactionCardContentParams = {
-	currentPendingTransaction: SimulatedPendingTransaction,
+	currentPendingTransaction: ReadonlySignal<SimulatedPendingTransaction | undefined>,
 	pendingTransactionsAndSignableMessages: readonly PendingTransactionOrSignableMessage[],
 	renameAddressCallBack: RenameAddressCallBack,
 	editEnsNamedHashCallBack: EditEnsNamedHashCallBack,
@@ -270,8 +278,21 @@ type TransactionCardContentParams = {
 	numberOfUnderTransactions: number,
 }
 
+function getRenderableTransaction(currentPendingTransaction: PendingTransactionOrSignableMessage | undefined): SimulatedPendingTransaction | undefined {
+	if (currentPendingTransaction === undefined || currentPendingTransaction.type !== 'Transaction') return undefined
+	if (currentPendingTransaction.transactionOrMessageCreationStatus !== 'Simulated' && currentPendingTransaction.transactionOrMessageCreationStatus !== 'FailedToSimulate') return undefined
+	return currentPendingTransaction
+}
+
+function getSuccessfulTransactionPopupVisualisation(currentPendingTransaction: SimulatedPendingTransaction | undefined) {
+	if (currentPendingTransaction === undefined || currentPendingTransaction.popupVisualisation.statusCode !== 'success') return undefined
+	if (currentPendingTransaction.popupVisualisation.data.transactionToSimulate.success === false) return undefined
+	return currentPendingTransaction.popupVisualisation
+}
+
 function TransactionCardContent(param: TransactionCardContentParams) {
-	const currentPendingTransaction = param.currentPendingTransaction
+	const currentPendingTransaction = param.currentPendingTransaction.value
+	if (currentPendingTransaction === undefined) return <></>
 	const popupVisualisation = currentPendingTransaction.popupVisualisation
 	const getErrorMesssage = () => {
 		if (popupVisualisation.statusCode === 'failed') return `${ popupVisualisation.data.error.decodedErrorMessage } ${ popupVisualisation.data.error.data !== undefined ? ` (data: '${ popupVisualisation.data.error.data }')` : '' }`
@@ -295,9 +316,9 @@ function TransactionCardContent(param: TransactionCardContentParams) {
 			/>
 		</>
 	}
-	const activeAddress = useComputed(() => popupVisualisation.data.activeAddress)
-	const addressMetaData = useComputed(() => popupVisualisation.data.addressBookEntries)
-	const rpcNetwork = useComputed(() => popupVisualisation.data.simulationState.rpcNetwork)
+	const activeAddress = useComputed(() => getSuccessfulTransactionPopupVisualisation(param.currentPendingTransaction.value)?.data.activeAddress)
+	const addressMetaData = useComputed(() => getSuccessfulTransactionPopupVisualisation(param.currentPendingTransaction.value)?.data.addressBookEntries ?? popupVisualisation.data.addressBookEntries)
+	const rpcNetwork = useComputed(() => getSuccessfulTransactionPopupVisualisation(param.currentPendingTransaction.value)?.data.simulationState.rpcNetwork ?? popupVisualisation.data.simulationState.rpcNetwork)
 	const simulationAndVisualisationResults = {
 		blockNumber: popupVisualisation.data.simulationState.blockNumber,
 		blockTimestamp: popupVisualisation.data.simulationState.blockTimestamp,
@@ -650,8 +671,16 @@ export function ConfirmTransaction() {
 		return false
 	})
 
+	function getCurrentAddressBookEntries() {
+		const current = currentPendingTransactionOrSignableMessage.value
+		if (current?.type === 'Transaction' && current.transactionOrMessageCreationStatus === 'Simulated' && current.popupVisualisation.statusCode === 'success') {
+			return current.popupVisualisation.data.addressBookEntries
+		}
+		return completeVisualizedSimulation.value.addressBookEntries
+	}
+
 	function renameAddressCallBack(entry: AddressBookEntry) {
-		modalState.value = { page: 'modifyAddress', state: new Signal(addressEditEntry(entry)) }
+		modalState.value = { page: 'modifyAddress', state: new Signal(addressEditEntry(getAddressBookEntryForEdit(entry, getCurrentAddressBookEntries()))) }
 	}
 
 	function editEnsNamedHashCallBack(type: 'nameHash' | 'labelHash', nameHash: EthereumBytes32, name: string | undefined) {

--- a/app/ts/simulation/services/EtherScanAbiFetcher.ts
+++ b/app/ts/simulation/services/EtherScanAbiFetcher.ts
@@ -27,6 +27,29 @@ function getBlockExplorer(chainId: ChainIdWithUniversal, rpcEntries: RpcEntries)
 
 export const isBlockExplorerAvailableForChain = (chainId: ChainIdWithUniversal, rpcEntries: RpcEntries) => getBlockExplorer(chainId, rpcEntries) !== undefined
 
+const parseAbiArray = (abi: string): readonly unknown[] | undefined => {
+	try {
+		const parsed: unknown = JSON.parse(abi)
+		if (!Array.isArray(parsed)) return undefined
+		return parsed
+	} catch {
+		return undefined
+	}
+}
+
+export const mergeProxyAndImplementationAbi = (proxyAbi: string, implementationAbi: string) => {
+	const isProxyAbiValid = isValidAbi(proxyAbi)
+	const isImplementationAbiValid = isValidAbi(implementationAbi)
+	if (!isProxyAbiValid) return implementationAbi
+	if (!isImplementationAbiValid) return proxyAbi
+	const proxyAbiEntries = parseAbiArray(proxyAbi)
+	const implementationAbiEntries = parseAbiArray(implementationAbi)
+	if (proxyAbiEntries === undefined) return implementationAbi
+	if (implementationAbiEntries === undefined) return proxyAbi
+	const mergedAbi = JSON.stringify([...proxyAbiEntries, ...implementationAbiEntries])
+	return isValidAbi(mergedAbi) ? mergedAbi : implementationAbi
+}
+
 async function fetchAbi(contractAddress: EthereumAddress, maybeExplorer: BlockExplorer | undefined, chainId: bigint): Promise<Result<EtherscanSourceCodeResult>> {
 	const normalizedAddressString = addressString(contractAddress)
 	let bestResult: Result<EtherscanSourceCodeResult> = { success: false, message: 'Failed to fetch Abi' } as const
@@ -76,8 +99,9 @@ export async function fetchAbiFromBlockExplorer(contractAddress: EthereumAddress
 		const implementationName = EtherscanSourceCodeResult.safeParse(sourceCodeResult.result)
 
 		if (!implResult.success || !implementationName.success) return { success: false as const, error: 'Failed to parse Etherscan results.' }
-		if (!isValidAbi(implResult.value.result)) return { success: false as const, error: 'Etherscan returned an invalid ABI' }
-		return { success: true as const, address: contractAddress, abi: implResult.value.result, contractName: `Proxy: ${ implementationName.value.result[0].ContractName }` }
+		const proxyAndImplementationAbi = mergeProxyAndImplementationAbi(parsedSourceCode.value.result[0].ABI, implResult.value.result)
+		if (!isValidAbi(proxyAndImplementationAbi)) return { success: false as const, error: 'Etherscan returned an invalid ABI' }
+		return { success: true as const, address: contractAddress, abi: proxyAndImplementationAbi, contractName: `Proxy: ${ implementationName.value.result[0].ContractName }` }
 	}
 	const abi = parsedSourceCode.value.result[0].ABI
 	if (abi && abi !== 'Contract source code not verified') {

--- a/test/tests/addNewAddress.test.ts
+++ b/test/tests/addNewAddress.test.ts
@@ -1,6 +1,8 @@
 import * as assert from 'assert'
 import { describe, test } from 'bun:test'
-import { saveAddressBookEntry } from '../../app/ts/components/pages/AddNewAddress.js'
+import { Signal } from '@preact/signals'
+import { mergeAddressWindowErrorState, saveAddressBookEntry, updateModifyAddressWindowState } from '../../app/ts/components/pages/AddNewAddress.js'
+import type { ModifyAddressWindowState } from '../../app/ts/types/visualizer-types.js'
 
 const sampleAddressBookEntry = {
 	type: 'contact',
@@ -35,5 +37,52 @@ describe('add new address save flow', () => {
 
 		assert.equal(sent, false)
 		assert.equal(closed, false)
+	})
+
+	test('keeps non-blocking block explorer errors when validation has no error', () => {
+		const blockExplorerError = { blockEditing: false, message: 'No ABI available for this contract.' }
+
+		assert.deepEqual(mergeAddressWindowErrorState(blockExplorerError, undefined), blockExplorerError)
+	})
+
+	test('clears blocking validation errors when validation has no error', () => {
+		const validationError = { blockEditing: true, message: 'The address is invalid.' }
+
+		assert.equal(mergeAddressWindowErrorState(validationError, undefined), undefined)
+	})
+
+	test('shows a non-blocking error when address window state sync fails', async () => {
+		const state = new Signal<ModifyAddressWindowState>({
+			windowStateId: '1',
+			errorState: undefined,
+			incompleteAddressBookEntry: {
+				addingAddress: false,
+				type: 'contract',
+				address: '0x0000000000000000000000000000000000000001',
+				askForAddressAccess: true,
+				name: 'Contract',
+				symbol: undefined,
+				decimals: undefined,
+				logoUri: undefined,
+				entrySource: 'User',
+				abi: undefined,
+				useAsActiveAddress: undefined,
+				declarativeNetRequestBlockMode: undefined,
+				chainId: 1n,
+			}
+		})
+
+		await updateModifyAddressWindowState(
+			state,
+			previousState => previousState,
+			async () => {
+				throw new Error('background unavailable')
+			}
+		)
+
+		assert.deepEqual(state.value.errorState, {
+			blockEditing: false,
+			message: 'Failed to update address window state: background unavailable',
+		})
 	})
 })

--- a/test/tests/addressEditEntry.test.ts
+++ b/test/tests/addressEditEntry.test.ts
@@ -1,0 +1,31 @@
+import * as assert from 'assert'
+import { describe, test } from 'bun:test'
+import { addressEditEntry } from '../../app/ts/components/ui-utils.js'
+import { getAddressBookEntryForEdit } from '../../app/ts/components/pages/ConfirmTransaction.js'
+
+describe('address edit entry state', () => {
+	test('does not reopen with a stale ABI after the current address book entry has removed it', () => {
+		const address = 0xe72ecea44b6d8b2b3cf5171214d9730e86213ca2n
+		const staleClickedEntry = {
+			type: 'contract',
+			name: 'Contract with stale ABI',
+			address,
+			entrySource: 'User',
+			chainId: 1n,
+			abi: '[{"type":"function","name":"stale","inputs":[],"outputs":[],"stateMutability":"view"}]',
+		} as const
+		const currentSavedEntry = {
+			type: 'contract',
+			name: 'Contract without ABI',
+			address,
+			entrySource: 'User',
+			chainId: 1n,
+		} as const
+
+		assert.equal('abi' in currentSavedEntry, false)
+
+		const editState = addressEditEntry(getAddressBookEntryForEdit(staleClickedEntry, [currentSavedEntry]))
+
+		assert.equal(editState.incompleteAddressBookEntry.abi, undefined)
+	})
+})

--- a/test/tests/etherscanAbiFetcher.test.ts
+++ b/test/tests/etherscanAbiFetcher.test.ts
@@ -1,0 +1,73 @@
+import * as assert from 'assert'
+import { describe, test } from 'bun:test'
+import { isValidAbiString } from '../../app/ts/utils/abiRuntime.js'
+import { mergeProxyAndImplementationAbi } from '../../app/ts/simulation/services/EtherScanAbiFetcher.js'
+
+describe('Etherscan ABI fetcher', () => {
+	test('keeps proxy ABI events when merging with implementation ABI', () => {
+		const proxyAbi = JSON.stringify([
+			{
+				type: 'event',
+				name: 'TransferWithConversionAndReference',
+				inputs: [
+					{ indexed: false, name: 'amount', type: 'uint256' },
+					{ indexed: false, name: 'currency', type: 'address' },
+					{ indexed: true, name: 'paymentReference', type: 'bytes' },
+					{ indexed: false, name: 'feeAmount', type: 'uint256' },
+					{ indexed: false, name: 'maxRateTimespan', type: 'uint256' },
+				],
+				anonymous: false,
+			},
+		])
+		const implementationAbi = JSON.stringify([
+			{
+				type: 'event',
+				name: 'TransferWithReferenceAndFee',
+				inputs: [
+					{ indexed: false, name: 'tokenAddress', type: 'address' },
+					{ indexed: false, name: 'to', type: 'address' },
+					{ indexed: false, name: 'amount', type: 'uint256' },
+					{ indexed: true, name: 'paymentReference', type: 'bytes' },
+					{ indexed: false, name: 'feeAmount', type: 'uint256' },
+					{ indexed: false, name: 'feeAddress', type: 'address' },
+				],
+				anonymous: false,
+			},
+		])
+
+		const mergedAbi = mergeProxyAndImplementationAbi(proxyAbi, implementationAbi)
+
+		assert.equal(isValidAbiString(mergedAbi), true)
+		assert.equal(mergedAbi.includes('TransferWithConversionAndReference'), true)
+		assert.equal(mergedAbi.includes('TransferWithReferenceAndFee'), true)
+	})
+
+	test('falls back to implementation ABI when proxy ABI is invalid', () => {
+		const invalidProxyAbi = JSON.stringify([
+			{
+				name: 'MissingType',
+				inputs: [],
+			},
+		])
+		const implementationAbi = JSON.stringify([
+			{
+				type: 'event',
+				name: 'TransferWithReferenceAndFee',
+				inputs: [
+					{ indexed: false, name: 'tokenAddress', type: 'address' },
+					{ indexed: false, name: 'to', type: 'address' },
+					{ indexed: false, name: 'amount', type: 'uint256' },
+					{ indexed: true, name: 'paymentReference', type: 'bytes' },
+					{ indexed: false, name: 'feeAmount', type: 'uint256' },
+					{ indexed: false, name: 'feeAddress', type: 'address' },
+				],
+				anonymous: false,
+			},
+		])
+
+		const mergedAbi = mergeProxyAndImplementationAbi(invalidProxyAbi, implementationAbi)
+
+		assert.equal(isValidAbiString(mergedAbi), true)
+		assert.equal(mergedAbi, implementationAbi)
+	})
+})


### PR DESCRIPTION
## Summary
- sync block explorer ABI/name fetch results back to the persisted address modal state
- merge proxy and implementation ABIs from Etherscan so proxy-emitted events can decode correctly
- reopen address edits from the current address book entry instead of stale clicked metadata
- refresh confirm-transaction address metadata signals when pending transaction visualization updates
- keep block explorer fetch errors visible when validation replies have no error

## Validation
- `bun test`
- `bun run setup-chrome`
- `bun run typecheck`
- `bun run lint`
