### PR TITLE
Preserve JSON-RPC error data across the inpage bridge

### DIFF
--- a/app/inpage/ts/inpage.ts
+++ b/app/inpage/ts/inpage.ts
@@ -48,7 +48,7 @@ class InterceptorFuture<T> implements PromiseLike<T> {
 }
 
 class EthereumJsonRpcError extends Error {
-	constructor(public readonly code: number, message: string, public readonly data?: object) {
+	constructor(public readonly code: number, message: string, public readonly data?: unknown) {
 		super(message)
 		this.name = this.constructor.name
 	}
@@ -89,7 +89,7 @@ type InterceptedRequestForwardWithError = InterceptedRequestBase & {
 	readonly error: {
 		readonly code: number,
 		readonly message: string,
-		readonly data?: object
+		readonly data?: unknown
 	}
 }
 
@@ -165,7 +165,7 @@ function parseInterceptorApprovedMessage(data: unknown): InterceptedRequestForwa
 			error: {
 				code,
 				message,
-				...(errorData !== undefined && typeof errorData === 'object' && errorData !== null ? { data: errorData } : {}),
+				...(errorData !== undefined ? { data: errorData } : {}),
 			},
 		}
 	}

--- a/app/inpage/ts/inpage.ts
+++ b/app/inpage/ts/inpage.ts
@@ -765,7 +765,7 @@ class InterceptorMessageListener {
 			&& maybeErrorObject.code !== undefined && typeof maybeErrorObject.code === 'number'
 			&& 'message' in maybeErrorObject && maybeErrorObject.message !== undefined && typeof maybeErrorObject.message === 'string'
 		) {
-			return new EthereumJsonRpcError(maybeErrorObject.code, maybeErrorObject.message, 'data' in maybeErrorObject && typeof maybeErrorObject.data === 'object' && maybeErrorObject.data !== null ? maybeErrorObject.data : undefined)
+			return new EthereumJsonRpcError(maybeErrorObject.code, maybeErrorObject.message, 'data' in maybeErrorObject && maybeErrorObject.data !== undefined ? maybeErrorObject.data : undefined)
 		}
 		return new EthereumJsonRpcError(METAMASK_ERROR_BLANKET_ERROR, 'Unexpected thrown value.', maybeErrorObject )
 	}

--- a/test/tests/inpageSignerBridge.test.ts
+++ b/test/tests/inpageSignerBridge.test.ts
@@ -7,6 +7,7 @@ type InpageRequest = { readonly method: string, readonly requestId: number, read
 type FakeWindowOptions = {
 	readonly onConnectedToSignerRequest?: () => void
 	readonly handleRequest?: (request: InpageRequest, sendBackgroundMessage: (data: unknown) => void) => boolean
+	readonly handleSignerRequest?: (request: { readonly method: string, readonly params?: readonly unknown[] }) => unknown | Promise<unknown>
 }
 
 const isRecord = (value: unknown): value is Record<string, unknown> => typeof value === 'object' && value !== null
@@ -26,7 +27,7 @@ function parseInpageRequest(value: unknown): InpageRequest | undefined {
 	}
 }
 
-function createFakeWindow({ onConnectedToSignerRequest, handleRequest }: FakeWindowOptions = {}) {
+function createFakeWindow({ onConnectedToSignerRequest, handleRequest, handleSignerRequest }: FakeWindowOptions = {}) {
 	const listeners = new Map<string, Set<Listener>>()
 	const signerRequests: string[] = []
 	const backgroundEthAccountsReplies: unknown[] = []
@@ -39,7 +40,9 @@ function createFakeWindow({ onConnectedToSignerRequest, handleRequest }: FakeWin
 	const fakeSigner = {
 		isMetaMask: true,
 		isConnected: () => true,
-		request: async ({ method }: { method: string }) => {
+		request: async ({ method, params }: { method: string, params?: readonly unknown[] }) => {
+			const customReply = handleSignerRequest?.({ method, ...(params === undefined ? {} : { params }) })
+			if (customReply !== undefined) return await customReply
 			signerRequests.push(method)
 			switch (method) {
 				case 'eth_chainId':
@@ -415,6 +418,66 @@ describe('inpage signer bridge', () => {
 
 		try {
 			await import('../../app/inpage/ts/inpage.js?json-rpc-error-data')
+			await waitFor(() => signerRequests.length >= 1)
+			const provider = fakeWindow.ethereum as {
+				request: (payload: { method: string, params?: readonly unknown[] }) => Promise<unknown>
+			}
+			await assert.rejects(
+				provider.request({ method: 'eth_call', params: [] }),
+				(error: unknown) => {
+					if (!isRecord(error)) return false
+					assert.equal(error.code, -32000)
+					assert.equal(error.message, 'execution reverted')
+					assert.equal(error.data, revertData)
+					return true
+				},
+			)
+		} finally {
+			;(globalThis as { window?: unknown }).window = previousWindow
+			if (previousCustomEvent === undefined) {
+				delete (globalThis as { CustomEvent?: typeof CustomEvent }).CustomEvent
+			} else {
+				;(globalThis as { CustomEvent: typeof CustomEvent }).CustomEvent = previousCustomEvent
+			}
+		}
+	})
+
+	test('preserves string JSON-RPC error data from signer replies', async () => {
+		const previousWindow = (globalThis as { window?: unknown }).window
+		const previousCustomEvent = (globalThis as { CustomEvent?: typeof CustomEvent }).CustomEvent
+		const revertData = '0x08c379a0'
+		const { fakeWindow, signerRequests } = createFakeWindow({
+			handleRequest: (request, sendBackgroundMessage) => {
+				if (request.method !== 'eth_call') return false
+				sendBackgroundMessage({
+					interceptorApproved: true,
+					requestId: request.requestId,
+					type: 'forwardToSigner',
+					method: 'eth_call',
+					params: request.params,
+					replyWithSignersReply: true,
+				})
+				return true
+			},
+			handleSignerRequest: ({ method }) => {
+				if (method !== 'eth_call') return undefined
+				throw { code: -32000, message: 'execution reverted', data: revertData }
+			},
+		})
+		;(globalThis as unknown as { window: typeof fakeWindow }).window = fakeWindow
+		if (typeof (globalThis as { CustomEvent?: typeof CustomEvent }).CustomEvent !== 'function') {
+			;(globalThis as { CustomEvent: typeof CustomEvent }).CustomEvent = class CustomEvent<T = unknown> extends Event {
+				public detail: T
+				constructor(type: string, init?: CustomEventInit<T>) {
+					super(type)
+					this.detail = init?.detail as T
+				}
+				public initCustomEvent(): void { return undefined }
+			}
+		}
+
+		try {
+			await import('../../app/inpage/ts/inpage.js?signer-json-rpc-error-data')
 			await waitFor(() => signerRequests.length >= 1)
 			const provider = fakeWindow.ethereum as {
 				request: (payload: { method: string, params?: readonly unknown[] }) => Promise<unknown>

--- a/test/tests/inpageSignerBridge.test.ts
+++ b/test/tests/inpageSignerBridge.test.ts
@@ -6,6 +6,7 @@ type Listener = (event: WindowEvent) => void
 type InpageRequest = { readonly method: string, readonly requestId: number, readonly params?: readonly unknown[], readonly internal?: true }
 type FakeWindowOptions = {
 	readonly onConnectedToSignerRequest?: () => void
+	readonly handleRequest?: (request: InpageRequest, sendBackgroundMessage: (data: unknown) => void) => boolean
 }
 
 const isRecord = (value: unknown): value is Record<string, unknown> => typeof value === 'object' && value !== null
@@ -25,7 +26,7 @@ function parseInpageRequest(value: unknown): InpageRequest | undefined {
 	}
 }
 
-function createFakeWindow({ onConnectedToSignerRequest }: FakeWindowOptions = {}) {
+function createFakeWindow({ onConnectedToSignerRequest, handleRequest }: FakeWindowOptions = {}) {
 	const listeners = new Map<string, Set<Listener>>()
 	const signerRequests: string[] = []
 	const backgroundEthAccountsReplies: unknown[] = []
@@ -95,6 +96,7 @@ function createFakeWindow({ onConnectedToSignerRequest }: FakeWindowOptions = {}
 		const request = parseInpageRequest(data)
 		if (request === undefined) return
 		queueMicrotask(() => {
+			if (handleRequest?.(request, sendBackgroundMessage) === true) return
 			switch (request.method) {
 				case 'connected_to_signer':
 					onConnectedToSignerRequest?.()
@@ -368,6 +370,65 @@ describe('inpage signer bridge', () => {
 			assert.equal(lateSignerRequests[0], 'eth_chainId')
 			assert.equal((fakeWindow.ethereum as { isInterceptor?: boolean }).isInterceptor, true)
 			assert.strictEqual(fakeWindow.dispatchEvent, originalDispatchEvent)
+		} finally {
+			;(globalThis as { window?: unknown }).window = previousWindow
+			if (previousCustomEvent === undefined) {
+				delete (globalThis as { CustomEvent?: typeof CustomEvent }).CustomEvent
+			} else {
+				;(globalThis as { CustomEvent: typeof CustomEvent }).CustomEvent = previousCustomEvent
+			}
+		}
+	})
+
+	test('preserves string JSON-RPC error data from background replies', async () => {
+		const previousWindow = (globalThis as { window?: unknown }).window
+		const previousCustomEvent = (globalThis as { CustomEvent?: typeof CustomEvent }).CustomEvent
+		const revertData = '0x08c379a0'
+		const { fakeWindow, signerRequests } = createFakeWindow({
+			handleRequest: (request, sendBackgroundMessage) => {
+				if (request.method !== 'eth_call') return false
+				sendBackgroundMessage({
+					interceptorApproved: true,
+					requestId: request.requestId,
+					type: 'result',
+					method: 'eth_call',
+					error: {
+						code: -32000,
+						message: 'execution reverted',
+						data: revertData,
+					},
+				})
+				return true
+			},
+		})
+		;(globalThis as unknown as { window: typeof fakeWindow }).window = fakeWindow
+		if (typeof (globalThis as { CustomEvent?: typeof CustomEvent }).CustomEvent !== 'function') {
+			;(globalThis as { CustomEvent: typeof CustomEvent }).CustomEvent = class CustomEvent<T = unknown> extends Event {
+				public detail: T
+				constructor(type: string, init?: CustomEventInit<T>) {
+					super(type)
+					this.detail = init?.detail as T
+				}
+				public initCustomEvent(): void { return undefined }
+			}
+		}
+
+		try {
+			await import('../../app/inpage/ts/inpage.js?json-rpc-error-data')
+			await waitFor(() => signerRequests.length >= 1)
+			const provider = fakeWindow.ethereum as {
+				request: (payload: { method: string, params?: readonly unknown[] }) => Promise<unknown>
+			}
+			await assert.rejects(
+				provider.request({ method: 'eth_call', params: [] }),
+				(error: unknown) => {
+					if (!isRecord(error)) return false
+					assert.equal(error.code, -32000)
+					assert.equal(error.message, 'execution reverted')
+					assert.equal(error.data, revertData)
+					return true
+				},
+			)
 		} finally {
 			;(globalThis as { window?: unknown }).window = previousWindow
 			if (previousCustomEvent === undefined) {


### PR DESCRIPTION
## Summary
- Preserve defined JSON-RPC `error.data` values when background replies are parsed by the inpage provider.
- Widen the inpage error typing from object-only data to `unknown`, matching JSON-RPC and the background schema where revert data is commonly a string.
- Add regression coverage for an `eth_call` error to verify string revert data survives the MessagePort bridge unchanged.

## Why
The release audit found that the stricter inpage reply parser dropped string `error.data` values. That could hide revert data from dapps even when the background sent it correctly.

## Testing
- `bun test` - 307 pass
- `bun run setup-chrome`
- `bun run typecheck`
- `bun run lint`
- `bun run test:chrome-communication`