### PR TITLE
Surface unexpected simulation state failures

### DIFF
--- a/app/ts/background/background.ts
+++ b/app/ts/background/background.ts
@@ -15,7 +15,7 @@ import { assertNever, assertUnreachable } from '../utils/typescript.js'
 import type { EthereumClientService } from '../simulation/services/EthereumClientService.js'
 import { appendTransactionsToInput, mockSignTransaction } from '../simulation/services/SimulationModeEthereumClientService.js'
 import { Semaphore } from '../utils/semaphore.js'
-import { JsonRpcResponseError, handleUnexpectedError, isFailedToFetchError, isNewBlockAbort, printError } from '../utils/errors.js'
+import { JsonRpcResponseError, handleUnexpectedError, isFailedToFetchError, isNewBlockAbort } from '../utils/errors.js'
 import { InterceptedRequest, type UniqueRequestIdentifier, type WebsiteSocket } from '../utils/requests.js'
 import { replyToInterceptedRequest } from './messageSending.js'
 import { bumpPopupRefreshGeneration } from './popupRefreshGeneration.js'
@@ -52,7 +52,7 @@ export async function getUpdatedSimulationState(ethereum: EthereumClientService)
 		return toResolvedSimulationState(await createSimulationStateWithNonceAndBaseFeeFixing(await getCurrentSimulationInput(), ethereum))
 	} catch(error: unknown) {
 		if (error instanceof Error && (isNewBlockAbort(error) || isFailedToFetchError(error))) return PASSTHROUGH_STATE
-		printError(error)
+		await handleUnexpectedError(error, { code: 'simulation_state_update_failed' })
 	}
 	return PASSTHROUGH_STATE
 }

--- a/test/tests/unexpectedErrorDiagnostics.test.ts
+++ b/test/tests/unexpectedErrorDiagnostics.test.ts
@@ -3,6 +3,7 @@ import { h, render } from 'preact'
 import { act } from 'preact/test-utils'
 import { describe, test } from 'bun:test'
 import { installDateMock, installDomMock } from './domMock.js'
+import type { IEthereumJSONRpcRequestHandler } from '../../app/ts/simulation/services/EthereumJSONRpcRequestHandler.js'
 
 type RuntimeMessage = {
 	method?: string
@@ -86,6 +87,8 @@ async function loadModules() {
 	return {
 		...await import('../../app/ts/utils/errors.js'),
 		...await import('../../app/ts/background/storageVariables.js'),
+		...await import('../../app/ts/background/background.js'),
+		...await import('../../app/ts/simulation/services/EthereumClientService.js'),
 		...await import('../../app/ts/components/subcomponents/Error.js'),
 	}
 }
@@ -119,6 +122,41 @@ describe('unexpected error diagnostics', () => {
 		assert.equal(latestUnexpectedError?.data.source, 'internal')
 		assert.equal(latestUnexpectedError?.data.code, 'unexpected_error')
 		assert.equal(typeof latestUnexpectedError?.data.debugId, 'string')
+	})
+
+	test('records unexpected simulation state failures before falling back to passthrough', async () => {
+		browserMock.reset()
+		const { getUpdatedSimulationState, getLatestUnexpectedError, EthereumClientService } = await modulesPromise
+		const requestHandler: IEthereumJSONRpcRequestHandler = {
+			rpcUrl: 'https://example.invalid',
+			clearCache: () => undefined,
+			getChainId: async () => 1n,
+			jsonRpcRequest: async () => {
+				throw new Error('simulation state exploded')
+			},
+		}
+		const ethereum = new EthereumClientService(
+			requestHandler,
+			async () => undefined,
+			async () => undefined,
+			{
+				name: 'Test Chain',
+				chainId: 1n,
+				httpsRpc: 'https://example.invalid',
+				currencyName: 'Ether',
+				currencyTicker: 'ETH',
+				currencyLogoUri: undefined,
+				primary: true,
+				minimized: true,
+			}
+		)
+
+		const simulationState = await getUpdatedSimulationState(ethereum)
+		const latestUnexpectedError = await getLatestUnexpectedError()
+
+		assert.deepEqual(simulationState, { kind: 'passthrough' })
+		assert.equal(latestUnexpectedError?.data.message, 'simulation state exploded')
+		assert.equal(latestUnexpectedError?.data.code, 'simulation_state_update_failed')
 	})
 
 	test('renders forwarded diagnostics directly from the message string in the existing unexpected error popup', async () => {


### PR DESCRIPTION
## Summary
- route unexpected `getUpdatedSimulationState` failures through `handleUnexpectedError` before falling back to passthrough
- keep new-block aborts and fetch failures as quiet passthrough cases
- add a regression test for recording the unexpected simulation-state error

## Validation
- `bun test`
- `bun run setup-chrome`
- `bun run typecheck`
- `bun run lint`

## Self-review
- verified the diff keeps expected network/new-block fallbacks unchanged and only changes the unexpected branch.