### PR TITLE
Scope website access by origin

### DIFF
--- a/app/ts/background/accessManagement.ts
+++ b/app/ts/background/accessManagement.ts
@@ -6,7 +6,7 @@ import type { TabConnection, WebsiteTabConnections } from '../types/user-interfa
 import type { InpageScriptCallBack, Settings } from '../types/interceptor-messages.js'
 import { getSettings, getWebsiteAccess, updateWebsiteAccess } from './settings.js'
 import { sendSubscriptionReplyOrCallBack } from './messageSending.js'
-import { type WebsiteSocket, getHostWithPort, getHostWithPortFromOriginLike, getMatchingWebsiteAccessOrigin } from '../utils/requests.js'
+import { type WebsiteSocket, getHostname, getHostnameFromOriginLike, getMatchingWebsiteAccessOrigin } from '../utils/requests.js'
 import { getAllTabStates } from './storageVariables.js'
 import type { Website, WebsiteAccess, WebsiteAccessArray, WebsiteAddressAccess } from '../types/websiteAccessTypes.js'
 import { getUniqueItemsByProperties, replaceElementInReadonlyArray } from '../utils/typed-arrays.js'
@@ -257,7 +257,8 @@ const getTabsAndAddressesToBlock = async (websiteTabConnections: WebsiteTabConne
 	const tabIdsToBlock = (await getActiveAddressesForAllTabs(await getSettings())).filter((tabData) => approvedTabIds.has(tabData.tabId)).filter((tabData) => tabData.activeAddress?.declarativeNetRequestBlockMode === 'block-all').map((tabData) => tabData.tabId)
 	const sitesToBlock = (await getWebsiteAccess())
 		.filter((access) => access.declarativeNetRequestBlockMode === 'block-all')
-		.map((acccess) => getHostWithPortFromOriginLike(acccess.website.websiteOrigin))
+		// declarativeNetRequest initiatorDomains is domain-based, so request blocking intentionally collapses schemeful origins to hostnames.
+		.map((acccess) => getHostnameFromOriginLike(acccess.website.websiteOrigin))
 		.filter((websiteOrigin) => websiteOrigin.length > 0)
 	return {
 		tabIdsToBlock,
@@ -314,8 +315,8 @@ export async function updateDeclarativeNetRequestBlocks(websiteTabConnections: W
 				if (tabIdsToBlock.find((tabId) => tabId === details.tabId) !== undefined) return { cancel: true }
 				if (details.originUrl === undefined) return {}
 				if (details.type === 'main_frame') return {}
-				const websiteOrigin = getHostWithPort(details.originUrl)
-				const destinationHost = getHostWithPort(details.url)
+				const websiteOrigin = getHostname(details.originUrl)
+				const destinationHost = getHostname(details.url)
 				if (destinationHost === websiteOrigin) return {}
 				if (sitesToBlock.find((blockUrl) => blockUrl === websiteOrigin) !== undefined) return { cancel: true }
 				return {}
@@ -328,7 +329,7 @@ export async function updateDeclarativeNetRequestBlocks(websiteTabConnections: W
 
 export const areWeBlocking = async (websiteTabConnections: WebsiteTabConnections, tabId: number, websiteOrigin: string) => {
 	const { tabIdsToBlock, sitesToBlock } = await getTabsAndAddressesToBlock(websiteTabConnections)
-	const websiteHost = getHostWithPortFromOriginLike(websiteOrigin)
+	const websiteHost = getHostnameFromOriginLike(websiteOrigin)
 	if (sitesToBlock.find((blockUrl) => blockUrl === websiteHost) !== undefined) return true
 	if (tabIdsToBlock.find((blockTab) => blockTab === tabId) !== undefined) return true
 	return false

--- a/app/ts/background/accessManagement.ts
+++ b/app/ts/background/accessManagement.ts
@@ -6,9 +6,9 @@ import type { TabConnection, WebsiteTabConnections } from '../types/user-interfa
 import type { InpageScriptCallBack, Settings } from '../types/interceptor-messages.js'
 import { getSettings, getWebsiteAccess, updateWebsiteAccess } from './settings.js'
 import { sendSubscriptionReplyOrCallBack } from './messageSending.js'
-import { type WebsiteSocket, getHostWithPort } from '../utils/requests.js'
+import { type WebsiteSocket, getHostWithPort, getHostWithPortFromOriginLike, getMatchingWebsiteAccessOrigin } from '../utils/requests.js'
 import { getAllTabStates } from './storageVariables.js'
-import type { Website, WebsiteAccessArray, WebsiteAddressAccess } from '../types/websiteAccessTypes.js'
+import type { Website, WebsiteAccess, WebsiteAccessArray, WebsiteAddressAccess } from '../types/websiteAccessTypes.js'
 import { getUniqueItemsByProperties, replaceElementInReadonlyArray } from '../utils/typed-arrays.js'
 import { modifyObject } from '../utils/typescript.js'
 import type { AddressBookEntries, AddressBookEntry } from '../types/addressBookTypes.js'
@@ -34,6 +34,12 @@ function setWebsitePortApproval(websiteTabConnections: WebsiteTabConnections, so
 }
 
 export type ApprovalState = 'hasAccess' | 'noAccess' | 'askAccess' | 'interceptorDisabled' | 'notFound'
+
+function findWebsiteAccess(websiteAccess: WebsiteAccessArray, websiteOrigin: string): WebsiteAccess | undefined {
+	const matchingWebsiteOrigin = getMatchingWebsiteAccessOrigin(websiteAccess.map((web) => web.website.websiteOrigin), websiteOrigin)
+	if (matchingWebsiteOrigin === undefined) return undefined
+	return websiteAccess.find((web) => web.website.websiteOrigin === matchingWebsiteOrigin)
+}
 
 export function verifyAccess(websiteTabConnections: WebsiteTabConnections, socket: WebsiteSocket, askAccessIfUnknown: boolean, websiteOrigin: string, requestAccessForAddress: AddressBookEntry | undefined, settings: Settings) {
 	const connection = getConnectionDetails(websiteTabConnections, socket)
@@ -83,41 +89,31 @@ export async function sendActiveAccountChangeToApprovedWebsitePorts(websiteTabCo
 }
 
 export function hasAccess(websiteAccess: WebsiteAccessArray, websiteOrigin: string) : ApprovalState {
-	for (const web of websiteAccess) {
-		if (web.website.websiteOrigin === websiteOrigin) {
-			if (web.interceptorDisabled) return 'interceptorDisabled'
-			return web.access ? 'hasAccess' : 'noAccess'
-		}
-	}
-	return 'notFound'
+	const web = findWebsiteAccess(websiteAccess, websiteOrigin)
+	if (web === undefined) return 'notFound'
+	if (web.interceptorDisabled) return 'interceptorDisabled'
+	return web.access ? 'hasAccess' : 'noAccess'
 }
 
 export function hasAddressAccess(websiteAccess: WebsiteAccessArray, websiteOrigin: string, address: AddressBookEntry) : ApprovalState {
-	for (const web of websiteAccess) {
-		if (web.website.websiteOrigin === websiteOrigin) {
-			if (web.interceptorDisabled) return 'interceptorDisabled'
-			if (!web.access) return 'noAccess'
-			if (web.addressAccess !== undefined) {
-				for (const addressAccess of web.addressAccess) {
-					if (addressAccess.address === address.address) {
-						return addressAccess.access ? 'hasAccess' : 'noAccess'
-					}
-				}
+	const web = findWebsiteAccess(websiteAccess, websiteOrigin)
+	if (web === undefined) return 'notFound'
+	if (web.interceptorDisabled) return 'interceptorDisabled'
+	if (!web.access) return 'noAccess'
+	if (web.addressAccess !== undefined) {
+		for (const addressAccess of web.addressAccess) {
+			if (addressAccess.address === address.address) {
+				return addressAccess.access ? 'hasAccess' : 'noAccess'
 			}
-			if (address.askForAddressAccess === false) return 'hasAccess'
-			return 'notFound'
 		}
 	}
+	if (address.askForAddressAccess === false) return 'hasAccess'
 	return 'notFound'
 }
 
 function getAddressAccesses(websiteAccess: WebsiteAccessArray, websiteOrigin: string) : readonly WebsiteAddressAccess[] {
-	for (const web of websiteAccess) {
-		if (web.website.websiteOrigin === websiteOrigin) {
-			return web.addressAccess === undefined ? [] : web.addressAccess
-		}
-	}
-	return []
+	const web = findWebsiteAccess(websiteAccess, websiteOrigin)
+	return web?.addressAccess === undefined ? [] : web.addressAccess
 }
 function getAddressesThatDoNotNeedIndividualAccesses(activeAddressEntries: AddressBookEntries) : AddressBookEntries {
 	return activeAddressEntries.filter((x) => x.askForAddressAccess === false)
@@ -125,7 +121,8 @@ function getAddressesThatDoNotNeedIndividualAccesses(activeAddressEntries: Addre
 
 export async function setInterceptorDisabledForWebsite(website: Website, interceptorDisabled: boolean) {
 	return await updateWebsiteAccess((previousWebsiteAccess) => {
-		const index = previousWebsiteAccess.findIndex((entry) => entry.website.websiteOrigin === website.websiteOrigin)
+		const matchingWebsiteOrigin = getMatchingWebsiteAccessOrigin(previousWebsiteAccess.map((entry) => entry.website.websiteOrigin), website.websiteOrigin)
+		const index = matchingWebsiteOrigin === undefined ? -1 : previousWebsiteAccess.findIndex((entry) => entry.website.websiteOrigin === matchingWebsiteOrigin)
 		const previousAccess = index !== -1 ? previousWebsiteAccess[index] : undefined;
 		if (previousAccess === undefined) return [...previousWebsiteAccess, { website, addressAccess: [], interceptorDisabled } ]
 		return replaceElementInReadonlyArray(previousWebsiteAccess, index, { ...previousAccess, interceptorDisabled })
@@ -134,10 +131,11 @@ export async function setInterceptorDisabledForWebsite(website: Website, interce
 
 export async function setAccess(website: Website, access: boolean, address: bigint | undefined) {
 	return await updateWebsiteAccess((previousWebsiteAccess) => {
-		const foundEntry = previousWebsiteAccess.find((entry) => entry.website.websiteOrigin === website.websiteOrigin)
+		const matchingWebsiteOrigin = getMatchingWebsiteAccessOrigin(previousWebsiteAccess.map((entry) => entry.website.websiteOrigin), website.websiteOrigin)
+		const foundEntry = matchingWebsiteOrigin === undefined ? undefined : previousWebsiteAccess.find((entry) => entry.website.websiteOrigin === matchingWebsiteOrigin)
 		if (foundEntry === undefined) return [...previousWebsiteAccess, { website, access, addressAccess: address === undefined || !access ? undefined : [ { address, access } ] }]
 		return previousWebsiteAccess.map((prevAccess) => {
-			if (prevAccess.website.websiteOrigin === website.websiteOrigin) {
+			if (prevAccess.website.websiteOrigin === matchingWebsiteOrigin) {
 				const websiteData = mergeStoredWebsiteMetadata(prevAccess.website, website)
 				if (address === undefined) return modifyObject(prevAccess, { website: websiteData, access })
 				const addressAccess = { address, access }
@@ -257,7 +255,10 @@ const getApprovedTabs = (websiteTabConnections: WebsiteTabConnections) => {
 const getTabsAndAddressesToBlock = async (websiteTabConnections: WebsiteTabConnections) => {
 	const approvedTabIds = getApprovedTabs(websiteTabConnections)
 	const tabIdsToBlock = (await getActiveAddressesForAllTabs(await getSettings())).filter((tabData) => approvedTabIds.has(tabData.tabId)).filter((tabData) => tabData.activeAddress?.declarativeNetRequestBlockMode === 'block-all').map((tabData) => tabData.tabId)
-	const sitesToBlock = (await getWebsiteAccess()).filter((access) => access.declarativeNetRequestBlockMode === 'block-all').map((acccess) => acccess.website.websiteOrigin)
+	const sitesToBlock = (await getWebsiteAccess())
+		.filter((access) => access.declarativeNetRequestBlockMode === 'block-all')
+		.map((acccess) => getHostWithPortFromOriginLike(acccess.website.websiteOrigin))
+		.filter((websiteOrigin) => websiteOrigin.length > 0)
 	return {
 		tabIdsToBlock,
 		sitesToBlock
@@ -327,7 +328,8 @@ export async function updateDeclarativeNetRequestBlocks(websiteTabConnections: W
 
 export const areWeBlocking = async (websiteTabConnections: WebsiteTabConnections, tabId: number, websiteOrigin: string) => {
 	const { tabIdsToBlock, sitesToBlock } = await getTabsAndAddressesToBlock(websiteTabConnections)
-	if (sitesToBlock.find((blockUrl) => blockUrl === websiteOrigin) !== undefined) return true
+	const websiteHost = getHostWithPortFromOriginLike(websiteOrigin)
+	if (sitesToBlock.find((blockUrl) => blockUrl === websiteHost) !== undefined) return true
 	if (tabIdsToBlock.find((blockTab) => blockTab === tabId) !== undefined) return true
 	return false
 }

--- a/app/ts/background/background-startup.ts
+++ b/app/ts/background/background-startup.ts
@@ -9,7 +9,7 @@ import type { EthereumClientService } from '../simulation/services/EthereumClien
 import { getSocketFromPort, sendPopupMessageToOpenWindows, websiteSocketToString } from './backgroundUtils.js'
 import { sendSubscriptionMessagesForNewBlock } from '../simulation/services/EthereumSubscriptionService.js'
 import { Semaphore } from '../utils/semaphore.js'
-import { RawInterceptedRequest, checkAndThrowRuntimeLastError, getHostWithPort, silenceChromeUnCaughtPromise } from '../utils/requests.js'
+import { RawInterceptedRequest, checkAndThrowRuntimeLastError, getWebsiteOrigin, silenceChromeUnCaughtPromise } from '../utils/requests.js'
 import { DEFAULT_TAB_CONNECTION, ICON_NOT_ACTIVE } from '../utils/constants.js'
 import { handleUnexpectedError, isNewBlockAbort, printError } from '../utils/errors.js'
 import { updateContentScriptInjectionStrategyManifestV2 } from '../utils/contentScriptsUpdating.js'
@@ -74,7 +74,7 @@ async function onContentScriptConnected(waitForStartup: () => Promise<{ resetAct
 		printError(`Could not connect to a port: ${ port.name}`)
 		return
 	}
-	const websiteOrigin = getHostWithPort(port.sender.url)
+	const websiteOrigin = getWebsiteOrigin(port.sender.url)
 	const identifier = websiteSocketToString(socket)
 	const websitePromise = (async () => {
 		const website = { websiteOrigin, ...await retrieveWebsiteDetails(socket.tabId, websiteOrigin) }
@@ -238,7 +238,7 @@ const onTabUpdated = async (tabId: number, changeInfo: browser.tabs._OnUpdatedCh
 	await waitForBackgroundStartup()
 	if (changeInfo.status !== 'complete') return
 	if (tab.url === undefined) return
-	const websiteOrigin = getHostWithPort(tab.url)
+	const websiteOrigin = getWebsiteOrigin(tab.url)
 	const website = { websiteOrigin, ...await retrieveWebsiteDetails(tabId, websiteOrigin) }
 	await updateKnownWebsiteMetadata(website)
 	await updateTabState(tabId, (previousState: TabState) => modifyObject(previousState, { website, tabIconDetails: DEFAULT_TAB_CONNECTION }))

--- a/app/ts/background/iconHandler.ts
+++ b/app/ts/background/iconHandler.ts
@@ -6,7 +6,7 @@ import { TabIcon, type TabState, type WebsiteTabConnections } from '../types/use
 import { getSettings, getWebsiteAccess } from './settings.js'
 import { getRpcConnectionStatus, getTabState, removeTabState, updateTabState } from './storageVariables.js'
 import { getLastKnownCurrentTabId } from './popupMessageHandlers.js'
-import { checkAndPrintRuntimeLastError, doesTabExist, safeGetTab, silenceChromeUnCaughtPromise } from '../utils/requests.js'
+import { checkAndPrintRuntimeLastError, doesTabExist, getMatchingWebsiteAccessOrigin, safeGetTab, silenceChromeUnCaughtPromise } from '../utils/requests.js'
 import { modifyObject } from '../utils/typescript.js'
 import { getRpcWarningState } from '../utils/rpcConnectionUi.js'
 import { getPrettySignerName } from '../utils/signerMetadata.js'
@@ -17,10 +17,11 @@ const ALLOWED_FAVICON_PROTOCOLS = new Set(['http:', 'https:', 'data:'])
 
 async function getCachedWebsiteIcon(tabId: number, websiteOrigin: string) {
 	const storedWebsiteAccess = await getWebsiteAccess()
-	const storedWebsite = storedWebsiteAccess.find((entry) => entry.website.websiteOrigin === websiteOrigin)
+	const matchingWebsiteOrigin = getMatchingWebsiteAccessOrigin(storedWebsiteAccess.map((entry) => entry.website.websiteOrigin), websiteOrigin)
+	const storedWebsite = matchingWebsiteOrigin === undefined ? undefined : storedWebsiteAccess.find((entry) => entry.website.websiteOrigin === matchingWebsiteOrigin)
 	if (storedWebsite === undefined) return { cachedIcon: undefined, hasStoredWebsiteAccess: false as const }
 	const currentWebsite = (await getTabState(tabId)).website
-	if (currentWebsite?.websiteOrigin === websiteOrigin) {
+	if (currentWebsite !== undefined && getMatchingWebsiteAccessOrigin([currentWebsite.websiteOrigin], websiteOrigin) !== undefined) {
 		const currentIcon = sanitizeStoredWebsiteIcon(currentWebsite.icon)
 		if (currentIcon !== undefined) return { cachedIcon: currentIcon, hasStoredWebsiteAccess: true as const }
 	}

--- a/app/ts/background/popupMessageHandlers.ts
+++ b/app/ts/background/popupMessageHandlers.ts
@@ -6,7 +6,7 @@ import { type ChangeActiveAddress, type ModifyMakeMeRich, type ChangePage, type 
 import { formEthSendTransaction, formSendRawTransaction, resolvePendingTransactionOrMessage, updateConfirmTransactionView, setGasLimitForTransaction, toPopupPendingTransactionOrSignableMessage } from './windows/confirmTransaction.js'
 import { askForSignerAccountsFromSignerIfNotAvailable, getAddressMetadataForAccess, requestAddressChange, resolveInterceptorAccess } from './windows/interceptorAccess.js'
 import { resolveChainChange } from './windows/changeChain.js'
-import { sendMessageToApprovedWebsitePorts, setInterceptorDisabledForWebsite, updateWebsiteApprovalAccesses } from './accessManagement.js'
+import { hasAccess, sendMessageToApprovedWebsitePorts, setInterceptorDisabledForWebsite, updateWebsiteApprovalAccesses } from './accessManagement.js'
 import { getHtmlFile, sendPopupMessageToOpenWindows } from './backgroundUtils.js'
 import { findEntryWithSymbolOrName, getMetadataForAddressBookData } from './medataSearch.js'
 import { getActiveAddressEntry, getActiveAddresses, identifyAddress } from './metadataUtils.js'
@@ -25,7 +25,7 @@ import { updateContentScriptInjectionStrategyManifestV2, updateContentScriptInje
 import type { Website } from '../types/websiteAccessTypes.js'
 import { makeSureInterceptorIsNotSleeping } from './sleeping.js'
 import { craftPersonalSignPopupMessage } from './windows/personalSign.js'
-import { checkAndThrowRuntimeLastError, silenceChromeUnCaughtPromise, updateTabIfExists } from '../utils/requests.js'
+import { checkAndThrowRuntimeLastError, getMatchingWebsiteAccessOrigin, silenceChromeUnCaughtPromise, updateTabIfExists } from '../utils/requests.js'
 import { assertNever, modifyObject } from '../utils/typescript.js'
 import type { VisualizedPersonalSignRequestSafeTx } from '../types/personal-message-definitions.js'
 import type { TokenPriceService } from '../simulation/services/priceEstimator.js'
@@ -223,11 +223,16 @@ export async function addOrModifyAddressBookEntry(ethereum: EthereumClientServic
 
 export async function changeInterceptorAccess(ethereum: EthereumClientService, tokenPriceService: TokenPriceService, resetSimulationServices: ResetSimulationServices, websiteTabConnections: WebsiteTabConnections, accessChange: ChangeInterceptorAccess) {
 	await updateWebsiteAccess((previousAccess) => {
-		const withEntriesRemoved = previousAccess.filter((acc) => accessChange.data.find((change) => change.newEntry.website.websiteOrigin === acc.website.websiteOrigin)?.removed !== true)
+		const previousWebsiteOrigins = previousAccess.map((access) => access.website.websiteOrigin)
+		const changeTargets = accessChange.data.map((change) => ({
+			change,
+			websiteOrigin: getMatchingWebsiteAccessOrigin(previousWebsiteOrigins, change.newEntry.website.websiteOrigin)
+		}))
+		const withEntriesRemoved = previousAccess.filter((access) => changeTargets.find((target) => target.websiteOrigin === access.website.websiteOrigin)?.change.removed !== true)
 		return withEntriesRemoved.map((entry) => {
-			const changeForEntry = accessChange.data.find((change) => change.newEntry.website.websiteOrigin === entry.website.websiteOrigin)
+			const changeForEntry = changeTargets.find((target) => target.websiteOrigin === entry.website.websiteOrigin)
 			if (changeForEntry === undefined) return entry
-			return changeForEntry.newEntry
+			return changeForEntry.change.newEntry
 		})
 	})
 
@@ -752,8 +757,10 @@ export async function retrieveWebsiteAccess(parsedRequest: RetrieveWebsiteAccess
 
 async function blockOrAllowWebsiteExternalRequests(websiteTabConnections: WebsiteTabConnections, website: Website, shouldBlock: boolean) {
 	await updateWebsiteAccess((previousAccessList) => {
+		const matchingWebsiteOrigin = getMatchingWebsiteAccessOrigin(previousAccessList.map((access) => access.website.websiteOrigin), website.websiteOrigin)
+		if (matchingWebsiteOrigin === undefined) return previousAccessList
 		return previousAccessList.map((access) => {
-			if (access.website.websiteOrigin !== website.websiteOrigin) return access
+			if (access.website.websiteOrigin !== matchingWebsiteOrigin) return access
 			return modifyObject(access, { declarativeNetRequestBlockMode: shouldBlock ? 'block-all' : 'disabled' })
 		})
 	})
@@ -769,8 +776,10 @@ export async function blockOrAllowExternalRequests(ethereum: EthereumClientServi
 
 async function removeAddressAccessByAddress(websiteOrigin: string, address: EthereumAddress) {
 	await updateWebsiteAccess((previousAccessList) => {
+		const matchingWebsiteOrigin = getMatchingWebsiteAccessOrigin(previousAccessList.map((access) => access.website.websiteOrigin), websiteOrigin)
+		if (matchingWebsiteOrigin === undefined) return previousAccessList
 		return previousAccessList.map(access => {
-			if (access.website.websiteOrigin !== websiteOrigin || !access.addressAccess) return access
+			if (access.website.websiteOrigin !== matchingWebsiteOrigin || !access.addressAccess) return access
 			const strippedAddressAccess = access.addressAccess.filter(addressAccess => addressAccess.address !== address)
 			return modifyObject(access, { addressAccess: strippedAddressAccess })
 		})
@@ -786,8 +795,10 @@ export async function removeWebsiteAddressAccess(ethereum: EthereumClientService
 
 async function setAdressAccessForWebsite(websiteOrigin: string, address: EthereumAddress, allowAccess: boolean) {
 	await updateWebsiteAccess((previousAccessList) => {
+		const matchingWebsiteOrigin = getMatchingWebsiteAccessOrigin(previousAccessList.map((access) => access.website.websiteOrigin), websiteOrigin)
+		if (matchingWebsiteOrigin === undefined) return previousAccessList
 		return previousAccessList.map((access) => {
-			if (access.website.websiteOrigin !== websiteOrigin || access.addressAccess === undefined) return access
+			if (access.website.websiteOrigin !== matchingWebsiteOrigin || access.addressAccess === undefined) return access
 			const addressAccessList = access.addressAccess.map(addressAccess => (addressAccess.address !== address) ? addressAccess : modifyObject(addressAccess, { access: allowAccess }))
 			return modifyObject(access, { addressAccess: addressAccessList })
 		})
@@ -802,7 +813,11 @@ export async function allowOrPreventAddressAccessForWebsite(websiteTabConnection
 }
 
 export async function removeWebsiteAccess(ethereum: EthereumClientService, tokenPriceService: TokenPriceService, resetSimulationServices: ResetSimulationServices, websiteTabConnections: WebsiteTabConnections, parsedRequest: RemoveWebsiteAccess) {
-	await updateWebsiteAccess((previousAccess) => previousAccess.filter(access => access.website.websiteOrigin !== parsedRequest.data.websiteOrigin))
+	await updateWebsiteAccess((previousAccess) => {
+		const matchingWebsiteOrigin = getMatchingWebsiteAccessOrigin(previousAccess.map((access) => access.website.websiteOrigin), parsedRequest.data.websiteOrigin)
+		if (matchingWebsiteOrigin === undefined) return previousAccess
+		return previousAccess.filter(access => access.website.websiteOrigin !== matchingWebsiteOrigin)
+	})
 	await updateWebsiteApprovalAccesses(ethereum, tokenPriceService, resetSimulationServices, websiteTabConnections, await getSettings(), true)
 	await sendPopupMessageToOpenWindows({ method: 'popup_websiteAccess_changed' })
 }
@@ -936,7 +951,7 @@ async function buildHomePageUpdate(
 	let tabState = await tabStatePromise
 	tabState = await refreshSignerAccountsForTabIfNeeded(websiteTabConnections, tabId, tabState, shouldRefreshSignerAccounts)
 	const websiteOrigin = tabState.website?.websiteOrigin
-	const interceptorDisabled = websiteOrigin === undefined ? false : settings.websiteAccess.find((entry) => entry.website.websiteOrigin === websiteOrigin && entry.interceptorDisabled === true) !== undefined
+	const interceptorDisabled = websiteOrigin === undefined ? false : hasAccess(settings.websiteAccess, websiteOrigin) === 'interceptorDisabled'
 	const richData = await richDataPromise
 	return {
 		method: 'popup_UpdateHomePage' as const,
@@ -1009,7 +1024,8 @@ export async function importSimulationStack(ethereum: EthereumClientService, tok
 
 	const websiteAccess = await getWebsiteAccess()
 	const updateWebsiteDetails = (website: Website) => {
-		const websiteData = websiteAccess.find((access) => access.website.websiteOrigin === website.websiteOrigin)?.website
+		const matchingWebsiteOrigin = getMatchingWebsiteAccessOrigin(websiteAccess.map((access) => access.website.websiteOrigin), website.websiteOrigin)
+		const websiteData = matchingWebsiteOrigin === undefined ? undefined : websiteAccess.find((access) => access.website.websiteOrigin === matchingWebsiteOrigin)?.website
 		return websiteData ?? website
 	}
 

--- a/app/ts/background/settings.ts
+++ b/app/ts/background/settings.ts
@@ -11,8 +11,9 @@ import { getUniqueItemsByProperties } from '../utils/typed-arrays.js'
 import type { AddressBookEntries, AddressBookEntry } from '../types/addressBookTypes.js'
 import type { BlockTimeManipulation } from '../types/visualizer-types.js'
 import { DEFAULT_BLOCK_MANIPULATION } from '../simulation/services/SimulationModeEthereumClientService.js'
-import { silenceChromeUnCaughtPromise } from '../utils/requests.js'
+import { getMatchingWebsiteAccessOrigin, silenceChromeUnCaughtPromise } from '../utils/requests.js'
 import { mergeStoredWebsiteMetadata, sanitizeWebsiteAccess } from '../utils/websiteIcons.js'
+import { migrateWebsiteAccessOrigins } from './websiteAccessMigration.js'
 
 export const defaultActiveAddresses: AddressBookEntries = [
 	{
@@ -141,7 +142,9 @@ export async function getSettings() : Promise<Settings> {
 }
 
 export function getInterceptorDisabledSites(settings: Settings): string[] {
-	return settings.websiteAccess.filter((site) => site.interceptorDisabled === true).map((site) => site.website.websiteOrigin)
+	return settings.websiteAccess
+		.filter((site) => site.interceptorDisabled === true)
+		.map((site) => site.website.websiteOrigin)
 }
 
 export const setPage = async (openedPageV2: Page) => await browserStorageLocalSet({ openedPageV2 })
@@ -172,7 +175,7 @@ export async function changeSimulationMode(changes: { simulationMode: boolean, r
 const websiteAccessSemaphore = new Semaphore(1)
 async function getNormalizedWebsiteAccessFromStorage() {
 	const rawWebsiteAccess = await getParsedStorageValueOrDefault('websiteAccess', [])
-	const sanitizedWebsiteAccess = sanitizeWebsiteAccess(rawWebsiteAccess)
+	const sanitizedWebsiteAccess = migrateWebsiteAccessOrigins(sanitizeWebsiteAccess(rawWebsiteAccess))
 	return { rawWebsiteAccess, sanitizedWebsiteAccess }
 }
 
@@ -183,7 +186,7 @@ export async function getWebsiteAccess() {
 export async function updateWebsiteAccess(updateFunc: (prevState: WebsiteAccessArray) => WebsiteAccessArray) {
 	await websiteAccessSemaphore.execute(async () => {
 		const { rawWebsiteAccess, sanitizedWebsiteAccess } = await getNormalizedWebsiteAccessFromStorage()
-		const nextWebsiteAccess = sanitizeWebsiteAccess(updateFunc(sanitizedWebsiteAccess))
+		const nextWebsiteAccess = migrateWebsiteAccessOrigins(sanitizeWebsiteAccess(updateFunc(sanitizedWebsiteAccess)))
 		if (nextWebsiteAccess === sanitizedWebsiteAccess && rawWebsiteAccess === sanitizedWebsiteAccess) return
 		return await browserStorageLocalSet({ websiteAccess: nextWebsiteAccess })
 	})
@@ -191,9 +194,11 @@ export async function updateWebsiteAccess(updateFunc: (prevState: WebsiteAccessA
 
 export async function updateKnownWebsiteMetadata(website: Website) {
 	await updateWebsiteAccess((previousWebsiteAccess) => {
+		const matchingWebsiteOrigin = getMatchingWebsiteAccessOrigin(previousWebsiteAccess.map((entry) => entry.website.websiteOrigin), website.websiteOrigin)
+		if (matchingWebsiteOrigin === undefined) return previousWebsiteAccess
 		let changed = false
 		const nextWebsiteAccess = previousWebsiteAccess.map((entry) => {
-			if (entry.website.websiteOrigin !== website.websiteOrigin) return entry
+			if (entry.website.websiteOrigin !== matchingWebsiteOrigin) return entry
 			const mergedWebsite = mergeStoredWebsiteMetadata(entry.website, website)
 			if (mergedWebsite === entry.website) return entry
 			changed = true

--- a/app/ts/background/websiteAccessMigration.ts
+++ b/app/ts/background/websiteAccessMigration.ts
@@ -1,7 +1,50 @@
-import { WebsiteAccessArray, type WebsiteAccess } from '../types/websiteAccessTypes.js'
+import { WebsiteAccessArray, type WebsiteAccess, type WebsiteAddressAccess } from '../types/websiteAccessTypes.js'
 import { browserStorageLocalSet } from '../utils/storageUtils.js'
 import { getSchemefulOriginsForLegacyWebsiteOrigin, isSchemefulWebsiteOrigin, normalizeSchemefulWebsiteOrigin } from '../utils/requests.js'
-import { sanitizeWebsiteAccess } from '../utils/websiteIcons.js'
+import { mergeStoredWebsiteMetadata, sanitizeWebsiteAccess } from '../utils/websiteIcons.js'
+
+const mergeAccessFlag = (first: boolean | undefined, second: boolean | undefined): boolean | undefined => {
+	if (first === false || second === false) return false
+	if (first === true || second === true) return true
+	return undefined
+}
+
+const mergeAddressAccess = (first: readonly WebsiteAddressAccess[] | undefined, second: readonly WebsiteAddressAccess[] | undefined): readonly WebsiteAddressAccess[] | undefined => {
+	if (first === undefined) return second
+	if (second === undefined) return first
+	const byAddress = new Map<bigint, WebsiteAddressAccess>()
+	for (const addressAccess of first.concat(second)) {
+		const previousAccess = byAddress.get(addressAccess.address)
+		if (previousAccess === undefined) {
+			byAddress.set(addressAccess.address, addressAccess)
+			continue
+		}
+		byAddress.set(addressAccess.address, {
+			address: addressAccess.address,
+			access: previousAccess.access && addressAccess.access,
+		})
+	}
+	return [...byAddress.values()]
+}
+
+const mergeBlockMode = (first: WebsiteAccess['declarativeNetRequestBlockMode'], second: WebsiteAccess['declarativeNetRequestBlockMode']): WebsiteAccess['declarativeNetRequestBlockMode'] => {
+	if (first === 'block-all' || second === 'block-all') return 'block-all'
+	if (first === 'disabled' || second === 'disabled') return 'disabled'
+	return undefined
+}
+
+const mergeWebsiteAccess = (first: WebsiteAccess, second: WebsiteAccess): WebsiteAccess => {
+	const access = mergeAccessFlag(first.access, second.access)
+	const interceptorDisabled = first.interceptorDisabled === true || second.interceptorDisabled === true ? true : undefined
+	const declarativeNetRequestBlockMode = mergeBlockMode(first.declarativeNetRequestBlockMode, second.declarativeNetRequestBlockMode)
+	return {
+		website: mergeStoredWebsiteMetadata(first.website, second.website),
+		addressAccess: mergeAddressAccess(first.addressAccess, second.addressAccess),
+		...access === undefined ? {} : { access },
+		...interceptorDisabled === undefined ? {} : { interceptorDisabled },
+		...declarativeNetRequestBlockMode === undefined ? {} : { declarativeNetRequestBlockMode },
+	}
+}
 
 export function migrateWebsiteAccessOrigins(websiteAccess: WebsiteAccessArray): WebsiteAccessArray {
 	let changed = false
@@ -11,14 +54,21 @@ export function migrateWebsiteAccessOrigins(websiteAccess: WebsiteAccessArray): 
 			.map((entry) => normalizeSchemefulWebsiteOrigin(entry.website.websiteOrigin))
 	)
 	const migratedWebsiteAccess: WebsiteAccess[] = []
-	const seenWebsiteOrigins = new Set<string>()
+	const seenWebsiteOrigins = new Map<string, number>()
 
 	const addEntry = (entry: WebsiteAccess, websiteOrigin: string) => {
-		if (seenWebsiteOrigins.has(websiteOrigin)) {
+		const previousIndex = seenWebsiteOrigins.get(websiteOrigin)
+		if (previousIndex !== undefined) {
+			const previousEntry = migratedWebsiteAccess[previousIndex]
+			if (previousEntry === undefined) throw new Error('seen website origin was missing from migrated access list')
+			migratedWebsiteAccess[previousIndex] = mergeWebsiteAccess(previousEntry, {
+				...entry,
+				website: { ...entry.website, websiteOrigin },
+			})
 			changed = true
 			return
 		}
-		seenWebsiteOrigins.add(websiteOrigin)
+		seenWebsiteOrigins.set(websiteOrigin, migratedWebsiteAccess.length)
 		if (entry.website.websiteOrigin === websiteOrigin) {
 			migratedWebsiteAccess.push(entry)
 			return

--- a/app/ts/background/websiteAccessMigration.ts
+++ b/app/ts/background/websiteAccessMigration.ts
@@ -1,6 +1,55 @@
-import { WebsiteAccessArray } from '../types/websiteAccessTypes.js'
+import { WebsiteAccessArray, type WebsiteAccess } from '../types/websiteAccessTypes.js'
 import { browserStorageLocalSet } from '../utils/storageUtils.js'
+import { getSchemefulOriginsForLegacyWebsiteOrigin, isSchemefulWebsiteOrigin, normalizeSchemefulWebsiteOrigin } from '../utils/requests.js'
 import { sanitizeWebsiteAccess } from '../utils/websiteIcons.js'
+
+export function migrateWebsiteAccessOrigins(websiteAccess: WebsiteAccessArray): WebsiteAccessArray {
+	let changed = false
+	const exactSchemefulOrigins = new Set(
+		websiteAccess
+			.filter((entry) => isSchemefulWebsiteOrigin(entry.website.websiteOrigin))
+			.map((entry) => normalizeSchemefulWebsiteOrigin(entry.website.websiteOrigin))
+	)
+	const migratedWebsiteAccess: WebsiteAccess[] = []
+	const seenWebsiteOrigins = new Set<string>()
+
+	const addEntry = (entry: WebsiteAccess, websiteOrigin: string) => {
+		if (seenWebsiteOrigins.has(websiteOrigin)) {
+			changed = true
+			return
+		}
+		seenWebsiteOrigins.add(websiteOrigin)
+		if (entry.website.websiteOrigin === websiteOrigin) {
+			migratedWebsiteAccess.push(entry)
+			return
+		}
+		changed = true
+		migratedWebsiteAccess.push({
+			...entry,
+			website: {
+				...entry.website,
+				websiteOrigin,
+			}
+		})
+	}
+
+	for (const entry of websiteAccess) {
+		const storedWebsiteOrigin = entry.website.websiteOrigin
+		if (isSchemefulWebsiteOrigin(storedWebsiteOrigin)) {
+			addEntry(entry, normalizeSchemefulWebsiteOrigin(storedWebsiteOrigin))
+			continue
+		}
+		for (const websiteOrigin of getSchemefulOriginsForLegacyWebsiteOrigin(storedWebsiteOrigin)) {
+			if (exactSchemefulOrigins.has(websiteOrigin)) {
+				changed = true
+				continue
+			}
+			addEntry(entry, websiteOrigin)
+		}
+	}
+
+	return changed ? migratedWebsiteAccess : websiteAccess
+}
 
 export async function migrateWebsiteAccess() {
 	const storageEntries: Partial<Record<'websiteAccess', unknown>> = await browser.storage.local.get('websiteAccess')
@@ -9,6 +58,7 @@ export async function migrateWebsiteAccess() {
 	const parsedWebsiteAccess = WebsiteAccessArray.safeParse(rawWebsiteAccess)
 	if (!parsedWebsiteAccess.success) return
 	const sanitizedWebsiteAccess = sanitizeWebsiteAccess(parsedWebsiteAccess.value)
-	if (sanitizedWebsiteAccess === parsedWebsiteAccess.value) return
-	await browserStorageLocalSet({ websiteAccess: sanitizedWebsiteAccess })
+	const migratedWebsiteAccess = migrateWebsiteAccessOrigins(sanitizedWebsiteAccess)
+	if (migratedWebsiteAccess === parsedWebsiteAccess.value) return
+	await browserStorageLocalSet({ websiteAccess: migratedWebsiteAccess })
 }

--- a/app/ts/utils/contentScriptsUpdating.ts
+++ b/app/ts/utils/contentScriptsUpdating.ts
@@ -1,11 +1,20 @@
 import { getInterceptorDisabledSites, getSettings } from '../background/settings.js'
-import { checkAndThrowRuntimeLastError, getHostWithPort } from './requests.js'
+import { checkAndThrowRuntimeLastError, getHostWithPort, getHostWithPortFromOriginLike } from './requests.js'
 
 const injectableSitesWildcard = ['file://*/*', 'http://*/*', 'https://*/*']
 const injectableSitesRegexp = [/^file:\/\/.*/, /^http:\/\/.*/, /^https:\/\/.*/]
 
+const getInterceptorDisabledSiteHost = (originLike: string): string => getHostWithPortFromOriginLike(originLike)
+
+const getInterceptorDisabledSiteExcludeMatches = (originLike: string): readonly string[] => {
+	if (originLike === 'file://') return ['file://*/*']
+	const host = getInterceptorDisabledSiteHost(originLike)
+	if (host.length === 0) return []
+	return [`*://${ host }/*`, `*://*.${ host }/*`]
+}
+
 export const updateContentScriptInjectionStrategyManifestV3 = async () => {
-	const excludeMatches = getInterceptorDisabledSites(await getSettings()).map((origin) => `*://*.${ origin }/*`)
+	const excludeMatches = getInterceptorDisabledSites(await getSettings()).flatMap((origin) => getInterceptorDisabledSiteExcludeMatches(origin))
 	try {
 		type RegisteredContentScript = Parameters<typeof browser.scripting.registerContentScripts>[0][0]
 		// 'MAIN'` is not supported in `browser.` but its in `chrome.`. This code is only going to be run in manifest v3 environment (chrome) so this should be fine, just ugly
@@ -41,7 +50,7 @@ const injectLogic = async (content: browser.webNavigation._OnCommittedDetails) =
 	const thisTab = allTabs.find((tab) => tab.id === content.tabId)
 	const urls = [content.url, ...thisTab?.url === undefined ? [] : [thisTab.url]]
 	const hostnames = urls.map((url) => getHostWithPort(url))
-	const disabledSites = getInterceptorDisabledSites(await getSettings())
+	const disabledSites = getInterceptorDisabledSites(await getSettings()).map((origin) => getInterceptorDisabledSiteHost(origin))
 	const noMatches = disabledSites.every(excludeMatch => !hostnames.includes(excludeMatch))
 	if (!noMatches) return false
 	try {

--- a/app/ts/utils/contentScriptsUpdating.ts
+++ b/app/ts/utils/contentScriptsUpdating.ts
@@ -1,16 +1,36 @@
 import { getInterceptorDisabledSites, getSettings } from '../background/settings.js'
-import { checkAndThrowRuntimeLastError, getHostWithPort, getHostWithPortFromOriginLike } from './requests.js'
+import { checkAndThrowRuntimeLastError, getHostnameFromOriginLike, getMatchingWebsiteAccessOrigin, getWebsiteOrigin, isSchemefulWebsiteOrigin } from './requests.js'
 
 const injectableSitesWildcard = ['file://*/*', 'http://*/*', 'https://*/*']
 const injectableSitesRegexp = [/^file:\/\/.*/, /^http:\/\/.*/, /^https:\/\/.*/]
 
-const getInterceptorDisabledSiteHost = (originLike: string): string => getHostWithPortFromOriginLike(originLike)
+const getHttpOriginMatchParts = (originLike: string): { scheme: 'http' | 'https', hostname: string } | undefined => {
+	if (!isSchemefulWebsiteOrigin(originLike)) return undefined
+	try {
+		const url = new URL(originLike)
+		if (url.protocol === 'http:') return { scheme: 'http', hostname: url.hostname }
+		if (url.protocol === 'https:') return { scheme: 'https', hostname: url.hostname }
+	} catch {
+		return undefined
+	}
+	return undefined
+}
 
-const getInterceptorDisabledSiteExcludeMatches = (originLike: string): readonly string[] => {
+export const getInterceptorDisabledSiteExcludeMatches = (originLike: string): readonly string[] => {
 	if (originLike === 'file://') return ['file://*/*']
-	const host = getInterceptorDisabledSiteHost(originLike)
+	const httpOriginParts = getHttpOriginMatchParts(originLike)
+	if (httpOriginParts !== undefined) return [`${ httpOriginParts.scheme }://${ httpOriginParts.hostname }/*`]
+	const host = getHostnameFromOriginLike(originLike)
 	if (host.length === 0) return []
 	return [`*://${ host }/*`, `*://*.${ host }/*`]
+}
+
+export const isUrlExcludedByInterceptorDisabledSite = (disabledSites: readonly string[], urlString: string): boolean => {
+	try {
+		return getMatchingWebsiteAccessOrigin(disabledSites, getWebsiteOrigin(urlString)) !== undefined
+	} catch {
+		return false
+	}
 }
 
 export const updateContentScriptInjectionStrategyManifestV3 = async () => {
@@ -49,9 +69,8 @@ const injectLogic = async (content: browser.webNavigation._OnCommittedDetails) =
 	const allTabs = await browser.tabs.query({})
 	const thisTab = allTabs.find((tab) => tab.id === content.tabId)
 	const urls = [content.url, ...thisTab?.url === undefined ? [] : [thisTab.url]]
-	const hostnames = urls.map((url) => getHostWithPort(url))
-	const disabledSites = getInterceptorDisabledSites(await getSettings()).map((origin) => getInterceptorDisabledSiteHost(origin))
-	const noMatches = disabledSites.every(excludeMatch => !hostnames.includes(excludeMatch))
+	const disabledSites = getInterceptorDisabledSites(await getSettings())
+	const noMatches = urls.every((url) => !isUrlExcludedByInterceptorDisabledSite(disabledSites, url))
 	if (!noMatches) return false
 	try {
 		await browser.tabs.executeScript(content.tabId, { file: '/vendor/webextension-polyfill/dist/browser-polyfill.js', allFrames: false, runAt: 'document_start' })

--- a/app/ts/utils/contentScriptsUpdating.ts
+++ b/app/ts/utils/contentScriptsUpdating.ts
@@ -1,18 +1,14 @@
 import { getInterceptorDisabledSites, getSettings } from '../background/settings.js'
-import { checkAndThrowRuntimeLastError, getHostnameFromOriginLike, getMatchingWebsiteAccessOrigin, getWebsiteOrigin, isSchemefulWebsiteOrigin } from './requests.js'
+import { checkAndThrowRuntimeLastError, getHostnameFromOriginLike, getMatchingWebsiteAccessOrigin, isSchemefulWebsiteOrigin, parseUrlOrUndefined } from './requests.js'
 
 const injectableSitesWildcard = ['file://*/*', 'http://*/*', 'https://*/*']
 const injectableSitesRegexp = [/^file:\/\/.*/, /^http:\/\/.*/, /^https:\/\/.*/]
 
 const getHttpOriginMatchParts = (originLike: string): { scheme: 'http' | 'https', hostname: string } | undefined => {
 	if (!isSchemefulWebsiteOrigin(originLike)) return undefined
-	try {
-		const url = new URL(originLike)
-		if (url.protocol === 'http:') return { scheme: 'http', hostname: url.hostname }
-		if (url.protocol === 'https:') return { scheme: 'https', hostname: url.hostname }
-	} catch {
-		return undefined
-	}
+	const url = parseUrlOrUndefined(originLike)
+	if (url?.protocol === 'http:') return { scheme: 'http', hostname: url.hostname }
+	if (url?.protocol === 'https:') return { scheme: 'https', hostname: url.hostname }
 	return undefined
 }
 
@@ -26,11 +22,10 @@ export const getInterceptorDisabledSiteExcludeMatches = (originLike: string): re
 }
 
 export const isUrlExcludedByInterceptorDisabledSite = (disabledSites: readonly string[], urlString: string): boolean => {
-	try {
-		return getMatchingWebsiteAccessOrigin(disabledSites, getWebsiteOrigin(urlString)) !== undefined
-	} catch {
-		return false
-	}
+	const url = parseUrlOrUndefined(urlString)
+	if (url === undefined) return false
+	const websiteOrigin = url.protocol === 'file:' ? 'file://' : url.origin === 'null' ? (url.port ? `${ url.hostname }:${ url.port }` : url.hostname) : url.origin
+	return getMatchingWebsiteAccessOrigin(disabledSites, websiteOrigin) !== undefined
 }
 
 export const updateContentScriptInjectionStrategyManifestV3 = async () => {

--- a/app/ts/utils/requests.ts
+++ b/app/ts/utils/requests.ts
@@ -132,6 +132,15 @@ export const checkAndPrintRuntimeLastError = () => {
 	if (error !== null && error !== undefined && error.message !== undefined) console.error(error)
 }
 
+export const parseUrlOrUndefined = (urlString: string): URL | undefined => {
+	try {
+		return new URL(urlString)
+	} catch (error: unknown) {
+		if (error instanceof TypeError) return undefined
+		throw error
+	}
+}
+
 export const getHostWithPort = (urlString: string): string => {
 	const url = new URL(urlString)
 	return url.port ? `${ url.hostname }:${ url.port }` : url.hostname
@@ -149,31 +158,26 @@ export const getWebsiteOrigin = (urlString: string): string => {
 export const getHostWithPortFromOriginLike = (originLike: string): string => {
 	if (originLike === 'file://') return ''
 	if (!originLike.includes('://')) return originLike
-	try {
-		return getHostWithPort(originLike)
-	} catch {
-		return originLike
-	}
+	const url = parseUrlOrUndefined(originLike)
+	if (url === undefined) return originLike
+	return url.port ? `${ url.hostname }:${ url.port }` : url.hostname
 }
 
 export const getHostnameFromOriginLike = (originLike: string): string => {
 	if (originLike === 'file://') return ''
-	try {
-		return getHostname(originLike.includes('://') ? originLike : `https://${ originLike }`)
-	} catch {
-		return originLike
-	}
+	const url = parseUrlOrUndefined(originLike.includes('://') ? originLike : `https://${ originLike }`)
+	return url?.hostname ?? originLike
 }
 
 export const isSchemefulWebsiteOrigin = (originLike: string): boolean => originLike.includes('://')
 
 export const normalizeSchemefulWebsiteOrigin = (originLike: string): string => {
 	if (!isSchemefulWebsiteOrigin(originLike)) return originLike
-	try {
-		return getWebsiteOrigin(originLike)
-	} catch {
-		return originLike
-	}
+	const url = parseUrlOrUndefined(originLike)
+	if (url === undefined) return originLike
+	if (url.protocol === 'http:' || url.protocol === 'https:') return url.origin
+	if (url.protocol === 'file:') return 'file://'
+	return url.origin === 'null' ? (url.port ? `${ url.hostname }:${ url.port }` : url.hostname) : url.origin
 }
 
 export const getLegacyWebsiteAccessOrigin = (websiteOrigin: string): string => getHostWithPortFromOriginLike(websiteOrigin)
@@ -196,11 +200,8 @@ export const getSchemefulOriginsForLegacyWebsiteOrigin = (legacyWebsiteOrigin: s
 	if (legacyWebsiteOrigin === '') return ['file://']
 	const toOrigin = (scheme: 'http' | 'https') => {
 		const originLike = `${ scheme }://${ legacyWebsiteOrigin }`
-		try {
-			return getWebsiteOrigin(originLike)
-		} catch {
-			return originLike
-		}
+		const url = parseUrlOrUndefined(originLike)
+		return url === undefined ? originLike : url.origin
 	}
 	return [toOrigin('https'), toOrigin('http')]
 }

--- a/app/ts/utils/requests.ts
+++ b/app/ts/utils/requests.ts
@@ -137,6 +137,63 @@ export const getHostWithPort = (urlString: string): string => {
 	return url.port ? `${ url.hostname }:${ url.port }` : url.hostname
 }
 
+export const getWebsiteOrigin = (urlString: string): string => {
+	const url = new URL(urlString)
+	if (url.protocol === 'http:' || url.protocol === 'https:') return url.origin
+	if (url.protocol === 'file:') return 'file://'
+	return url.origin === 'null' ? getHostWithPort(urlString) : url.origin
+}
+
+export const getHostWithPortFromOriginLike = (originLike: string): string => {
+	if (originLike === 'file://') return ''
+	if (!originLike.includes('://')) return originLike
+	try {
+		return getHostWithPort(originLike)
+	} catch {
+		return originLike
+	}
+}
+
+export const isSchemefulWebsiteOrigin = (originLike: string): boolean => originLike.includes('://')
+
+export const normalizeSchemefulWebsiteOrigin = (originLike: string): string => {
+	if (!isSchemefulWebsiteOrigin(originLike)) return originLike
+	try {
+		return getWebsiteOrigin(originLike)
+	} catch {
+		return originLike
+	}
+}
+
+export const getLegacyWebsiteAccessOrigin = (websiteOrigin: string): string => getHostWithPortFromOriginLike(websiteOrigin)
+
+export const getWebsiteAccessLookupOrigins = (websiteOrigin: string): readonly string[] => {
+	const normalizedWebsiteOrigin = normalizeSchemefulWebsiteOrigin(websiteOrigin)
+	const legacyWebsiteOrigin = getLegacyWebsiteAccessOrigin(normalizedWebsiteOrigin)
+	return legacyWebsiteOrigin === normalizedWebsiteOrigin ? [normalizedWebsiteOrigin] : [normalizedWebsiteOrigin, legacyWebsiteOrigin]
+}
+
+export const getMatchingWebsiteAccessOrigin = (storedWebsiteOrigins: Iterable<string>, websiteOrigin: string): string | undefined => {
+	const storedWebsiteOriginSet = new Set(storedWebsiteOrigins)
+	for (const lookupOrigin of getWebsiteAccessLookupOrigins(websiteOrigin)) {
+		if (storedWebsiteOriginSet.has(lookupOrigin)) return lookupOrigin
+	}
+	return undefined
+}
+
+export const getSchemefulOriginsForLegacyWebsiteOrigin = (legacyWebsiteOrigin: string): readonly string[] => {
+	if (legacyWebsiteOrigin === '') return ['file://']
+	const toOrigin = (scheme: 'http' | 'https') => {
+		const originLike = `${ scheme }://${ legacyWebsiteOrigin }`
+		try {
+			return getWebsiteOrigin(originLike)
+		} catch {
+			return originLike
+		}
+	}
+	return [toOrigin('https'), toOrigin('http')]
+}
+
 export const silenceChromeUnCaughtPromise = async <ReturnValue>(maybeAwaitedFunction: Promise<ReturnValue>) => {
 	maybeAwaitedFunction.catch(() => undefined)
 	return maybeAwaitedFunction

--- a/app/ts/utils/requests.ts
+++ b/app/ts/utils/requests.ts
@@ -137,6 +137,8 @@ export const getHostWithPort = (urlString: string): string => {
 	return url.port ? `${ url.hostname }:${ url.port }` : url.hostname
 }
 
+export const getHostname = (urlString: string): string => new URL(urlString).hostname
+
 export const getWebsiteOrigin = (urlString: string): string => {
 	const url = new URL(urlString)
 	if (url.protocol === 'http:' || url.protocol === 'https:') return url.origin
@@ -149,6 +151,15 @@ export const getHostWithPortFromOriginLike = (originLike: string): string => {
 	if (!originLike.includes('://')) return originLike
 	try {
 		return getHostWithPort(originLike)
+	} catch {
+		return originLike
+	}
+}
+
+export const getHostnameFromOriginLike = (originLike: string): string => {
+	if (originLike === 'file://') return ''
+	try {
+		return getHostname(originLike.includes('://') ? originLike : `https://${ originLike }`)
 	} catch {
 		return originLike
 	}

--- a/app/ts/utils/websiteData.ts
+++ b/app/ts/utils/websiteData.ts
@@ -1,4 +1,5 @@
 import * as funtypes from 'funtypes'
+import { getHostWithPortFromOriginLike } from './requests.js'
 
 type WebsiteMetadataInfo  = funtypes.Static<typeof WebsiteMetadataInfo>
 const WebsiteMetadataInfo = funtypes.Intersect(
@@ -17,7 +18,7 @@ type WebsiteMetaData  = funtypes.Static<typeof WebsiteMetaData>
 const WebsiteMetaData = funtypes.ReadonlyRecord(funtypes.String, WebsiteMetadataInfo)
 
 export const getWebsiteWarningMessage = (websiteOrigin: string, simulationMode: boolean): { message: string, suggestedAlternative: string | undefined } | undefined => {
-	const data = websiteMetaData[websiteOrigin]
+	const data = websiteMetaData[getHostWithPortFromOriginLike(websiteOrigin)]
 	if (data === undefined) return undefined
 	if (data.message !== undefined) return { message: data.message, suggestedAlternative: data.suggestedAlternative }
 	if (simulationMode === false) return undefined

--- a/test/tests/iconHandler.test.ts
+++ b/test/tests/iconHandler.test.ts
@@ -191,12 +191,12 @@ describe('retrieveWebsiteDetails favicon handling', () => {
 	test('fetches same-origin favicon urls once for stored websites that are missing an icon', async () => {
 		installSuccessfulFileReader('data:image/png;base64,b2s=')
 		storageState.websiteAccess = [{
-			website: { websiteOrigin: 'same-origin.test', icon: undefined, title: 'Same origin favicon' },
+			website: { websiteOrigin: 'https://same-origin.test', icon: undefined, title: 'Same origin favicon' },
 			access: true,
 		}]
 		tabsById.set(4, { id: 4, status: 'complete', title: 'Same origin favicon', url: 'https://same-origin.test/page', favIconUrl: '/favicon.png' })
 
-		const result = await retrieveWebsiteDetails(4, 'same-origin.test')
+		const result = await retrieveWebsiteDetails(4, 'https://same-origin.test')
 
 		assert.deepEqual(result, { title: 'Same origin favicon', icon: 'data:image/png;base64,b2s=' })
 		assert.deepEqual(fetchCalls, ['https://same-origin.test/favicon.png'])
@@ -207,7 +207,7 @@ describe('retrieveWebsiteDetails favicon handling', () => {
 		installSuccessfulFileReader('data:image/png;base64,b2s=')
 		tabsById.set(11, { id: 11, status: 'complete', title: 'Untracked favicon', url: 'https://untracked.test/page', favIconUrl: '/favicon.png' })
 
-		const result = await retrieveWebsiteDetails(11, 'untracked.test')
+		const result = await retrieveWebsiteDetails(11, 'https://untracked.test')
 
 		assert.deepEqual(result, { title: 'Untracked favicon', icon: undefined })
 		assert.equal(fetchCalls.length, 0)
@@ -217,12 +217,12 @@ describe('retrieveWebsiteDetails favicon handling', () => {
 
 	test('reuses cached favicon data urls without refetching them', async () => {
 		storageState.websiteAccess = [{
-			website: { websiteOrigin: 'cached.test', icon: 'data:image/png;base64,Y2FjaGVk', title: 'Cached favicon' },
+			website: { websiteOrigin: 'https://cached.test', icon: 'data:image/png;base64,Y2FjaGVk', title: 'Cached favicon' },
 			access: true,
 		}]
 		tabsById.set(8, { id: 8, status: 'complete', title: 'Cached favicon', url: 'https://cached.test/page', favIconUrl: '/favicon.png' })
 
-		const result = await retrieveWebsiteDetails(8, 'cached.test')
+		const result = await retrieveWebsiteDetails(8, 'https://cached.test')
 
 		assert.deepEqual(result, { title: 'Cached favicon', icon: 'data:image/png;base64,Y2FjaGVk' })
 		assert.equal(fetchCalls.length, 0)
@@ -232,12 +232,12 @@ describe('retrieveWebsiteDetails favicon handling', () => {
 
 	test('allows image data url favicons for stored websites without fetching them in the background', async () => {
 		storageState.websiteAccess = [{
-			website: { websiteOrigin: 'data-icon.test', icon: undefined, title: 'Data favicon' },
+			website: { websiteOrigin: 'https://data-icon.test', icon: undefined, title: 'Data favicon' },
 			access: true,
 		}]
 		tabsById.set(7, { id: 7, status: 'complete', title: 'Data favicon', url: 'https://data-icon.test/page', favIconUrl: 'data:image/png;base64,Zm9v' })
 
-		const result = await retrieveWebsiteDetails(7, 'data-icon.test')
+		const result = await retrieveWebsiteDetails(7, 'https://data-icon.test')
 
 		assert.deepEqual(result, { title: 'Data favicon', icon: 'data:image/png;base64,Zm9v' })
 		assert.equal(fetchCalls.length, 0)
@@ -247,7 +247,7 @@ describe('retrieveWebsiteDetails favicon handling', () => {
 	test('does not store data url favicons for websites without stored access', async () => {
 		tabsById.set(12, { id: 12, status: 'complete', title: 'Untracked data favicon', url: 'https://untracked-data.test/page', favIconUrl: 'data:image/png;base64,Zm9v' })
 
-		const result = await retrieveWebsiteDetails(12, 'untracked-data.test')
+		const result = await retrieveWebsiteDetails(12, 'https://untracked-data.test')
 
 		assert.deepEqual(result, { title: 'Untracked data favicon', icon: undefined })
 		assert.equal(fetchCalls.length, 0)

--- a/test/tests/requestMakeMeRichData.test.ts
+++ b/test/tests/requestMakeMeRichData.test.ts
@@ -200,8 +200,8 @@ describe('startup storage recovery', () => {
 		const storageState = installBrowserMock()
 		const { getSettings, getWebsiteAccess } = await loadModules()
 		storageState.websiteAccess = [
-			{ website: { websiteOrigin: 'remote.example', icon: 'https://remote.example/favicon.png', title: 'Remote' }, access: true },
-			{ website: { websiteOrigin: 'cached.example', icon: 'data:image/png;base64,Y2FjaGVk', title: 'Cached' }, access: true },
+			{ website: { websiteOrigin: 'https://remote.example', icon: 'https://remote.example/favicon.png', title: 'Remote' }, access: true },
+			{ website: { websiteOrigin: 'https://cached.example', icon: 'data:image/png;base64,Y2FjaGVk', title: 'Cached' }, access: true },
 		]
 
 		const settings = await withSilencedConsole(async () => await getSettings())

--- a/test/tests/settingsImport.test.ts
+++ b/test/tests/settingsImport.test.ts
@@ -136,8 +136,8 @@ describe('settings import', () => {
 	test('sanitizes imported website access icons before persisting them', async () => {
 		const { getWebsiteAccess, importSettingsAndAddressBook } = await settingsModulePromise
 		await importSettingsAndAddressBook(buildVersion14Import(false, false, [
-			{ website: { websiteOrigin: 'remote.example', icon: 'https://remote.example/favicon.png', title: 'Remote' }, access: true },
-			{ website: { websiteOrigin: 'cached.example', icon: 'data:image/png;base64,Y2FjaGVk', title: 'Cached' }, access: true },
+			{ website: { websiteOrigin: 'https://remote.example', icon: 'https://remote.example/favicon.png', title: 'Remote' }, access: true },
+			{ website: { websiteOrigin: 'https://cached.example', icon: 'data:image/png;base64,Y2FjaGVk', title: 'Cached' }, access: true },
 		]))
 
 		const storedWebsiteAccess = (await browser.storage.local.get('websiteAccess')).websiteAccess

--- a/test/tests/websiteAccessMigration.test.ts
+++ b/test/tests/websiteAccessMigration.test.ts
@@ -86,4 +86,44 @@ describe('website access migration', () => {
 			['https://conflict.example', false],
 		])
 	})
+
+	test('merges duplicate entries that normalize to the same schemeful origin', async () => {
+		const storageState = installBrowserMock()
+		const { migrateWebsiteAccess } = await import('../../app/ts/background/websiteAccessMigration.js')
+		const sharedAddress = '0x1111111111111111111111111111111111111111'
+		const extraAddress = '0x2222222222222222222222222222222222222222'
+		storageState.websiteAccess = [
+			{
+				website: { websiteOrigin: 'https://duplicate.example:443', icon: undefined, title: undefined },
+				access: true,
+				addressAccess: [{ address: sharedAddress, access: true }],
+			},
+			{
+				website: { websiteOrigin: 'https://duplicate.example', icon: 'data:image/png;base64,ZHVw', title: 'Duplicate' },
+				access: false,
+				addressAccess: [
+					{ address: sharedAddress, access: false },
+					{ address: extraAddress, access: true },
+				],
+				interceptorDisabled: true,
+				declarativeNetRequestBlockMode: 'block-all',
+			},
+		]
+
+		await migrateWebsiteAccess()
+
+		assert.equal(Array.isArray(storageState.websiteAccess), true)
+		if (!Array.isArray(storageState.websiteAccess)) throw new Error('Expected websiteAccess to remain an array')
+		assert.equal(storageState.websiteAccess.length, 1)
+		assert.equal(storageState.websiteAccess[0]?.website.websiteOrigin, 'https://duplicate.example')
+		assert.equal(storageState.websiteAccess[0]?.website.icon, 'data:image/png;base64,ZHVw')
+		assert.equal(storageState.websiteAccess[0]?.website.title, 'Duplicate')
+		assert.equal(storageState.websiteAccess[0]?.access, false)
+		assert.equal(storageState.websiteAccess[0]?.interceptorDisabled, true)
+		assert.equal(storageState.websiteAccess[0]?.declarativeNetRequestBlockMode, 'block-all')
+		assert.deepEqual(storageState.websiteAccess[0]?.addressAccess, [
+			{ address: sharedAddress, access: false },
+			{ address: extraAddress, access: true },
+		])
+	})
 })

--- a/test/tests/websiteAccessMigration.test.ts
+++ b/test/tests/websiteAccessMigration.test.ts
@@ -31,8 +31,8 @@ describe('website access migration', () => {
 		const storageState = installBrowserMock()
 		const { migrateWebsiteAccess } = await import('../../app/ts/background/websiteAccessMigration.js')
 		storageState.websiteAccess = [
-			{ website: { websiteOrigin: 'remote.example', icon: 'https://remote.example/favicon.png', title: 'Remote' }, access: true },
-			{ website: { websiteOrigin: 'cached.example', icon: 'data:image/png;base64,Y2FjaGVk', title: 'Cached' }, access: true },
+			{ website: { websiteOrigin: 'https://remote.example', icon: 'https://remote.example/favicon.png', title: 'Remote' }, access: true },
+			{ website: { websiteOrigin: 'https://cached.example', icon: 'data:image/png;base64,Y2FjaGVk', title: 'Cached' }, access: true },
 		]
 
 		await migrateWebsiteAccess()
@@ -41,5 +41,49 @@ describe('website access migration', () => {
 		if (!Array.isArray(storageState.websiteAccess)) throw new Error('Expected websiteAccess to remain an array')
 		assert.equal(storageState.websiteAccess[0]?.website.icon, undefined)
 		assert.equal(storageState.websiteAccess[1]?.website.icon, 'data:image/png;base64,Y2FjaGVk')
+	})
+
+	test('migrates legacy host-only access to schemeful http and https origins', async () => {
+		const storageState = installBrowserMock()
+		const { migrateWebsiteAccess } = await import('../../app/ts/background/websiteAccessMigration.js')
+		storageState.websiteAccess = [{
+			website: { websiteOrigin: 'legacy.example:8443', icon: 'https://legacy.example/favicon.png', title: 'Legacy' },
+			access: true,
+			addressAccess: [{ address: '0x1111111111111111111111111111111111111111', access: true }],
+			interceptorDisabled: true,
+			declarativeNetRequestBlockMode: 'block-all',
+		}]
+
+		await migrateWebsiteAccess()
+
+		assert.equal(Array.isArray(storageState.websiteAccess), true)
+		if (!Array.isArray(storageState.websiteAccess)) throw new Error('Expected websiteAccess to remain an array')
+		assert.deepEqual(storageState.websiteAccess.map((entry) => entry.website.websiteOrigin), [
+			'https://legacy.example:8443',
+			'http://legacy.example:8443',
+		])
+		assert.equal(storageState.websiteAccess[0]?.website.icon, undefined)
+		assert.equal(storageState.websiteAccess[1]?.access, true)
+		assert.equal(storageState.websiteAccess[1]?.interceptorDisabled, true)
+		assert.equal(storageState.websiteAccess[1]?.declarativeNetRequestBlockMode, 'block-all')
+		assert.deepEqual(storageState.websiteAccess[1]?.addressAccess, [{ address: '0x1111111111111111111111111111111111111111', access: true }])
+	})
+
+	test('keeps exact schemeful entries when migrating conflicting legacy access', async () => {
+		const storageState = installBrowserMock()
+		const { migrateWebsiteAccess } = await import('../../app/ts/background/websiteAccessMigration.js')
+		storageState.websiteAccess = [
+			{ website: { websiteOrigin: 'conflict.example', icon: undefined, title: 'Legacy' }, access: true },
+			{ website: { websiteOrigin: 'https://conflict.example', icon: undefined, title: 'HTTPS' }, access: false },
+		]
+
+		await migrateWebsiteAccess()
+
+		assert.equal(Array.isArray(storageState.websiteAccess), true)
+		if (!Array.isArray(storageState.websiteAccess)) throw new Error('Expected websiteAccess to remain an array')
+		assert.deepEqual(storageState.websiteAccess.map((entry) => [entry.website.websiteOrigin, entry.access]), [
+			['http://conflict.example', true],
+			['https://conflict.example', false],
+		])
 	})
 })

--- a/test/tests/websiteOriginAccess.test.ts
+++ b/test/tests/websiteOriginAccess.test.ts
@@ -81,4 +81,30 @@ describe('website origin access', () => {
 		if (!Array.isArray(storedWebsiteAccess)) throw new Error('Expected websiteAccess to be stored as an array')
 		assert.deepEqual(storedWebsiteAccess.map((entry) => entry.website.websiteOrigin), ['https://new.example'])
 	})
+
+	test('excludes disabled content scripts with scheme-aware matching', async () => {
+		const { getInterceptorDisabledSiteExcludeMatches, isUrlExcludedByInterceptorDisabledSite } = await import('../../app/ts/utils/contentScriptsUpdating.js')
+
+		assert.deepEqual(getInterceptorDisabledSiteExcludeMatches('https://scheme.example'), ['https://scheme.example/*'])
+		assert.deepEqual(getInterceptorDisabledSiteExcludeMatches('http://scheme.example'), ['http://scheme.example/*'])
+		assert.deepEqual(getInterceptorDisabledSiteExcludeMatches('legacy.example'), ['*://legacy.example/*', '*://*.legacy.example/*'])
+		assert.deepEqual(getInterceptorDisabledSiteExcludeMatches('file://'), ['file://*/*'])
+		assert.equal(isUrlExcludedByInterceptorDisabledSite(['https://scheme.example'], 'https://scheme.example/page'), true)
+		assert.equal(isUrlExcludedByInterceptorDisabledSite(['https://scheme.example'], 'http://scheme.example/page'), false)
+		assert.equal(isUrlExcludedByInterceptorDisabledSite(['https://scheme.example'], 'https://sub.scheme.example/page'), false)
+		assert.equal(isUrlExcludedByInterceptorDisabledSite(['legacy.example'], 'http://legacy.example/page'), true)
+	})
+
+	test('keeps external request blocking domain-scoped for declarativeNetRequest compatibility', async () => {
+		const { areWeBlocking } = await import('../../app/ts/background/accessManagement.js')
+		storageState.websiteAccess = [{
+			website: { websiteOrigin: 'https://blocked.example:8443', icon: undefined, title: 'Blocked' },
+			access: true,
+			addressAccess: undefined,
+			declarativeNetRequestBlockMode: 'block-all',
+		}]
+
+		assert.equal(await areWeBlocking(new Map(), 1, 'http://blocked.example:3000'), true)
+		assert.equal(await areWeBlocking(new Map(), 1, 'https://other.example'), false)
+	})
 })

--- a/test/tests/websiteOriginAccess.test.ts
+++ b/test/tests/websiteOriginAccess.test.ts
@@ -1,0 +1,84 @@
+import * as assert from 'assert'
+import { beforeEach, describe, test } from 'bun:test'
+import type { WebsiteAccessArray } from '../../app/ts/types/websiteAccessTypes.js'
+
+const storageState: Record<string, unknown> = {}
+
+function installBrowserMock() {
+	for (const key of Object.keys(storageState)) delete storageState[key]
+	Object.defineProperty(globalThis, 'browser', {
+		configurable: true,
+		writable: true,
+		value: {
+			runtime: {
+				lastError: undefined,
+				async sendMessage() {
+					return undefined
+				},
+				getManifest: () => ({ manifest_version: 3 }),
+				onMessage: { addListener: () => undefined, removeListener: () => undefined },
+				onConnect: { addListener: () => undefined, removeListener: () => undefined },
+			},
+			storage: {
+				local: {
+					async get(keys?: string | string[] | Record<string, unknown> | null) {
+						if (keys === undefined || keys === null) return { ...storageState }
+						if (Array.isArray(keys)) return Object.fromEntries(keys.filter((key) => key in storageState).map((key) => [key, storageState[key]]))
+						if (typeof keys === 'string') return keys in storageState ? { [keys]: storageState[keys] } : {}
+						return Object.fromEntries(Object.entries(keys).map(([key, defaultValue]) => [key, key in storageState ? storageState[key] : defaultValue]))
+					},
+					async set(items: Record<string, unknown>) {
+						Object.assign(storageState, items)
+					},
+					async remove(keys: string | string[]) {
+						for (const key of Array.isArray(keys) ? keys : [keys]) delete storageState[key]
+					},
+				},
+			},
+		},
+	})
+	Object.defineProperty(globalThis, 'chrome', {
+		configurable: true,
+		writable: true,
+		value: { runtime: { id: 'test-extension' } },
+	})
+}
+
+describe('website origin access', () => {
+	beforeEach(() => {
+		installBrowserMock()
+	})
+
+	test('uses schemeful origins for pages', async () => {
+		const { getWebsiteOrigin } = await import('../../app/ts/utils/requests.js')
+
+		assert.equal(getWebsiteOrigin('https://example.test/path?query=1'), 'https://example.test')
+		assert.equal(getWebsiteOrigin('http://example.test:8080/path'), 'http://example.test:8080')
+		assert.equal(getWebsiteOrigin('file:///tmp/interceptor-test.html'), 'file://')
+	})
+
+	test('keeps legacy host-only grants as fallback without overriding exact schemeful grants', async () => {
+		const { hasAccess } = await import('../../app/ts/background/accessManagement.js')
+		const websiteAccess = [
+			{ website: { websiteOrigin: 'legacy.example', icon: undefined, title: 'Legacy' }, access: true, addressAccess: undefined },
+			{ website: { websiteOrigin: 'split.example', icon: undefined, title: 'Legacy Split' }, access: true, addressAccess: undefined },
+			{ website: { websiteOrigin: 'https://split.example', icon: undefined, title: 'HTTPS Split' }, access: false, addressAccess: undefined },
+		] satisfies WebsiteAccessArray
+
+		assert.equal(hasAccess(websiteAccess, 'https://legacy.example'), 'hasAccess')
+		assert.equal(hasAccess(websiteAccess, 'http://legacy.example'), 'hasAccess')
+		assert.equal(hasAccess(websiteAccess, 'https://split.example'), 'noAccess')
+		assert.equal(hasAccess(websiteAccess, 'http://split.example'), 'hasAccess')
+	})
+
+	test('stores newly approved websites with the scheme included', async () => {
+		const { setAccess } = await import('../../app/ts/background/accessManagement.js')
+
+		await setAccess({ websiteOrigin: 'https://new.example', icon: undefined, title: 'New' }, true, undefined)
+
+		const storedWebsiteAccess = storageState.websiteAccess
+		assert.equal(Array.isArray(storedWebsiteAccess), true)
+		if (!Array.isArray(storedWebsiteAccess)) throw new Error('Expected websiteAccess to be stored as an array')
+		assert.deepEqual(storedWebsiteAccess.map((entry) => entry.website.websiteOrigin), ['https://new.example'])
+	})
+})


### PR DESCRIPTION
## Summary
- store new website access records with schemeful origins instead of host-only keys
- migrate legacy host-only access to http/https entries while exact schemeful grants take precedence
- keep backward-compatible lookup fallback for unmigrated host-only records and update popup/icon/blocking paths to use it
- preserve file-origin disabled-site handling when building content-script exclusions

## Validation
- bun test
- bun run setup-chrome
- bun run typecheck
- bun run lint
- CHROME_BIN=/usr/bin/chromium bun run test:chrome-communication

No CI/release gate files were changed.