### PR TITLE
Remove bundled Etherscan API key

### DIFF
--- a/app/ts/background/settings.ts
+++ b/app/ts/background/settings.ts
@@ -95,7 +95,7 @@ const wethForChainId = new Map<string, EthereumAddress>([
 	['42161', 0x82af49447d8a07e3bd95bd0d56f35241523fbab1n], // Arbitrum
 ])
 
-export const getDefaultBlockExplorer = (): BlockExplorer => ({ apiUrl: 'https://api.etherscan.io/v2/api', apiKey: 'PSW8C433Q667DVEX5BCRMGNAH9FSGFZ7Q8' })
+export const getDefaultBlockExplorer = (): BlockExplorer => ({ apiUrl: 'https://api.etherscan.io/v2/api', apiKey: '' })
 
 export const getWethForChainId = (chainId: bigint) => wethForChainId.get(chainId.toString())
 

--- a/app/ts/simulation/services/EtherScanAbiFetcher.ts
+++ b/app/ts/simulation/services/EtherScanAbiFetcher.ts
@@ -50,13 +50,26 @@ export const mergeProxyAndImplementationAbi = (proxyAbi: string, implementationA
 	return isValidAbi(mergedAbi) ? mergedAbi : implementationAbi
 }
 
+type ContractApiAction = 'getabi' | 'getsourcecode'
+
+export function getBlockExplorerContractUrl(blockExplorer: BlockExplorer, action: ContractApiAction, contractAddress: EthereumAddress, chainId: bigint) {
+	const url = new URL(blockExplorer.apiUrl)
+	url.searchParams.set('chainId', chainId.toString())
+	url.searchParams.set('module', 'contract')
+	url.searchParams.set('action', action)
+	url.searchParams.set('address', addressString(contractAddress))
+	const apiKey = blockExplorer.apiKey.trim()
+	if (apiKey.length > 0) url.searchParams.set('apiKey', apiKey)
+	return url.toString()
+}
+
 async function fetchAbi(contractAddress: EthereumAddress, maybeExplorer: BlockExplorer | undefined, chainId: bigint): Promise<Result<EtherscanSourceCodeResult>> {
 	const normalizedAddressString = addressString(contractAddress)
 	let bestResult: Result<EtherscanSourceCodeResult> = { success: false, message: 'Failed to fetch Abi' } as const
 	try {
 		if (maybeExplorer !== undefined) {
 			try {
-				const result = await fetch(`${ maybeExplorer.apiUrl }?chainId=${ chainId.toString() }&module=contract&action=getsourcecode&address=${ normalizedAddressString }&apiKey=${ maybeExplorer.apiKey }`)
+				const result = await fetch(getBlockExplorerContractUrl(maybeExplorer, 'getsourcecode', contractAddress, chainId))
 				bestResult = EtherscanSourceCodeResult.safeParse(await result.json())
 				if (bestResult.success) return bestResult
 			} catch(error: unknown) {
@@ -83,18 +96,19 @@ async function fetchAbi(contractAddress: EthereumAddress, maybeExplorer: BlockEx
 
 export async function fetchAbiFromBlockExplorer(contractAddress: EthereumAddress, chainId: ChainIdWithUniversal) {
 	const api = getBlockExplorer(chainId, await getRpcList())
+	const resolvedChainId = chainId === 'AllChains' ? 1n : chainId
 
-	const parsedSourceCode = await fetchAbi(contractAddress, api, chainId === 'AllChains' ? 1n : chainId)
+	const parsedSourceCode = await fetchAbi(contractAddress, api, resolvedChainId)
 
 	// Extract ABI from getSourceCode request if not proxy, otherwise attempt to fetch ABI of implementation
 	if (parsedSourceCode.success === false || parsedSourceCode.value.status !== 'success') return { success: false as const, error: 'Could not get ABI for the contract.' }
 
 	if (api !== undefined && parsedSourceCode.value.result[0].Proxy === 'yes' && parsedSourceCode.value.result[0].Implementation !== '') {
-		const implReq = await fetchJson(`${ api.apiUrl }?chainId=${ chainId.toString() }&module=contract&action=getabi&address=${ addressString(parsedSourceCode.value.result[0].Implementation) }&apiKey=${ api.apiKey }`)
+		const implReq = await fetchJson(getBlockExplorerContractUrl(api, 'getabi', parsedSourceCode.value.result[0].Implementation, resolvedChainId))
 		if (!implReq.success) return implReq
 		const implResult = EtherscanGetABIResult.safeParse(implReq.result)
 
-		const sourceCodeResult = await fetchJson(`${ api.apiUrl }?chainId=${ chainId.toString() }&module=contract&action=getsourcecode&address=${ addressString(parsedSourceCode.value.result[0].Implementation) }&apiKey=${ api.apiKey }`)
+		const sourceCodeResult = await fetchJson(getBlockExplorerContractUrl(api, 'getsourcecode', parsedSourceCode.value.result[0].Implementation, resolvedChainId))
 		if (!sourceCodeResult.success) return sourceCodeResult
 		const implementationName = EtherscanSourceCodeResult.safeParse(sourceCodeResult.result)
 

--- a/test/tests/etherscanAbiFetcher.test.ts
+++ b/test/tests/etherscanAbiFetcher.test.ts
@@ -1,9 +1,44 @@
 import * as assert from 'assert'
 import { describe, test } from 'bun:test'
 import { isValidAbiString } from '../../app/ts/utils/abiRuntime.js'
-import { mergeProxyAndImplementationAbi } from '../../app/ts/simulation/services/EtherScanAbiFetcher.js'
+import { getBlockExplorerContractUrl, mergeProxyAndImplementationAbi } from '../../app/ts/simulation/services/EtherScanAbiFetcher.js'
+import { getDefaultBlockExplorer } from '../../app/ts/background/settings.js'
 
 describe('Etherscan ABI fetcher', () => {
+	test('does not ship with a default Etherscan API key', () => {
+		assert.equal(getDefaultBlockExplorer().apiKey, '')
+	})
+
+	test('omits empty API keys from block explorer contract URLs', () => {
+		const url = new URL(getBlockExplorerContractUrl(
+			{ apiUrl: 'https://api.etherscan.io/v2/api', apiKey: '' },
+			'getsourcecode',
+			0x1111111111111111111111111111111111111111n,
+			1n,
+		))
+
+		assert.equal(url.origin + url.pathname, 'https://api.etherscan.io/v2/api')
+		assert.equal(url.searchParams.get('chainId'), '1')
+		assert.equal(url.searchParams.get('module'), 'contract')
+		assert.equal(url.searchParams.get('action'), 'getsourcecode')
+		assert.equal(url.searchParams.get('address'), '0x1111111111111111111111111111111111111111')
+		assert.equal(url.searchParams.has('apiKey'), false)
+	})
+
+	test('includes configured API keys in block explorer contract URLs', () => {
+		const url = new URL(getBlockExplorerContractUrl(
+			{ apiUrl: 'https://api.etherscan.io/v2/api', apiKey: ' configured-key ' },
+			'getabi',
+			0x2222222222222222222222222222222222222222n,
+			11155111n,
+		))
+
+		assert.equal(url.searchParams.get('chainId'), '11155111')
+		assert.equal(url.searchParams.get('action'), 'getabi')
+		assert.equal(url.searchParams.get('address'), '0x2222222222222222222222222222222222222222')
+		assert.equal(url.searchParams.get('apiKey'), 'configured-key')
+	})
+
 	test('keeps proxy ABI events when merging with implementation ABI', () => {
 		const proxyAbi = JSON.stringify([
 			{


### PR DESCRIPTION
## Summary
- remove the hardcoded default Etherscan API key from shipped settings
- build block explorer contract URLs with URLSearchParams and omit apiKey when no key is configured
- keep configured user/API keys working by including trimmed non-empty keys

## Validation
- bun test
- bun run setup-chrome
- bun run typecheck
- bun run lint
- CHROME_BIN=/usr/bin/chromium bun run test:chrome-communication

No CI/release gate files were changed.