### PR TITLE
Cap 1559 simulation fees by sender balance and improve proxy ABI/address editing behavior

### DIFF
--- a/app/ts/background/simulationUpdating.ts
+++ b/app/ts/background/simulationUpdating.ts
@@ -1,5 +1,5 @@
 import type { EthereumClientService } from '../simulation/services/EthereumClientService.js'
-import { DEFAULT_BLOCK_MANIPULATION, appendTransactionToInputAndSimulate, calculateRealizedEffectiveGasPrice, createExecutionSimulationState, createSimulationState, getAddressToMakeRich, getBaseFeeAdjustedTransactions, getNonceFixedSimulationStateInput, getSimulatedCode, getTokenBalancesAfterForTransaction, getWebsiteCreatedEthereumUnsignedTransactions, mockSignTransaction, simulateEstimateGasFromInput, sliceSimulationState } from '../simulation/services/SimulationModeEthereumClientService.js'
+import { DEFAULT_BLOCK_MANIPULATION, appendTransactionToInputAndSimulate, calculateRealizedEffectiveGasPrice, createExecutionSimulationState, createSimulationState, getAddressToMakeRich, getBaseFeeAdjustmentBalances, getNonceFixedSimulationStateInput, getSimulatedCode, getTokenBalancesAfterForTransaction, getWebsiteCreatedEthereumUnsignedTransactions, mockSignTransaction, simulateEstimateGasFromInput, sliceSimulationState } from '../simulation/services/SimulationModeEthereumClientService.js'
 import type { TokenPriceService } from '../simulation/services/priceEstimator.js'
 import { parseEvents, parseInputData } from '../simulation/parsing.js'
 import { runProtectorsForTransaction } from '../simulation/protectorRunner.js'
@@ -371,9 +371,16 @@ export const updateSimulationMetadata = async (ethereum: EthereumClientService, 
 
 export const prepareSimulationInputForRpc = async (simulationInput: SimulationStateInput, ethereum: EthereumClientService) => {
 	const parentBlock = await ethereum.getBlock(undefined)
-	const baseFeeFixedInputStateBlocks = parentBlock === undefined ? simulationInput : simulationInput.map((block) => (
-		modifyObject(block, { transactions: getBaseFeeAdjustedTransactions(parentBlock, block.transactions) })
-	))
+	const getBaseFeeFixedInputStateBlocks = async () => {
+		if (parentBlock === undefined) return simulationInput
+		const baseFeeFixedInputStateBlocks: SimulationStateInputBlock[] = []
+		for (const block of simulationInput) {
+			const { transactions } = await getBaseFeeAdjustmentBalances(ethereum, undefined, parentBlock, baseFeeFixedInputStateBlocks, block)
+			baseFeeFixedInputStateBlocks.push(modifyObject(block, { transactions }))
+		}
+		return baseFeeFixedInputStateBlocks
+	}
+	const baseFeeFixedInputStateBlocks = await getBaseFeeFixedInputStateBlocks()
 	const nonceFixed = await getNonceFixedSimulationStateInput(ethereum, undefined, baseFeeFixedInputStateBlocks)
 	return nonceFixed.nonceFixed ? nonceFixed.simulationStateInput : baseFeeFixedInputStateBlocks
 }

--- a/app/ts/background/windows/confirmTransaction.ts
+++ b/app/ts/background/windows/confirmTransaction.ts
@@ -1,5 +1,5 @@
 import type { EthereumClientService } from '../../simulation/services/EthereumClientService.js'
-import { getInputFieldFromDataOrInput, getSimulatedTransactionCount, mockSignTransaction, simulateEstimateGas, simulatePersonalSign } from '../../simulation/services/SimulationModeEthereumClientService.js'
+import { getInputFieldFromDataOrInput, getSimulatedBalance, getSimulatedTransactionCount, mockSignTransaction, simulateEstimateGas, simulatePersonalSign } from '../../simulation/services/SimulationModeEthereumClientService.js'
 import { CANNOT_SIMULATE_OFF_LEGACY_BLOCK, ERROR_INTERCEPTOR_NO_ACTIVE_ADDRESS, METAMASK_ERROR_BLANKET_ERROR, METAMASK_ERROR_FAILED_TO_PARSE_REQUEST, METAMASK_ERROR_USER_REJECTED_REQUEST } from '../../utils/constants.js'
 import { type TransactionConfirmation, UpdateConfirmTransactionDialog, UpdateConfirmTransactionDialogPendingTransactions } from '../../types/interceptor-messages.js'
 import { Semaphore } from '../../utils/semaphore.js'
@@ -33,6 +33,7 @@ import { updatePopupVisualisationIfNeeded } from '../popupVisualisationUpdater.j
 import { POPUP_PERFORMANCE_MARKS, markPerformance } from '../../utils/popupPerformance.js'
 import type { TokenPriceService } from '../../simulation/services/priceEstimator.js'
 import { closePopupOrTabById, getPopupOrTabById, openPopupOrTab, tryFocusingTabOrWindow } from '../../utils/popupOrTab.js'
+import { getDesiredMaxFeePerGasForBaseFee, getTransactionFeesForBaseFee, hasExplicitMaxFeePerGas } from '../../utils/transactionFees.js'
 
 const pendingConfirmationSemaphore = new Semaphore(1)
 
@@ -330,16 +331,22 @@ export const formEthSendTransaction = async(ethereumClientService: EthereumClien
 	const parentBlock = await parentBlockPromise
 	if (parentBlock === null) throw new Error('The latest block is null')
 	if (parentBlock.baseFeePerGas === undefined) throw new Error(CANNOT_SIMULATE_OFF_LEGACY_BLOCK)
+	const parentBaseFeePerGas = parentBlock.baseFeePerGas
+	const balancePromise = silenceChromeUnCaughtPromise(getSimulatedBalance(ethereumClientService, requestAbortController, simulationState, from))
 	const maxPriorityFeePerGas = transactionDetails.maxPriorityFeePerGas !== undefined && transactionDetails.maxPriorityFeePerGas !== null ? transactionDetails.maxPriorityFeePerGas : 10n**8n // 0.1 nanoEth/gas
+	const value = transactionDetails.value !== undefined  ? transactionDetails.value : 0n
+	const getFeePerGas = async (gasLimit: bigint) => {
+		return getTransactionFeesForBaseFee(parentBaseFeePerGas, maxPriorityFeePerGas, transactionDetails.maxFeePerGas, await balancePromise, value, gasLimit)
+	}
 	const transactionWithoutGas = {
 		type: '1559' as const,
 		from,
 		chainId: ethereumClientService.getChainId(),
 		nonce: await transactionCountPromise,
-		maxFeePerGas: transactionDetails.maxFeePerGas !== undefined && transactionDetails.maxFeePerGas !== null ? transactionDetails.maxFeePerGas : parentBlock.baseFeePerGas * 2n + maxPriorityFeePerGas,
+		maxFeePerGas: hasExplicitMaxFeePerGas(transactionDetails.maxFeePerGas) ? transactionDetails.maxFeePerGas : getDesiredMaxFeePerGasForBaseFee(parentBaseFeePerGas, maxPriorityFeePerGas),
 		maxPriorityFeePerGas,
 		to: transactionDetails.to === undefined ? null : transactionDetails.to,
-		value: transactionDetails.value !== undefined  ? transactionDetails.value : 0n,
+		value,
 		input: getInputFieldFromDataOrInput(transactionDetails),
 		accessList: [],
 	}
@@ -354,7 +361,7 @@ export const formEthSendTransaction = async(ethereumClientService: EthereumClien
 		try {
 			const estimateGas = await simulateEstimateGas(ethereumClientService, requestAbortController, simulationState, transactionWithoutGas)
 			if ('error' in estimateGas) return { ...extraParams, ...estimateGas, success: false }
-			return { transaction: { ...transactionWithoutGas, gas: estimateGas.gas }, ...extraParams, success: true }
+			return { transaction: { ...transactionWithoutGas, ...await getFeePerGas(estimateGas.gas), gas: estimateGas.gas }, ...extraParams, success: true }
 		} catch(error: unknown) {
 			if (error instanceof JsonRpcResponseError) return { ...extraParams, error: { code: error.code, message: error.message, data: typeof error.data === 'string' ? error.data : '0x' }, success: false }
 			printError(error)
@@ -362,7 +369,7 @@ export const formEthSendTransaction = async(ethereumClientService: EthereumClien
 			return { ...extraParams, error: { code: 123456, message: 'Unknown Error', data: '0x' }, success: false }
 		}
 	}
-	return { transaction: { ...transactionWithoutGas, gas: transactionDetails.gas }, ...extraParams, success: true }
+	return { transaction: { ...transactionWithoutGas, ...await getFeePerGas(transactionDetails.gas), gas: transactionDetails.gas }, ...extraParams, success: true }
 }
 
 const getPendingTransactionWindow = async (ethereum: EthereumClientService, tokenPriceService: TokenPriceService, websiteTabConnections: WebsiteTabConnections) => {

--- a/app/ts/simulation/services/SimulationModeEthereumClientService.ts
+++ b/app/ts/simulation/services/SimulationModeEthereumClientService.ts
@@ -22,6 +22,7 @@ import type { ErrorWithCodeAndOptionalData } from '../../types/error.js'
 import { getSimulationInputHash } from '../../utils/simulationFingerprint.js'
 import { decodeCallDataLoose, decodeEventLoose, decodeFunctionOutput, encodeFunctionCall, type AbiLike } from '../../utils/abiRuntime.js'
 import { Erc20ABI, Erc1155ABI } from '../../utils/abi.js'
+import { getDesiredMaxFeePerGasForBaseFee, getTransactionFeesForBaseFee, hasExplicitMaxFeePerGas } from '../../utils/transactionFees.js'
 
 type SuccessfulExecutionSimulationState = Extract<ExecutionSimulationState, { success: true }>
 
@@ -683,14 +684,136 @@ export const getNonceFixedSimulationStateInput = async(ethereumClientService: Et
 	return { nonceFixed: true, simulationStateInput: simulationInputBlocks }
 }
 
-export const getBaseFeeAdjustedTransactions = (parentBlock: EthereumBlockHeader, preSimulationTransactions: readonly PreSimulationTransaction[]): readonly PreSimulationTransaction[] => {
+const canAffordMaxGasCost = (balance: bigint, value: bigint, gasLimit: bigint, maxFeePerGas: bigint) => {
+	return balance >= value + gasLimit * maxFeePerGas
+}
+
+const subtractMaxGasCost = (balance: bigint, value: bigint, gasLimit: bigint, maxFeePerGas: bigint) => {
+	const maxCost = value + gasLimit * maxFeePerGas
+	return balance > maxCost ? balance - maxCost : 0n
+}
+
+const usesInterceptorFilledMaxFeePerGas = (transaction: PreSimulationTransaction) => {
+	return transaction.originalRequestParameters.method === 'eth_sendTransaction'
+		&& transaction.signedTransaction.type === '1559'
+		&& !hasExplicitMaxFeePerGas(transaction.originalRequestParameters.params[0].maxFeePerGas)
+}
+
+const getBaseFeeAdjustedTransaction = (
+	transaction: PreSimulationTransaction,
+	parentBaseFeePerGas: bigint,
+	balance: bigint,
+) => {
+	if (!usesInterceptorFilledMaxFeePerGas(transaction)) return transaction
+	if (transaction.signedTransaction.type !== '1559') return transaction
+	const feePerGas = getTransactionFeesForBaseFee(
+		parentBaseFeePerGas,
+		transaction.signedTransaction.maxPriorityFeePerGas,
+		undefined,
+		balance,
+		transaction.signedTransaction.value,
+		transaction.signedTransaction.gas,
+	)
+	return modifyObject(transaction, { signedTransaction: modifyObject(transaction.signedTransaction, feePerGas) })
+}
+
+const getBalanceBeforeSimulationInputTransaction = async (
+	ethereumClientService: EthereumClientService,
+	requestAbortController: AbortController | undefined,
+	parentBlock: NonNullable<EthereumBlockHeader>,
+	simulationInputBeforeBlock: SimulationStateInput,
+	currentBlock: SimulationStateInput[number],
+	transactionsBefore: readonly PreSimulationTransaction[],
+	address: bigint,
+) => {
+	const overrideBalance = currentBlock.stateOverrides[addressString(address)]?.balance
+	if (transactionsBefore.length === 0 && overrideBalance !== undefined) return overrideBalance
+	if (simulationInputBeforeBlock.length === 0 && transactionsBefore.length === 0) return await ethereumClientService.getBalance(address, parentBlock.number, requestAbortController)
+	const simulationInputBeforeTransaction = [
+		...simulationInputBeforeBlock,
+		modifyObject(currentBlock, { transactions: transactionsBefore }),
+	]
+	return await getSimulatedBalanceFromInput(
+		ethereumClientService,
+		requestAbortController,
+		{ kind: 'simulated', value: simulationInputBeforeTransaction },
+		address,
+		'latest',
+		parentBlock.number,
+	)
+}
+
+const getBaseFeeAdjustedTransactionWithBalances = (
+	parentBlock: NonNullable<EthereumBlockHeader>,
+	transaction: PreSimulationTransaction,
+	balances: ReadonlyMap<EthereumQuantity, bigint>,
+) => {
+	const adjustedTransactions = getBaseFeeAdjustedTransactions(parentBlock, [transaction], balances)
+	const adjustedTransaction = adjustedTransactions[0]
+	if (adjustedTransaction === undefined) throw new Error('missing base fee adjusted transaction')
+	return adjustedTransaction
+}
+
+export const getBaseFeeAdjustmentBalances = async (
+	ethereumClientService: EthereumClientService,
+	requestAbortController: AbortController | undefined,
+	parentBlock: EthereumBlockHeader,
+	simulationInputBeforeBlock: SimulationStateInput,
+	currentBlock: SimulationStateInput[number],
+): Promise<{ balances: ReadonlyMap<EthereumQuantity, bigint>, transactions: readonly PreSimulationTransaction[] }> => {
+	const balances = new Map<EthereumQuantity, bigint>()
+	if (parentBlock === null) return { balances, transactions: currentBlock.transactions }
+	const parentBaseFeePerGas = parentBlock.baseFeePerGas
+	if (parentBaseFeePerGas === undefined) return { balances, transactions: currentBlock.transactions }
+	const adjustedTransactions: PreSimulationTransaction[] = []
+	const conservativeBalances = new Map<bigint, bigint>()
+	for (const transaction of currentBlock.transactions) {
+		if (!usesInterceptorFilledMaxFeePerGas(transaction)) {
+			if (transaction.originalRequestParameters.method === 'eth_sendTransaction'
+				&& transaction.signedTransaction.type === '1559'
+				&& hasExplicitMaxFeePerGas(transaction.originalRequestParameters.params[0].maxFeePerGas)
+			) {
+				const conservativeBalance = conservativeBalances.get(transaction.signedTransaction.from)
+				if (conservativeBalance !== undefined) {
+					conservativeBalances.set(
+						transaction.signedTransaction.from,
+						subtractMaxGasCost(conservativeBalance, transaction.signedTransaction.value, transaction.signedTransaction.gas, transaction.originalRequestParameters.params[0].maxFeePerGas),
+					)
+				}
+			} else {
+				conservativeBalances.delete(transaction.signedTransaction.from)
+			}
+			adjustedTransactions.push(getBaseFeeAdjustedTransactionWithBalances(parentBlock, transaction, balances))
+			continue
+		}
+		if (transaction.signedTransaction.type !== '1559') throw new Error('Expected 1559 transaction for interceptor-filled max fee per gas')
+		const desiredMaxFeePerGas = getDesiredMaxFeePerGasForBaseFee(parentBaseFeePerGas, transaction.signedTransaction.maxPriorityFeePerGas)
+		const conservativeBalance = conservativeBalances.get(transaction.signedTransaction.from)
+		const balance = conservativeBalance !== undefined && canAffordMaxGasCost(conservativeBalance, transaction.signedTransaction.value, transaction.signedTransaction.gas, desiredMaxFeePerGas)
+			? conservativeBalance
+			: await getBalanceBeforeSimulationInputTransaction(ethereumClientService, requestAbortController, parentBlock, simulationInputBeforeBlock, currentBlock, adjustedTransactions, transaction.signedTransaction.from)
+		balances.set(transaction.transactionIdentifier, balance)
+		const adjustedTransaction = getBaseFeeAdjustedTransactionWithBalances(parentBlock, transaction, balances)
+		if (adjustedTransaction.signedTransaction.type !== '1559') throw new Error('Expected 1559 transaction after base fee adjustment')
+		conservativeBalances.set(transaction.signedTransaction.from, subtractMaxGasCost(balance, transaction.signedTransaction.value, transaction.signedTransaction.gas, adjustedTransaction.signedTransaction.maxFeePerGas))
+		adjustedTransactions.push(adjustedTransaction)
+	}
+	return { balances, transactions: adjustedTransactions }
+}
+
+export const getBaseFeeAdjustedTransactions = (
+	parentBlock: EthereumBlockHeader,
+	preSimulationTransactions: readonly PreSimulationTransaction[],
+	balances: ReadonlyMap<EthereumQuantity, bigint>,
+): readonly PreSimulationTransaction[] => {
 	if (parentBlock === null) return preSimulationTransactions
 	const parentBaseFeePerGas = parentBlock.baseFeePerGas
 	if (parentBaseFeePerGas === undefined) return preSimulationTransactions
 	return preSimulationTransactions.map((transaction) => {
-		if (transaction.originalRequestParameters.method !== 'eth_sendTransaction') return transaction
-		if (transaction.signedTransaction.type !== '1559') return transaction
-		return modifyObject(transaction, { signedTransaction: modifyObject(transaction.signedTransaction, { maxFeePerGas: parentBaseFeePerGas * 2n + transaction.signedTransaction.maxPriorityFeePerGas }) })
+		if (!usesInterceptorFilledMaxFeePerGas(transaction)) return transaction
+		const balance = balances.get(transaction.transactionIdentifier)
+		if (balance === undefined) throw new Error('missing balance for base fee adjusted transaction')
+		return getBaseFeeAdjustedTransaction(transaction, parentBaseFeePerGas, balance)
 	})
 }
 
@@ -1076,9 +1199,13 @@ export const getSimulatedBalanceFromInput = async (
 	simulationStateInput: ResolvedSimulationInput,
 	address: bigint,
 	blockTag: EthereumBlockTag = 'latest',
+	baseBlockTag: EthereumBlockTag = 'latest',
 ): Promise<bigint> => {
-	const context = await createPreparedSimulationExecutionContext(ethereumClientService, requestAbortController, simulationStateInput)
-	if (context === undefined || canQueryNodeDirectlyFromInput(context.parentBlock.number, context.executionBlocks.length, blockTag)) {
+	const context = await createPreparedSimulationExecutionContext(ethereumClientService, requestAbortController, simulationStateInput, baseBlockTag)
+	if (context === undefined) {
+		return await ethereumClientService.getBalance(address, blockTag, requestAbortController)
+	}
+	if (canQueryNodeDirectlyFromInput(context.parentBlock.number, context.executionBlocks.length, blockTag)) {
 		return await ethereumClientService.getBalance(address, blockTag, requestAbortController)
 	}
 	const executionBlocksToApply = getExecutionBlocksUpToTag(context, blockTag)

--- a/app/ts/utils/transactionFees.ts
+++ b/app/ts/utils/transactionFees.ts
@@ -1,0 +1,30 @@
+import { min } from './bigint.js'
+
+export const getAffordableTransactionFees = (desiredMaxFeePerGas: bigint, desiredMaxPriorityFeePerGas: bigint, balance: bigint, value: bigint, gasLimit: bigint) => {
+	if (gasLimit === 0n) return { maxFeePerGas: desiredMaxFeePerGas, maxPriorityFeePerGas: desiredMaxPriorityFeePerGas }
+	const availableForGas = balance > value ? balance - value : 0n
+	const maxFeePerGas = min(desiredMaxFeePerGas, availableForGas / gasLimit)
+	return {
+		maxFeePerGas,
+		maxPriorityFeePerGas: min(desiredMaxPriorityFeePerGas, maxFeePerGas),
+	}
+}
+
+export const hasExplicitMaxFeePerGas = (maxFeePerGas: bigint | null | undefined): maxFeePerGas is bigint => maxFeePerGas !== undefined && maxFeePerGas !== null
+
+export const getDesiredMaxFeePerGasForBaseFee = (parentBaseFeePerGas: bigint, maxPriorityFeePerGas: bigint) => parentBaseFeePerGas * 2n + maxPriorityFeePerGas
+
+export const getTransactionFeesForBaseFee = (
+	parentBaseFeePerGas: bigint,
+	maxPriorityFeePerGas: bigint,
+	maxFeePerGas: bigint | null | undefined,
+	balance: bigint,
+	value: bigint,
+	gasLimit: bigint,
+) => {
+	if (hasExplicitMaxFeePerGas(maxFeePerGas)) return {
+		maxFeePerGas,
+		maxPriorityFeePerGas,
+	}
+	return getAffordableTransactionFees(getDesiredMaxFeePerGasForBaseFee(parentBaseFeePerGas, maxPriorityFeePerGas), maxPriorityFeePerGas, balance, value, gasLimit)
+}

--- a/test/tests/SimulationModeEthereumClientService.test.ts
+++ b/test/tests/SimulationModeEthereumClientService.test.ts
@@ -6,7 +6,7 @@ import { EthereumClientService } from '../../app/ts/simulation/services/Ethereum
 import { EthereumSignedTransactionToSignedTransaction, EthereumUnsignedTransactionToUnsignedTransaction, serializeSignedTransactionToBytes, serializeUnsignedTransactionToBytes } from '../../app/ts/utils/ethereum.js'
 import { bytes32String, dataStringWith0xStart } from '../../app/ts/utils/bigint.js'
 import { EthereumSignatureParity, EthereumSignedTransaction, EthereumSignedTransaction1559, EthereumSignedTransactionWithBlockData, EthereumUnsignedTransaction } from '../../app/ts/types/wire-types.js'
-import { createExecutionSimulationState, createSimulationState, getSimulatedBlockByHashFromInput, getSimulatedBlockFromInput, getSimulatedBlockNumberFromInput, getSimulatedCodeFromInput, getSimulatedLogs, getSimulatedTransactionByHashFromInput, getSimulatedTransactionReceipt, groupEthSimulateV1ResultByInputBlocks, mockSignTransaction, simulateEstimateGasFromInput, simulatedCallFromInput } from '../../app/ts/simulation/services/SimulationModeEthereumClientService.js'
+import { createExecutionSimulationState, createSimulationState, getBaseFeeAdjustedTransactions, getBaseFeeAdjustmentBalances, getSimulatedBalanceFromInput, getSimulatedBlockByHashFromInput, getSimulatedBlockFromInput, getSimulatedBlockNumberFromInput, getSimulatedCodeFromInput, getSimulatedLogs, getSimulatedTransactionByHashFromInput, getSimulatedTransactionReceipt, groupEthSimulateV1ResultByInputBlocks, mockSignTransaction, simulateEstimateGasFromInput, simulatedCallFromInput } from '../../app/ts/simulation/services/SimulationModeEthereumClientService.js'
 import { EthTransactionReceiptResponse, JsonRpcResponse, type EthereumJsonRpcRequest } from '../../app/ts/types/JsonRpc-types.js'
 import type { EthSimulateV1Result } from '../../app/ts/types/ethSimulate-types.js'
 import { toResolvedExecutionSimulationState, toResolvedSimulationInput } from '../../app/ts/types/visualizer-types.js'
@@ -90,6 +90,8 @@ const zeroBytes256 = `0x${'0'.repeat(512)}`
 	class MockEthereumJSONRpcRequestHandler {
 		public rpcUrl = 'https://rpc.dark.florist/flipcardtrustone'
 		public rejectOmittedGas = false
+		public balance = 0n
+		public ethGetBalanceCalls: EthereumJsonRpcRequest[] = []
 		public readonly ethSimulateV1Calls: { blockStateCallCount: number, aggregate3BalanceQueryCount: number | undefined, lastCallGas: bigint | undefined }[] = []
 
 		public clearCache = () => undefined
@@ -100,6 +102,9 @@ const zeroBytes256 = `0x${'0'.repeat(512)}`
 			switch (rpcRequest.method) {
 				case 'eth_blockNumber': return `0x${ blockNumber.toString(16) }`
 				case 'eth_getTransactionCount': return '0x0'
+				case 'eth_getBalance':
+					this.ethGetBalanceCalls.push(rpcRequest)
+					return `0x${ this.balance.toString(16) }`
 				case 'eth_getBlockByNumber': {
 					if (rpcRequest.params[0] !== blockNumber && rpcRequest.params[0] !== 'latest') throw new Error('Unsupported block number')
 					if (rpcRequest.params[1] === true) return parseRequest(eth_getBlockByNumber_goerli_8443561_true)
@@ -492,6 +497,118 @@ const zeroBytes256 = `0x${'0'.repeat(512)}`
 			assert.equal(groupedBlock.calls[1]?.gasUsed, 0x6dd4n)
 		})
 
+		test('getBaseFeeAdjustedTransactions caps priority fee with affordable max fee', async () => {
+			requestHandler.balance = 50n
+			requestHandler.ethGetBalanceCalls.length = 0
+			requestHandler.ethSimulateV1Calls.length = 0
+			const parentBlock = await ethereum.getBlock(undefined)
+			const transaction = {
+				signedTransaction: mockSignTransaction({
+					...exampleTransaction,
+					nonce: 0n,
+					maxFeePerGas: 999n,
+					maxPriorityFeePerGas: 100n,
+					gas: 10n,
+					value: 0n,
+				}),
+				website: { websiteOrigin: 'test', icon: undefined, title: undefined },
+				created: new Date(),
+				originalRequestParameters: { method: 'eth_sendTransaction', params: [{}]},
+				transactionIdentifier: 20n,
+			} as const
+			const currentBlock = {
+				stateOverrides: {},
+				transactions: [transaction],
+				signedMessages: [],
+				blockTimeManipulation: { type: 'AddToTimestamp', deltaToAdd: 12n, deltaUnit: 'Seconds' },
+				simulateWithZeroBaseFee: false,
+			} as const
+
+			const { balances, transactions: adjusted } = await getBaseFeeAdjustmentBalances(ethereum, undefined, parentBlock, [], currentBlock)
+			assert.deepEqual(adjusted, getBaseFeeAdjustedTransactions(parentBlock, currentBlock.transactions, balances))
+			const adjustedTransaction = adjusted[0]?.signedTransaction
+			if (adjustedTransaction === undefined || adjustedTransaction.type !== '1559') throw new Error('missing adjusted 1559 transaction')
+			assert.equal(adjustedTransaction.maxFeePerGas, 5n)
+			assert.equal(adjustedTransaction.maxPriorityFeePerGas, 5n)
+			assert.equal(requestHandler.ethGetBalanceCalls.length, 1)
+			assert.equal(requestHandler.ethSimulateV1Calls.length, 0)
+		})
+
+		test('getBaseFeeAdjustedTransactions skips prefix simulation when conservative balance can afford desired fees', async () => {
+			requestHandler.balance = 100_000n
+			requestHandler.ethGetBalanceCalls.length = 0
+			requestHandler.ethSimulateV1Calls.length = 0
+			const parentBlock = await ethereum.getBlock(undefined)
+			const makeTransaction = (nonce: bigint, identifier: bigint) => ({
+				signedTransaction: mockSignTransaction({
+					...exampleTransaction,
+					nonce,
+					maxFeePerGas: 999n,
+					maxPriorityFeePerGas: 100n,
+					gas: 10n,
+					value: 0n,
+				}),
+				website: { websiteOrigin: 'test', icon: undefined, title: undefined },
+				created: new Date(),
+				originalRequestParameters: { method: 'eth_sendTransaction', params: [{}]},
+				transactionIdentifier: identifier,
+			} as const)
+			const currentBlock = {
+				stateOverrides: {},
+				transactions: [makeTransaction(0n, 21n), makeTransaction(1n, 22n)],
+				signedMessages: [],
+				blockTimeManipulation: { type: 'AddToTimestamp', deltaToAdd: 12n, deltaUnit: 'Seconds' },
+				simulateWithZeroBaseFee: false,
+			} as const
+
+			const { transactions: adjusted } = await getBaseFeeAdjustmentBalances(ethereum, undefined, parentBlock, [], currentBlock)
+			assert.equal(adjusted.length, 2)
+			for (const transaction of adjusted) {
+				if (transaction.signedTransaction.type !== '1559') throw new Error('wrong transaction type')
+				assert.equal(transaction.signedTransaction.maxFeePerGas, 284n)
+				assert.equal(transaction.signedTransaction.maxPriorityFeePerGas, 100n)
+			}
+			assert.equal(requestHandler.ethGetBalanceCalls.length, 1)
+			assert.equal(requestHandler.ethSimulateV1Calls.length, 0)
+		})
+
+		test('getBaseFeeAdjustmentBalances tracks explicit max fee in conservative balance', async () => {
+			requestHandler.balance = 100_000n
+			requestHandler.ethGetBalanceCalls.length = 0
+			requestHandler.ethSimulateV1Calls.length = 0
+			const parentBlock = await ethereum.getBlock(undefined)
+			const makeTransaction = (nonce: bigint, identifier: bigint, maxFeePerGas: bigint | undefined) => ({
+				signedTransaction: mockSignTransaction({
+					...exampleTransaction,
+					nonce,
+					maxFeePerGas: maxFeePerGas ?? 999n,
+					maxPriorityFeePerGas: 100n,
+					gas: 10n,
+					value: 0n,
+				}),
+				website: { websiteOrigin: 'test', icon: undefined, title: undefined },
+				created: new Date(),
+				originalRequestParameters: { method: 'eth_sendTransaction', params: maxFeePerGas === undefined ? [{}] : [{ maxFeePerGas }]},
+				transactionIdentifier: identifier,
+			} as const)
+			const currentBlock = {
+				stateOverrides: {},
+				transactions: [
+					makeTransaction(0n, 23n, undefined),
+					makeTransaction(1n, 24n, 200n),
+					makeTransaction(2n, 25n, undefined),
+				],
+				signedMessages: [],
+				blockTimeManipulation: { type: 'AddToTimestamp', deltaToAdd: 12n, deltaUnit: 'Seconds' },
+				simulateWithZeroBaseFee: false,
+			} as const
+
+			const { transactions: adjusted } = await getBaseFeeAdjustmentBalances(ethereum, undefined, parentBlock, [], currentBlock)
+			assert.equal(adjusted.length, 3)
+			assert.equal(requestHandler.ethGetBalanceCalls.length, 1)
+			assert.equal(requestHandler.ethSimulateV1Calls.length, 0)
+		})
+
 		test('simulateEstimateGasFromInput omits gas when input gas is omitted', async () => {
 			requestHandler.ethSimulateV1Calls.length = 0
 			const estimateGas = await simulateEstimateGasFromInput(ethereum, undefined, [], {
@@ -615,6 +732,15 @@ const zeroBytes256 = `0x${'0'.repeat(512)}`
 				const emptySimulationStateInput = [] as const
 
 				assert.equal(await getBlockNumberFromInput(emptySimulationStateInput), blockNumber)
+			})
+
+			test('input-based balance preserves pending block tag for empty input', async () => {
+				requestHandler.ethGetBalanceCalls.length = 0
+				const emptySimulationStateInput = [] as const
+
+				await getSimulatedBalanceFromInput(ethereum, undefined, toResolvedSimulationInput(emptySimulationStateInput), exampleTransaction.from, 'pending')
+
+				assert.deepEqual(requestHandler.ethGetBalanceCalls[0]?.params, [exampleTransaction.from, 'pending'])
 			})
 
 			test('input-based simulated block hash is deterministic and round-trips through getBlockByHash', async () => {


### PR DESCRIPTION
## Summary
- Added shared transaction-fee utilities (`getDesiredMaxFeePerGasForBaseFee`, `getTransactionFeesForBaseFee`, `getAffordableTransactionFees`) and reused across popup + simulation flows.
- Updated transaction form simulation path to cap auto-filled `maxFeePerGas` by sender affordability, while preserving explicit fee settings.
- Reworked base-fee adjustment to compute balances per transaction and apply capped fee adjustments only where needed, including conservative balance tracking and helper for obtaining pre-simulation balances.
- Split and refactored simulation preparation flow to apply base-fee-fixed transactions via new `getBaseFeeAdjustmentBalances` before nonce fixing.
- Improved popup confirm transaction rendering by making address edit selection resilient to exact chain match, chain-1 fallback, and generic fallback.
- Refactored address book state updates to centralize state mutations and prevent overwriting user edits when background sync errors occur.
- Added proxy+implementation ABI merge support and proxy-aware ABI parsing/merge logic in block explorer fetcher.
- Updated CI review workflow to OpenAI review bot v5 image.

## Testing
- Not run (no validation commands executed here).
- Suggested checks:
  - `bun test`
  - `bun run setup-chrome`
  - `bun run typecheck`
  - `bun run lint`
  - `bun run test:chrome-communication` (after `bun run install-chrome`/`CHROME_BIN` setup if needed)