### PR TITLE
Fix gas estimation error flag in confirm transaction UI

### DIFF
--- a/app/ts/components/pages/ConfirmTransaction.tsx
+++ b/app/ts/components/pages/ConfirmTransaction.tsx
@@ -345,7 +345,7 @@ function TransactionCardContent(param: TransactionCardContentParams) {
 				addressMetaData = { popupVisualisation.statusCode === 'success' ? popupVisualisation.data.addressBookEntries : [] }
 				created = { currentPendingTransaction.created }
 				errorMessage = { getErrorMesssage() }
-				isGasEstimationError = { popupVisualisation.data.transactionToSimulate.success }
+				isGasEstimationError = { !popupVisualisation.data.transactionToSimulate.success }
 				simulationBlockNumber = { popupVisualisation.data.simulationState.blockNumber }
 				simulationConductedTimestamp = { popupVisualisation.data.simulationState.simulationConductedTimestamp }
 				rpcConnectionStatus = { param.rpcConnectionStatus }

--- a/test/tests/confirmTransactionRenderedTimestamp.test.ts
+++ b/test/tests/confirmTransactionRenderedTimestamp.test.ts
@@ -246,6 +246,8 @@ describe('ConfirmTransaction', () => {
 		assert.equal(dom.document.body.textContent?.includes('Transaction Input'), true)
 		assert.equal(dom.document.body.textContent?.includes('Gas limit'), true)
 		assert.equal(dom.document.body.textContent?.includes('Change'), true)
+		assert.equal(dom.document.body.textContent?.includes('Gas estimation error'), true)
+		assert.equal(dom.document.body.textContent?.includes('Execution error'), false)
 
 		await unmountConfirmTransaction(dom)
 		clock.restore()


### PR DESCRIPTION
## Summary
- Fixed `isGasEstimationError` binding in `app/ts/components/pages/ConfirmTransaction.tsx` to correctly reflect failed simulation status (uses negation of `transactionToSimulate.success`).
- Added assertions in `test/tests/confirmTransactionRenderedTimestamp.test.ts` to confirm `Gas estimation error` is rendered and `Execution error` is not shown in the confirm transaction flow.

## Testing
- Not run: `bun test`
- Not run: `bun run setup-chrome`
- Not run: `bun run typecheck`
- Not run: `bun run lint`
- Not run: `bun run test:chrome-communication`
- Verified changes in files:
  - `app/ts/components/pages/ConfirmTransaction.tsx`
  - `test/tests/confirmTransactionRenderedTimestamp.test.ts`
- Branch context: base `main`, head `t3code/f935b5b3`