### PR TITLE
Align Noble dependencies and vendor import rewrites

### DIFF
--- a/build/bundler.mts
+++ b/build/bundler.mts
@@ -73,6 +73,22 @@ const getPackageSubpath = (specifier: string, packageRootName: string) => specif
 	? '.'
 	: `./${ specifier.slice(packageRootName.length + 1) }`
 
+function getPackageSpecifierFromNodeModulesPathParts(pathParts: readonly string[]) {
+	const nodeModulesIndex = pathParts.indexOf('node_modules')
+	if (nodeModulesIndex === -1) return undefined
+	const dependencyPathParts = pathParts.slice(nodeModulesIndex + 1)
+	const firstPathPart = dependencyPathParts[0]
+	if (firstPathPart === undefined) return undefined
+	if (!firstPathPart.startsWith('@')) return dependencyPathParts.join('/')
+	const secondPathPart = dependencyPathParts[1]
+	if (secondPathPart === undefined) return undefined
+	return dependencyPathParts.slice(0, 2).join('/') + (dependencyPathParts.length > 2 ? `/${ dependencyPathParts.slice(2).join('/') }` : '')
+}
+
+function getPackageSpecifierFromRelativeNodeModulesImport(specifier: string) {
+	return getPackageSpecifierFromNodeModulesPathParts(specifier.split(/[\\/]+/))
+}
+
 function getVendoredLocationForNodeModulesPath(resolvedPath: string) {
 	if (!isInsideDirectory(resolvedPath, nodeModulesDirectory)) return undefined
 	const relativePathParts = path.relative(nodeModulesDirectory, resolvedPath).split(path.sep)
@@ -287,8 +303,13 @@ function getRewrittenRelativeImportPath(filePath: string, specifier: string) {
 	if (specifier.startsWith('/')) return undefined
 	const basePath = getResolverBasePath(filePath)
 	const resolvedPath = resolveExistingModuleFile(path.resolve(path.dirname(basePath), specifier))
-	if (resolvedPath === undefined) return undefined
-	const vendoredLocation = getVendoredLocationForNodeModulesPath(resolvedPath)
+	const fallbackResolvedPath = resolvedPath ?? (() => {
+		const nodeModulesPackageSpecifier = getPackageSpecifierFromRelativeNodeModulesImport(specifier)
+		if (nodeModulesPackageSpecifier === undefined) return undefined
+		return resolvePackageSpecifierFromNodeModules(nodeModulesPackageSpecifier, basePath)
+	})()
+	if (fallbackResolvedPath === undefined) return undefined
+	const vendoredLocation = getVendoredLocationForNodeModulesPath(fallbackResolvedPath)
 	if (vendoredLocation === undefined) return undefined
 	const vendoredImportPath = getRelativePath(path.dirname(filePath), vendoredLocation).replace(/\\/g, '/')
 	return vendoredImportPath === specifier ? undefined : vendoredImportPath

--- a/bun.lock
+++ b/bun.lock
@@ -6,8 +6,8 @@
       "name": "interceptor-extension",
       "dependencies": {
         "@darkflorist/address-metadata": "0.10.0",
-        "@noble/curves": "0.8.0",
-        "@noble/hashes": "1.4.0",
+        "@noble/curves": "1.9.1",
+        "@noble/hashes": "1.8.0",
         "@preact/signals": "1.1.3",
         "funtypes": "5.1.0",
         "preact": "10.24.2",
@@ -27,9 +27,9 @@
 
     "@noble/ciphers": ["@noble/ciphers@1.3.0", "", {}, "sha512-2I0gnIVPtfnMw9ee9h1dJG7tp81+8Ob3OJb3Mv37rx5L40/b0i7djjCVvGOVqc9AEIQyvyu1i6ypKdFw8R8gQw=="],
 
-    "@noble/curves": ["@noble/curves@0.8.0", "", { "dependencies": { "@noble/hashes": "1.2.0" } }, ""],
+    "@noble/curves": ["@noble/curves@1.9.1", "", { "dependencies": { "@noble/hashes": "1.8.0" } }, "sha512-k11yZxZg+t+gWvBbIswW0yoJlu8cHOC7dhunwOzoWH/mXGBiYyR4YY6hAEK/3EUs4UpB8la1RfdRpeGsFHkWsA=="],
 
-    "@noble/hashes": ["@noble/hashes@1.4.0", "", {}, "sha512-V1JJ1WTRUqHHrOSh597hURcMqVKVGL/ea3kv0gSnEdsEZ0/+VyPghM1lMNGc00z7CIQorSvbKpuJkxvuHbvdbg=="],
+    "@noble/hashes": ["@noble/hashes@1.8.0", "", {}, "sha512-jCs9ldd7NwzpgXDIf6P3+NrHh9/sD6CQdxHyjQI+h/6rDNo88ypBxxz45UDuZHz9r3tNz7N/VInSVoVdtXEI4A=="],
 
     "@preact/signals": ["@preact/signals@1.1.3", "", { "dependencies": { "@preact/signals-core": "^1.2.3" }, "peerDependencies": { "preact": "10.x" } }, "sha512-N09DuAVvc90bBZVRwD+aFhtGyHAmJLhS3IFoawO/bYJRcil4k83nBOchpCEoS0s5+BXBpahgp0Mjf+IOqP57Og=="],
 
@@ -62,21 +62,5 @@
     "webextension-polyfill": ["webextension-polyfill@0.10.0", "", {}, "sha512-c5s35LgVa5tFaHhrZDnr3FpQpjj1BB+RXhLTYUxGqBVN460HkbM8TBtEqdXWbpTKfzwCcjAZVF7zXCYSKtcp9g=="],
 
     "ws": ["ws@8.18.3", "", { "peerDependencies": { "bufferutil": "^4.0.1", "utf-8-validate": ">=5.0.2" }, "optionalPeers": ["bufferutil", "utf-8-validate"] }, "sha512-PEIGCY5tSlUt50cqyMXfCzX+oOPqN0vuGqWzbcJ2xvnkzkq46oOpz7dQaTDBdfICb4N14+GARUDw2XV2N4tvzg=="],
-
-    "@noble/curves/@noble/hashes": ["@noble/hashes@1.2.0", "", {}, "sha512-FZfhjEDbT5GRswV3C6uvLPHMiVD6lQBmpoX5+eSiPaMTXte/IKqI5dykDxzZB/WBeK/CDuQRBWarPdi3FNY2zQ=="],
-
-    "@scure/bip32/@noble/curves": ["@noble/curves@1.9.1", "", { "dependencies": { "@noble/hashes": "1.8.0" } }, "sha512-k11yZxZg+t+gWvBbIswW0yoJlu8cHOC7dhunwOzoWH/mXGBiYyR4YY6hAEK/3EUs4UpB8la1RfdRpeGsFHkWsA=="],
-
-    "@scure/bip32/@noble/hashes": ["@noble/hashes@1.8.0", "", {}, "sha512-jCs9ldd7NwzpgXDIf6P3+NrHh9/sD6CQdxHyjQI+h/6rDNo88ypBxxz45UDuZHz9r3tNz7N/VInSVoVdtXEI4A=="],
-
-    "@scure/bip39/@noble/hashes": ["@noble/hashes@1.8.0", "", {}, "sha512-jCs9ldd7NwzpgXDIf6P3+NrHh9/sD6CQdxHyjQI+h/6rDNo88ypBxxz45UDuZHz9r3tNz7N/VInSVoVdtXEI4A=="],
-
-    "ox/@noble/curves": ["@noble/curves@1.9.1", "", { "dependencies": { "@noble/hashes": "1.8.0" } }, "sha512-k11yZxZg+t+gWvBbIswW0yoJlu8cHOC7dhunwOzoWH/mXGBiYyR4YY6hAEK/3EUs4UpB8la1RfdRpeGsFHkWsA=="],
-
-    "ox/@noble/hashes": ["@noble/hashes@1.8.0", "", {}, "sha512-jCs9ldd7NwzpgXDIf6P3+NrHh9/sD6CQdxHyjQI+h/6rDNo88ypBxxz45UDuZHz9r3tNz7N/VInSVoVdtXEI4A=="],
-
-    "viem/@noble/curves": ["@noble/curves@1.9.1", "", { "dependencies": { "@noble/hashes": "1.8.0" } }, "sha512-k11yZxZg+t+gWvBbIswW0yoJlu8cHOC7dhunwOzoWH/mXGBiYyR4YY6hAEK/3EUs4UpB8la1RfdRpeGsFHkWsA=="],
-
-    "viem/@noble/hashes": ["@noble/hashes@1.8.0", "", {}, "sha512-jCs9ldd7NwzpgXDIf6P3+NrHh9/sD6CQdxHyjQI+h/6rDNo88ypBxxz45UDuZHz9r3tNz7N/VInSVoVdtXEI4A=="],
   }
 }

--- a/package.json
+++ b/package.json
@@ -35,8 +35,8 @@
 	},
 	"dependencies": {
 		"@darkflorist/address-metadata": "0.10.0",
-		"@noble/curves": "0.8.0",
-		"@noble/hashes": "1.4.0",
+		"@noble/curves": "1.9.1",
+		"@noble/hashes": "1.8.0",
 		"@preact/signals": "1.1.3",
 		"funtypes": "5.1.0",
 		"preact": "10.24.2",

--- a/test/tests/bundlerImportRewrite.test.ts
+++ b/test/tests/bundlerImportRewrite.test.ts
@@ -28,13 +28,13 @@ describe('bundler import rewriting', () => {
 		assert.equal(rewritten, 'import"../../vendor/webextension-polyfill/dist/browser-polyfill.js";')
 	})
 
-	test('rewrites nested vendored package imports using the vendored dependency tree', () => {
+	test('rewrites deduped vendored package imports through the root vendor tree', () => {
 		const filePath = path.join(repositoryRoot, 'app', 'vendor', 'ox', '_esm', 'core', 'Hash.js')
 		const source = 'import { keccak_256 as noble_keccak256 } from \'@noble/hashes/sha3\';'
 
 		const rewritten = replaceImport(filePath, source)
 
-		assert.equal(rewritten, 'import { keccak_256 as noble_keccak256 } from \'../../__dependencies__/@noble/hashes/esm/sha3.js\';')
+		assert.equal(rewritten, 'import { keccak_256 as noble_keccak256 } from \'../../../@noble/hashes/esm/sha3.js\';')
 	})
 
 	test('rewrites vendored relative node_modules imports away from node_modules paths', () => {
@@ -43,7 +43,7 @@ describe('bundler import rewriting', () => {
 
 		const rewritten = replaceImport(filePath, source)
 
-		assert.equal(rewritten, 'import { keccak_256 } from \'../../../__dependencies__/@noble/hashes/esm/sha3.js\';')
+		assert.equal(rewritten, 'import { keccak_256 } from \'../../../../@noble/hashes/esm/sha3.js\';')
 	})
 
 	test('does not rewrite comment examples that are not real imports', () => {


### PR DESCRIPTION
## Summary
- Align root `@noble/curves` and `@noble/hashes` with the versions required by `viem`/`ox`, which avoids `ox` declarations resolving against the older root Noble types on Windows.
- Keep the Chrome bundler working with Bun's deduped dependency layout by resolving legacy relative `node_modules` imports through normal package resolution when the nested path no longer exists.
- Update bundler import-rewrite tests for the deduped root vendor layout and relative `node_modules` fallback behavior.

## Testing
- `bun test`
- `bun run setup-chrome`
- `bun run typecheck`
- `bun run lint`
