### PR TITLE
Prune extension package exposure

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -21,7 +21,7 @@ COPY app/ts/ /workspace/app/ts/
 COPY app/img/ /workspace/app/img/
 COPY app/inpage/ /workspace/app/inpage/
 COPY app/fonts/ /workspace/app/fonts/
-COPY build/tsconfig.json build/vendor.mts build/bundler.mts build/cleanOutput.mts /workspace/build/
+COPY build/tsconfig.json build/vendor.mts build/bundler.mts build/cleanOutput.mts build/pruneExtensionPackage.mts /workspace/build/
 
 COPY tsconfig-test.json /workspace/
 COPY test/ /workspace/test/
@@ -30,15 +30,17 @@ COPY scripts/ /workspace/scripts/
 WORKDIR /workspace
 RUN bun run setup-firefox
 RUN bun test
+RUN bun ./build/pruneExtensionPackage.mts app /tmp/interceptor-firefox-app
 
-WORKDIR /workspace/app
-RUN zip ../interceptor-firefox.zip -r .
+WORKDIR /tmp/interceptor-firefox-app
+RUN zip /workspace/interceptor-firefox.zip -r .
 
 WORKDIR /workspace
 RUN bun run setup-chrome
+RUN bun ./build/pruneExtensionPackage.mts app /tmp/interceptor-chrome-app
 
-WORKDIR /workspace/app
-RUN zip ../interceptor-chrome.zip -r .
+WORKDIR /tmp/interceptor-chrome-app
+RUN zip /workspace/interceptor-chrome.zip -r .
 
 WORKDIR /workspace
 RUN mv interceptor-firefox.zip /interceptor-firefox.zip && mv interceptor-chrome.zip /interceptor-chrome.zip

--- a/app/manifestV2.json
+++ b/app/manifestV2.json
@@ -30,6 +30,6 @@
 		"webRequest",
 		"webRequestBlocking"
 	],
-	"web_accessible_resources": ["vendor/*", "js/*", "inpage/*"],
+	"web_accessible_resources": ["inpage/js/inpage.js"],
 	"content_security_policy": "object-src 'self'; script-src 'self'"
 }

--- a/app/manifestV3.json
+++ b/app/manifestV3.json
@@ -25,7 +25,7 @@
 	],
 	"web_accessible_resources": [
 		{
-			"resources": ["vendor/*", "js/*", "inpage/*"],
+			"resources": ["inpage/js/inpage.js"],
 			"matches": ["<all_urls>"]
 		}
 	],

--- a/build/pruneExtensionPackage.mts
+++ b/build/pruneExtensionPackage.mts
@@ -1,0 +1,76 @@
+import * as fs from 'node:fs/promises'
+import * as path from 'node:path'
+
+const prunableVendorDirectoryNames = new Set([
+	'__tests__',
+	'benchmark',
+	'benchmarks',
+	'src',
+	'test',
+	'tests',
+])
+
+const toPortablePath = (filePath: string) => filePath.split(path.sep).join('/')
+
+function isVendorPath(relativePath: string) {
+	return relativePath === 'vendor' || relativePath.startsWith('vendor/')
+}
+
+function hasPrunableVendorDirectory(relativePath: string) {
+	if (!isVendorPath(relativePath)) return false
+	return relativePath.split('/').some((part) => prunableVendorDirectoryNames.has(part))
+}
+
+export function shouldPruneExtensionPackageDirectory(relativePath: string): boolean {
+	const portablePath = toPortablePath(relativePath)
+	if (portablePath === 'ts') return true
+	if (portablePath === 'inpage/ts') return true
+	if (portablePath === 'vendor/@darkflorist/address-metadata/lib/images') return true
+	return hasPrunableVendorDirectory(portablePath)
+}
+
+export function shouldPruneExtensionPackageFile(relativePath: string): boolean {
+	const portablePath = toPortablePath(relativePath)
+	const baseName = path.basename(portablePath)
+	if (portablePath === 'manifestV2.json' || portablePath === 'manifestV3.json') return true
+	if (isVendorPath(portablePath) && baseName === 'package.json') return true
+	if (portablePath.endsWith('.d.ts')) return true
+	if (portablePath.endsWith('.d.ts.map')) return true
+	if (portablePath.endsWith('.map')) return true
+	if (/[.][cm]?tsx?$/.test(portablePath)) return true
+	return false
+}
+
+async function pruneExtensionPackageDirectory(packageDirectory: string, currentDirectory: string) {
+	const entries = await fs.readdir(currentDirectory, { withFileTypes: true })
+	for (const entry of entries) {
+		const entryPath = path.join(currentDirectory, entry.name)
+		const relativePath = path.relative(packageDirectory, entryPath)
+		if (entry.isDirectory()) {
+			if (shouldPruneExtensionPackageDirectory(relativePath)) {
+				await fs.rm(entryPath, { recursive: true, force: true })
+				continue
+			}
+			await pruneExtensionPackageDirectory(packageDirectory, entryPath)
+			continue
+		}
+		if (entry.isFile() && shouldPruneExtensionPackageFile(relativePath)) {
+			await fs.rm(entryPath, { force: true })
+		}
+	}
+}
+
+export async function prepareExtensionPackage(sourceAppDirectory: string, destinationAppDirectory: string) {
+	await fs.rm(destinationAppDirectory, { recursive: true, force: true })
+	await fs.cp(sourceAppDirectory, destinationAppDirectory, { recursive: true })
+	await pruneExtensionPackageDirectory(destinationAppDirectory, destinationAppDirectory)
+}
+
+if (import.meta.main) {
+	const [sourceAppDirectory, destinationAppDirectory] = process.argv.slice(2)
+	if (sourceAppDirectory === undefined || destinationAppDirectory === undefined) {
+		console.error('Usage: bun ./build/pruneExtensionPackage.mts <source-app-directory> <destination-app-directory>')
+		process.exit(1)
+	}
+	await prepareExtensionPackage(sourceAppDirectory, destinationAppDirectory)
+}

--- a/test/tests/packageScripts.test.ts
+++ b/test/tests/packageScripts.test.ts
@@ -1,7 +1,9 @@
 import * as assert from 'assert'
 import * as fs from 'node:fs'
+import * as os from 'node:os'
 import * as path from 'node:path'
 import { describe, test } from 'bun:test'
+import { prepareExtensionPackage } from '../../build/pruneExtensionPackage.mts'
 
 const repositoryRoot = process.cwd()
 
@@ -16,6 +18,16 @@ function getPackageScripts() {
 	const scripts = packageJson.scripts
 	if (!isRecord(scripts)) throw new Error('package.json scripts must be an object')
 	return scripts
+}
+
+function readJsonFile(filePath: string): unknown {
+	return JSON.parse(fs.readFileSync(filePath, 'utf8'))
+}
+
+function getManifest(manifestName: string) {
+	const manifest = readJsonFile(path.join(repositoryRoot, 'app', manifestName))
+	if (!isRecord(manifest)) throw new Error(`${ manifestName } root must be an object`)
+	return manifest
 }
 
 function getScript(scripts: Record<string, unknown>, scriptName: string) {
@@ -34,5 +46,77 @@ describe('package scripts', () => {
 			'bun run bundle',
 			'bun run firefox',
 		])
+	})
+
+	test('manifests only expose the inpage provider script to websites', () => {
+		const manifestV2 = getManifest('manifestV2.json')
+		const manifestV3 = getManifest('manifestV3.json')
+
+		assert.deepEqual(manifestV2.web_accessible_resources, ['inpage/js/inpage.js'])
+		assert.deepEqual(manifestV3.web_accessible_resources, [{
+			resources: ['inpage/js/inpage.js'],
+			matches: ['<all_urls>'],
+		}])
+	})
+
+	test('extension package pruning removes source and metadata from staged app copies', async () => {
+		const tempDirectory = fs.mkdtempSync(path.join(os.tmpdir(), 'interceptor-package-'))
+		try {
+			const sourceDirectory = path.join(tempDirectory, 'source-app')
+			const destinationDirectory = path.join(tempDirectory, 'package-app')
+			for (const directory of [
+				'ts',
+				'inpage/ts',
+				'inpage/js',
+				'js',
+				'vendor/example-package/dist',
+				'vendor/example-package/src',
+				'vendor/@darkflorist/address-metadata/images/tokens',
+				'vendor/@darkflorist/address-metadata/lib/images/tokens',
+			]) {
+				fs.mkdirSync(path.join(sourceDirectory, directory), { recursive: true })
+			}
+			for (const [relativePath, contents] of Object.entries({
+				'manifest.json': '{}',
+				'manifestV2.json': '{}',
+				'manifestV3.json': '{}',
+				'ts/source.ts': 'export {}',
+				'inpage/ts/inpage.ts': 'export {}',
+				'inpage/js/inpage.js': 'globalThis.ethereum = {}',
+				'inpage/js/inpage.js.map': '{}',
+				'js/popup.js': 'export {}',
+				'js/popup.d.ts': 'export {}',
+				'js/popup.js.map': '{}',
+				'vendor/example-package/package.json': '{}',
+				'vendor/example-package/dist/index.js': 'export {}',
+				'vendor/example-package/dist/index.d.ts': 'export {}',
+				'vendor/example-package/src/index.ts': 'export {}',
+				'vendor/@darkflorist/address-metadata/images/tokens/token.png': 'image',
+				'vendor/@darkflorist/address-metadata/lib/images/tokens/token.png': 'duplicate image',
+			})) {
+				fs.writeFileSync(path.join(sourceDirectory, relativePath), contents)
+			}
+
+			await prepareExtensionPackage(sourceDirectory, destinationDirectory)
+
+			assert.equal(fs.existsSync(path.join(destinationDirectory, 'manifest.json')), true)
+			assert.equal(fs.existsSync(path.join(destinationDirectory, 'manifestV2.json')), false)
+			assert.equal(fs.existsSync(path.join(destinationDirectory, 'manifestV3.json')), false)
+			assert.equal(fs.existsSync(path.join(destinationDirectory, 'ts')), false)
+			assert.equal(fs.existsSync(path.join(destinationDirectory, 'inpage/ts')), false)
+			assert.equal(fs.existsSync(path.join(destinationDirectory, 'inpage/js/inpage.js')), true)
+			assert.equal(fs.existsSync(path.join(destinationDirectory, 'inpage/js/inpage.js.map')), false)
+			assert.equal(fs.existsSync(path.join(destinationDirectory, 'js/popup.js')), true)
+			assert.equal(fs.existsSync(path.join(destinationDirectory, 'js/popup.d.ts')), false)
+			assert.equal(fs.existsSync(path.join(destinationDirectory, 'js/popup.js.map')), false)
+			assert.equal(fs.existsSync(path.join(destinationDirectory, 'vendor/example-package/package.json')), false)
+			assert.equal(fs.existsSync(path.join(destinationDirectory, 'vendor/example-package/dist/index.js')), true)
+			assert.equal(fs.existsSync(path.join(destinationDirectory, 'vendor/example-package/dist/index.d.ts')), false)
+			assert.equal(fs.existsSync(path.join(destinationDirectory, 'vendor/example-package/src')), false)
+			assert.equal(fs.existsSync(path.join(destinationDirectory, 'vendor/@darkflorist/address-metadata/images/tokens/token.png')), true)
+			assert.equal(fs.existsSync(path.join(destinationDirectory, 'vendor/@darkflorist/address-metadata/lib/images')), false)
+		} finally {
+			fs.rmSync(tempDirectory, { recursive: true, force: true })
+		}
 	})
 })


### PR DESCRIPTION
## Summary
- narrow web_accessible_resources to only the inpage provider script that pages need to load
- add a staged package-prune step for extension zips that removes source, maps, declarations, package metadata, and duplicate address-metadata image copies
- update Docker packaging to zip the pruned staged app copy while leaving the build/test app tree intact
- cover manifest exposure and pruning behavior with package tests

## Validation
- bun test
- bun run setup-chrome
- bun run typecheck
- bun run lint
- CHROME_BIN=/usr/bin/chromium bun run test:chrome-communication
- exercised prune script against generated app: staged copy was about 90M vs 258M source app and contained zero pruned source/map/declaration/package metadata matches

Docker is not installed in this environment, so I could not run a Docker build locally. No CI workflow files were changed.