### PR TITLE
Handle extension port lifecycle teardown errors without false-positive failures

### DIFF
--- a/app/inpage/ts/document_start.ts
+++ b/app/inpage/ts/document_start.ts
@@ -115,20 +115,34 @@ function injectScript(_content: string) {
 		}
 		const serializeForwardedDiagnostics = (source: 'inpage' | 'content-script' | 'document-start', phase: string, error: unknown, context: ForwardedDiagnosticsRequestContext = {}): string => formatForwardedDiagnostics(source, phase, getForwardedDiagnosticsSummary(error), error, context)
 		const createForwardedDiagnosticsFromRaw = (source: 'inpage' | 'content-script' | 'document-start', phase: string, message: string, raw: unknown, context: ForwardedDiagnosticsRequestContext = {}): string => formatForwardedDiagnostics(source, phase, message, raw, context)
+		const isIgnorablePortLifecycleError = (error: Error) => error.message.includes('Attempting to use a disconnected port object')
+			|| error.message.includes('Could not establish connection. Receiving end does not exist')
+			|| error.message.includes('Extension context invalidated')
+		const markExtensionPortDisconnected = (port: browser.runtime.Port) => {
+			if (extensionPort !== port) return
+			extensionPort = undefined
+			pageHidden = true
+		}
 		const reportInterceptorError = (diagnostics: string) => {
-			if (extensionPort === undefined) return
+			const currentExtensionPort = extensionPort
+			if (currentExtensionPort === undefined) return
 			try {
-				extensionPort.postMessage({ data: { interceptorRequest: true, interceptorInternalRequest: true, usingInterceptorWithoutSigner: false, requestId: -1, method: 'InterceptorError', params: [diagnostics] } })
+				currentExtensionPort.postMessage({ data: { interceptorRequest: true, interceptorInternalRequest: true, usingInterceptorWithoutSigner: false, requestId: -1, method: 'InterceptorError', params: [diagnostics] } })
 			} catch(reportingError: unknown) {
+				if (reportingError instanceof Error && isIgnorablePortLifecycleError(reportingError)) {
+					markExtensionPortDisconnected(currentExtensionPort)
+					return
+				}
 				console.error(reportingError)
 			}
 		}
 
 		const forwardInpageMessageToBackground = (data: unknown) => {
-			if (extensionPort === undefined) return
+			const currentExtensionPort = extensionPort
+			if (currentExtensionPort === undefined) return
 			if (!isBridgeRequest(data)) return
 			try {
-				extensionPort.postMessage({ data: {
+				currentExtensionPort.postMessage({ data: {
 					interceptorRequest: true,
 					method: data.method,
 					...(data.params !== undefined ? { params: data.params } : {}),
@@ -139,8 +153,8 @@ function injectScript(_content: string) {
 				checkAndThrowRuntimeLastError()
 			} catch (error) {
 				if (error instanceof Error) {
-					if (error.message?.includes('Extension context invalidated.')) {
-						// this error happens when the extension is refreshed and the page cannot reach The Interceptor anymore
+					if (isIgnorablePortLifecycleError(error)) {
+						markExtensionPortDisconnected(currentExtensionPort)
 						return
 					}
 					if (error.message?.includes('User denied')) return // user denied signature
@@ -168,11 +182,20 @@ function injectScript(_content: string) {
 		})
 
 		const connect = () => {
-			if (extensionPort) extensionPort.disconnect()
-			extensionPort = browser.runtime.connect({ name: connectionNameNotUndefined })
+			const previousExtensionPort = extensionPort
+			extensionPort = undefined
+			if (previousExtensionPort !== undefined) {
+				try {
+					previousExtensionPort.disconnect()
+				} catch (error: unknown) {
+					if (!(error instanceof Error && isIgnorablePortLifecycleError(error))) throw error
+				}
+			}
+			const connectedExtensionPort = browser.runtime.connect({ name: connectionNameNotUndefined })
+			extensionPort = connectedExtensionPort
 
 			// forward all messages we get from the background script to the window so the page script can filter and process them
-			extensionPort.onMessage.addListener(messageEvent => {
+			connectedExtensionPort.onMessage.addListener(messageEvent => {
 				if (typeof messageEvent !== 'object' || messageEvent === null || !('interceptorApproved' in messageEvent)) {
 					console.error('Malformed message:')
 					console.error(messageEvent)
@@ -191,7 +214,7 @@ function injectScript(_content: string) {
 				}
 			})
 
-			extensionPort.onDisconnect.addListener(() => { pageHidden = true })
+			connectedExtensionPort.onDisconnect.addListener(() => { markExtensionPortDisconnected(connectedExtensionPort) })
 		}
 		connect()
 

--- a/app/inpage/ts/document_start.ts
+++ b/app/inpage/ts/document_start.ts
@@ -115,7 +115,7 @@ function injectScript(_content: string) {
 		}
 		const serializeForwardedDiagnostics = (source: 'inpage' | 'content-script' | 'document-start', phase: string, error: unknown, context: ForwardedDiagnosticsRequestContext = {}): string => formatForwardedDiagnostics(source, phase, getForwardedDiagnosticsSummary(error), error, context)
 		const createForwardedDiagnosticsFromRaw = (source: 'inpage' | 'content-script' | 'document-start', phase: string, message: string, raw: unknown, context: ForwardedDiagnosticsRequestContext = {}): string => formatForwardedDiagnostics(source, phase, message, raw, context)
-		const isIgnorablePortLifecycleError = (error: Error) => error.message.includes('Attempting to use a disconnected port object')
+		const isIgnorableContentScriptPortError = (error: Error) => error.message.includes('Attempting to use a disconnected port object')
 			|| error.message.includes('Could not establish connection. Receiving end does not exist')
 			|| error.message.includes('Extension context invalidated')
 		const markExtensionPortDisconnected = (port: browser.runtime.Port) => {
@@ -129,7 +129,7 @@ function injectScript(_content: string) {
 			try {
 				currentExtensionPort.postMessage({ data: { interceptorRequest: true, interceptorInternalRequest: true, usingInterceptorWithoutSigner: false, requestId: -1, method: 'InterceptorError', params: [diagnostics] } })
 			} catch(reportingError: unknown) {
-				if (reportingError instanceof Error && isIgnorablePortLifecycleError(reportingError)) {
+				if (reportingError instanceof Error && isIgnorableContentScriptPortError(reportingError)) {
 					markExtensionPortDisconnected(currentExtensionPort)
 					return
 				}
@@ -153,7 +153,7 @@ function injectScript(_content: string) {
 				checkAndThrowRuntimeLastError()
 			} catch (error) {
 				if (error instanceof Error) {
-					if (isIgnorablePortLifecycleError(error)) {
+					if (isIgnorableContentScriptPortError(error)) {
 						markExtensionPortDisconnected(currentExtensionPort)
 						return
 					}
@@ -188,7 +188,7 @@ function injectScript(_content: string) {
 				try {
 					previousExtensionPort.disconnect()
 				} catch (error: unknown) {
-					if (!(error instanceof Error && isIgnorablePortLifecycleError(error))) throw error
+					if (!(error instanceof Error && isIgnorableContentScriptPortError(error))) throw error
 				}
 			}
 			const connectedExtensionPort = browser.runtime.connect({ name: connectionNameNotUndefined })

--- a/app/inpage/ts/listenContentScript.ts
+++ b/app/inpage/ts/listenContentScript.ts
@@ -106,7 +106,7 @@ function listenContentScript(connectionName: string | undefined) {
 	}
 	const serializeForwardedDiagnostics = (source: 'inpage' | 'content-script' | 'document-start', phase: string, error: unknown, context: ForwardedDiagnosticsRequestContext = {}): string => formatForwardedDiagnostics(source, phase, getForwardedDiagnosticsSummary(error), error, context)
 	const createForwardedDiagnosticsFromRaw = (source: 'inpage' | 'content-script' | 'document-start', phase: string, message: string, raw: unknown, context: ForwardedDiagnosticsRequestContext = {}): string => formatForwardedDiagnostics(source, phase, message, raw, context)
-	const isIgnorablePortLifecycleError = (error: Error) => error.message.includes('Attempting to use a disconnected port object')
+	const isIgnorableContentScriptPortError = (error: Error) => error.message.includes('Attempting to use a disconnected port object')
 		|| error.message.includes('Could not establish connection. Receiving end does not exist')
 		|| error.message.includes('Extension context invalidated')
 	const markExtensionPortDisconnected = (port: browser.runtime.Port) => {
@@ -120,7 +120,7 @@ function listenContentScript(connectionName: string | undefined) {
 		try {
 			currentExtensionPort.postMessage({ data: { interceptorRequest: true, interceptorInternalRequest: true, usingInterceptorWithoutSigner: false, requestId: -1, method: 'InterceptorError', params: [diagnostics] } })
 		} catch(reportingError: unknown) {
-			if (reportingError instanceof Error && isIgnorablePortLifecycleError(reportingError)) {
+			if (reportingError instanceof Error && isIgnorableContentScriptPortError(reportingError)) {
 				markExtensionPortDisconnected(currentExtensionPort)
 				return
 			}
@@ -144,7 +144,7 @@ function listenContentScript(connectionName: string | undefined) {
 			checkAndThrowRuntimeLastError()
 		} catch (error) {
 			if (error instanceof Error) {
-				if (isIgnorablePortLifecycleError(error)) {
+				if (isIgnorableContentScriptPortError(error)) {
 					markExtensionPortDisconnected(currentExtensionPort)
 					return
 				}
@@ -179,7 +179,7 @@ function listenContentScript(connectionName: string | undefined) {
 			try {
 				previousExtensionPort.disconnect()
 			} catch (error: unknown) {
-				if (!(error instanceof Error && isIgnorablePortLifecycleError(error))) throw error
+				if (!(error instanceof Error && isIgnorableContentScriptPortError(error))) throw error
 			}
 		}
 		const connectedExtensionPort = browser.runtime.connect({ name: connectionNameNotUndefined })

--- a/app/inpage/ts/listenContentScript.ts
+++ b/app/inpage/ts/listenContentScript.ts
@@ -106,20 +106,34 @@ function listenContentScript(connectionName: string | undefined) {
 	}
 	const serializeForwardedDiagnostics = (source: 'inpage' | 'content-script' | 'document-start', phase: string, error: unknown, context: ForwardedDiagnosticsRequestContext = {}): string => formatForwardedDiagnostics(source, phase, getForwardedDiagnosticsSummary(error), error, context)
 	const createForwardedDiagnosticsFromRaw = (source: 'inpage' | 'content-script' | 'document-start', phase: string, message: string, raw: unknown, context: ForwardedDiagnosticsRequestContext = {}): string => formatForwardedDiagnostics(source, phase, message, raw, context)
+	const isIgnorablePortLifecycleError = (error: Error) => error.message.includes('Attempting to use a disconnected port object')
+		|| error.message.includes('Could not establish connection. Receiving end does not exist')
+		|| error.message.includes('Extension context invalidated')
+	const markExtensionPortDisconnected = (port: browser.runtime.Port) => {
+		if (extensionPort !== port) return
+		extensionPort = undefined
+		pageHidden = true
+	}
 	const reportInterceptorError = (diagnostics: string) => {
-		if (extensionPort === undefined) return
+		const currentExtensionPort = extensionPort
+		if (currentExtensionPort === undefined) return
 		try {
-			extensionPort.postMessage({ data: { interceptorRequest: true, interceptorInternalRequest: true, usingInterceptorWithoutSigner: false, requestId: -1, method: 'InterceptorError', params: [diagnostics] } })
+			currentExtensionPort.postMessage({ data: { interceptorRequest: true, interceptorInternalRequest: true, usingInterceptorWithoutSigner: false, requestId: -1, method: 'InterceptorError', params: [diagnostics] } })
 		} catch(reportingError: unknown) {
+			if (reportingError instanceof Error && isIgnorablePortLifecycleError(reportingError)) {
+				markExtensionPortDisconnected(currentExtensionPort)
+				return
+			}
 			console.error(reportingError)
 		}
 	}
 
 	const forwardInpageMessageToBackground = (data: unknown) => {
-		if (extensionPort === undefined) return
+		const currentExtensionPort = extensionPort
+		if (currentExtensionPort === undefined) return
 		if (!isBridgeRequest(data)) return
 		try {
-			extensionPort.postMessage({ data: {
+			currentExtensionPort.postMessage({ data: {
 				interceptorRequest: true,
 				method: data.method,
 				...(data.params !== undefined ? { params: data.params } : {}),
@@ -130,8 +144,8 @@ function listenContentScript(connectionName: string | undefined) {
 			checkAndThrowRuntimeLastError()
 		} catch (error) {
 			if (error instanceof Error) {
-				if (error.message?.includes('Extension context invalidated.')) {
-					// this error happens when the extension is refreshed and the page cannot reach The Interceptor anymore
+				if (isIgnorablePortLifecycleError(error)) {
+					markExtensionPortDisconnected(currentExtensionPort)
 					return
 				}
 				if (error.message?.includes('User denied')) return // user denied signature
@@ -159,11 +173,20 @@ function listenContentScript(connectionName: string | undefined) {
 	})
 
 	const connect = () => {
-		if (extensionPort) extensionPort.disconnect()
-		extensionPort = browser.runtime.connect({ name: connectionNameNotUndefined })
+		const previousExtensionPort = extensionPort
+		extensionPort = undefined
+		if (previousExtensionPort !== undefined) {
+			try {
+				previousExtensionPort.disconnect()
+			} catch (error: unknown) {
+				if (!(error instanceof Error && isIgnorablePortLifecycleError(error))) throw error
+			}
+		}
+		const connectedExtensionPort = browser.runtime.connect({ name: connectionNameNotUndefined })
+		extensionPort = connectedExtensionPort
 
 		// forward all messages we get from the background script to the window so the page script can filter and process them
-		extensionPort.onMessage.addListener(messageEvent => {
+		connectedExtensionPort.onMessage.addListener(messageEvent => {
 			if (typeof messageEvent !== 'object' || messageEvent === null || !('interceptorApproved' in messageEvent)) {
 				console.error('Malformed message:')
 				console.error(messageEvent)
@@ -182,7 +205,7 @@ function listenContentScript(connectionName: string | undefined) {
 			}
 		})
 
-		extensionPort.onDisconnect.addListener(() => { pageHidden = true })
+		connectedExtensionPort.onDisconnect.addListener(() => { markExtensionPortDisconnected(connectedExtensionPort) })
 	}
 	connect()
 

--- a/app/ts/background/backgroundUtils.ts
+++ b/app/ts/background/backgroundUtils.ts
@@ -7,9 +7,12 @@ import { getActiveAddressEntry } from './metadataUtils.js'
 import { handleUnexpectedError } from '../utils/errors.js'
 import { PopupMessageReplyRequests, type PopupRequests, PopupRequestsReplies, type PopupRequestsReplyReturn } from '../types/interceptor-reply-messages.js'
 
-function isIgnorableClosedMessageChannelError(error: Error) {
+function isIgnorableExtensionMessagingError(error: Error) {
 	return error.message?.includes('A listener indicated an asynchronous response by returning true, but the message channel closed before a response was received')
 		|| error.message?.includes('The message port closed before a response was received')
+		|| error.message?.includes('Attempting to use a disconnected port object')
+		|| error.message?.includes('Could not establish connection. Receiving end does not exist')
+		|| error.message?.includes('Extension context invalidated')
 }
 
 export async function getActiveAddress(settings: Settings, tabId: number) {
@@ -41,7 +44,7 @@ export async function sendPopupMessageToOpenWindows(message: MessageToPopupPaylo
 				// we are ignoring this error because the popup messaging is used to update a popups UI, and if a popup is not open, we don't need to update the UI
 				return
 			}
-			if (isIgnorableClosedMessageChannelError(error)) return
+			if (isIgnorableExtensionMessagingError(error)) return
 		}
 		await handleUnexpectedError(error)
 	}
@@ -53,7 +56,7 @@ export async function sendPopupMessageToBackgroundPage(message: PopupMessage) {
 		checkAndThrowRuntimeLastError()
 	} catch (error) {
 		if (error instanceof Error) {
-			if (isIgnorableClosedMessageChannelError(error)) return
+			if (isIgnorableExtensionMessagingError(error)) return
 		}
 		await handleUnexpectedError(error)
 	}
@@ -78,7 +81,7 @@ export async function sendPopupMessageWithReply<Request extends PopupRequests>(m
 		return parsePopupReply(message, response)
 	} catch (error) {
 		if (error instanceof Error) {
-			if (isIgnorableClosedMessageChannelError(error)) return undefined
+			if (isIgnorableExtensionMessagingError(error)) return undefined
 			if (error.message?.includes('Could not establish connection.')) return undefined
 		}
 		await handleUnexpectedError(error)

--- a/app/ts/background/backgroundUtils.ts
+++ b/app/ts/background/backgroundUtils.ts
@@ -6,13 +6,11 @@ import { getAllTabStates, getTabState } from './storageVariables.js'
 import { getActiveAddressEntry } from './metadataUtils.js'
 import { handleUnexpectedError } from '../utils/errors.js'
 import { PopupMessageReplyRequests, type PopupRequests, PopupRequestsReplies, type PopupRequestsReplyReturn } from '../types/interceptor-reply-messages.js'
+import { isIgnorablePortLifecycleError } from './contentScriptPortLifecycle.js'
 
 function isIgnorableExtensionMessagingError(error: Error) {
-	return error.message?.includes('A listener indicated an asynchronous response by returning true, but the message channel closed before a response was received')
-		|| error.message?.includes('The message port closed before a response was received')
-		|| error.message?.includes('Attempting to use a disconnected port object')
-		|| error.message?.includes('Could not establish connection. Receiving end does not exist')
-		|| error.message?.includes('Extension context invalidated')
+	return isIgnorablePortLifecycleError(error)
+		|| error.message?.includes('A listener indicated an asynchronous response by returning true, but the message channel closed before a response was received')
 }
 
 export async function getActiveAddress(settings: Settings, tabId: number) {

--- a/app/ts/background/messageSending.ts
+++ b/app/ts/background/messageSending.ts
@@ -1,22 +1,19 @@
 import { type InterceptedRequestForward, InterceptorMessageToInpage, type SubscriptionReplyOrCallBack } from '../types/interceptor-messages.js'
-import { type WebsiteSocket, checkAndPrintRuntimeLastError } from '../utils/requests.js'
+import { type WebsiteSocket, checkAndThrowRuntimeLastError } from '../utils/requests.js'
 import type { WebsiteTabConnections } from '../types/user-interface-types.js'
 import { websiteSocketToString } from './backgroundUtils.js'
 import { serialize } from '../types/wire-types.js'
+import { isIgnorablePortLifecycleError } from './contentScriptPortLifecycle.js'
 
 function postMessageToPortIfConnected(port: browser.runtime.Port, message: InterceptorMessageToInpage) {
 	try {
-		checkAndPrintRuntimeLastError()
+		checkAndThrowRuntimeLastError()
 		port.postMessage(serialize(InterceptorMessageToInpage, message) as Object)
+		checkAndThrowRuntimeLastError()
 	} catch (error) {
-		if (error instanceof Error) {
-			if (error.message?.includes('Attempting to use a disconnected port object')) return
-			if (error.message?.includes('Could not establish connection. Receiving end does not exist')) return
-			if (error.message?.includes('No tab with id')) return
-		}
+		if (error instanceof Error && (isIgnorablePortLifecycleError(error) || error.message?.includes('No tab with id'))) return
 		throw error
 	}
-	checkAndPrintRuntimeLastError()
 }
 
 export function replyToInterceptedRequest(websiteTabConnections: WebsiteTabConnections, message: InterceptedRequestForward) {

--- a/test/tests/backgroundUtilsMessaging.test.ts
+++ b/test/tests/backgroundUtilsMessaging.test.ts
@@ -106,6 +106,27 @@ describe('backgroundUtils messaging', () => {
 		assert.equal(await getLatestUnexpectedError(), undefined)
 	})
 
+	test('ignore extension teardown errors for popup fire-and-forget messages', async () => {
+		const storageState = installBrowserMock('Extension context invalidated.')
+		const { sendPopupMessageToBackgroundPage, getLatestUnexpectedError } = await loadModules()
+
+		await sendPopupMessageToBackgroundPage({ method: 'popup_requestSettings' })
+
+		assert.equal(storageState.latestUnexpectedError, undefined)
+		assert.equal(await getLatestUnexpectedError(), undefined)
+	})
+
+	test('ignore disconnected port errors when requesting popup replies', async () => {
+		const storageState = installBrowserMock('Attempting to use a disconnected port object')
+		const { sendPopupMessageWithReply, getLatestUnexpectedError } = await loadModules()
+
+		const reply = await sendPopupMessageWithReply({ method: 'popup_requestSimulationMode' })
+
+		assert.equal(reply, undefined)
+		assert.equal(storageState.latestUnexpectedError, undefined)
+		assert.equal(await getLatestUnexpectedError(), undefined)
+	})
+
 	test('treat null popup replies as no reply without recording an unexpected error', async () => {
 		const storageState = installBrowserMock('')
 		globalThis.browser.runtime.sendMessage = async () => null

--- a/test/tests/messageSendingPortLifecycle.test.ts
+++ b/test/tests/messageSendingPortLifecycle.test.ts
@@ -1,0 +1,42 @@
+import * as assert from 'assert'
+import { describe, test } from 'bun:test'
+import { sendSubscriptionReplyOrCallBackToPort } from '../../app/ts/background/messageSending.js'
+
+function installBrowserMock() {
+	globalThis.browser = {
+		runtime: {
+			lastError: undefined,
+		},
+	} as unknown as typeof globalThis.browser
+}
+
+describe('background messageSending port lifecycle', () => {
+	test('ignores disconnected runtime lastError after posting to a content-script port', () => {
+		installBrowserMock()
+		let postedMessages = 0
+		const port = {
+			postMessage() {
+				postedMessages += 1
+				globalThis.browser.runtime.lastError = { message: 'Attempting to use a disconnected port object' }
+			},
+		} as unknown as browser.runtime.Port
+
+		assert.doesNotThrow(() => {
+			sendSubscriptionReplyOrCallBackToPort(port, { type: 'result', method: 'accountsChanged', result: [] })
+		})
+		assert.equal(postedMessages, 1)
+	})
+
+	test('ignores disconnected content-script ports that throw during postMessage', () => {
+		installBrowserMock()
+		const port = {
+			postMessage() {
+				throw new Error('Could not establish connection. Receiving end does not exist.')
+			},
+		} as unknown as browser.runtime.Port
+
+		assert.doesNotThrow(() => {
+			sendSubscriptionReplyOrCallBackToPort(port, { type: 'result', method: 'accountsChanged', result: [] })
+		})
+	})
+})


### PR DESCRIPTION
## Summary
- Added resilient port cleanup in inpage and content-script bridge startup/forwarding flow by introducing lifecycle-aware checks and explicit disconnect marking when ports are torn down.
- Expanded background messaging error filtering to treat extension teardown failures (`Attempting to use a disconnected port object`, `Could not establish connection...`, `Extension context invalidated`) as ignorable for popup and background communication.
- Updated background message sending to always re-check runtime last error after `postMessage`, and centralize ignorable lifecycle error handling.
- Added tests covering popup messaging ignore behavior and port lifecycle cases, including message posting paths that surface `lastError` or throw on `postMessage`.

## Testing
- Added/updated unit tests:
  - `test/tests/backgroundUtilsMessaging.test.ts`
  - `test/tests/messageSendingPortLifecycle.test.ts`
- `Not run` (runtime validation/tests not executed in this environment).