### PR TITLE
Improve Interceptor error reporting and diagnostics

### DIFF
--- a/app/ts/background/accessManagement.ts
+++ b/app/ts/background/accessManagement.ts
@@ -17,7 +17,7 @@ import type { EthereumClientService } from '../simulation/services/EthereumClien
 import type { TokenPriceService } from '../simulation/services/priceEstimator.js'
 import type { ResetSimulationServices } from '../simulation/serviceLifecycle.js'
 import { mergeStoredWebsiteMetadata } from '../utils/websiteIcons.js'
-import { handleUnexpectedError } from '../utils/errors.js'
+import { reportUnexpectedError } from '../utils/errors.js'
 import { bumpPopupRefreshGeneration } from './popupRefreshGeneration.js'
 
 function getConnectionDetails(websiteTabConnections: WebsiteTabConnections, socket: WebsiteSocket) {
@@ -347,7 +347,7 @@ export async function updateWebsiteApprovalAccesses(
 	try {
 		await updateDeclarativeNetRequestBlocks(websiteTabConnections)
 	} catch (error) {
-		await handleUnexpectedError(error)
+		await reportUnexpectedError(error)
 	}
 	// update port connections and disconnect from ports that should not have access anymore
 	const updatePromises = [...websiteTabConnections.entries()].map(async ([_tab, tabConnection]) => {
@@ -362,7 +362,7 @@ export async function updateWebsiteApprovalAccesses(
 	try {
 		await Promise.all(updatePromises)
 	} catch (error) {
-		await handleUnexpectedError(error)
+		await reportUnexpectedError(error)
 	}
 	const iconRefreshPromises = [...iconRefreshTargets.values()].map(({ tabId, websiteOrigin }) =>
 		updateExtensionIcon(websiteTabConnections, tabId, websiteOrigin, popupRefreshGeneration)
@@ -370,7 +370,7 @@ export async function updateWebsiteApprovalAccesses(
 	try {
 		await Promise.all(iconRefreshPromises)
 	} catch (error) {
-		await handleUnexpectedError(error)
+		await reportUnexpectedError(error)
 	}
 	return popupRefreshGeneration
 }

--- a/app/ts/background/background-startup.ts
+++ b/app/ts/background/background-startup.ts
@@ -42,6 +42,7 @@ const catchAllErrorsAndCall = async (func: () => Promise<unknown>) => {
 		checkAndThrowRuntimeLastError()
 		return reply
 	} catch(error: unknown) {
+		if (isNewBlockAbort(error)) return
 		if (error instanceof Error) {
 			if (error.message.startsWith('No tab with id')) return
 			if (error.message.includes('the message channel is closed')) {
@@ -51,10 +52,9 @@ const catchAllErrorsAndCall = async (func: () => Promise<unknown>) => {
 			}
 			if (isIgnorablePortLifecycleError(error)) return
 			if (error.message.includes('Failed to fetch')) return
-			if (isNewBlockAbort(error)) return
 		}
 		console.error(error)
-		handleUnexpectedError(error)
+		await handleUnexpectedError(error)
 	}
 	return undefined
 }
@@ -175,7 +175,7 @@ async function newBlockAttemptCallback(blockheader: EthereumBlockHeader, ethereu
 		}
 		await sendPopupMessageToOpenWindows({ method: 'popup_new_block_arrived', data: { rpcConnectionStatus } })
 	} catch(error) {
-		if (error instanceof Error && isNewBlockAbort(error)) return
+		if (isNewBlockAbort(error)) return
 		await handleUnexpectedError(error)
 	}
 }

--- a/app/ts/background/background-startup.ts
+++ b/app/ts/background/background-startup.ts
@@ -11,7 +11,7 @@ import { sendSubscriptionMessagesForNewBlock } from '../simulation/services/Ethe
 import { Semaphore } from '../utils/semaphore.js'
 import { RawInterceptedRequest, checkAndThrowRuntimeLastError, getHostWithPort, silenceChromeUnCaughtPromise } from '../utils/requests.js'
 import { DEFAULT_TAB_CONNECTION, ICON_NOT_ACTIVE } from '../utils/constants.js'
-import { handleUnexpectedError, isNewBlockAbort, printError } from '../utils/errors.js'
+import { reportUnexpectedError, isExpectedInfrastructureError, printError } from '../utils/errors.js'
 import { updateContentScriptInjectionStrategyManifestV2 } from '../utils/contentScriptsUpdating.js'
 import { checkIfInterceptorShouldSleep } from './sleeping.js'
 import { onCloseWindowOrTab } from './windows/confirmTransaction.js'
@@ -42,7 +42,7 @@ const catchAllErrorsAndCall = async (func: () => Promise<unknown>) => {
 		checkAndThrowRuntimeLastError()
 		return reply
 	} catch(error: unknown) {
-		if (isNewBlockAbort(error)) return
+		if (isExpectedInfrastructureError(error)) return
 		if (error instanceof Error) {
 			if (error.message.startsWith('No tab with id')) return
 			if (error.message.includes('the message channel is closed')) {
@@ -51,10 +51,8 @@ const catchAllErrorsAndCall = async (func: () => Promise<unknown>) => {
 				return
 			}
 			if (isIgnorablePortLifecycleError(error)) return
-			if (error.message.includes('Failed to fetch')) return
 		}
-		console.error(error)
-		await handleUnexpectedError(error)
+		await reportUnexpectedError(error)
 	}
 	return undefined
 }
@@ -142,9 +140,8 @@ async function onContentScriptConnected(waitForStartup: () => Promise<{ resetAct
 		await updateTabState(socket.tabId, (previousState: TabState) => modifyObject(previousState, { website }))
 		checkAndThrowRuntimeLastError()
 	} catch(error: unknown) {
-		console.error(error)
 		if (error instanceof Error && error.message.startsWith('No tab with id')) return
-		await handleUnexpectedError(error)
+		await reportUnexpectedError(error)
 	}
 }
 
@@ -175,8 +172,8 @@ async function newBlockAttemptCallback(blockheader: EthereumBlockHeader, ethereu
 		}
 		await sendPopupMessageToOpenWindows({ method: 'popup_new_block_arrived', data: { rpcConnectionStatus } })
 	} catch(error) {
-		if (isNewBlockAbort(error)) return
-		await handleUnexpectedError(error)
+		if (isExpectedInfrastructureError(error)) return
+		await reportUnexpectedError(error)
 	}
 }
 
@@ -194,7 +191,7 @@ async function onErrorBlockCallback(ethereumClientService: EthereumClientService
 		await updateExtensionBadge()
 		await sendPopupMessageToOpenWindows({ method: 'popup_failed_to_get_block', data: { rpcConnectionStatus } })
 	} catch(error) {
-		await handleUnexpectedError(error)
+		await reportUnexpectedError(error)
 	}
 }
 

--- a/app/ts/background/background.ts
+++ b/app/ts/background/background.ts
@@ -3,7 +3,7 @@ import 'webextension-polyfill'
 import { getTabState, promoteRpcAsPrimary, setLatestUnexpectedError, updateInterceptorTransactionStack } from './storageVariables.js'
 import { changeSimulationMode, getFixedAddressRichList, getSettings, setFixedMakeMeRichList } from './settings.js'
 import { blockNumber, call, chainId, estimateGas, gasPrice, getAccounts, getBalance, getBlockByNumber, getCode, getLogs, getPermissions, getTransactionByHash, getTransactionCount, getTransactionReceipt, netVersion, personalSign, sendTransaction, subscribe, switchEthereumChain, unsubscribe, web3ClientVersion, getBlockByHash, feeHistory, installNewFilter, uninstallNewFilter, getFilterChanges, getFilterLogs, handleIterceptorError, requestInterceptorSimulatorStack } from './simulationModeHanders.js'
-import { changeActiveAddress, changePage, confirmDialog, removeTransactionOrSignedMessage, requestAccountsFromSigner, refreshPopupConfirmTransactionSimulation, confirmRequestAccess, changeInterceptorAccess, changeChainDialog, popupChangeActiveRpc, enableSimulationMode, addOrModifyAddressBookEntry, getAddressBookData, removeAddressBookEntry, refreshHomeData, interceptorAccessChangeAddressOrRefresh, refreshPopupConfirmTransactionMetadata, changeSettings, importSettings, exportSettings, setNewRpcList, simulateGovernanceContractExecutionOnPass, openNewTab, settingsOpened, changeAddOrModifyAddressWindowState, requestAbiAndNameFromBlockExplorer, openWebPage, disableInterceptor, requestNewHomeData, setEnsNameForHash, simulateGnosisSafeTransactionOnPass, retrieveWebsiteAccess, blockOrAllowExternalRequests, removeWebsiteAccess, allowOrPreventAddressAccessForWebsite, removeWebsiteAddressAccess, forceSetGasLimitForTransaction, changePreSimulationBlockTimeManipulation, setTransactionOrMessageBlockTimeManipulator, modifyMakeMeRich, requestMakeMeRichList, requestActiveAddresses, requestSimulationMode, requestLatestUnexpectedError, fetchSimulationStackRequestConfirmation, handleUnexpectedErrorInWindow, requestInterceptorSimulationInput, importSimulationStack, requestCompleteVisualizedSimulation, requestSimulationMetadata, requestIdentifyAddress, popupReadyAndListening } from './popupMessageHandlers.js'
+import { changeActiveAddress, changePage, confirmDialog, removeTransactionOrSignedMessage, requestAccountsFromSigner, refreshPopupConfirmTransactionSimulation, confirmRequestAccess, changeInterceptorAccess, changeChainDialog, popupChangeActiveRpc, enableSimulationMode, addOrModifyAddressBookEntry, getAddressBookData, removeAddressBookEntry, refreshHomeData, interceptorAccessChangeAddressOrRefresh, refreshPopupConfirmTransactionMetadata, changeSettings, importSettings, exportSettings, setNewRpcList, simulateGovernanceContractExecutionOnPass, openNewTab, settingsOpened, changeAddOrModifyAddressWindowState, requestAbiAndNameFromBlockExplorer, openWebPage, disableInterceptor, requestNewHomeData, setEnsNameForHash, simulateGnosisSafeTransactionOnPass, retrieveWebsiteAccess, blockOrAllowExternalRequests, removeWebsiteAccess, allowOrPreventAddressAccessForWebsite, removeWebsiteAddressAccess, forceSetGasLimitForTransaction, changePreSimulationBlockTimeManipulation, setTransactionOrMessageBlockTimeManipulator, modifyMakeMeRich, requestMakeMeRichList, requestActiveAddresses, requestSimulationMode, requestLatestUnexpectedError, fetchSimulationStackRequestConfirmation, reportUnexpectedErrorInWindow, requestInterceptorSimulationInput, importSimulationStack, requestCompleteVisualizedSimulation, requestSimulationMetadata, requestIdentifyAddress, popupReadyAndListening } from './popupMessageHandlers.js'
 import { PASSTHROUGH_STATE, type ResolvedExecutionSimulationState, type ResolvedSimulationInput, type ResolvedSimulationState, type WebsiteCreatedEthereumUnsignedTransactionOrFailed, toResolvedExecutionSimulationState, toResolvedSimulationInput, toResolvedSimulationState } from '../types/visualizer-types.js'
 import type { WebsiteTabConnections } from '../types/user-interface-types.js'
 import { askForSignerAccountsFromSignerIfNotAvailable, interceptorAccessMetadataRefresh, requestAccessFromUser } from './windows/interceptorAccess.js'
@@ -15,7 +15,7 @@ import { assertNever, assertUnreachable } from '../utils/typescript.js'
 import type { EthereumClientService } from '../simulation/services/EthereumClientService.js'
 import { appendTransactionsToInput, mockSignTransaction } from '../simulation/services/SimulationModeEthereumClientService.js'
 import { Semaphore } from '../utils/semaphore.js'
-import { JsonRpcResponseError, handleUnexpectedError, isExpectedInfrastructureError, isFailedToFetchError, isNewBlockAbort, printError } from '../utils/errors.js'
+import { JsonRpcResponseError, reportUnexpectedError, isExpectedInfrastructureError, isFailedToFetchError, isNewBlockAbort, reportNonFatalError } from '../utils/errors.js'
 import { InterceptedRequest, type UniqueRequestIdentifier, type WebsiteSocket } from '../utils/requests.js'
 import { replyToInterceptedRequest } from './messageSending.js'
 import { bumpPopupRefreshGeneration } from './popupRefreshGeneration.js'
@@ -52,7 +52,7 @@ export async function getUpdatedSimulationState(ethereum: EthereumClientService)
 		return toResolvedSimulationState(await createSimulationStateWithNonceAndBaseFeeFixing(await getCurrentSimulationInput(), ethereum))
 	} catch(error: unknown) {
 		if (isExpectedInfrastructureError(error)) return PASSTHROUGH_STATE
-		printError(error)
+		await reportNonFatalError(error, { code: 'simulation_state_refresh_failed' })
 	}
 	return PASSTHROUGH_STATE
 }
@@ -473,7 +473,7 @@ async function handleContentScriptMessage(ethereum: EthereumClientService, token
 		if (error instanceof JsonRpcResponseError) {
 			return replyToInterceptedRequest(websiteTabConnections, { type: 'result', ...getRequestWithDefinedParams(request), ...error.serialize() })
 		}
-		await handleUnexpectedError(error)
+		await reportUnexpectedError(error)
 		return replyToInterceptedRequest(websiteTabConnections, {
 			type: 'result',
 			...getRequestWithDefinedParams(request),
@@ -588,7 +588,7 @@ export async function popupMessageHandler(
 				case 'popup_requestLatestUnexpectedError': return await requestLatestUnexpectedError()
 				case 'popup_fetchSimulationStackRequestConfirmation': return await fetchSimulationStackRequestConfirmation(ethereum, websiteTabConnections, parsedRequest)
 				case 'popup_readyAndListening': return await popupReadyAndListening(ethereum, parsedRequest.data.page)
-				case 'popup_UnexpectedErrorOccured': return await handleUnexpectedErrorInWindow(parsedRequest)
+				case 'popup_UnexpectedErrorOccured': return await reportUnexpectedErrorInWindow(parsedRequest)
 				case 'popup_requestInterceptorSimulationInput': return await requestInterceptorSimulationInput(ethereum)
 				case 'popup_importSimulationStack': return await importSimulationStack(ethereum, tokenPriceService, parsedRequest)
 				case 'popup_requestCompleteVisualizedSimulation': return await requestCompleteVisualizedSimulation(ethereum, tokenPriceService)

--- a/app/ts/background/background.ts
+++ b/app/ts/background/background.ts
@@ -15,7 +15,7 @@ import { assertNever, assertUnreachable } from '../utils/typescript.js'
 import type { EthereumClientService } from '../simulation/services/EthereumClientService.js'
 import { appendTransactionsToInput, mockSignTransaction } from '../simulation/services/SimulationModeEthereumClientService.js'
 import { Semaphore } from '../utils/semaphore.js'
-import { JsonRpcResponseError, handleUnexpectedError, isFailedToFetchError, isNewBlockAbort, printError } from '../utils/errors.js'
+import { JsonRpcResponseError, handleUnexpectedError, isExpectedInfrastructureError, isFailedToFetchError, isNewBlockAbort, printError } from '../utils/errors.js'
 import { InterceptedRequest, type UniqueRequestIdentifier, type WebsiteSocket } from '../utils/requests.js'
 import { replyToInterceptedRequest } from './messageSending.js'
 import { bumpPopupRefreshGeneration } from './popupRefreshGeneration.js'
@@ -51,7 +51,7 @@ export async function getUpdatedSimulationState(ethereum: EthereumClientService)
 	try {
 		return toResolvedSimulationState(await createSimulationStateWithNonceAndBaseFeeFixing(await getCurrentSimulationInput(), ethereum))
 	} catch(error: unknown) {
-		if (error instanceof Error && (isNewBlockAbort(error) || isFailedToFetchError(error))) return PASSTHROUGH_STATE
+		if (isExpectedInfrastructureError(error)) return PASSTHROUGH_STATE
 		printError(error)
 	}
 	return PASSTHROUGH_STATE
@@ -130,8 +130,8 @@ export async function refreshConfirmTransactionSimulation(
 			}
 		}
 	} catch (error) {
-		if (error instanceof Error && isNewBlockAbort(error)) return undefined
-		if (error instanceof Error && isFailedToFetchError(error)) return undefined
+		if (isNewBlockAbort(error)) return undefined
+		if (isFailedToFetchError(error)) return undefined
 		if (!(error instanceof JsonRpcResponseError)) throw error
 
 		const extractToAbi = async () => {
@@ -467,13 +467,13 @@ async function handleContentScriptMessage(ethereum: EthereumClientService, token
 		const resolved = await handleRPCRequest(ethereum, tokenPriceService, resetSimulationServices, getSimulationInput, getExecutionSimulationState, getSimulationState, websiteTabConnections, request.uniqueRequestIdentifier.requestSocket, website, request, settings, activeAddress)
 		return replyToInterceptedRequest(websiteTabConnections, { ...requestWithDefinedParams, ...resolved })
 	} catch (error: unknown) {
-		if ((error instanceof Error && isFailedToFetchError(error))) {
+		if (isFailedToFetchError(error)) {
 			return replyToInterceptedRequest(websiteTabConnections, { type: 'result', ...getRequestWithDefinedParams(request), ...METAMASK_ERROR_NOT_CONNECTED_TO_CHAIN })
 		}
 		if (error instanceof JsonRpcResponseError) {
 			return replyToInterceptedRequest(websiteTabConnections, { type: 'result', ...getRequestWithDefinedParams(request), ...error.serialize() })
 		}
-		handleUnexpectedError(error)
+		await handleUnexpectedError(error)
 		return replyToInterceptedRequest(websiteTabConnections, {
 			type: 'result',
 			...getRequestWithDefinedParams(request),
@@ -602,7 +602,7 @@ export async function popupMessageHandler(
 		if (requestReply === undefined) return undefined
 		return PopupReplyOption.serialize(requestReply)
 	} catch(error: unknown) {
-		if (error instanceof Error && (isNewBlockAbort(error) || isFailedToFetchError(error))) return
+		if (isExpectedInfrastructureError(error)) return
 		throw error
 	}
 }

--- a/app/ts/background/background.ts
+++ b/app/ts/background/background.ts
@@ -15,7 +15,7 @@ import { assertNever, assertUnreachable } from '../utils/typescript.js'
 import type { EthereumClientService } from '../simulation/services/EthereumClientService.js'
 import { appendTransactionsToInput, mockSignTransaction } from '../simulation/services/SimulationModeEthereumClientService.js'
 import { Semaphore } from '../utils/semaphore.js'
-import { JsonRpcResponseError, reportUnexpectedError, isExpectedInfrastructureError, isFailedToFetchError, isNewBlockAbort, reportNonFatalError } from '../utils/errors.js'
+import { JsonRpcResponseError, reportUnexpectedError, isExpectedInfrastructureError, isFailedToFetchError, isNewBlockAbort } from '../utils/errors.js'
 import { InterceptedRequest, type UniqueRequestIdentifier, type WebsiteSocket } from '../utils/requests.js'
 import { replyToInterceptedRequest } from './messageSending.js'
 import { bumpPopupRefreshGeneration } from './popupRefreshGeneration.js'
@@ -52,7 +52,7 @@ export async function getUpdatedSimulationState(ethereum: EthereumClientService)
 		return toResolvedSimulationState(await createSimulationStateWithNonceAndBaseFeeFixing(await getCurrentSimulationInput(), ethereum))
 	} catch(error: unknown) {
 		if (isExpectedInfrastructureError(error)) return PASSTHROUGH_STATE
-		await reportNonFatalError(error, { code: 'simulation_state_refresh_failed' })
+		await reportUnexpectedError(error, { code: 'simulation_state_refresh_failed' })
 	}
 	return PASSTHROUGH_STATE
 }

--- a/app/ts/background/backgroundUtils.ts
+++ b/app/ts/background/backgroundUtils.ts
@@ -31,7 +31,7 @@ export async function getActiveAddressesForAllTabs(settings: Settings) {
 	return Promise.all(tabStates.map(async (state) => ({ tabId: state.tabId, activeAddress: state.activeSigningAddress === undefined ? undefined : await getActiveAddressEntry(state.activeSigningAddress) })))
 }
 
-export async function sendPopupMessageToOpenWindows(message: MessageToPopupPayload, role: MessageToPopup['role'] = 'all') {
+export async function sendPopupMessageToOpenWindowsWithoutUnexpectedErrorReport(message: MessageToPopupPayload, role: MessageToPopup['role'] = 'all') {
 	try {
 		await browser.runtime.sendMessage(serialize(MessageToPopup, { role, ...message }))
 		checkAndThrowRuntimeLastError()
@@ -44,6 +44,14 @@ export async function sendPopupMessageToOpenWindows(message: MessageToPopupPaylo
 			}
 			if (isIgnorableExtensionMessagingError(error)) return
 		}
+		throw error
+	}
+}
+
+export async function sendPopupMessageToOpenWindows(message: MessageToPopupPayload, role: MessageToPopup['role'] = 'all') {
+	try {
+		await sendPopupMessageToOpenWindowsWithoutUnexpectedErrorReport(message, role)
+	} catch (error) {
 		await handleUnexpectedError(error)
 	}
 }

--- a/app/ts/background/backgroundUtils.ts
+++ b/app/ts/background/backgroundUtils.ts
@@ -4,7 +4,7 @@ import { EthereumQuantity, serialize } from '../types/wire-types.js'
 import type { PopupOrTabId } from '../types/websiteAccessTypes.js'
 import { getAllTabStates, getTabState } from './storageVariables.js'
 import { getActiveAddressEntry } from './metadataUtils.js'
-import { handleUnexpectedError } from '../utils/errors.js'
+import { reportUnexpectedError } from '../utils/errors.js'
 import { PopupMessageReplyRequests, type PopupRequests, PopupRequestsReplies, type PopupRequestsReplyReturn } from '../types/interceptor-reply-messages.js'
 import { isIgnorablePortLifecycleError } from './contentScriptPortLifecycle.js'
 
@@ -52,7 +52,7 @@ export async function sendPopupMessageToOpenWindows(message: MessageToPopupPaylo
 	try {
 		await sendPopupMessageToOpenWindowsWithoutUnexpectedErrorReport(message, role)
 	} catch (error) {
-		await handleUnexpectedError(error)
+		await reportUnexpectedError(error)
 	}
 }
 
@@ -64,7 +64,7 @@ export async function sendPopupMessageToBackgroundPage(message: PopupMessage) {
 		if (error instanceof Error) {
 			if (isIgnorableExtensionMessagingError(error)) return
 		}
-		await handleUnexpectedError(error)
+		await reportUnexpectedError(error)
 	}
 }
 
@@ -90,7 +90,7 @@ export async function sendPopupMessageWithReply<Request extends PopupRequests>(m
 			if (isIgnorableExtensionMessagingError(error)) return undefined
 			if (error.message?.includes('Could not establish connection.')) return undefined
 		}
-		await handleUnexpectedError(error)
+		await reportUnexpectedError(error)
 		return undefined
 	}
 }

--- a/app/ts/background/popupMessageHandlers.ts
+++ b/app/ts/background/popupMessageHandlers.ts
@@ -31,7 +31,7 @@ import type { VisualizedPersonalSignRequestSafeTx } from '../types/personal-mess
 import type { TokenPriceService } from '../simulation/services/priceEstimator.js'
 import { searchWebsiteAccess } from './websiteAccessSearch.js'
 import { getCurrentSimulationInput, getMetadataForSimulation, simulateGnosisSafeMetaTransaction, simulateGovernanceContractExecution, updateSimulationMetadata, visualizeSimulatorState } from './simulationUpdating.js'
-import { handleUnexpectedError, isFailedToFetchError, isNewBlockAbort } from '../utils/errors.js'
+import { getErrorMessage, handleUnexpectedError, isExpectedInfrastructureError, isNewBlockAbort } from '../utils/errors.js'
 import type { ImportSimulationStackReply, RequestAbiAndNameFromBlockExplorer, RequestIdentifyAddress, UnexpectedErrorOccured } from '../types/interceptor-reply-messages.js'
 import { getWebsiteCreatedEthereumUnsignedTransactions } from '../simulation/services/SimulationModeEthereumClientService.js'
 import { updatePopupVisualisationIfNeeded, updatePopupVisualisationState } from './popupVisualisationUpdater.js'
@@ -54,7 +54,7 @@ type TimestampedPopupVisualisation = {
 
 const getSimulationConductedTimestamp = (popupVisualisation: TimestampedPopupVisualisation) => popupVisualisation.data.simulationState.simulationConductedTimestamp
 
-const getErrorMessage = (error: unknown) => error instanceof Error ? error.message : 'Unknown error'
+const formatCaughtErrorMessage = (error: unknown) => getErrorMessage(error) ?? 'Unknown error'
 
 const importSimulationStackSuccess = (): ImportSimulationStackReply => ({ type: 'ImportSimulationStackReply', ok: true })
 const importSimulationStackFailure = (message: string): ImportSimulationStackReply => ({ type: 'ImportSimulationStackReply', ok: false, message })
@@ -384,8 +384,7 @@ export async function refreshPopupConfirmTransactionMetadata(ethereum: EthereumC
 				])
 				return
 			} catch(error: unknown) {
-				if (error instanceof Error && isNewBlockAbort(error)) return
-				if (error instanceof Error && isFailedToFetchError(error)) return
+				if (isExpectedInfrastructureError(error)) return
 				throw error
 			}
 		}
@@ -862,8 +861,9 @@ export async function requestMakeMeRichList(ethereumClientService: EthereumClien
 		try {
 			return { ...element, addressBookEntry: await identifyAddress(ethereumClientService, requestAbortController, element.address) }
 		} catch (error) {
+			if (isNewBlockAbort(error)) throw error
 			const address = checksummedAddress(element.address)
-			const errorMessage = error instanceof Error ? error.message : 'Unknown error'
+			const errorMessage = formatCaughtErrorMessage(error)
 			await handleUnexpectedError(new Error(`Failed to identify rich list address ${ address }: ${ errorMessage }`))
 			return {
 				...element,
@@ -970,6 +970,7 @@ export async function handleUnexpectedErrorInWindow(parsedRequest: UnexpectedErr
 	return handleUnexpectedError(new Error(parsedRequest.data.message), {
 		source: parsedRequest.data.source,
 		code: parsedRequest.data.code,
+		debugId: parsedRequest.data.debugId,
 	})
 }
 
@@ -1028,7 +1029,7 @@ export async function importSimulationStack(ethereum: EthereumClientService, tok
 			})) }
 		})
 	} catch (error) {
-		return importSimulationStackFailure(`Failed to store the imported simulation stack (${ formatEstimatedBytes(importedStackBytes) }): ${ getErrorMessage(error) }`)
+		return importSimulationStackFailure(`Failed to store the imported simulation stack (${ formatEstimatedBytes(importedStackBytes) }): ${ formatCaughtErrorMessage(error) }`)
 	}
 
 	const updatedStackBytes = estimateSerializedStateBytes(InterceptorTransactionStack, updatedStack)
@@ -1040,7 +1041,7 @@ export async function importSimulationStack(ethereum: EthereumClientService, tok
 		const popupVisualisationBytes = estimateSerializedStateBytes(CompleteVisualizedSimulation, popupVisualisation)
 		console.info(`[simulation-stack import] persisted popup visualisation at ${ formatEstimatedBytes(popupVisualisationBytes) }.`)
 	} catch (error) {
-		return importSimulationStackFailure(`Imported stack was stored (${ formatEstimatedBytes(updatedStackBytes) }), but updating the visualized simulation failed: ${ getErrorMessage(error) }`)
+		return importSimulationStackFailure(`Imported stack was stored (${ formatEstimatedBytes(updatedStackBytes) }), but updating the visualized simulation failed: ${ formatCaughtErrorMessage(error) }`)
 	}
 
 	return importSimulationStackSuccess()

--- a/app/ts/background/popupMessageHandlers.ts
+++ b/app/ts/background/popupMessageHandlers.ts
@@ -865,7 +865,7 @@ export async function requestMakeMeRichList(ethereumClientService: EthereumClien
 			const address = checksummedAddress(element.address)
 			const errorMessage = formatCaughtErrorMessage(error)
 			await reportUnexpectedError(error, {
-				message: `Failed to identify rich list address ${ address }: ${ errorMessage }`,
+				displayMessage: `Failed to identify rich list address ${ address }: ${ errorMessage }`,
 				details: { address, richListEntry: element },
 				suppressExpectedInfrastructure: false,
 			})
@@ -972,7 +972,7 @@ export async function fetchSimulationStackRequestConfirmation(ethereumClientServ
 
 export async function reportUnexpectedErrorInWindow(parsedRequest: UnexpectedErrorOccured) {
 	return reportUnexpectedError(parsedRequest, {
-		message: parsedRequest.data.message,
+		displayMessage: parsedRequest.data.message,
 		source: parsedRequest.data.source,
 		code: parsedRequest.data.code,
 		debugId: parsedRequest.data.debugId,

--- a/app/ts/background/popupMessageHandlers.ts
+++ b/app/ts/background/popupMessageHandlers.ts
@@ -864,7 +864,11 @@ export async function requestMakeMeRichList(ethereumClientService: EthereumClien
 			if (isExpectedInfrastructureError(error)) throw error
 			const address = checksummedAddress(element.address)
 			const errorMessage = formatCaughtErrorMessage(error)
-			await reportUnexpectedError({ message: `Failed to identify rich list address ${ address }: ${ errorMessage }` }, { suppressExpectedInfrastructure: false })
+			await reportUnexpectedError(error, {
+				message: `Failed to identify rich list address ${ address }: ${ errorMessage }`,
+				details: { address, richListEntry: element },
+				suppressExpectedInfrastructure: false,
+			})
 			return {
 				...element,
 				addressBookEntry: {
@@ -967,10 +971,12 @@ export async function fetchSimulationStackRequestConfirmation(ethereumClientServ
 }
 
 export async function reportUnexpectedErrorInWindow(parsedRequest: UnexpectedErrorOccured) {
-	return reportUnexpectedError({ message: parsedRequest.data.message }, {
+	return reportUnexpectedError(parsedRequest, {
+		message: parsedRequest.data.message,
 		source: parsedRequest.data.source,
 		code: parsedRequest.data.code,
 		debugId: parsedRequest.data.debugId,
+		details: parsedRequest.data,
 		suppressExpectedInfrastructure: false,
 	})
 }

--- a/app/ts/background/popupMessageHandlers.ts
+++ b/app/ts/background/popupMessageHandlers.ts
@@ -31,7 +31,7 @@ import type { VisualizedPersonalSignRequestSafeTx } from '../types/personal-mess
 import type { TokenPriceService } from '../simulation/services/priceEstimator.js'
 import { searchWebsiteAccess } from './websiteAccessSearch.js'
 import { getCurrentSimulationInput, getMetadataForSimulation, simulateGnosisSafeMetaTransaction, simulateGovernanceContractExecution, updateSimulationMetadata, visualizeSimulatorState } from './simulationUpdating.js'
-import { getErrorMessage, handleUnexpectedError, isExpectedInfrastructureError, isNewBlockAbort } from '../utils/errors.js'
+import { getErrorMessage, reportUnexpectedError, isExpectedInfrastructureError } from '../utils/errors.js'
 import type { ImportSimulationStackReply, RequestAbiAndNameFromBlockExplorer, RequestIdentifyAddress, UnexpectedErrorOccured } from '../types/interceptor-reply-messages.js'
 import { getWebsiteCreatedEthereumUnsignedTransactions } from '../simulation/services/SimulationModeEthereumClientService.js'
 import { updatePopupVisualisationIfNeeded, updatePopupVisualisationState } from './popupVisualisationUpdater.js'
@@ -861,10 +861,10 @@ export async function requestMakeMeRichList(ethereumClientService: EthereumClien
 		try {
 			return { ...element, addressBookEntry: await identifyAddress(ethereumClientService, requestAbortController, element.address) }
 		} catch (error) {
-			if (isNewBlockAbort(error)) throw error
+			if (isExpectedInfrastructureError(error)) throw error
 			const address = checksummedAddress(element.address)
 			const errorMessage = formatCaughtErrorMessage(error)
-			await handleUnexpectedError(new Error(`Failed to identify rich list address ${ address }: ${ errorMessage }`))
+			await reportUnexpectedError({ message: `Failed to identify rich list address ${ address }: ${ errorMessage }` }, { suppressExpectedInfrastructure: false })
 			return {
 				...element,
 				addressBookEntry: {
@@ -966,11 +966,12 @@ export async function fetchSimulationStackRequestConfirmation(ethereumClientServ
 	await resolveFetchSimulationStackRequest(simulationState, websiteTabConnections, confirmation)
 }
 
-export async function handleUnexpectedErrorInWindow(parsedRequest: UnexpectedErrorOccured) {
-	return handleUnexpectedError(new Error(parsedRequest.data.message), {
+export async function reportUnexpectedErrorInWindow(parsedRequest: UnexpectedErrorOccured) {
+	return reportUnexpectedError({ message: parsedRequest.data.message }, {
 		source: parsedRequest.data.source,
 		code: parsedRequest.data.code,
 		debugId: parsedRequest.data.debugId,
+		suppressExpectedInfrastructure: false,
 	})
 }
 

--- a/app/ts/background/popupMessageHandlers.ts
+++ b/app/ts/background/popupMessageHandlers.ts
@@ -971,7 +971,7 @@ export async function fetchSimulationStackRequestConfirmation(ethereumClientServ
 }
 
 export async function reportUnexpectedErrorInWindow(parsedRequest: UnexpectedErrorOccured) {
-	return reportUnexpectedError(parsedRequest, {
+	return reportUnexpectedError(parsedRequest.data.message, {
 		displayMessage: parsedRequest.data.message,
 		source: parsedRequest.data.source,
 		code: parsedRequest.data.code,

--- a/app/ts/background/popupRefreshGeneration.ts
+++ b/app/ts/background/popupRefreshGeneration.ts
@@ -1,11 +1,15 @@
 import { getPopupRefreshGeneration as getPopupRefreshGenerationFromStorage, setPopupRefreshGeneration } from './storageVariables.js'
+import { reportLocalRecoveryAtAsyncBoundary } from '../utils/errors.js'
 
 let popupRefreshGeneration = 0
 
 const persistPopupRefreshGeneration = (value: number) => {
-	void setPopupRefreshGeneration(value).catch((error) => {
-		console.warn('Could not persist popup refresh generation:')
-		console.warn(error)
+	reportLocalRecoveryAtAsyncBoundary(async () => {
+		await setPopupRefreshGeneration(value)
+	}, {
+		code: 'popup_refresh_generation_persist_failed',
+		message: 'Continuing with the in-memory popup refresh generation.',
+		details: { popupRefreshGeneration: value },
 	})
 }
 

--- a/app/ts/background/popupVisualisationUpdater.ts
+++ b/app/ts/background/popupVisualisationUpdater.ts
@@ -4,7 +4,7 @@ import type { TokenPriceService } from '../simulation/services/priceEstimator.js
 import type { CompleteVisualizedSimulation, SimulationState } from '../types/visualizer-types.js'
 import { createPassthroughCompleteVisualizedSimulation, toResolvedSimulationState } from '../types/visualizer-types.js'
 import { NEW_BLOCK_ABORT, TIME_BETWEEN_BLOCKS } from '../utils/constants.js'
-import { handleUnexpectedError, isExpectedInfrastructureError, isFailedToFetchError, isNewBlockAbort } from '../utils/errors.js'
+import { reportUnexpectedError, isExpectedInfrastructureError, isFailedToFetchError, isNewBlockAbort } from '../utils/errors.js'
 import { silenceChromeUnCaughtPromise } from '../utils/requests.js'
 import { Semaphore } from '../utils/semaphore.js'
 import { modifyObject } from '../utils/typescript.js'
@@ -85,7 +85,7 @@ export const updatePopupVisualisationIfNeeded = async (ethereum: EthereumClientS
 		await updatePopupVisualisationState(ethereum, tokenPriceService, thisAbortController)
 	} catch(error: unknown) {
 		if (isExpectedInfrastructureError(error)) return await getPopupVisualisationState()
-		await handleUnexpectedError(error)
+		await reportUnexpectedError(error)
 	}
 	return await getPopupVisualisationState()
 }
@@ -137,13 +137,13 @@ export async function updatePopupVisualisationState(ethereum: EthereumClientServ
 				if (throwOnUnexpectedError) throw error
 				const state = await setPopupVisualisationState(modifyObject(popupVisualisation, { simulationId, simulationUpdatingState: 'failed' }))
 				await sendPopupMessageToOpenWindows({ method: 'popup_simulation_state_changed', data: { visualizedSimulatorState: state }  })
-				await handleUnexpectedError(error)
+				await reportUnexpectedError(error)
 			}
 		})
 	} catch (error) {
 		if (throwOnUnexpectedError) throw error
 		if (isExpectedInfrastructureError(error)) return
-		await handleUnexpectedError(error)
+		await reportUnexpectedError(error)
 	}
 }
 

--- a/app/ts/background/popupVisualisationUpdater.ts
+++ b/app/ts/background/popupVisualisationUpdater.ts
@@ -4,7 +4,7 @@ import type { TokenPriceService } from '../simulation/services/priceEstimator.js
 import type { CompleteVisualizedSimulation, SimulationState } from '../types/visualizer-types.js'
 import { createPassthroughCompleteVisualizedSimulation, toResolvedSimulationState } from '../types/visualizer-types.js'
 import { NEW_BLOCK_ABORT, TIME_BETWEEN_BLOCKS } from '../utils/constants.js'
-import { handleUnexpectedError, isFailedToFetchError, isNewBlockAbort } from '../utils/errors.js'
+import { handleUnexpectedError, isExpectedInfrastructureError, isFailedToFetchError, isNewBlockAbort } from '../utils/errors.js'
 import { silenceChromeUnCaughtPromise } from '../utils/requests.js'
 import { Semaphore } from '../utils/semaphore.js'
 import { modifyObject } from '../utils/typescript.js'
@@ -79,68 +79,72 @@ export const updatePopupVisualisationIfNeeded = async (ethereum: EthereumClientS
 		const thisAbortController = abortController
 		if (invalidateOldState) {
 			const simulationId = popupVisualisation.simulationId + 1
-				const visualizedSimulatorState = await setPopupVisualisationState(modifyObject(popupVisualisation, { simulationId, simulationResultState: 'invalid', simulationUpdatingState: 'updating' }))
-				await sendPopupMessageToOpenWindows({ method: 'popup_simulation_state_changed', data: { visualizedSimulatorState } })
-			}
-			await updatePopupVisualisationState(ethereum, tokenPriceService, thisAbortController)
-		} catch(error: unknown) {
-			if (error instanceof Error && (isNewBlockAbort(error) || isFailedToFetchError(error))) return await getPopupVisualisationState()
-			await handleUnexpectedError(error)
+			const visualizedSimulatorState = await setPopupVisualisationState(modifyObject(popupVisualisation, { simulationId, simulationResultState: 'invalid', simulationUpdatingState: 'updating' }))
+			await sendPopupMessageToOpenWindows({ method: 'popup_simulation_state_changed', data: { visualizedSimulatorState } })
+		}
+		await updatePopupVisualisationState(ethereum, tokenPriceService, thisAbortController)
+	} catch(error: unknown) {
+		if (isExpectedInfrastructureError(error)) return await getPopupVisualisationState()
+		await handleUnexpectedError(error)
 	}
 	return await getPopupVisualisationState()
 }
 
 const updateSimulationVisualisationSemaphore = new Semaphore(1)
 export async function updatePopupVisualisationState(ethereum: EthereumClientService, tokenPriceService: TokenPriceService, abortController: AbortController | undefined, throwOnUnexpectedError = false) {
-	return await updateSimulationVisualisationSemaphore.execute(async () => {
-		if (abortController?.signal.aborted) return
-		const popupVisualisation = await getPopupVisualisationState()
-		const simulationId = popupVisualisation.simulationId + 1
-		const simulationState = await getUpdatedSimulationState(ethereum)
-		const doneState = { simulationUpdatingState: 'done' as const, simulationResultState: 'done' as const, simulationId }
-		const numberOfAddressesMadeRich = (await getAddressesbeingMadeRich()).length
-		if (simulationState.kind === 'passthrough') {
-			const newState = buildPassthroughVisualizedState(simulationId, numberOfAddressesMadeRich)
-			await setPopupVisualisationState(newState)
-			await sendPopupMessageToOpenWindows({ method: 'popup_simulation_state_changed', data: { visualizedSimulatorState: newState } })
-			return
-		}
-		if (!hasSimulationInputOperations(simulationState.value)) {
-			const newState = simulationState.value.success
-				? buildDefinedEmptyVisualizedState(simulationState.value, simulationId, numberOfAddressesMadeRich)
-				: buildPassthroughVisualizedState(simulationId, numberOfAddressesMadeRich)
-			await setPopupVisualisationState(newState)
-			await sendPopupMessageToOpenWindows({ method: 'popup_simulation_state_changed', data: { visualizedSimulatorState: newState } })
-			return
-		}
-		const visualizedSimulatorState = await setPopupVisualisationState(modifyObject(popupVisualisation, { simulationId, simulationUpdatingState: 'updating' }))
-		const changedMessagePromise = silenceChromeUnCaughtPromise(sendPopupMessageToOpenWindows({ method: 'popup_simulation_state_changed', data: { visualizedSimulatorState } }))
-		try {
-			const getUpdatedState = async () => {
-				if (ethereum.getChainId() === simulationState.value.rpcNetwork.chainId) {
-					const refreshed = await visualizeSimulatorState(simulationState.value, ethereum, tokenPriceService, abortController)
-					return await setPopupVisualisationState({ ...refreshed, ...doneState, simulationState: toResolvedSimulationState(refreshed.simulationState), numberOfAddressesMadeRich })
-				}
-				return await setPopupVisualisationState(buildPassthroughVisualizedState(simulationId, numberOfAddressesMadeRich, 'corrupted'))
-			}
-			const newVisualizedState = await getUpdatedState()
-			await changedMessagePromise
-			await sendPopupMessageToOpenWindows({ method: 'popup_simulation_state_changed', data: { visualizedSimulatorState: newVisualizedState } })
-		} catch (error) {
-			if (error instanceof Error && isNewBlockAbort(error)) return
-			if (error instanceof Error && isFailedToFetchError(error)) {
-				const state = await setPopupVisualisationState(modifyObject(popupVisualisation, { simulationId, simulationUpdatingState: 'updating' }))
-				await sendPopupMessageToOpenWindows({ method: 'popup_simulation_state_changed', data: { visualizedSimulatorState: state }  })
+	try {
+		return await updateSimulationVisualisationSemaphore.execute(async () => {
+			if (abortController?.signal.aborted) return
+			const popupVisualisation = await getPopupVisualisationState()
+			const simulationId = popupVisualisation.simulationId + 1
+			const simulationState = await getUpdatedSimulationState(ethereum)
+			const doneState = { simulationUpdatingState: 'done' as const, simulationResultState: 'done' as const, simulationId }
+			const numberOfAddressesMadeRich = (await getAddressesbeingMadeRich()).length
+			if (simulationState.kind === 'passthrough') {
+				const newState = buildPassthroughVisualizedState(simulationId, numberOfAddressesMadeRich)
+				await setPopupVisualisationState(newState)
+				await sendPopupMessageToOpenWindows({ method: 'popup_simulation_state_changed', data: { visualizedSimulatorState: newState } })
 				return
 			}
-			if (throwOnUnexpectedError) throw error
-			const state = await setPopupVisualisationState(modifyObject(popupVisualisation, { simulationId, simulationUpdatingState: 'failed' }))
-			await sendPopupMessageToOpenWindows({ method: 'popup_simulation_state_changed', data: { visualizedSimulatorState: state }  })
-			handleUnexpectedError(error)
-		}
-	}).catch((error) => {
+			if (!hasSimulationInputOperations(simulationState.value)) {
+				const newState = simulationState.value.success
+					? buildDefinedEmptyVisualizedState(simulationState.value, simulationId, numberOfAddressesMadeRich)
+					: buildPassthroughVisualizedState(simulationId, numberOfAddressesMadeRich)
+				await setPopupVisualisationState(newState)
+				await sendPopupMessageToOpenWindows({ method: 'popup_simulation_state_changed', data: { visualizedSimulatorState: newState } })
+				return
+			}
+			const visualizedSimulatorState = await setPopupVisualisationState(modifyObject(popupVisualisation, { simulationId, simulationUpdatingState: 'updating' }))
+			const changedMessagePromise = silenceChromeUnCaughtPromise(sendPopupMessageToOpenWindows({ method: 'popup_simulation_state_changed', data: { visualizedSimulatorState } }))
+			try {
+				const getUpdatedState = async () => {
+					if (ethereum.getChainId() === simulationState.value.rpcNetwork.chainId) {
+						const refreshed = await visualizeSimulatorState(simulationState.value, ethereum, tokenPriceService, abortController)
+						return await setPopupVisualisationState({ ...refreshed, ...doneState, simulationState: toResolvedSimulationState(refreshed.simulationState), numberOfAddressesMadeRich })
+					}
+					return await setPopupVisualisationState(buildPassthroughVisualizedState(simulationId, numberOfAddressesMadeRich, 'corrupted'))
+				}
+				const newVisualizedState = await getUpdatedState()
+				await changedMessagePromise
+				await sendPopupMessageToOpenWindows({ method: 'popup_simulation_state_changed', data: { visualizedSimulatorState: newVisualizedState } })
+			} catch (error) {
+				if (isNewBlockAbort(error)) return
+				if (isFailedToFetchError(error)) {
+					const state = await setPopupVisualisationState(modifyObject(popupVisualisation, { simulationId, simulationUpdatingState: 'updating' }))
+					await sendPopupMessageToOpenWindows({ method: 'popup_simulation_state_changed', data: { visualizedSimulatorState: state }  })
+					return
+				}
+				if (throwOnUnexpectedError) throw error
+				const state = await setPopupVisualisationState(modifyObject(popupVisualisation, { simulationId, simulationUpdatingState: 'failed' }))
+				await sendPopupMessageToOpenWindows({ method: 'popup_simulation_state_changed', data: { visualizedSimulatorState: state }  })
+				await handleUnexpectedError(error)
+			}
+		})
+	} catch (error) {
 		if (throwOnUnexpectedError) throw error
-	})
+		if (isExpectedInfrastructureError(error)) return
+		await handleUnexpectedError(error)
+	}
 }
 
 async function getCurrentSimulationStateInput(ethereum: EthereumClientService) {

--- a/app/ts/background/providerMessageHandlers.ts
+++ b/app/ts/background/providerMessageHandlers.ts
@@ -9,7 +9,7 @@ import { resolveSignerChainChange } from './windows/changeChain.js'
 import type { ApprovalState } from './accessManagement.js'
 import type { ProviderMessage } from '../utils/requests.js'
 import { METAMASK_ERROR_USER_REJECTED_REQUEST } from '../utils/constants.js'
-import { handleUnexpectedError } from '../utils/errors.js'
+import { reportUnexpectedError } from '../utils/errors.js'
 import { resolvePendingTransactionOrMessage, updateConfirmTransactionView } from './windows/confirmTransaction.js'
 import { addressString } from '../utils/bigint.js'
 import { modifyObject } from '../utils/typescript.js'
@@ -136,7 +136,7 @@ export async function signerReply(ethereum: EthereumClientService, tokenPriceSer
 						}
 					})
 				} catch(e) {
-					await handleUnexpectedError(e)
+					await reportUnexpectedError(e)
 				}
 				return doNotReply
 				}

--- a/app/ts/background/simulationUpdating.ts
+++ b/app/ts/background/simulationUpdating.ts
@@ -156,6 +156,7 @@ async function getDelegationAddressesForSimulation(
 				delegationEntry: await identifyAddress(ethereum, requestAbortController, delegationAddress),
 			}
 		} catch(error: unknown) {
+			if (error instanceof Error && isNewBlockAbort(error)) throw error
 			const errorMessage = error instanceof Error ? error.message : 'Unknown error'
 			await handleUnexpectedError(new Error(`Failed to retrieve EIP-7702 delegation for ${ addressString(senderAddress) }: ${ errorMessage }`), {
 				code: 'delegation_lookup_failed',

--- a/app/ts/background/simulationUpdating.ts
+++ b/app/ts/background/simulationUpdating.ts
@@ -19,7 +19,7 @@ import { CompoundGovernanceAbi } from '../utils/abi.js'
 import type { VisualizedPersonalSignRequestSafeTx } from '../types/personal-message-definitions.js'
 import { getGnosisSafeProxyProxy } from '../utils/ethereumByteCodes.js'
 import { getInterceptorTransactionStack, updatePopupVisualisationWithCallBack } from './storageVariables.js'
-import { JsonRpcResponseError, handleUnexpectedError, isExpectedInfrastructureError, isNewBlockAbort } from '../utils/errors.js'
+import { JsonRpcResponseError, reportUnexpectedError, isExpectedInfrastructureError } from '../utils/errors.js'
 import { craftPersonalSignPopupMessage } from './windows/personalSign.js'
 import { formSimulatedAndVisualizedTransactions, getFromAndToMetadata } from '../components/formVisualizerResults.js'
 import { promiseAllMapAbortSafe, silenceChromeUnCaughtPromise } from '../utils/requests.js'
@@ -156,10 +156,11 @@ async function getDelegationAddressesForSimulation(
 				delegationEntry: await identifyAddress(ethereum, requestAbortController, delegationAddress),
 			}
 		} catch(error: unknown) {
-			if (isNewBlockAbort(error)) throw error
+			if (isExpectedInfrastructureError(error)) throw error
 			const errorMessage = error instanceof Error ? error.message : 'Unknown error'
-			await handleUnexpectedError(new Error(`Failed to retrieve EIP-7702 delegation for ${ addressString(senderAddress) }: ${ errorMessage }`), {
+			await reportUnexpectedError({ message: `Failed to retrieve EIP-7702 delegation for ${ addressString(senderAddress) }: ${ errorMessage }` }, {
 				code: 'delegation_lookup_failed',
+				suppressExpectedInfrastructure: false,
 			})
 			return undefined
 		}
@@ -390,7 +391,7 @@ export const updateSimulationMetadata = async (ethereum: EthereumClientService, 
 			return { ...prevState, ...metadata }
 		} catch (error) {
 			if (isExpectedInfrastructureError(error)) return prevState
-			await handleUnexpectedError(error)
+			await reportUnexpectedError(error)
 			return prevState
 		}
 	})

--- a/app/ts/background/simulationUpdating.ts
+++ b/app/ts/background/simulationUpdating.ts
@@ -19,7 +19,7 @@ import { CompoundGovernanceAbi } from '../utils/abi.js'
 import type { VisualizedPersonalSignRequestSafeTx } from '../types/personal-message-definitions.js'
 import { getGnosisSafeProxyProxy } from '../utils/ethereumByteCodes.js'
 import { getInterceptorTransactionStack, updatePopupVisualisationWithCallBack } from './storageVariables.js'
-import { JsonRpcResponseError, handleUnexpectedError, isFailedToFetchError, isNewBlockAbort } from '../utils/errors.js'
+import { JsonRpcResponseError, handleUnexpectedError, isExpectedInfrastructureError, isNewBlockAbort } from '../utils/errors.js'
 import { craftPersonalSignPopupMessage } from './windows/personalSign.js'
 import { formSimulatedAndVisualizedTransactions, getFromAndToMetadata } from '../components/formVisualizerResults.js'
 import { promiseAllMapAbortSafe, silenceChromeUnCaughtPromise } from '../utils/requests.js'
@@ -156,7 +156,7 @@ async function getDelegationAddressesForSimulation(
 				delegationEntry: await identifyAddress(ethereum, requestAbortController, delegationAddress),
 			}
 		} catch(error: unknown) {
-			if (error instanceof Error && isNewBlockAbort(error)) throw error
+			if (isNewBlockAbort(error)) throw error
 			const errorMessage = error instanceof Error ? error.message : 'Unknown error'
 			await handleUnexpectedError(new Error(`Failed to retrieve EIP-7702 delegation for ${ addressString(senderAddress) }: ${ errorMessage }`), {
 				code: 'delegation_lookup_failed',
@@ -389,9 +389,8 @@ export const updateSimulationMetadata = async (ethereum: EthereumClientService, 
 			const metadata = await getMetadataForSimulation(prevState.simulationState.value, ethereum, requestAbortController, events, inputData)
 			return { ...prevState, ...metadata }
 		} catch (error) {
-			if (error instanceof Error && isNewBlockAbort(error)) return prevState
-			if (error instanceof Error && isFailedToFetchError(error)) return prevState
-			handleUnexpectedError(error)
+			if (isExpectedInfrastructureError(error)) return prevState
+			await handleUnexpectedError(error)
 			return prevState
 		}
 	})

--- a/app/ts/background/simulationUpdating.ts
+++ b/app/ts/background/simulationUpdating.ts
@@ -19,7 +19,7 @@ import { CompoundGovernanceAbi } from '../utils/abi.js'
 import type { VisualizedPersonalSignRequestSafeTx } from '../types/personal-message-definitions.js'
 import { getGnosisSafeProxyProxy } from '../utils/ethereumByteCodes.js'
 import { getInterceptorTransactionStack, updatePopupVisualisationWithCallBack } from './storageVariables.js'
-import { JsonRpcResponseError, reportUnexpectedError, isExpectedInfrastructureError } from '../utils/errors.js'
+import { JsonRpcResponseError, reportUnexpectedError, isExpectedInfrastructureError, getErrorMessage } from '../utils/errors.js'
 import { craftPersonalSignPopupMessage } from './windows/personalSign.js'
 import { formSimulatedAndVisualizedTransactions, getFromAndToMetadata } from '../components/formVisualizerResults.js'
 import { promiseAllMapAbortSafe, silenceChromeUnCaughtPromise } from '../utils/requests.js'
@@ -157,9 +157,12 @@ async function getDelegationAddressesForSimulation(
 			}
 		} catch(error: unknown) {
 			if (isExpectedInfrastructureError(error)) throw error
-			const errorMessage = error instanceof Error ? error.message : 'Unknown error'
-			await reportUnexpectedError({ message: `Failed to retrieve EIP-7702 delegation for ${ addressString(senderAddress) }: ${ errorMessage }` }, {
+			const senderAddressString = addressString(senderAddress)
+			const errorMessage = getErrorMessage(error) ?? 'Unknown error'
+			await reportUnexpectedError(error, {
+				message: `Failed to retrieve EIP-7702 delegation for ${ senderAddressString }: ${ errorMessage }`,
 				code: 'delegation_lookup_failed',
+				details: { senderAddress: senderAddressString },
 				suppressExpectedInfrastructure: false,
 			})
 			return undefined

--- a/app/ts/background/simulationUpdating.ts
+++ b/app/ts/background/simulationUpdating.ts
@@ -160,7 +160,7 @@ async function getDelegationAddressesForSimulation(
 			const senderAddressString = addressString(senderAddress)
 			const errorMessage = getErrorMessage(error) ?? 'Unknown error'
 			await reportUnexpectedError(error, {
-				message: `Failed to retrieve EIP-7702 delegation for ${ senderAddressString }: ${ errorMessage }`,
+				displayMessage: `Failed to retrieve EIP-7702 delegation for ${ senderAddressString }: ${ errorMessage }`,
 				code: 'delegation_lookup_failed',
 				details: { senderAddress: senderAddressString },
 				suppressExpectedInfrastructure: false,

--- a/app/ts/background/storageVariables.ts
+++ b/app/ts/background/storageVariables.ts
@@ -16,6 +16,7 @@ import { isValidEnsName } from '../utils/ens.js'
 import { modifyObject } from '../utils/typescript.js'
 import type { UnexpectedErrorOccured } from '../types/interceptor-reply-messages.js'
 import { getLargeStateValue, setLargeStateValue } from '../utils/largeStateStore.js'
+import type { InterceptorErrorDiagnostic } from '../types/errorDiagnostics.js'
 
 export const getIdsOfOpenedTabs = async () => (await browserStorageLocalGet('idsOfOpenedTabs'))?.idsOfOpenedTabs ?? { settingsView: undefined, addressBook: undefined, websiteAccess: undefined }
 export const setIdsOfOpenedTabs = async (ids: PartialIdsOfOpenedTabs) => await browserStorageLocalSet({ idsOfOpenedTabs: { ...await getIdsOfOpenedTabs(), ...ids } })
@@ -294,6 +295,33 @@ export async function getLatestUnexpectedError(): Promise<UnexpectedErrorOccured
 	console.warn(rawError)
 	await browserStorageLocalRemove('latestUnexpectedError')
 	return undefined
+}
+
+const MAX_INTERCEPTOR_ERROR_DIAGNOSTICS = 50
+const interceptorErrorDiagnosticsSemaphore = new Semaphore(1)
+
+export async function getInterceptorErrorDiagnostics(): Promise<readonly InterceptorErrorDiagnostic[]> {
+	try {
+		return (await browserStorageLocalGet('interceptorErrorDiagnostics'))?.interceptorErrorDiagnostics ?? []
+	} catch (error) {
+		console.warn('interceptorErrorDiagnostics were corrupt:')
+		console.warn(error)
+		await browserStorageLocalRemove('interceptorErrorDiagnostics')
+		return []
+	}
+}
+
+export async function appendInterceptorErrorDiagnostic(diagnostic: InterceptorErrorDiagnostic) {
+	await interceptorErrorDiagnosticsSemaphore.execute(async () => {
+		const diagnostics = await getInterceptorErrorDiagnostics()
+		await browserStorageLocalSet({
+			interceptorErrorDiagnostics: [...diagnostics, diagnostic].slice(-MAX_INTERCEPTOR_ERROR_DIAGNOSTICS),
+		})
+	})
+}
+
+export async function clearInterceptorErrorDiagnostics() {
+	await browserStorageLocalRemove('interceptorErrorDiagnostics')
 }
 
 export const getEnsNodeHashes = async () => (await browserStorageLocalGet('ensNameHashes'))?.ensNameHashes ?? []

--- a/app/ts/background/windows/confirmTransaction.ts
+++ b/app/ts/background/windows/confirmTransaction.ts
@@ -21,7 +21,7 @@ import {
 import { dataStringWith0xStart, stringToUint8Array } from '../../utils/bigint.js'
 import { EthereumAddress, EthereumBytes32, EthereumQuantity, serialize } from '../../types/wire-types.js'
 import type { PopupOrTabId, Website } from '../../types/websiteAccessTypes.js'
-import { JsonRpcResponseError, handleUnexpectedError, isExpectedInfrastructureError, printError } from '../../utils/errors.js'
+import { JsonRpcResponseError, reportUnexpectedError, isExpectedInfrastructureError, reportLocalRecovery } from '../../utils/errors.js'
 import type { PendingTransactionOrSignableMessage, PopupPendingTransactionOrSignableMessage } from '../../types/accessRequest.js'
 import type { SignMessageParams } from '../../types/jsonRpc-signing-types.js'
 import { craftPersonalSignPopupMessage } from './personalSign.js'
@@ -126,7 +126,7 @@ export async function updateConfirmTransactionView(ethereum: EthereumClientServi
 		return true
 	} catch(error: unknown) {
 		if (isExpectedInfrastructureError(error)) return false
-		await handleUnexpectedError(error)
+		await reportUnexpectedError(error)
 	}
 	return false
 }
@@ -236,7 +236,7 @@ const resolveAllPendingTransactionsAndMessageAsNoResponse = async (transactions:
 		try {
 			await resolvePendingTransactionOrMessage(ethereum, tokenPriceService, websiteTabConnections, { method: 'popup_confirmDialog', data: { uniqueRequestIdentifier: transaction.uniqueRequestIdentifier, action: 'noResponse' } })
 		} catch(e) {
-			printError(e)
+			await reportLocalRecovery(e, { code: 'pending_request_no_response_resolution_failed', message: 'Failed to resolve a pending request as no-response after a popup closed.' })
 		}
 	}
 	await clearPendingTransactions()
@@ -364,7 +364,7 @@ export const formEthSendTransaction = async(ethereumClientService: EthereumClien
 			return { transaction: { ...transactionWithoutGas, ...await getFeePerGas(estimateGas.gas), gas: estimateGas.gas }, ...extraParams, success: true }
 		} catch(error: unknown) {
 			if (error instanceof JsonRpcResponseError) return { ...extraParams, error: { code: error.code, message: error.message, data: typeof error.data === 'string' ? error.data : '0x' }, success: false }
-			printError(error)
+			await reportLocalRecovery(error, { code: 'transaction_gas_estimation_failed', message: 'Returning a typed RPC error to the requesting page.' })
 			if (error instanceof Error) return { ...extraParams, error: { code: 123456, message: error.message, data: 'data' in error && typeof error.data === 'string' ? error.data : '0x' }, success: false }
 			return { ...extraParams, error: { code: 123456, message: 'Unknown Error', data: '0x' }, success: false }
 		}
@@ -446,7 +446,7 @@ export async function openConfirmTransactionDialogForMessage(
 			}
 		})
 	} catch(e) {
-		await handleUnexpectedError(e)
+		await reportUnexpectedError(e)
 		return formRejectMessage(METAMASK_ERROR_BLANKET_ERROR, 'Failed to process message signing request. See Interceptor for error message')
 	}
 	const pendingTransactionData = await getPendingTransactionOrMessageByidentifier(request.uniqueRequestIdentifier)
@@ -513,7 +513,7 @@ export async function openConfirmTransactionDialogForTransaction(
 			await tryFocusingTabOrWindow(openedDialog)
 			return { success: true }
 		} catch(e: unknown) {
-			printError(e)
+			await reportLocalRecovery(e, { code: 'send_transaction_preparation_failed', message: 'Returning a wallet-compatible rejection to the requesting page.' })
 			return formRejectMessage(METAMASK_ERROR_FAILED_TO_PARSE_REQUEST, 'The Interceptor failed to send transaction')
 		}
 	})

--- a/app/ts/background/windows/confirmTransaction.ts
+++ b/app/ts/background/windows/confirmTransaction.ts
@@ -21,7 +21,7 @@ import {
 import { dataStringWith0xStart, stringToUint8Array } from '../../utils/bigint.js'
 import { EthereumAddress, EthereumBytes32, EthereumQuantity, serialize } from '../../types/wire-types.js'
 import type { PopupOrTabId, Website } from '../../types/websiteAccessTypes.js'
-import { JsonRpcResponseError, handleUnexpectedError, isFailedToFetchError, isNewBlockAbort, printError } from '../../utils/errors.js'
+import { JsonRpcResponseError, handleUnexpectedError, isExpectedInfrastructureError, printError } from '../../utils/errors.js'
 import type { PendingTransactionOrSignableMessage, PopupPendingTransactionOrSignableMessage } from '../../types/accessRequest.js'
 import type { SignMessageParams } from '../../types/jsonRpc-signing-types.js'
 import { craftPersonalSignPopupMessage } from './personalSign.js'
@@ -125,7 +125,7 @@ export async function updateConfirmTransactionView(ethereum: EthereumClientServi
 		])
 		return true
 	} catch(error: unknown) {
-		if (error instanceof Error && (isNewBlockAbort(error) || isFailedToFetchError(error))) return false
+		if (isExpectedInfrastructureError(error)) return false
 		await handleUnexpectedError(error)
 	}
 	return false

--- a/app/ts/components/App.tsx
+++ b/app/ts/components/App.tsx
@@ -28,6 +28,7 @@ import { CenterToPageTextSpinner } from './subcomponents/Spinner.js'
 import { POPUP_PERFORMANCE_MARKS, markPerformance, markPerformanceOnce } from '../utils/popupPerformance.js'
 import { getRpcWarningState, shouldShowRpcWarningCountdown } from '../utils/rpcConnectionUi.js'
 import type { AddAddressParam, ChangeActiveAddressParam, InterceptorAccessListParams } from '../types/user-interface-types.js'
+import { createUnexpectedErrorPopupMessage } from '../utils/unexpectedErrorPopupMessage.js'
 
 type ProviderErrorsParam = {
 	tabState: Signal<TabState | undefined>
@@ -478,7 +479,15 @@ export function App() {
 		await sendPopupMessageToBackgroundPage({ method: 'popup_openSettings' })
 		return globalThis.close() // close extension popup, chrome closes it by default, but firefox does not
 	}
-	function onRenderError(error: Error) { unexpectedError.value = { method: 'popup_UnexpectedErrorOccured', data: { message: error.message, timestamp: new Date(), source: 'popup', code: 'render_error', debugId: undefined } } }
+	function onRenderError(error: Error) {
+		unexpectedError.value = createUnexpectedErrorPopupMessage({
+			timestamp: new Date(),
+			message: error.message,
+			source: 'popup',
+			code: 'render_error',
+			debugId: undefined,
+		})
+	}
 	async function clearUnexpectedError() {
 		unexpectedError.value = undefined
 		boundaryResetKey.value += 1

--- a/app/ts/components/pages/ConfirmTransaction.tsx
+++ b/app/ts/components/pages/ConfirmTransaction.tsx
@@ -610,7 +610,7 @@ export function ConfirmTransaction() {
 				return false
 			}
 			if (parsed.method === 'popup_UnexpectedErrorOccured') {
-				unexpectedError.value = { message: parsed.data.message, timestamp: parsed.data.timestamp }
+				unexpectedError.value = parsed.data
 				return false
 			}
 			if (parsed.method === 'popup_addressBookEntriesChanged') {

--- a/app/ts/components/subcomponents/ConfigureRpcConnection.tsx
+++ b/app/ts/components/subcomponents/ConfigureRpcConnection.tsx
@@ -13,6 +13,7 @@ import { type EthSimulateV1Params, EthSimulateV1Result } from '../../types/ethSi
 import { XMarkIcon } from './icons.js'
 import { JsonRpcResponseError } from '../../utils/errors.js'
 import { EthereumQuantity } from '../../types/wire-types.js'
+import { isBrowserFetchTransportError } from '../../utils/caughtErrors.js'
 
 type RpcProbeResult = {
 	chainId: bigint
@@ -26,9 +27,11 @@ type ConfigureRpcContext = {
 
 const ConfigureRpcContext = createContext<ConfigureRpcContext | undefined>(undefined)
 
-const throwImprovedError = (error: Error, url: string) => {
-	if (error.message.startsWith('unsupported protocol')) throw new Error(`Unsupported protocol, did you mean https://${ url }?`)
-	if (error.message.startsWith('Failed to fetch')) throw new Error('Failed to connect to the RPC.')
+const throwImprovedError = (error: unknown, url: string, fallbackMessage: string) => {
+	const message = error instanceof Error ? error.message : undefined
+	if (message?.startsWith('unsupported protocol')) throw new Error(`Unsupported protocol, did you mean https://${ url }?`)
+	if (isBrowserFetchTransportError(error)) throw new Error('Failed to connect to the RPC.')
+	if (!(error instanceof Error)) throw new Error(fallbackMessage)
 	throw error
 }
 
@@ -41,9 +44,7 @@ const RpcQueryProvider = ({ children }: { children: ComponentChildren }) => {
 			const chainId = await requestHandler.jsonRpcRequest({ method: 'eth_chainId' }, undefined, false, 10000)
 			return { chainId: EthereumQuantity.parse(chainId) }
 		} catch(error: unknown) {
-			if (error instanceof Error) return throwImprovedError(error, url)
-			console.warn('RPC chain id error', error)
-			throw new Error('Unable to fetch network information from the RPC.')
+			return throwImprovedError(error, url, 'Unable to fetch network information from the RPC.')
 		}
 	}
 
@@ -88,9 +89,7 @@ const RpcQueryProvider = ({ children }: { children: ComponentChildren }) => {
 			if (!resultContainsLog(parsedResult)) throw new Error(`The RPC server does not have a support for eth_simulateV1 (it doesn't return ETH logs). The Interceptor requires this feature to function.`)
 		} catch (error: unknown) {
 			if (error instanceof JsonRpcResponseError) throw new Error(`The RPC server does not have a support for eth_simulateV1 ("${ error.message }"). The Interceptor requires this feature to function.`)
-			if (error instanceof Error) return throwImprovedError(error, url)
-			console.warn('RPC eth_simulateV1 validation error', error)
-			throw new Error('The RPC server does not have a support for eth_simulateV1. The Interceptor requires this feature to function.')
+			return throwImprovedError(error, url, 'The RPC server does not have a support for eth_simulateV1. The Interceptor requires this feature to function.')
 		}
 	}
 

--- a/app/ts/components/subcomponents/Error.tsx
+++ b/app/ts/components/subcomponents/Error.tsx
@@ -109,6 +109,11 @@ type UnexpectedErrorParams = {
 
 export function UnexpectedError({ error, close }: UnexpectedErrorParams) {
 	if (error === undefined) return <></>
+	const metadata = [
+		error.source === undefined ? undefined : `source: ${ error.source }`,
+		error.code === undefined ? undefined : `code: ${ error.code }`,
+		error.debugId === undefined ? undefined : `debug: ${ error.debugId }`,
+	].filter((value): value is string => value !== undefined)
 	return (
 		<div class = 'notification' style = { 'background-color: var(--error-box-color); padding: 10px; margin: 10px;' }>
 			<div style = 'display: flex; padding-bottom: 10px;'>
@@ -121,6 +126,7 @@ export function UnexpectedError({ error, close }: UnexpectedErrorParams) {
 			</div>
 			<div style = { 'overflow-y: auto; overflow-x: hidden; max-height: 100px; border-style: solid;' }>
 				<p class = 'paragraph' style = { 'color: var(--error-box-text);' }> { error.message } </p>
+				{ metadata.length > 0 ? <p class = 'paragraph' style = { 'color: var(--error-box-text); font-size: 0.8em;' }> { metadata.join(' | ') } </p> : <></> }
 			</div>
 			<div style = 'overflow: hidden; display: flex; justify-content: space-around; width: 100%; height: 50px; padding-top: 10px;'>
 				<button class = 'button is-success is-primary' onClick = { close }> { 'close' } </button>

--- a/app/ts/simulation/parsing.ts
+++ b/app/ts/simulation/parsing.ts
@@ -13,6 +13,7 @@ import { assertNever } from '../utils/typescript.js'
 import type { EthereumEvent } from '../types/ethSimulate-types.js'
 import type { EnrichedEthereumEvent, EnrichedEthereumInputData, ParsedEvent, TokenVisualizerResult } from '../types/EnrichedEthereumData.js'
 import { promiseAllMapAbortSafe } from '../utils/requests.js'
+import { reportLocalRecovery } from '../utils/errors.js'
 
 type TokenLogHandler = (event: EthereumEvent) => TokenVisualizerResult[]
 
@@ -118,8 +119,11 @@ export const parseInputData = async (transaction: { to: EthereumAddress | undefi
 			args: valuesWithTypes,
 		}
 	} catch (e: unknown) {
-		console.warn({ transaction })
-		console.error(e)
+		await reportLocalRecovery(e, {
+			code: 'transaction_input_parse_failed',
+			message: 'Falling back to showing unparsed calldata.',
+			details: { transaction },
+		})
 		return nonParsed
 	}
 }

--- a/app/ts/simulation/parsing.ts
+++ b/app/ts/simulation/parsing.ts
@@ -13,7 +13,7 @@ import { assertNever } from '../utils/typescript.js'
 import type { EthereumEvent } from '../types/ethSimulate-types.js'
 import type { EnrichedEthereumEvent, EnrichedEthereumInputData, ParsedEvent, TokenVisualizerResult } from '../types/EnrichedEthereumData.js'
 import { promiseAllMapAbortSafe } from '../utils/requests.js'
-import { reportLocalRecovery } from '../utils/errors.js'
+import { reportLocalRecoveryBestEffort } from '../utils/errors.js'
 
 type TokenLogHandler = (event: EthereumEvent) => TokenVisualizerResult[]
 
@@ -119,7 +119,7 @@ export const parseInputData = async (transaction: { to: EthereumAddress | undefi
 			args: valuesWithTypes,
 		}
 	} catch (e: unknown) {
-		await reportLocalRecovery(e, {
+		reportLocalRecoveryBestEffort(e, {
 			code: 'transaction_input_parse_failed',
 			message: 'Falling back to showing unparsed calldata.',
 			details: { transaction },

--- a/app/ts/simulation/services/EtherScanAbiFetcher.ts
+++ b/app/ts/simulation/services/EtherScanAbiFetcher.ts
@@ -7,9 +7,13 @@ import type { BlockExplorer, RpcEntries } from '../../types/rpc.js'
 import { getRpcList } from '../../background/storageVariables.js'
 import type { Result } from 'funtypes'
 import { isValidAbiString } from '../../utils/abiRuntime.js'
+import { fetchWithTimeout } from '../../utils/requests.js'
+import { reportLocalRecovery } from '../../utils/errors.js'
+
+const BLOCK_EXPLORER_FETCH_TIMEOUT_MS = 15_000
 
 async function fetchJson(url: string): Promise<{ success: true, result: unknown } | { success: false, error: string }> {
-	const response = await fetch(url)
+	const response = await fetchWithTimeout(url, undefined, BLOCK_EXPLORER_FETCH_TIMEOUT_MS)
 	if (!response.ok) return { success: false, error: `Ethercan returned error: ${ response.status }.` }
 	return { success: true, result: await response.json() }
 }
@@ -56,15 +60,19 @@ async function fetchAbi(contractAddress: EthereumAddress, maybeExplorer: BlockEx
 	try {
 		if (maybeExplorer !== undefined) {
 			try {
-				const result = await fetch(`${ maybeExplorer.apiUrl }?chainId=${ chainId.toString() }&module=contract&action=getsourcecode&address=${ normalizedAddressString }&apiKey=${ maybeExplorer.apiKey }`)
+				const result = await fetchWithTimeout(`${ maybeExplorer.apiUrl }?chainId=${ chainId.toString() }&module=contract&action=getsourcecode&address=${ normalizedAddressString }&apiKey=${ maybeExplorer.apiKey }`, undefined, BLOCK_EXPLORER_FETCH_TIMEOUT_MS)
 				bestResult = EtherscanSourceCodeResult.safeParse(await result.json())
 				if (bestResult.success) return bestResult
 			} catch(error: unknown) {
-				console.error(`Failed to retrieve ABI for ${ normalizedAddressString } from ${ maybeExplorer.apiUrl }`)
-				console.error(error)
+				await reportLocalRecovery(error, {
+					code: 'etherscan_source_fetch_failed',
+					category: 'external_service',
+					message: 'Falling back to Sourcify.',
+					details: { address: normalizedAddressString, apiUrl: maybeExplorer.apiUrl },
+				})
 			}
 		}
-		const result = await fetch(`https://repo.sourcify.dev/contracts/full_match/${ chainId.toString(10) }/${ normalizedAddressString }/metadata.json`)
+		const result = await fetchWithTimeout(`https://repo.sourcify.dev/contracts/full_match/${ chainId.toString(10) }/${ normalizedAddressString }/metadata.json`, undefined, BLOCK_EXPLORER_FETCH_TIMEOUT_MS)
 		if (result.status === 404) return { success: false, message: 'No source available' } as const
 		const parsed = SourcifyMetadataResult.safeParse(await result.json())
 		if (parsed.success) {
@@ -76,7 +84,12 @@ async function fetchAbi(contractAddress: EthereumAddress, maybeExplorer: BlockEx
 			}] } } as const
 		}
 	} catch(error: unknown) {
-		console.error(error)
+		await reportLocalRecovery(error, {
+			code: 'sourcify_source_fetch_failed',
+			category: 'external_service',
+			message: 'Returning the best ABI lookup failure collected so far.',
+			details: { address: normalizedAddressString },
+		})
 	}
 	return bestResult
 }

--- a/app/ts/types/errorDiagnostics.ts
+++ b/app/ts/types/errorDiagnostics.ts
@@ -1,0 +1,32 @@
+import * as funtypes from 'funtypes'
+import { EthereumTimestamp } from './wire-types.js'
+
+export type InterceptorErrorCategory = funtypes.Static<typeof InterceptorErrorCategory>
+export const InterceptorErrorCategory = funtypes.Union(
+	funtypes.Literal('expected_infrastructure'),
+	funtypes.Literal('external_service'),
+	funtypes.Literal('user_action'),
+	funtypes.Literal('local_recovery'),
+	funtypes.Literal('unexpected'),
+)
+
+export type InterceptorErrorSeverity = funtypes.Static<typeof InterceptorErrorSeverity>
+export const InterceptorErrorSeverity = funtypes.Union(
+	funtypes.Literal('info'),
+	funtypes.Literal('warning'),
+	funtypes.Literal('error'),
+)
+
+export type InterceptorErrorDiagnostic = funtypes.Static<typeof InterceptorErrorDiagnostic>
+export const InterceptorErrorDiagnostic = funtypes.ReadonlyObject({
+	timestamp: EthereumTimestamp,
+	source: funtypes.String,
+	code: funtypes.String,
+	category: InterceptorErrorCategory,
+	severity: InterceptorErrorSeverity,
+	message: funtypes.String,
+	cause: funtypes.Union(funtypes.String, funtypes.Undefined),
+	userVisible: funtypes.Boolean,
+	debugId: funtypes.Union(funtypes.String, funtypes.Undefined),
+	details: funtypes.Union(funtypes.String, funtypes.Undefined),
+})

--- a/app/ts/types/errorDiagnostics.ts
+++ b/app/ts/types/errorDiagnostics.ts
@@ -5,7 +5,6 @@ export type InterceptorErrorCategory = funtypes.Static<typeof InterceptorErrorCa
 export const InterceptorErrorCategory = funtypes.Union(
 	funtypes.Literal('expected_infrastructure'),
 	funtypes.Literal('external_service'),
-	funtypes.Literal('user_action'),
 	funtypes.Literal('local_recovery'),
 	funtypes.Literal('unexpected'),
 )

--- a/app/ts/utils/browser.ts
+++ b/app/ts/utils/browser.ts
@@ -1,7 +1,34 @@
+import { PopupMessage, type PopupMessage as PopupMessageType } from '../types/interceptor-messages.js'
+
+function getErrorMessage(error: unknown) {
+	if (error instanceof Error) return error.message
+	if (typeof error === 'string') return error
+	return 'Unknown popup listener error'
+}
+
+async function reportPopupMessageListenerError(error: unknown) {
+	try {
+		const unexpectedErrorMessage: PopupMessageType = {
+			method: 'popup_UnexpectedErrorOccured',
+			data: {
+				timestamp: new Date(),
+				message: getErrorMessage(error),
+				source: 'popup',
+				code: 'popup_message_listener_failed',
+				debugId: globalThis.crypto.randomUUID().slice(0, 8),
+			}
+		}
+		await browser.runtime.sendMessage(PopupMessage.serialize(unexpectedErrorMessage))
+	} catch (reportingError: unknown) {
+		// error-reporting: console-only fallback when the popup cannot reach the background reporter.
+		console.error(reportingError)
+	}
+}
+
 export const noReplyExpectingBrowserRuntimeOnMessageListener = (callback: (msg: unknown) => false | Promise<false>) => {
 	return browser.runtime.onMessage.addListener((message: unknown) => {
 		void Promise.resolve(callback(message)).catch((error: unknown) => {
-			console.error(error)
+			void reportPopupMessageListenerError(error)
 		})
 		return undefined
 	})

--- a/app/ts/utils/browser.ts
+++ b/app/ts/utils/browser.ts
@@ -1,23 +1,16 @@
-import { PopupMessage, type PopupMessage as PopupMessageType } from '../types/interceptor-messages.js'
-
-function getErrorMessage(error: unknown) {
-	if (error instanceof Error) return error.message
-	if (typeof error === 'string') return error
-	return 'Unknown popup listener error'
-}
+import { PopupMessage } from '../types/interceptor-messages.js'
+import { getErrorMessage } from './caughtErrors.js'
+import { createErrorDebugId, createUnexpectedErrorPopupMessage } from './unexpectedErrorPopupMessage.js'
 
 async function reportPopupMessageListenerError(error: unknown) {
 	try {
-		const unexpectedErrorMessage: PopupMessageType = {
-			method: 'popup_UnexpectedErrorOccured',
-			data: {
-				timestamp: new Date(),
-				message: getErrorMessage(error),
-				source: 'popup',
-				code: 'popup_message_listener_failed',
-				debugId: globalThis.crypto.randomUUID().slice(0, 8),
-			}
-		}
+		const unexpectedErrorMessage = createUnexpectedErrorPopupMessage({
+			timestamp: new Date(),
+			message: getErrorMessage(error) ?? 'Unknown popup listener error',
+			source: 'popup',
+			code: 'popup_message_listener_failed',
+			debugId: createErrorDebugId(),
+		})
 		await browser.runtime.sendMessage(PopupMessage.serialize(unexpectedErrorMessage))
 	} catch (reportingError: unknown) {
 		// error-reporting: console-only fallback when the popup cannot reach the background reporter.

--- a/app/ts/utils/caughtErrors.ts
+++ b/app/ts/utils/caughtErrors.ts
@@ -1,0 +1,36 @@
+export type InterceptorInternalErrorCode =
+	| 'fetch_aborted'
+	| 'fetch_timeout'
+	| 'fetch_transport_failed'
+
+const interceptorInternalErrorCodes: readonly InterceptorInternalErrorCode[] = [
+	'fetch_aborted',
+	'fetch_timeout',
+	'fetch_transport_failed',
+]
+
+export function getErrorMessage(error: unknown) {
+	if (error instanceof Error) return error.message
+	if (typeof error === 'string') return error
+	if (typeof error === 'object' && error !== null && 'message' in error && typeof error.message === 'string') return error.message
+	return undefined
+}
+
+export function createInterceptorInternalError(message: string, interceptorErrorCode: InterceptorInternalErrorCode) {
+	return Object.assign(new Error(message), { interceptorErrorCode })
+}
+
+export function getInterceptorInternalErrorCode(error: unknown): InterceptorInternalErrorCode | undefined {
+	if (typeof error !== 'object' || error === null || !('interceptorErrorCode' in error)) return undefined
+	const code = error.interceptorErrorCode
+	if (typeof code !== 'string') return undefined
+	return interceptorInternalErrorCodes.find((knownCode) => knownCode === code)
+}
+
+export function isBrowserFetchTransportError(error: unknown) {
+	const message = getErrorMessage(error)
+	if (message === undefined) return false
+	if (message === 'Failed to fetch') return true
+	if (message === 'NetworkError when attempting to fetch resource') return true
+	return false
+}

--- a/app/ts/utils/contentScriptsUpdating.ts
+++ b/app/ts/utils/contentScriptsUpdating.ts
@@ -1,5 +1,6 @@
 import { getInterceptorDisabledSites, getSettings } from '../background/settings.js'
 import { checkAndThrowRuntimeLastError, getHostWithPort } from './requests.js'
+import { reportLocalRecovery } from './errors.js'
 
 const injectableSitesWildcard = ['file://*/*', 'http://*/*', 'https://*/*']
 const injectableSitesRegexp = [/^file:\/\/.*/, /^http:\/\/.*/, /^https:\/\/.*/]
@@ -50,7 +51,7 @@ const injectLogic = async (content: browser.webNavigation._OnCommittedDetails) =
 		checkAndThrowRuntimeLastError()
 	} catch(error) {
 		if (error instanceof Error && error.message.startsWith('No tab with id')) return false
-		console.error(error)
+		await reportLocalRecovery(error, { code: 'manifest_v2_content_script_injection_failed', message: 'Leaving this navigation without early injection.' })
 	}
 	return false
 }

--- a/app/ts/utils/contentScriptsUpdating.ts
+++ b/app/ts/utils/contentScriptsUpdating.ts
@@ -1,6 +1,6 @@
 import { getInterceptorDisabledSites, getSettings } from '../background/settings.js'
 import { checkAndThrowRuntimeLastError, getHostWithPort } from './requests.js'
-import { reportLocalRecovery } from './errors.js'
+import { reportLocalRecoveryBestEffort, reportUnexpectedError } from './errors.js'
 
 const injectableSitesWildcard = ['file://*/*', 'http://*/*', 'https://*/*']
 const injectableSitesRegexp = [/^file:\/\/.*/, /^http:\/\/.*/, /^https:\/\/.*/]
@@ -32,7 +32,7 @@ export const updateContentScriptInjectionStrategyManifestV3 = async () => {
 			matchOriginAsFallback: true
 		}])
 	} catch (error: unknown) {
-		await handleUnexpectedError(error, { code: 'content_script_registration_failed' })
+		await reportUnexpectedError(error, { code: 'content_script_registration_failed' })
 	}
 }
 
@@ -51,7 +51,7 @@ const injectLogic = async (content: browser.webNavigation._OnCommittedDetails) =
 		checkAndThrowRuntimeLastError()
 	} catch(error) {
 		if (error instanceof Error && error.message.startsWith('No tab with id')) return false
-		await reportLocalRecovery(error, { code: 'manifest_v2_content_script_injection_failed', message: 'Leaving this navigation without early injection.' })
+		reportLocalRecoveryBestEffort(error, { code: 'manifest_v2_content_script_injection_failed', message: 'Leaving this navigation without early injection.' })
 	}
 	return false
 }

--- a/app/ts/utils/errorDecoding.ts
+++ b/app/ts/utils/errorDecoding.ts
@@ -1,5 +1,5 @@
 import type { Abi, AbiItem } from 'viem'
-import { reportLocalRecovery } from './errors.js'
+import { reportLocalRecoveryBestEffort } from './errors.js'
 import type { ErrorWithCodeAndOptionalData } from '../types/error.js'
 import { decodeAbiValues, decodeErrorLoose, normalizeAbi, type AbiLike } from './abiRuntime.js'
 
@@ -179,7 +179,7 @@ export const decodeEthereumError = (errorAbis: readonly AbiLike[], error: ErrorW
 		if (error.data !== undefined) return handleCustomError(errorAbis, error)
 		return unknownErrorResult({ data: error.data, reason: error.message, name: 'unknown' })
 	} catch (decodingError: unknown) {
-		void reportLocalRecovery(decodingError, { code: 'ethereum_error_decode_failed', message: 'Returning an unknown decoded error result.' })
+		reportLocalRecoveryBestEffort(decodingError, { code: 'ethereum_error_decode_failed', message: 'Returning an unknown decoded error result.' })
 		return unknownErrorResult({ data: error.data, reason: `Failed to decode error: ${ error.message }`, name: 'unknown' })
 	}
 }

--- a/app/ts/utils/errorDecoding.ts
+++ b/app/ts/utils/errorDecoding.ts
@@ -1,5 +1,5 @@
 import type { Abi, AbiItem } from 'viem'
-import { printError } from './errors.js'
+import { reportLocalRecovery } from './errors.js'
 import type { ErrorWithCodeAndOptionalData } from '../types/error.js'
 import { decodeAbiValues, decodeErrorLoose, normalizeAbi, type AbiLike } from './abiRuntime.js'
 
@@ -179,7 +179,7 @@ export const decodeEthereumError = (errorAbis: readonly AbiLike[], error: ErrorW
 		if (error.data !== undefined) return handleCustomError(errorAbis, error)
 		return unknownErrorResult({ data: error.data, reason: error.message, name: 'unknown' })
 	} catch (decodingError: unknown) {
-		printError(decodingError)
+		void reportLocalRecovery(decodingError, { code: 'ethereum_error_decode_failed', message: 'Returning an unknown decoded error result.' })
 		return unknownErrorResult({ data: error.data, reason: `Failed to decode error: ${ error.message }`, name: 'unknown' })
 	}
 }

--- a/app/ts/utils/errors.ts
+++ b/app/ts/utils/errors.ts
@@ -4,6 +4,7 @@ import { InterceptorError, type JsonRpcErrorResponse } from '../types/JsonRpc-ty
 import type { InterceptorErrorCategory, InterceptorErrorDiagnostic, InterceptorErrorSeverity } from '../types/errorDiagnostics.js'
 import { getErrorMessage, getInterceptorInternalErrorCode, isBrowserFetchTransportError } from './caughtErrors.js'
 import { NEW_BLOCK_ABORT } from './constants.js'
+import { createErrorDebugId, createUnexpectedErrorPopupMessage } from './unexpectedErrorPopupMessage.js'
 export { createInterceptorInternalError, getErrorMessage } from './caughtErrors.js'
 
 export const GENERIC_UNEXPECTED_ERROR_MESSAGE = 'An internal Interceptor error occurred. Please see The Interceptor console for technical details.'
@@ -153,12 +154,8 @@ export function printError(error: unknown) {
 	}
 }
 
-function generateDebugId() {
-	return globalThis.crypto.randomUUID().slice(0, 8)
-}
-
 function createErrorReport(error: unknown, metadata: ErrorReportMetadata, policy: ErrorPolicyEntry, defaultCode: string, message: string): InterceptorErrorReport {
-	const debugId = metadata.debugId ?? generateDebugId()
+	const debugId = metadata.debugId ?? createErrorDebugId()
 	const source = metadata.source ?? 'internal'
 	return {
 		timestamp: new Date(),
@@ -183,19 +180,6 @@ async function appendErrorDiagnostic(report: InterceptorErrorReport) {
 	}
 }
 
-function popupMessageFromUnexpectedReport(report: InterceptorErrorReport) {
-	return {
-		method: 'popup_UnexpectedErrorOccured' as const,
-		data: {
-			timestamp: report.timestamp,
-			message: report.message,
-			source: report.source,
-			code: report.code,
-			debugId: report.debugId,
-		}
-	}
-}
-
 export async function reportUnexpectedError(error: unknown, metadata: ErrorReportMetadata = {}) {
 	if ((metadata.suppressExpectedInfrastructure ?? true) && isExpectedInfrastructureError(error)) return
 	const defaultCode = isWrappedNewBlockAbort(error) ? 'wrapped_new_block_abort' : 'unexpected_error'
@@ -210,7 +194,7 @@ export async function reportUnexpectedError(error: unknown, metadata: ErrorRepor
 	printError(error)
 	console.trace()
 	await appendErrorDiagnostic(report)
-	const errorMessage = popupMessageFromUnexpectedReport(report)
+	const errorMessage = createUnexpectedErrorPopupMessage(report)
 	let messageToBroadcast = errorMessage
 	try {
 		await setLatestUnexpectedError(errorMessage)
@@ -268,17 +252,4 @@ export function reportLocalRecoveryAtAsyncBoundary(operation: () => Promise<unkn
 	void operation().catch((error: unknown) => {
 		reportLocalRecoveryBestEffort(error, metadata)
 	})
-}
-
-export function reportUnexpectedErrorAtAsyncBoundary(operation: () => Promise<unknown>, metadata: ErrorReportMetadata = {}) {
-	void operation().catch((error: unknown) => {
-		void reportUnexpectedError(error, metadata)
-	})
-}
-
-export function withUnexpectedErrorReporting<Args extends readonly unknown[]>(callback: (...args: Args) => Promise<unknown>, metadata: ErrorReportMetadata = {}) {
-	return (...args: Args) => {
-		reportUnexpectedErrorAtAsyncBoundary(async () => await callback(...args), metadata)
-		return undefined
-	}
 }

--- a/app/ts/utils/errors.ts
+++ b/app/ts/utils/errors.ts
@@ -33,10 +33,14 @@ type ErrorPolicyEntry = {
 	userVisible: boolean
 }
 
+// Reporting policy:
+// - expected_infrastructure is benign network/block churn and is suppressed at unexpected-error boundaries.
+// - external_service is a third-party lookup failure where Interceptor can keep operating.
+// - local_recovery is an internal fallback path that should not surface a popup error.
+// - unexpected is a user-visible internal failure that should be persisted and broadcast.
 export const ERROR_REPORTING_POLICY = {
 	expectedInfrastructure: { category: 'expected_infrastructure', severity: 'info', userVisible: false },
 	externalService: { category: 'external_service', severity: 'warning', userVisible: false },
-	userAction: { category: 'user_action', severity: 'info', userVisible: false },
 	localRecovery: { category: 'local_recovery', severity: 'warning', userVisible: false },
 	unexpected: { category: 'unexpected', severity: 'error', userVisible: true },
 } satisfies Record<string, ErrorPolicyEntry>
@@ -227,6 +231,16 @@ export async function reportNonFatalError(error: unknown, metadata: ErrorReportM
 }
 
 export async function reportLocalRecovery(error: unknown, metadata: LocalRecoveryMetadata) {
+	const report = logLocalRecovery(error, metadata)
+	await appendErrorDiagnostic(report)
+}
+
+export function reportLocalRecoveryBestEffort(error: unknown, metadata: LocalRecoveryMetadata) {
+	const report = logLocalRecovery(error, metadata)
+	void appendErrorDiagnostic(report)
+}
+
+function logLocalRecovery(error: unknown, metadata: LocalRecoveryMetadata) {
 	const report = createErrorReport(error, {
 		source: metadata.source,
 		code: metadata.code,
@@ -246,12 +260,12 @@ export async function reportLocalRecovery(error: unknown, metadata: LocalRecover
 	})
 	if (report.details !== undefined) console.warn(report.details)
 	printError(error)
-	await appendErrorDiagnostic(report)
+	return report
 }
 
 export function reportLocalRecoveryAtAsyncBoundary(operation: () => Promise<unknown>, metadata: LocalRecoveryMetadata) {
 	void operation().catch((error: unknown) => {
-		void reportLocalRecovery(error, metadata)
+		reportLocalRecoveryBestEffort(error, metadata)
 	})
 }
 

--- a/app/ts/utils/errors.ts
+++ b/app/ts/utils/errors.ts
@@ -211,10 +211,6 @@ export async function reportUnexpectedError(error: unknown, metadata: ErrorRepor
 	}
 }
 
-export async function reportNonFatalError(error: unknown, metadata: ErrorReportMetadata = {}) {
-	await reportUnexpectedError(error, { ...metadata, code: metadata.code ?? 'non_fatal_error' })
-}
-
 export async function reportLocalRecovery(error: unknown, metadata: LocalRecoveryMetadata) {
 	const report = logLocalRecovery(error, metadata)
 	await appendErrorDiagnostic(report)

--- a/app/ts/utils/errors.ts
+++ b/app/ts/utils/errors.ts
@@ -12,6 +12,7 @@ type ErrorReportMetadata = {
 	source?: string
 	code?: string
 	debugId?: string
+	message?: string
 	category?: InterceptorErrorCategory
 	severity?: InterceptorErrorSeverity
 	details?: unknown
@@ -198,7 +199,7 @@ function popupMessageFromUnexpectedReport(report: InterceptorErrorReport) {
 export async function reportUnexpectedError(error: unknown, metadata: ErrorReportMetadata = {}) {
 	if ((metadata.suppressExpectedInfrastructure ?? true) && isExpectedInfrastructureError(error)) return
 	const defaultCode = isWrappedNewBlockAbort(error) ? 'wrapped_new_block_abort' : 'unexpected_error'
-	const report = createErrorReport(error, metadata, ERROR_REPORTING_POLICY.unexpected, defaultCode, normalizeUnexpectedError(error).message)
+	const report = createErrorReport(error, metadata, ERROR_REPORTING_POLICY.unexpected, defaultCode, metadata.message ?? normalizeUnexpectedError(error).message)
 	console.error('Unexpected Interceptor error', {
 		debugId: report.debugId,
 		source: report.source,

--- a/app/ts/utils/errors.ts
+++ b/app/ts/utils/errors.ts
@@ -12,7 +12,7 @@ type ErrorReportMetadata = {
 	source?: string
 	code?: string
 	debugId?: string
-	message?: string
+	displayMessage?: string
 	category?: InterceptorErrorCategory
 	severity?: InterceptorErrorSeverity
 	details?: unknown
@@ -199,7 +199,7 @@ function popupMessageFromUnexpectedReport(report: InterceptorErrorReport) {
 export async function reportUnexpectedError(error: unknown, metadata: ErrorReportMetadata = {}) {
 	if ((metadata.suppressExpectedInfrastructure ?? true) && isExpectedInfrastructureError(error)) return
 	const defaultCode = isWrappedNewBlockAbort(error) ? 'wrapped_new_block_abort' : 'unexpected_error'
-	const report = createErrorReport(error, metadata, ERROR_REPORTING_POLICY.unexpected, defaultCode, metadata.message ?? normalizeUnexpectedError(error).message)
+	const report = createErrorReport(error, metadata, ERROR_REPORTING_POLICY.unexpected, defaultCode, metadata.displayMessage ?? normalizeUnexpectedError(error).message)
 	console.error('Unexpected Interceptor error', {
 		debugId: report.debugId,
 		source: report.source,

--- a/app/ts/utils/errors.ts
+++ b/app/ts/utils/errors.ts
@@ -1,4 +1,4 @@
-import { sendPopupMessageToOpenWindows } from '../background/backgroundUtils.js'
+import { sendPopupMessageToOpenWindowsWithoutUnexpectedErrorReport } from '../background/backgroundUtils.js'
 import { setLatestUnexpectedError } from '../background/storageVariables.js'
 import { InterceptorError, type JsonRpcErrorResponse } from '../types/JsonRpc-types.js'
 import { NEW_BLOCK_ABORT } from './constants.js'
@@ -42,12 +42,36 @@ export class JsonRpcResponseError extends Error {
 	}
 }
 
-export function isFailedToFetchError(error: Error) {
-	if (error.message.includes('Fetch request timed out.') || error.message.includes('Failed to fetch') || error.message.includes('NetworkError when attempting to fetch resource')) return true
+export function getErrorMessage(error: unknown) {
+	if (error instanceof Error) return error.message
+	if (typeof error === 'string') return error
+	if (typeof error === 'object' && error !== null && 'message' in error && typeof error.message === 'string') return error.message
+	return undefined
+}
+
+export function isFailedToFetchError(error: unknown) {
+	const message = getErrorMessage(error)
+	if (message === undefined) return false
+	if (message.includes('Fetch request timed out.') || message.includes('Fetch request aborted.') || message.includes('Failed to fetch') || message.includes('NetworkError when attempting to fetch resource')) return true
 	return false
 }
 
-export const isNewBlockAbort = (error: Error) => error.message?.includes(NEW_BLOCK_ABORT)
+export const isNewBlockAbort = (error: unknown) => getErrorMessage(error) === NEW_BLOCK_ABORT
+
+export const isWrappedNewBlockAbort = (error: unknown) => {
+	const message = getErrorMessage(error)
+	return message !== undefined && message !== NEW_BLOCK_ABORT && message.includes(NEW_BLOCK_ABORT)
+}
+
+export type CaughtErrorClassification = 'newBlockAbort' | 'failedToFetch' | 'unexpected'
+
+export function classifyCaughtError(error: unknown): CaughtErrorClassification {
+	if (isNewBlockAbort(error)) return 'newBlockAbort'
+	if (isFailedToFetchError(error)) return 'failedToFetch'
+	return 'unexpected'
+}
+
+export const isExpectedInfrastructureError = (error: unknown) => classifyCaughtError(error) !== 'unexpected'
 
 function getForwardedDiagnostics(error: unknown): string | undefined {
 	const maybeInterceptorError = InterceptorError.safeParse(error)
@@ -81,8 +105,11 @@ function generateDebugId() {
 }
 
 export async function handleUnexpectedError(error: unknown, metadata: UnexpectedErrorMetadata = {}) {
+	if (isNewBlockAbort(error)) return
 	const debugId = metadata.debugId ?? generateDebugId()
-	console.error('Unexpected Interceptor error', { debugId, source: metadata.source ?? 'internal', code: metadata.code ?? 'unexpected_error' })
+	const source = metadata.source ?? 'internal'
+	const code = metadata.code ?? (isWrappedNewBlockAbort(error) ? 'wrapped_new_block_abort' : 'unexpected_error')
+	console.error('Unexpected Interceptor error', { debugId, source, code })
 	printError(error)
 	console.trace()
 	const normalizedError = normalizeUnexpectedError(error)
@@ -91,11 +118,22 @@ export async function handleUnexpectedError(error: unknown, metadata: Unexpected
 		data: {
 			timestamp: new Date(),
 			message: normalizedError.message,
-			source: metadata.source ?? 'internal',
-			code: metadata.code ?? 'unexpected_error',
+			source,
+			code,
 			debugId,
 		}
 	}
-	await setLatestUnexpectedError(errorMessage)
-	await sendPopupMessageToOpenWindows(errorMessage)
+	try {
+		await setLatestUnexpectedError(errorMessage)
+	} catch (storageError: unknown) {
+		console.error('Failed to persist unexpected error.')
+		printError(storageError)
+		return
+	}
+	try {
+		await sendPopupMessageToOpenWindowsWithoutUnexpectedErrorReport(errorMessage)
+	} catch (broadcastError: unknown) {
+		console.error('Failed to broadcast unexpected error to open popup windows.')
+		printError(broadcastError)
+	}
 }

--- a/app/ts/utils/errors.ts
+++ b/app/ts/utils/errors.ts
@@ -1,15 +1,47 @@
 import { sendPopupMessageToOpenWindowsWithoutUnexpectedErrorReport } from '../background/backgroundUtils.js'
-import { setLatestUnexpectedError } from '../background/storageVariables.js'
+import { appendInterceptorErrorDiagnostic, setLatestUnexpectedError } from '../background/storageVariables.js'
 import { InterceptorError, type JsonRpcErrorResponse } from '../types/JsonRpc-types.js'
+import type { InterceptorErrorCategory, InterceptorErrorDiagnostic, InterceptorErrorSeverity } from '../types/errorDiagnostics.js'
+import { getErrorMessage, getInterceptorInternalErrorCode, isBrowserFetchTransportError } from './caughtErrors.js'
 import { NEW_BLOCK_ABORT } from './constants.js'
+export { createInterceptorInternalError, getErrorMessage } from './caughtErrors.js'
 
 export const GENERIC_UNEXPECTED_ERROR_MESSAGE = 'An internal Interceptor error occurred. Please see The Interceptor console for technical details.'
 
-type UnexpectedErrorMetadata = {
+type ErrorReportMetadata = {
 	source?: string
 	code?: string
 	debugId?: string
+	category?: InterceptorErrorCategory
+	severity?: InterceptorErrorSeverity
+	details?: unknown
+	userVisible?: boolean
+	suppressExpectedInfrastructure?: boolean
 }
+
+type LocalRecoveryMetadata = {
+	source?: string
+	code: string
+	message?: string
+	details?: unknown
+	category?: InterceptorErrorCategory
+}
+
+type ErrorPolicyEntry = {
+	category: InterceptorErrorCategory
+	severity: InterceptorErrorSeverity
+	userVisible: boolean
+}
+
+export const ERROR_REPORTING_POLICY = {
+	expectedInfrastructure: { category: 'expected_infrastructure', severity: 'info', userVisible: false },
+	externalService: { category: 'external_service', severity: 'warning', userVisible: false },
+	userAction: { category: 'user_action', severity: 'info', userVisible: false },
+	localRecovery: { category: 'local_recovery', severity: 'warning', userVisible: false },
+	unexpected: { category: 'unexpected', severity: 'error', userVisible: true },
+} satisfies Record<string, ErrorPolicyEntry>
+
+type InterceptorErrorReport = InterceptorErrorDiagnostic
 
 export class ErrorWithData extends Error {
 	public constructor(message: string, public data: unknown) {
@@ -42,18 +74,10 @@ export class JsonRpcResponseError extends Error {
 	}
 }
 
-export function getErrorMessage(error: unknown) {
-	if (error instanceof Error) return error.message
-	if (typeof error === 'string') return error
-	if (typeof error === 'object' && error !== null && 'message' in error && typeof error.message === 'string') return error.message
-	return undefined
-}
-
 export function isFailedToFetchError(error: unknown) {
-	const message = getErrorMessage(error)
-	if (message === undefined) return false
-	if (message.includes('Fetch request timed out.') || message.includes('Fetch request aborted.') || message.includes('Failed to fetch') || message.includes('NetworkError when attempting to fetch resource')) return true
-	return false
+	const code = getInterceptorInternalErrorCode(error)
+	if (code === 'fetch_timeout' || code === 'fetch_aborted' || code === 'fetch_transport_failed') return true
+	return isBrowserFetchTransportError(error)
 }
 
 export const isNewBlockAbort = (error: unknown) => getErrorMessage(error) === NEW_BLOCK_ABORT
@@ -86,6 +110,30 @@ function normalizeUnexpectedError(error: unknown) {
 	return { message: GENERIC_UNEXPECTED_ERROR_MESSAGE }
 }
 
+const MAX_DIAGNOSTIC_DETAILS_LENGTH = 2000
+
+function truncateDiagnosticDetails(details: string) {
+	if (details.length <= MAX_DIAGNOSTIC_DETAILS_LENGTH) return details
+	return `${ details.slice(0, MAX_DIAGNOSTIC_DETAILS_LENGTH) }...`
+}
+
+function stringifyDiagnosticDetails(details: unknown): string | undefined {
+	if (details === undefined) return undefined
+	if (typeof details === 'string') return truncateDiagnosticDetails(details)
+	try {
+		const serialized = JSON.stringify(details, (_key, value) => typeof value === 'bigint' ? value.toString() : value)
+		if (serialized !== undefined) return truncateDiagnosticDetails(serialized)
+	} catch {
+		const message = getErrorMessage(details)
+		if (message !== undefined) return truncateDiagnosticDetails(message)
+	}
+	try {
+		return truncateDiagnosticDetails(String(details))
+	} catch {
+		return undefined
+	}
+}
+
 export function printError(error: unknown) {
 	console.error(error)
 	const forwardedDiagnostics = getForwardedDiagnostics(error)
@@ -104,36 +152,118 @@ function generateDebugId() {
 	return globalThis.crypto.randomUUID().slice(0, 8)
 }
 
-export async function handleUnexpectedError(error: unknown, metadata: UnexpectedErrorMetadata = {}) {
-	if (isNewBlockAbort(error)) return
+function createErrorReport(error: unknown, metadata: ErrorReportMetadata, policy: ErrorPolicyEntry, defaultCode: string, message: string): InterceptorErrorReport {
 	const debugId = metadata.debugId ?? generateDebugId()
 	const source = metadata.source ?? 'internal'
-	const code = metadata.code ?? (isWrappedNewBlockAbort(error) ? 'wrapped_new_block_abort' : 'unexpected_error')
-	console.error('Unexpected Interceptor error', { debugId, source, code })
-	printError(error)
-	console.trace()
-	const normalizedError = normalizeUnexpectedError(error)
-	const errorMessage = {
+	return {
+		timestamp: new Date(),
+		message,
+		cause: getErrorMessage(error),
+		source,
+		code: metadata.code ?? defaultCode,
+		category: metadata.category ?? policy.category,
+		severity: metadata.severity ?? policy.severity,
+		userVisible: metadata.userVisible ?? policy.userVisible,
+		debugId,
+		details: stringifyDiagnosticDetails(metadata.details),
+	}
+}
+
+async function appendErrorDiagnostic(report: InterceptorErrorReport) {
+	try {
+		await appendInterceptorErrorDiagnostic(report)
+	} catch (error: unknown) {
+		console.error('Failed to persist interceptor error diagnostic.')
+		printError(error)
+	}
+}
+
+function popupMessageFromUnexpectedReport(report: InterceptorErrorReport) {
+	return {
 		method: 'popup_UnexpectedErrorOccured' as const,
 		data: {
-			timestamp: new Date(),
-			message: normalizedError.message,
-			source,
-			code,
-			debugId,
+			timestamp: report.timestamp,
+			message: report.message,
+			source: report.source,
+			code: report.code,
+			debugId: report.debugId,
 		}
 	}
+}
+
+export async function reportUnexpectedError(error: unknown, metadata: ErrorReportMetadata = {}) {
+	if ((metadata.suppressExpectedInfrastructure ?? true) && isExpectedInfrastructureError(error)) return
+	const defaultCode = isWrappedNewBlockAbort(error) ? 'wrapped_new_block_abort' : 'unexpected_error'
+	const report = createErrorReport(error, metadata, ERROR_REPORTING_POLICY.unexpected, defaultCode, normalizeUnexpectedError(error).message)
+	console.error('Unexpected Interceptor error', {
+		debugId: report.debugId,
+		source: report.source,
+		code: report.code,
+		category: report.category,
+		severity: report.severity,
+	})
+	printError(error)
+	console.trace()
+	await appendErrorDiagnostic(report)
+	const errorMessage = popupMessageFromUnexpectedReport(report)
+	let messageToBroadcast = errorMessage
 	try {
 		await setLatestUnexpectedError(errorMessage)
 	} catch (storageError: unknown) {
 		console.error('Failed to persist unexpected error.')
 		printError(storageError)
-		return
+		messageToBroadcast = { ...errorMessage, data: { ...errorMessage.data, code: 'unexpected_error_persist_failed' } }
 	}
 	try {
-		await sendPopupMessageToOpenWindowsWithoutUnexpectedErrorReport(errorMessage)
+		await sendPopupMessageToOpenWindowsWithoutUnexpectedErrorReport(messageToBroadcast)
 	} catch (broadcastError: unknown) {
 		console.error('Failed to broadcast unexpected error to open popup windows.')
 		printError(broadcastError)
+	}
+}
+
+export async function reportNonFatalError(error: unknown, metadata: ErrorReportMetadata = {}) {
+	await reportUnexpectedError(error, { ...metadata, code: metadata.code ?? 'non_fatal_error' })
+}
+
+export async function reportLocalRecovery(error: unknown, metadata: LocalRecoveryMetadata) {
+	const report = createErrorReport(error, {
+		source: metadata.source,
+		code: metadata.code,
+		category: metadata.category ?? ERROR_REPORTING_POLICY.localRecovery.category,
+		severity: ERROR_REPORTING_POLICY.localRecovery.severity,
+		userVisible: ERROR_REPORTING_POLICY.localRecovery.userVisible,
+		details: metadata.details,
+	}, ERROR_REPORTING_POLICY.localRecovery, metadata.code, metadata.message ?? getErrorMessage(error) ?? 'Recovered from an Interceptor error.')
+	console.warn('Local Interceptor recovery', {
+		debugId: report.debugId,
+		source: report.source,
+		code: report.code,
+		category: report.category,
+		severity: report.severity,
+		message: report.message,
+		...(report.cause === undefined ? {} : { cause: report.cause }),
+	})
+	if (report.details !== undefined) console.warn(report.details)
+	printError(error)
+	await appendErrorDiagnostic(report)
+}
+
+export function reportLocalRecoveryAtAsyncBoundary(operation: () => Promise<unknown>, metadata: LocalRecoveryMetadata) {
+	void operation().catch((error: unknown) => {
+		void reportLocalRecovery(error, metadata)
+	})
+}
+
+export function reportUnexpectedErrorAtAsyncBoundary(operation: () => Promise<unknown>, metadata: ErrorReportMetadata = {}) {
+	void operation().catch((error: unknown) => {
+		void reportUnexpectedError(error, metadata)
+	})
+}
+
+export function withUnexpectedErrorReporting<Args extends readonly unknown[]>(callback: (...args: Args) => Promise<unknown>, metadata: ErrorReportMetadata = {}) {
+	return (...args: Args) => {
+		reportUnexpectedErrorAtAsyncBoundary(async () => await callback(...args), metadata)
+		return undefined
 	}
 }

--- a/app/ts/utils/requests.ts
+++ b/app/ts/utils/requests.ts
@@ -1,6 +1,7 @@
 import * as funtypes from 'funtypes'
 import { EthereumQuantity } from '../types/wire-types.js'
 import { anySignal } from './anySignal.js'
+import { createInterceptorInternalError, getErrorMessage, isBrowserFetchTransportError } from './caughtErrors.js'
 
 export type WebsiteSocket = funtypes.Static<typeof WebsiteSocket>
 export const WebsiteSocket = funtypes.ReadonlyObject({
@@ -63,7 +64,7 @@ export const doesUniqueRequestIdentifiersMatch = (a: UniqueRequestIdentifier, b:
 
 export async function fetchWithTimeout(resource: RequestInfo | URL, init: RequestInit | undefined, timeoutMs: number, requestAbortController: AbortController | undefined = undefined) {
 	const timeoutAbortController = new AbortController()
-	const timeoutId = setTimeout(() => timeoutAbortController.abort(new Error('Fetch request timed out.')), timeoutMs)
+	const timeoutId = setTimeout(() => timeoutAbortController.abort(createInterceptorInternalError('Fetch request timed out.', 'fetch_timeout')), timeoutMs)
 	const requestAndTimeoutSignal = requestAbortController === undefined ? timeoutAbortController.signal : anySignal([timeoutAbortController.signal, requestAbortController.signal])
 	try {
 		if (requestAndTimeoutSignal.aborted) throw requestAndTimeoutSignal.reason
@@ -71,7 +72,8 @@ export async function fetchWithTimeout(resource: RequestInfo | URL, init: Reques
 	} catch(error: unknown) {
 		if (requestAbortController?.signal.aborted) throw requestAbortController.signal.reason
 		if (timeoutAbortController.signal.aborted) throw timeoutAbortController.signal.reason
-		if (error instanceof DOMException && error.message === 'The user aborted a request.') throw new Error('Fetch request aborted.')
+		if (error instanceof DOMException && error.message === 'The user aborted a request.') throw createInterceptorInternalError('Fetch request aborted.', 'fetch_aborted')
+		if (isBrowserFetchTransportError(error)) throw createInterceptorInternalError(getErrorMessage(error) ?? 'Fetch request failed.', 'fetch_transport_failed')
 		throw error
 	} finally {
 		clearTimeout(timeoutId)

--- a/app/ts/utils/requests.ts
+++ b/app/ts/utils/requests.ts
@@ -69,7 +69,9 @@ export async function fetchWithTimeout(resource: RequestInfo | URL, init: Reques
 		if (requestAndTimeoutSignal.aborted) throw requestAndTimeoutSignal.reason
 		return await fetch(resource, { ...init, signal: requestAndTimeoutSignal })
 	} catch(error: unknown) {
-		if (error instanceof DOMException && error.message === 'The user aborted a request.') throw new Error('Fetch request timed out.')
+		if (requestAbortController?.signal.aborted) throw requestAbortController.signal.reason
+		if (timeoutAbortController.signal.aborted) throw timeoutAbortController.signal.reason
+		if (error instanceof DOMException && error.message === 'The user aborted a request.') throw new Error('Fetch request aborted.')
 		throw error
 	} finally {
 		clearTimeout(timeoutId)

--- a/app/ts/utils/storageUtils.ts
+++ b/app/ts/utils/storageUtils.ts
@@ -10,6 +10,7 @@ import { PendingAccessRequests, PendingTransactionOrSignableMessage } from '../t
 import { RpcEntries, RpcNetwork } from '../types/rpc.js'
 import { ENSLabelHashes, ENSNameHashes } from '../types/ens.js'
 import { UnexpectedErrorOccured } from '../types/interceptor-reply-messages.js'
+import { InterceptorErrorDiagnostic } from '../types/errorDiagnostics.js'
 
 type IdsOfOpenedTabs = funtypes.Static<typeof IdsOfOpenedTabs>
 const IdsOfOpenedTabs = funtypes.ReadonlyObject({
@@ -67,6 +68,7 @@ const LocalStorageItemsRuntype = funtypes.ReadonlyPartial({
 	interceptorDisabled: funtypes.Boolean,
 	interceptorStartSleepingTimestamp: funtypes.Number,
 	latestUnexpectedError: UnexpectedErrorOccured,
+	interceptorErrorDiagnostics: funtypes.ReadonlyArray(InterceptorErrorDiagnostic),
 	ensNameHashes: ENSNameHashes,
 	ensLabelHashes: ENSLabelHashes,
 	preSimulationBlockTimeManipulation: BlockTimeManipulation,
@@ -104,6 +106,7 @@ const LocalStorageKey = funtypes.Union(
 	funtypes.Literal('idsOfOpenedTabs'),
 	funtypes.Literal('interceptorStartSleepingTimestamp'),
 	funtypes.Literal('latestUnexpectedError'),
+	funtypes.Literal('interceptorErrorDiagnostics'),
 	funtypes.Literal('ensNameHashes'),
 	funtypes.Literal('ensLabelHashes'),
 	funtypes.Literal('preSimulationBlockTimeManipulation'),

--- a/app/ts/utils/unexpectedErrorPopupMessage.ts
+++ b/app/ts/utils/unexpectedErrorPopupMessage.ts
@@ -1,0 +1,21 @@
+import type { InterceptorErrorDiagnostic } from '../types/errorDiagnostics.js'
+import type { UnexpectedErrorOccured } from '../types/interceptor-reply-messages.js'
+
+type UnexpectedErrorPopupMessageInput = Pick<InterceptorErrorDiagnostic, 'timestamp' | 'message' | 'source' | 'code' | 'debugId'>
+
+export function createErrorDebugId() {
+	return globalThis.crypto.randomUUID().slice(0, 8)
+}
+
+export function createUnexpectedErrorPopupMessage(report: UnexpectedErrorPopupMessageInput): UnexpectedErrorOccured {
+	return {
+		method: 'popup_UnexpectedErrorOccured',
+		data: {
+			timestamp: report.timestamp,
+			message: report.message,
+			source: report.source,
+			code: report.code,
+			debugId: report.debugId,
+		}
+	}
+}

--- a/package.json
+++ b/package.json
@@ -30,8 +30,10 @@
 		"lint:catches": "bun ./scripts/check-comment-only-catches.mts",
 		"lint:quotes": "bun ./scripts/check-single-quotes.mts",
 		"lint:quotes:fix": "bun ./scripts/check-single-quotes.mts --write",
+		"lint:error-reporting": "bun ./scripts/check-awaited-unexpected-error-reporting.mts",
+		"lint:new-block-abort": "bun ./scripts/check-new-block-abort-guards.mts",
 		"lint:signals": "bun ./scripts/check-signal-comparisons.mts",
-		"lint": "bun run biome:check && bun run lint:catches && bun run lint:quotes && bun run lint:signals"
+		"lint": "bun run biome:check && bun run lint:catches && bun run lint:quotes && bun run lint:error-reporting && bun run lint:new-block-abort && bun run lint:signals"
 	},
 	"dependencies": {
 		"@darkflorist/address-metadata": "0.10.0",

--- a/package.json
+++ b/package.json
@@ -31,9 +31,11 @@
 		"lint:quotes": "bun ./scripts/check-single-quotes.mts",
 		"lint:quotes:fix": "bun ./scripts/check-single-quotes.mts --write",
 		"lint:error-reporting": "bun ./scripts/check-awaited-unexpected-error-reporting.mts",
+		"lint:error-catches": "bun ./scripts/check-console-error-catches.mts",
 		"lint:new-block-abort": "bun ./scripts/check-new-block-abort-guards.mts",
+		"lint:fetch-error-messages": "bun ./scripts/check-raw-fetch-error-messages.mts",
 		"lint:signals": "bun ./scripts/check-signal-comparisons.mts",
-		"lint": "bun run biome:check && bun run lint:catches && bun run lint:quotes && bun run lint:error-reporting && bun run lint:new-block-abort && bun run lint:signals"
+		"lint": "bun run biome:check && bun run lint:catches && bun run lint:quotes && bun run lint:error-reporting && bun run lint:error-catches && bun run lint:new-block-abort && bun run lint:fetch-error-messages && bun run lint:signals"
 	},
 	"dependencies": {
 		"@darkflorist/address-metadata": "0.10.0",

--- a/scripts/check-awaited-unexpected-error-reporting.mts
+++ b/scripts/check-awaited-unexpected-error-reporting.mts
@@ -3,9 +3,10 @@ import process from 'node:process'
 const filePatterns = ['app/ts/**/*.ts', 'app/ts/**/*.tsx'] as const
 const allowedPrefixes = ['await ', 'return ', 'void ']
 const diagnostics: { file: string, line: number, text: string }[] = []
+const wrappedDiagnostics: { file: string, line: number, text: string }[] = []
 
-function isHandleUnexpectedErrorDeclaration(line: string) {
-	return line.includes('function handleUnexpectedError(')
+function isReportUnexpectedErrorDeclaration(line: string) {
+	return line.includes('function reportUnexpectedError(')
 }
 
 function isAllowedCall(line: string, index: number) {
@@ -18,19 +19,30 @@ for (const pattern of filePatterns) {
 		const sourceText = await Bun.file(path).text()
 		const lines = sourceText.split('\n')
 		for (const [index, line] of lines.entries()) {
-			if (isHandleUnexpectedErrorDeclaration(line)) continue
-			const callIndex = line.indexOf('handleUnexpectedError(')
+			if (isReportUnexpectedErrorDeclaration(line)) continue
+			const callIndex = line.indexOf('reportUnexpectedError(')
 			if (callIndex === -1) continue
+			if (line.includes('reportUnexpectedError(new Error(')) {
+				wrappedDiagnostics.push({ file: path, line: index + 1, text: line.trim() })
+			}
 			if (isAllowedCall(line, callIndex)) continue
 			diagnostics.push({ file: path, line: index + 1, text: line.trim() })
 		}
 	}
 }
 
-if (diagnostics.length > 0) {
-	console.error('handleUnexpectedError calls must be awaited, returned, or explicitly voided.')
-	for (const diagnostic of diagnostics) {
-		console.error(`${ diagnostic.file }:${ diagnostic.line }: ${ diagnostic.text }`)
+if (diagnostics.length > 0 || wrappedDiagnostics.length > 0) {
+	if (wrappedDiagnostics.length > 0) {
+		console.error('reportUnexpectedError must receive the original caught value. Do not wrap errors before reporting.')
+		for (const diagnostic of wrappedDiagnostics) {
+			console.error(`${ diagnostic.file }:${ diagnostic.line }: ${ diagnostic.text }`)
+		}
+	}
+	if (diagnostics.length > 0) {
+		console.error('reportUnexpectedError calls must be awaited, returned, or explicitly voided.')
+		for (const diagnostic of diagnostics) {
+			console.error(`${ diagnostic.file }:${ diagnostic.line }: ${ diagnostic.text }`)
+		}
 	}
 	process.exit(1)
 }

--- a/scripts/check-awaited-unexpected-error-reporting.mts
+++ b/scripts/check-awaited-unexpected-error-reporting.mts
@@ -91,7 +91,7 @@ function collectDiagnostics(path: string, sourceText: string) {
 		const isScopeBoundary = ts.isSourceFile(node) || ts.isBlock(node) || ts.isModuleBlock(node)
 		if (isScopeBoundary) scopes.unshift({ reportValues: new Map() })
 		if (ts.isVariableDeclaration(node) && ts.isIdentifier(node.name)) {
-			scopes[0]?.reportValues.set(node.name.text, node.initializer === undefined ? false : isWrappedReportExpression(node.initializer))
+			scopes[0]?.reportValues.set(node.name.text, node.initializer === undefined ? false : isWrappedReportExpression(node.initializer) || isWrappedIdentifier(node.initializer, scopes))
 		}
 		if (isReportUnexpectedErrorCall(node)) {
 			if (isWrappedErrorReport(node, scopes)) wrappedDiagnostics.push(diagnosticForNode(sourceFile, node))

--- a/scripts/check-awaited-unexpected-error-reporting.mts
+++ b/scripts/check-awaited-unexpected-error-reporting.mts
@@ -4,6 +4,7 @@ import ts from 'typescript'
 const defaultFilePatterns = ['app/ts/**/*.ts', 'app/ts/**/*.tsx'] as const
 
 type Diagnostic = { file: string, line: number, column: number, text: string }
+type Scope = { reportValues: Map<string, boolean> }
 
 function scriptKindForPath(path: string) {
 	if (path.endsWith('.tsx')) return ts.ScriptKind.TSX
@@ -46,13 +47,27 @@ function isMessageObjectLiteral(expression: ts.Expression) {
 	})
 }
 
-function isWrappedErrorReport(node: ts.CallExpression) {
-	const firstArgument = node.arguments[0]
-	if (firstArgument === undefined) return false
-	const expression = skipParentheses(firstArgument)
+function isWrappedReportExpression(expression: ts.Expression) {
+	expression = skipParentheses(expression)
 	if (ts.isNewExpression(expression)) return true
 	if (ts.isCallExpression(expression) && ts.isIdentifier(expression.expression) && expression.expression.text === 'Error') return true
 	return isMessageObjectLiteral(expression)
+}
+
+function isWrappedIdentifier(expression: ts.Expression, scopes: readonly Scope[]) {
+	expression = skipParentheses(expression)
+	if (!ts.isIdentifier(expression)) return false
+	for (const scope of scopes) {
+		const wrapped = scope.reportValues.get(expression.text)
+		if (wrapped !== undefined) return wrapped
+	}
+	return false
+}
+
+function isWrappedErrorReport(node: ts.CallExpression, scopes: readonly Scope[]) {
+	const firstArgument = node.arguments[0]
+	if (firstArgument === undefined) return false
+	return isWrappedReportExpression(firstArgument) || isWrappedIdentifier(firstArgument, scopes)
 }
 
 function isAllowedReportUsage(node: ts.CallExpression) {
@@ -70,13 +85,20 @@ function collectDiagnostics(path: string, sourceText: string) {
 	const sourceFile = ts.createSourceFile(path, sourceText, ts.ScriptTarget.Latest, true, scriptKindForPath(path))
 	const unhandledDiagnostics: Diagnostic[] = []
 	const wrappedDiagnostics: Diagnostic[] = []
+	const scopes: Scope[] = []
 
 	const visit = (node: ts.Node) => {
+		const isScopeBoundary = ts.isSourceFile(node) || ts.isBlock(node) || ts.isModuleBlock(node)
+		if (isScopeBoundary) scopes.unshift({ reportValues: new Map() })
+		if (ts.isVariableDeclaration(node) && ts.isIdentifier(node.name)) {
+			scopes[0]?.reportValues.set(node.name.text, node.initializer === undefined ? false : isWrappedReportExpression(node.initializer))
+		}
 		if (isReportUnexpectedErrorCall(node)) {
-			if (isWrappedErrorReport(node)) wrappedDiagnostics.push(diagnosticForNode(sourceFile, node))
+			if (isWrappedErrorReport(node, scopes)) wrappedDiagnostics.push(diagnosticForNode(sourceFile, node))
 			if (!isAllowedReportUsage(node)) unhandledDiagnostics.push(diagnosticForNode(sourceFile, node))
 		}
 		ts.forEachChild(node, visit)
+		if (isScopeBoundary) scopes.shift()
 	}
 
 	visit(sourceFile)

--- a/scripts/check-awaited-unexpected-error-reporting.mts
+++ b/scripts/check-awaited-unexpected-error-reporting.mts
@@ -1,47 +1,107 @@
 import process from 'node:process'
+import ts from 'typescript'
 
-const filePatterns = ['app/ts/**/*.ts', 'app/ts/**/*.tsx'] as const
-const allowedPrefixes = ['await ', 'return ', 'void ']
-const diagnostics: { file: string, line: number, text: string }[] = []
-const wrappedDiagnostics: { file: string, line: number, text: string }[] = []
+const defaultFilePatterns = ['app/ts/**/*.ts', 'app/ts/**/*.tsx'] as const
 
-function isReportUnexpectedErrorDeclaration(line: string) {
-	return line.includes('function reportUnexpectedError(')
+type Diagnostic = { file: string, line: number, column: number, text: string }
+
+function scriptKindForPath(path: string) {
+	if (path.endsWith('.tsx')) return ts.ScriptKind.TSX
+	return ts.ScriptKind.TS
 }
 
-function isAllowedCall(line: string, index: number) {
-	const prefix = line.slice(0, index).trimEnd()
-	return allowedPrefixes.some((allowedPrefix) => prefix.endsWith(allowedPrefix.trimEnd()))
-}
-
-for (const pattern of filePatterns) {
-	for await (const path of new Bun.Glob(pattern).scan('.')) {
-		const sourceText = await Bun.file(path).text()
-		const lines = sourceText.split('\n')
-		for (const [index, line] of lines.entries()) {
-			if (isReportUnexpectedErrorDeclaration(line)) continue
-			const callIndex = line.indexOf('reportUnexpectedError(')
-			if (callIndex === -1) continue
-			if (line.includes('reportUnexpectedError(new Error(')) {
-				wrappedDiagnostics.push({ file: path, line: index + 1, text: line.trim() })
-			}
-			if (isAllowedCall(line, callIndex)) continue
-			diagnostics.push({ file: path, line: index + 1, text: line.trim() })
-		}
+function diagnosticForNode(sourceFile: ts.SourceFile, node: ts.Node): Diagnostic {
+	const { line, character } = sourceFile.getLineAndCharacterOfPosition(node.getStart(sourceFile))
+	return {
+		file: sourceFile.fileName,
+		line: line + 1,
+		column: character + 1,
+		text: node.getText(sourceFile),
 	}
 }
 
-if (diagnostics.length > 0 || wrappedDiagnostics.length > 0) {
+function skipParentheses(expression: ts.Expression): ts.Expression {
+	let current = expression
+	while (ts.isParenthesizedExpression(current)) current = current.expression
+	return current
+}
+
+function isReportUnexpectedErrorCall(node: ts.Node): node is ts.CallExpression {
+	return ts.isCallExpression(node)
+		&& ts.isIdentifier(node.expression)
+		&& node.expression.text === 'reportUnexpectedError'
+}
+
+function isWrappedErrorReport(node: ts.CallExpression) {
+	const firstArgument = node.arguments[0]
+	if (firstArgument === undefined) return false
+	const expression = skipParentheses(firstArgument)
+	return ts.isNewExpression(expression)
+		&& ts.isIdentifier(expression.expression)
+		&& expression.expression.text === 'Error'
+}
+
+function isAllowedReportUsage(node: ts.CallExpression) {
+	let expression: ts.Node = node
+	while (expression.parent !== undefined && ts.isParenthesizedExpression(expression.parent)) expression = expression.parent
+	const parent = expression.parent
+	if (parent === undefined) return false
+	if (ts.isAwaitExpression(parent)) return true
+	if (ts.isVoidExpression(parent)) return true
+	if (ts.isReturnStatement(parent)) return true
+	return false
+}
+
+function collectDiagnostics(path: string, sourceText: string) {
+	const sourceFile = ts.createSourceFile(path, sourceText, ts.ScriptTarget.Latest, true, scriptKindForPath(path))
+	const unhandledDiagnostics: Diagnostic[] = []
+	const wrappedDiagnostics: Diagnostic[] = []
+
+	const visit = (node: ts.Node) => {
+		if (isReportUnexpectedErrorCall(node)) {
+			if (isWrappedErrorReport(node)) wrappedDiagnostics.push(diagnosticForNode(sourceFile, node))
+			if (!isAllowedReportUsage(node)) unhandledDiagnostics.push(diagnosticForNode(sourceFile, node))
+		}
+		ts.forEachChild(node, visit)
+	}
+
+	visit(sourceFile)
+	return { unhandledDiagnostics, wrappedDiagnostics }
+}
+
+async function getFilePaths() {
+	const explicitPaths = process.argv.slice(2)
+	if (explicitPaths.length > 0) return explicitPaths
+
+	const filePaths = new Set<string>()
+	for (const pattern of defaultFilePatterns) {
+		for await (const path of new Bun.Glob(pattern).scan('.')) {
+			filePaths.add(path)
+		}
+	}
+	return [...filePaths].sort()
+}
+
+const unhandledDiagnostics: Diagnostic[] = []
+const wrappedDiagnostics: Diagnostic[] = []
+for (const path of await getFilePaths()) {
+	const sourceText = await Bun.file(path).text()
+	const diagnostics = collectDiagnostics(path, sourceText)
+	unhandledDiagnostics.push(...diagnostics.unhandledDiagnostics)
+	wrappedDiagnostics.push(...diagnostics.wrappedDiagnostics)
+}
+
+if (unhandledDiagnostics.length > 0 || wrappedDiagnostics.length > 0) {
 	if (wrappedDiagnostics.length > 0) {
 		console.error('reportUnexpectedError must receive the original caught value. Do not wrap errors before reporting.')
 		for (const diagnostic of wrappedDiagnostics) {
-			console.error(`${ diagnostic.file }:${ diagnostic.line }: ${ diagnostic.text }`)
+			console.error(`${ diagnostic.file }:${ diagnostic.line }:${ diagnostic.column }: ${ diagnostic.text }`)
 		}
 	}
-	if (diagnostics.length > 0) {
+	if (unhandledDiagnostics.length > 0) {
 		console.error('reportUnexpectedError calls must be awaited, returned, or explicitly voided.')
-		for (const diagnostic of diagnostics) {
-			console.error(`${ diagnostic.file }:${ diagnostic.line }: ${ diagnostic.text }`)
+		for (const diagnostic of unhandledDiagnostics) {
+			console.error(`${ diagnostic.file }:${ diagnostic.line }:${ diagnostic.column }: ${ diagnostic.text }`)
 		}
 	}
 	process.exit(1)

--- a/scripts/check-awaited-unexpected-error-reporting.mts
+++ b/scripts/check-awaited-unexpected-error-reporting.mts
@@ -32,13 +32,27 @@ function isReportUnexpectedErrorCall(node: ts.Node): node is ts.CallExpression {
 		&& node.expression.text === 'reportUnexpectedError'
 }
 
+function isMessagePropertyName(name: ts.PropertyName): boolean {
+	if (ts.isIdentifier(name)) return name.text === 'message'
+	if (ts.isStringLiteralLike(name)) return name.text === 'message'
+	return false
+}
+
+function isMessageObjectLiteral(expression: ts.Expression) {
+	if (!ts.isObjectLiteralExpression(expression)) return false
+	return expression.properties.some((property) => {
+		if (ts.isPropertyAssignment(property) || ts.isShorthandPropertyAssignment(property) || ts.isMethodDeclaration(property)) return isMessagePropertyName(property.name)
+		return false
+	})
+}
+
 function isWrappedErrorReport(node: ts.CallExpression) {
 	const firstArgument = node.arguments[0]
 	if (firstArgument === undefined) return false
 	const expression = skipParentheses(firstArgument)
-	return ts.isNewExpression(expression)
-		&& ts.isIdentifier(expression.expression)
-		&& expression.expression.text === 'Error'
+	if (ts.isNewExpression(expression)) return true
+	if (ts.isCallExpression(expression) && ts.isIdentifier(expression.expression) && expression.expression.text === 'Error') return true
+	return isMessageObjectLiteral(expression)
 }
 
 function isAllowedReportUsage(node: ts.CallExpression) {

--- a/scripts/check-awaited-unexpected-error-reporting.mts
+++ b/scripts/check-awaited-unexpected-error-reporting.mts
@@ -1,0 +1,36 @@
+import process from 'node:process'
+
+const filePatterns = ['app/ts/**/*.ts', 'app/ts/**/*.tsx'] as const
+const allowedPrefixes = ['await ', 'return ', 'void ']
+const diagnostics: { file: string, line: number, text: string }[] = []
+
+function isHandleUnexpectedErrorDeclaration(line: string) {
+	return line.includes('function handleUnexpectedError(')
+}
+
+function isAllowedCall(line: string, index: number) {
+	const prefix = line.slice(0, index).trimEnd()
+	return allowedPrefixes.some((allowedPrefix) => prefix.endsWith(allowedPrefix.trimEnd()))
+}
+
+for (const pattern of filePatterns) {
+	for await (const path of new Bun.Glob(pattern).scan('.')) {
+		const sourceText = await Bun.file(path).text()
+		const lines = sourceText.split('\n')
+		for (const [index, line] of lines.entries()) {
+			if (isHandleUnexpectedErrorDeclaration(line)) continue
+			const callIndex = line.indexOf('handleUnexpectedError(')
+			if (callIndex === -1) continue
+			if (isAllowedCall(line, callIndex)) continue
+			diagnostics.push({ file: path, line: index + 1, text: line.trim() })
+		}
+	}
+}
+
+if (diagnostics.length > 0) {
+	console.error('handleUnexpectedError calls must be awaited, returned, or explicitly voided.')
+	for (const diagnostic of diagnostics) {
+		console.error(`${ diagnostic.file }:${ diagnostic.line }: ${ diagnostic.text }`)
+	}
+	process.exit(1)
+}

--- a/scripts/check-console-error-catches.mts
+++ b/scripts/check-console-error-catches.mts
@@ -1,0 +1,75 @@
+import process from 'node:process'
+import ts from 'typescript'
+
+const filePatterns = ['app/ts/**/*.ts', 'app/ts/**/*.tsx'] as const
+const allowedFiles = new Set(['app/ts/utils/errors.ts'])
+const allowedComments = ['error-reporting: console-only']
+
+type Diagnostic = { file: string, line: number, column: number, text: string }
+
+function scriptKindForPath(path: string) {
+	if (path.endsWith('.tsx')) return ts.ScriptKind.TSX
+	return ts.ScriptKind.TS
+}
+
+function hasAllowedComment(sourceText: string, node: ts.Node) {
+	return allowedComments.some((comment) => sourceText.slice(node.getFullStart(), node.getEnd()).includes(comment))
+}
+
+function isPrintErrorCall(node: ts.CallExpression) {
+	return ts.isIdentifier(node.expression) && node.expression.text === 'printError'
+}
+
+function isConsoleErrorCall(node: ts.CallExpression) {
+	if (!ts.isPropertyAccessExpression(node.expression)) return false
+	return ts.isIdentifier(node.expression.expression)
+		&& node.expression.expression.text === 'console'
+		&& node.expression.name.text === 'error'
+}
+
+function collectConsoleErrorCatchDiagnostics(path: string, sourceText: string) {
+	if (allowedFiles.has(path)) return []
+	const sourceFile = ts.createSourceFile(path, sourceText, ts.ScriptTarget.Latest, true, scriptKindForPath(path))
+	const diagnostics: Diagnostic[] = []
+
+	function visitCatch(catchClause: ts.CatchClause) {
+		if (hasAllowedComment(sourceText, catchClause.block)) return
+		const visit = (node: ts.Node) => {
+			if (ts.isCallExpression(node) && (isPrintErrorCall(node) || isConsoleErrorCall(node))) {
+				const { line, character } = sourceFile.getLineAndCharacterOfPosition(node.getStart(sourceFile))
+				diagnostics.push({ file: path, line: line + 1, column: character + 1, text: node.getText(sourceFile) })
+			}
+			ts.forEachChild(node, visit)
+		}
+		visit(catchClause.block)
+	}
+
+	const visit = (node: ts.Node) => {
+		if (ts.isCatchClause(node)) visitCatch(node)
+		ts.forEachChild(node, visit)
+	}
+
+	visit(sourceFile)
+	return diagnostics
+}
+
+const filePaths = new Set<string>()
+for (const pattern of filePatterns) {
+	for await (const path of new Bun.Glob(pattern).scan('.')) {
+		filePaths.add(path)
+	}
+}
+
+const diagnostics = []
+for (const path of [...filePaths].sort()) {
+	const sourceText = await Bun.file(path).text()
+	diagnostics.push(...collectConsoleErrorCatchDiagnostics(path, sourceText))
+}
+
+if (diagnostics.length > 0) {
+	console.error('console.error and printError inside catch blocks must use a reporting helper. Use reportLocalRecovery for local fallback paths.')
+	for (const diagnostic of diagnostics) {
+		console.error(`${ diagnostic.file }:${ diagnostic.line }:${ diagnostic.column }: ${ diagnostic.text }`)
+	}
+	process.exit(1)
+}

--- a/scripts/check-new-block-abort-guards.mts
+++ b/scripts/check-new-block-abort-guards.mts
@@ -1,0 +1,41 @@
+import process from 'node:process'
+
+const filePatterns = ['app/ts/**/*.ts', 'app/ts/**/*.tsx', 'test/**/*.ts'] as const
+const disallowedPatterns = [
+	/[\w.]+\s+instanceof\s+Error\s*\)?\s*&&\s*\(?\s*isNewBlockAbort\s*\(/g,
+	/isNewBlockAbort\s*\([^)]*\)\s*\)?\s*&&\s*\(?\s*[\w.]+\s+instanceof\s+Error/g,
+]
+
+const diagnostics: { file: string, line: number, text: string }[] = []
+
+function getLineNumber(sourceText: string, index: number) {
+	return sourceText.slice(0, index).split('\n').length
+}
+
+function getLineText(sourceText: string, lineNumber: number) {
+	return sourceText.split('\n')[lineNumber - 1]?.trim() ?? ''
+}
+
+for (const pattern of filePatterns) {
+	for await (const path of new Bun.Glob(pattern).scan('.')) {
+		const sourceText = await Bun.file(path).text()
+		for (const disallowedPattern of disallowedPatterns) {
+			for (const match of sourceText.matchAll(disallowedPattern)) {
+				const lineNumber = getLineNumber(sourceText, match.index)
+				diagnostics.push({
+					file: path,
+					line: lineNumber,
+					text: getLineText(sourceText, lineNumber),
+				})
+			}
+		}
+	}
+}
+
+if (diagnostics.length > 0) {
+	console.error('New-block abort checks must use isNewBlockAbort(error) directly. The helper accepts unknown values.')
+	for (const diagnostic of diagnostics) {
+		console.error(`${ diagnostic.file }:${ diagnostic.line }: ${ diagnostic.text }`)
+	}
+	process.exit(1)
+}

--- a/scripts/check-raw-fetch-error-messages.mts
+++ b/scripts/check-raw-fetch-error-messages.mts
@@ -1,0 +1,60 @@
+import process from 'node:process'
+import ts from 'typescript'
+
+const filePatterns = ['app/ts/**/*.ts', 'app/ts/**/*.tsx']
+const allowedFiles = new Set([
+	'app/ts/utils/caughtErrors.ts',
+	'app/ts/utils/requests.ts',
+])
+const rawFetchErrorMessages = new Set([
+	'Failed to fetch',
+	'NetworkError when attempting to fetch resource',
+	'The user aborted a request.',
+	'Fetch request timed out.',
+	'Fetch request aborted.',
+])
+
+type Diagnostic = { file: string, line: number, column: number, text: string }
+
+function scriptKindForPath(path: string) {
+	if (path.endsWith('.tsx')) return ts.ScriptKind.TSX
+	return ts.ScriptKind.TS
+}
+
+function collectDiagnostics(path: string, sourceText: string) {
+	if (allowedFiles.has(path)) return []
+	const sourceFile = ts.createSourceFile(path, sourceText, ts.ScriptTarget.Latest, true, scriptKindForPath(path))
+	const diagnostics: Diagnostic[] = []
+
+	const visit = (node: ts.Node) => {
+		if ((ts.isStringLiteral(node) || ts.isNoSubstitutionTemplateLiteral(node)) && rawFetchErrorMessages.has(node.text)) {
+			const { line, character } = sourceFile.getLineAndCharacterOfPosition(node.getStart(sourceFile))
+			diagnostics.push({ file: path, line: line + 1, column: character + 1, text: node.getText(sourceFile) })
+		}
+		ts.forEachChild(node, visit)
+	}
+
+	visit(sourceFile)
+	return diagnostics
+}
+
+const filePaths = new Set<string>()
+for (const pattern of filePatterns) {
+	for await (const path of new Bun.Glob(pattern).scan('.')) {
+		filePaths.add(path)
+	}
+}
+
+const diagnostics: Diagnostic[] = []
+for (const path of [...filePaths].sort()) {
+	const sourceText = await Bun.file(path).text()
+	diagnostics.push(...collectDiagnostics(path, sourceText))
+}
+
+if (diagnostics.length > 0) {
+	console.error('Raw browser fetch error messages must stay in app/ts/utils/caughtErrors.ts or app/ts/utils/requests.ts.')
+	for (const diagnostic of diagnostics) {
+		console.error(`${ diagnostic.file }:${ diagnostic.line }:${ diagnostic.column }: ${ diagnostic.text }`)
+	}
+	process.exit(1)
+}

--- a/test/tests/consoleSilence.ts
+++ b/test/tests/consoleSilence.ts
@@ -1,0 +1,17 @@
+export async function withSilencedConsole<T>(runWithConsoleSilenced: () => T | Promise<T>) {
+	const originalConsole = {
+		error: console.error,
+		trace: console.trace,
+		warn: console.warn,
+	}
+	console.error = () => undefined
+	console.trace = () => undefined
+	console.warn = () => undefined
+	try {
+		return await runWithConsoleSilenced()
+	} finally {
+		console.error = originalConsole.error
+		console.trace = originalConsole.trace
+		console.warn = originalConsole.warn
+	}
+}

--- a/test/tests/contentScriptsUpdating.test.ts
+++ b/test/tests/contentScriptsUpdating.test.ts
@@ -141,15 +141,20 @@ describe('content script injection strategy errors', () => {
 		assert.equal(await getLatestUnexpectedError(), undefined)
 	})
 
-	test('records unexpected manifest v2 injection failures', async () => {
+	test('records manifest v2 injection failures as local recovery diagnostics', async () => {
 		const { getCommittedListener } = installBrowserMock({ executeScriptError: new Error('executeScript failed') })
-		const { updateContentScriptInjectionStrategyManifestV2, getLatestUnexpectedError } = await loadModules()
+		const { updateContentScriptInjectionStrategyManifestV2, getInterceptorErrorDiagnostics, getLatestUnexpectedError } = await loadModules()
 
 		await updateContentScriptInjectionStrategyManifestV2()
 		await getCommittedListener()(committedDetails)
 
-		const latestUnexpectedError = await getLatestUnexpectedError()
-		assert.equal(latestUnexpectedError?.data.message, 'executeScript failed')
-		assert.equal(latestUnexpectedError?.data.code, 'content_script_injection_failed')
+		for (let index = 0; index < 10 && (await getInterceptorErrorDiagnostics()).length === 0; index++) await Promise.resolve()
+		assert.equal(await getLatestUnexpectedError(), undefined)
+		const diagnostics = await getInterceptorErrorDiagnostics()
+		assert.equal(diagnostics.length, 1)
+		assert.equal(diagnostics[0]?.message, 'Leaving this navigation without early injection.')
+		assert.equal(diagnostics[0]?.cause, 'executeScript failed')
+		assert.equal(diagnostics[0]?.code, 'manifest_v2_content_script_injection_failed')
+		assert.equal(diagnostics[0]?.category, 'local_recovery')
 	})
 })

--- a/test/tests/contentScriptsUpdating.test.ts
+++ b/test/tests/contentScriptsUpdating.test.ts
@@ -1,5 +1,6 @@
 import * as assert from 'assert'
 import { describe, test } from 'bun:test'
+import { withSilencedConsole } from './consoleSilence.js'
 
 type RuntimeMessage = {
 	readonly method?: string
@@ -123,7 +124,7 @@ describe('content script injection strategy errors', () => {
 		const { sentMessages } = installBrowserMock({ registerError: new Error('registration failed') })
 		const { updateContentScriptInjectionStrategyManifestV3, getLatestUnexpectedError } = await loadModules()
 
-		await updateContentScriptInjectionStrategyManifestV3()
+		await withSilencedConsole(async () => await updateContentScriptInjectionStrategyManifestV3())
 
 		const latestUnexpectedError = await getLatestUnexpectedError()
 		assert.equal(latestUnexpectedError?.data.message, 'registration failed')
@@ -136,7 +137,9 @@ describe('content script injection strategy errors', () => {
 		const { updateContentScriptInjectionStrategyManifestV2, getLatestUnexpectedError } = await loadModules()
 
 		await updateContentScriptInjectionStrategyManifestV2()
-		await getCommittedListener()(committedDetails)
+		await withSilencedConsole(async () => {
+			await getCommittedListener()(committedDetails)
+		})
 
 		assert.equal(await getLatestUnexpectedError(), undefined)
 	})
@@ -146,7 +149,9 @@ describe('content script injection strategy errors', () => {
 		const { updateContentScriptInjectionStrategyManifestV2, getInterceptorErrorDiagnostics, getLatestUnexpectedError } = await loadModules()
 
 		await updateContentScriptInjectionStrategyManifestV2()
-		await getCommittedListener()(committedDetails)
+		await withSilencedConsole(async () => {
+			await getCommittedListener()(committedDetails)
+		})
 
 		for (let index = 0; index < 10 && (await getInterceptorErrorDiagnostics()).length === 0; index++) await Promise.resolve()
 		assert.equal(await getLatestUnexpectedError(), undefined)

--- a/test/tests/errorReportingLint.test.ts
+++ b/test/tests/errorReportingLint.test.ts
@@ -82,16 +82,22 @@ describe('unexpected error reporting lint', () => {
 			async function sample(error: unknown) {
 				const wrapped = { message: 'wrapped' }
 				const wrappedError = new Error('wrapped')
+				const alias = wrapped
+				const errorAlias = wrappedError
 				await reportUnexpectedError({
 					message: 'wrapped'
 				})
 				await reportUnexpectedError(({ 'message': 'wrapped' }))
 				await reportUnexpectedError(wrapped)
 				await reportUnexpectedError(wrappedError)
+				await reportUnexpectedError(alias)
+				await reportUnexpectedError(errorAlias)
 			}
 		`)
 
 		assert.notEqual(result.exitCode, 0)
 		assert.equal(result.stderr.includes('Do not wrap errors before reporting.'), true)
+		assert.equal(result.stderr.includes('reportUnexpectedError(alias)'), true)
+		assert.equal(result.stderr.includes('reportUnexpectedError(errorAlias)'), true)
 	})
 })

--- a/test/tests/errorReportingLint.test.ts
+++ b/test/tests/errorReportingLint.test.ts
@@ -43,7 +43,7 @@ describe('unexpected error reporting lint', () => {
 				await (reportUnexpectedError(error))
 				void (reportUnexpectedError(error))
 				return (reportUnexpectedError(error))
-				await reportUnexpectedError(error, { message: 'display message' })
+				await reportUnexpectedError(error, { displayMessage: 'display message' })
 				await reportUnexpectedError({ arbitrary: 'value' })
 			}
 		`)
@@ -80,10 +80,14 @@ describe('unexpected error reporting lint', () => {
 	test('rejects object literal message wrappers', async () => {
 		const result = await runUnexpectedErrorReportingLint(`
 			async function sample(error: unknown) {
+				const wrapped = { message: 'wrapped' }
+				const wrappedError = new Error('wrapped')
 				await reportUnexpectedError({
 					message: 'wrapped'
 				})
 				await reportUnexpectedError(({ 'message': 'wrapped' }))
+				await reportUnexpectedError(wrapped)
+				await reportUnexpectedError(wrappedError)
 			}
 		`)
 

--- a/test/tests/errorReportingLint.test.ts
+++ b/test/tests/errorReportingLint.test.ts
@@ -43,6 +43,8 @@ describe('unexpected error reporting lint', () => {
 				await (reportUnexpectedError(error))
 				void (reportUnexpectedError(error))
 				return (reportUnexpectedError(error))
+				await reportUnexpectedError(error, { message: 'display message' })
+				await reportUnexpectedError({ arbitrary: 'value' })
 			}
 		`)
 
@@ -68,6 +70,20 @@ describe('unexpected error reporting lint', () => {
 				await reportUnexpectedError(
 					new Error('wrapped')
 				)
+			}
+		`)
+
+		assert.notEqual(result.exitCode, 0)
+		assert.equal(result.stderr.includes('Do not wrap errors before reporting.'), true)
+	})
+
+	test('rejects object literal message wrappers', async () => {
+		const result = await runUnexpectedErrorReportingLint(`
+			async function sample(error: unknown) {
+				await reportUnexpectedError({
+					message: 'wrapped'
+				})
+				await reportUnexpectedError(({ 'message': 'wrapped' }))
 			}
 		`)
 

--- a/test/tests/errorReportingLint.test.ts
+++ b/test/tests/errorReportingLint.test.ts
@@ -1,0 +1,77 @@
+import * as assert from 'assert'
+import { mkdtemp, rm, writeFile } from 'node:fs/promises'
+import { tmpdir } from 'node:os'
+import * as path from 'node:path'
+import { describe, test } from 'bun:test'
+
+const repositoryRoot = process.cwd()
+
+type ScriptResult = {
+	exitCode: number
+	stderr: string
+	stdout: string
+}
+
+async function runUnexpectedErrorReportingLint(sourceText: string): Promise<ScriptResult> {
+	const directory = await mkdtemp(path.join(tmpdir(), 'interceptor-error-lint-'))
+	const fixturePath = path.join(directory, 'fixture.ts')
+	await writeFile(fixturePath, sourceText)
+	try {
+		const process = Bun.spawn(['bun', './scripts/check-awaited-unexpected-error-reporting.mts', fixturePath], {
+			cwd: repositoryRoot,
+			stderr: 'pipe',
+			stdout: 'pipe',
+		})
+		const [exitCode, stderr, stdout] = await Promise.all([
+			process.exited,
+			process.stderr === undefined ? '' : new Response(process.stderr).text(),
+			process.stdout === undefined ? '' : new Response(process.stdout).text(),
+		])
+		return { exitCode, stderr, stdout }
+	} finally {
+		await rm(directory, { recursive: true, force: true })
+	}
+}
+
+describe('unexpected error reporting lint', () => {
+	test('allows awaited returned and voided reportUnexpectedError calls', async () => {
+		const result = await runUnexpectedErrorReportingLint(`
+			async function sample(error: unknown) {
+				await reportUnexpectedError(error)
+				void reportUnexpectedError(error)
+				return reportUnexpectedError(error)
+				await (reportUnexpectedError(error))
+				void (reportUnexpectedError(error))
+				return (reportUnexpectedError(error))
+			}
+		`)
+
+		assert.equal(result.exitCode, 0, result.stderr)
+	})
+
+	test('rejects multiline unhandled reportUnexpectedError calls', async () => {
+		const result = await runUnexpectedErrorReportingLint(`
+			async function sample(error: unknown) {
+				reportUnexpectedError(
+					error
+				)
+			}
+		`)
+
+		assert.notEqual(result.exitCode, 0)
+		assert.equal(result.stderr.includes('reportUnexpectedError calls must be awaited, returned, or explicitly voided.'), true)
+	})
+
+	test('rejects multiline wrapped reportUnexpectedError calls', async () => {
+		const result = await runUnexpectedErrorReportingLint(`
+			async function sample() {
+				await reportUnexpectedError(
+					new Error('wrapped')
+				)
+			}
+		`)
+
+		assert.notEqual(result.exitCode, 0)
+		assert.equal(result.stderr.includes('Do not wrap errors before reporting.'), true)
+	})
+})

--- a/test/tests/failedSimulationMetadata.test.ts
+++ b/test/tests/failedSimulationMetadata.test.ts
@@ -55,9 +55,10 @@ function installBrowserMock() {
 
 installBrowserMock()
 
-const { ETHEREUM_LOGS_LOGGER_ADDRESS } = await import('../../app/ts/utils/constants.js')
+const { ETHEREUM_LOGS_LOGGER_ADDRESS, NEW_BLOCK_ABORT } = await import('../../app/ts/utils/constants.js')
 const { visualizeSimulatorState } = await import('../../app/ts/background/simulationUpdating.js')
 const { EthereumClientService } = await import('../../app/ts/simulation/services/EthereumClientService.js')
+const { getLatestUnexpectedError } = await import('../../app/ts/background/storageVariables.js')
 
 describe('visualizeSimulatorState failed simulations', () => {
 	test('keeps fetched address metadata instead of returning an empty address book', async () => {
@@ -77,6 +78,7 @@ describe('visualizeSimulatorState failed simulations', () => {
 			rpcUrl: rpcNetwork.httpsRpc,
 			clearCache() { return undefined },
 			async jsonRpcRequest(request) {
+				if (request.method === 'eth_getCode') return '0x'
 				throw new Error(`Unexpected RPC method: ${ request.method }`)
 			},
 		}, async () => undefined, async () => undefined, rpcNetwork)
@@ -128,5 +130,73 @@ describe('visualizeSimulatorState failed simulations', () => {
 		assert.equal(visualized.visualizedSimulationState.success, false)
 		assert.equal(visualized.visualizedSimulationState.visualizedBlocks[0]?.simulatedAndVisualizedTransactions[0]?.transaction.from.address, 0n)
 		assert.equal(visualized.visualizedSimulationState.visualizedBlocks[0]?.simulatedAndVisualizedTransactions[0]?.transaction.to?.address, ETHEREUM_LOGS_LOGGER_ADDRESS)
+	})
+
+	test('propagates new-block aborts during delegation lookup without recording an unexpected error', async () => {
+		installBrowserMock()
+
+		const rpcNetwork = {
+			name: 'Test Chain',
+			chainId: 1337n,
+			httpsRpc: 'https://example.invalid',
+			currencyName: 'Ether',
+			currencyTicker: 'ETH',
+			primary: true,
+			minimized: true,
+		}
+
+		const ethereum = new EthereumClientService({
+			rpcUrl: rpcNetwork.httpsRpc,
+			clearCache() { return undefined },
+			async jsonRpcRequest(request) {
+				if (request.method === 'eth_getCode') throw new Error(NEW_BLOCK_ABORT)
+				throw new Error(`Unexpected RPC method: ${ request.method }`)
+			},
+		}, async () => undefined, async () => undefined, rpcNetwork)
+
+		const created = new Date('2024-01-01T00:00:00.000Z')
+		const failedSimulationState = {
+			success: false,
+			simulationStateInput: [{
+				stateOverrides: {},
+				transactions: [{
+					signedTransaction: {
+						type: '1559',
+						from: 0n,
+						nonce: 0n,
+						maxFeePerGas: 1n,
+						maxPriorityFeePerGas: 1n,
+						gas: 21_000n,
+						to: ETHEREUM_LOGS_LOGGER_ADDRESS,
+						value: 0n,
+						input: new Uint8Array(),
+						chainId: rpcNetwork.chainId,
+						hash: 1n,
+						v: 1n,
+						r: 1n,
+						s: 1n,
+					},
+					website: { websiteOrigin: 'https://example.com', icon: undefined, title: 'Example' },
+					created,
+					originalRequestParameters: { method: 'eth_sendTransaction', params: [{ from: 0n, to: ETHEREUM_LOGS_LOGGER_ADDRESS, value: 0n, input: new Uint8Array() }] },
+					transactionIdentifier: 1n,
+				}],
+				signedMessages: [],
+				blockTimeManipulation: { type: 'AddToTimestamp', deltaToAdd: 0n, deltaUnit: 'Seconds' },
+				simulateWithZeroBaseFee: false,
+			}],
+			jsonRpcError: { jsonrpc: '2.0', id: 1, error: { code: -32000, message: 'simulation failed' } },
+			blockNumber: 1n,
+			blockTimestamp: created,
+			baseFeePerGas: 1n,
+			simulationConductedTimestamp: created,
+			rpcNetwork,
+		}
+
+		await assert.rejects(
+			async () => await visualizeSimulatorState(failedSimulationState, ethereum, { estimateEthereumPricesForTokens: async () => [] }, undefined),
+			(error) => error instanceof Error && error.message === NEW_BLOCK_ABORT,
+		)
+		assert.equal(await getLatestUnexpectedError(), undefined)
 	})
 })

--- a/test/tests/failedSimulationMetadata.test.ts
+++ b/test/tests/failedSimulationMetadata.test.ts
@@ -149,7 +149,7 @@ describe('visualizeSimulatorState failed simulations', () => {
 			rpcUrl: rpcNetwork.httpsRpc,
 			clearCache() { return undefined },
 			async jsonRpcRequest(request) {
-				if (request.method === 'eth_getCode') throw new Error(NEW_BLOCK_ABORT)
+				if (request.method === 'eth_getCode') throw NEW_BLOCK_ABORT
 				throw new Error(`Unexpected RPC method: ${ request.method }`)
 			},
 		}, async () => undefined, async () => undefined, rpcNetwork)
@@ -195,7 +195,7 @@ describe('visualizeSimulatorState failed simulations', () => {
 
 		await assert.rejects(
 			async () => await visualizeSimulatorState(failedSimulationState, ethereum, { estimateEthereumPricesForTokens: async () => [] }, undefined),
-			(error) => error instanceof Error && error.message === NEW_BLOCK_ABORT,
+			(error) => error === NEW_BLOCK_ABORT,
 		)
 		assert.equal(await getLatestUnexpectedError(), undefined)
 	})

--- a/test/tests/requestMakeMeRichData.test.ts
+++ b/test/tests/requestMakeMeRichData.test.ts
@@ -90,7 +90,7 @@ async function withSilencedConsole<T>(runWithConsoleSilenced: () => Promise<T>) 
 describe('requestMakeMeRichList resilience', () => {
 	test('falls back per address and preserves the underlying error message', async () => {
 		const storageState = installBrowserMock()
-		const { requestMakeMeRichList, setFixedMakeMeRichList, setMakeCurrentAddressRich, getLatestUnexpectedError } = await loadModules()
+		const { requestMakeMeRichList, setFixedMakeMeRichList, setMakeCurrentAddressRich, getInterceptorErrorDiagnostics, getLatestUnexpectedError } = await loadModules()
 		const failingAddress = 0x1000000000000000000000000000000000000001n
 
 		await setFixedMakeMeRichList([
@@ -118,6 +118,10 @@ describe('requestMakeMeRichList resilience', () => {
 		assert.equal(reply.richList[1]?.makingRich, false)
 		assert.equal(reply.richList[1]?.type, 'PreviousActiveAddress')
 		assert.equal((await getLatestUnexpectedError())?.data.message, `Failed to identify rich list address ${ checksummedAddress(failingAddress) }: boom`)
+		const diagnostics = await getInterceptorErrorDiagnostics()
+		assert.equal(diagnostics.length, 1)
+		assert.equal(diagnostics[0]?.cause, 'boom')
+		assert.equal(diagnostics[0]?.details?.includes(checksummedAddress(failingAddress)), true)
 		assert.equal(typeof storageState.latestUnexpectedError, 'object')
 	})
 

--- a/test/tests/unexpectedErrorDiagnostics.test.ts
+++ b/test/tests/unexpectedErrorDiagnostics.test.ts
@@ -19,6 +19,9 @@ function createBrowserMock() {
 		sentMessages.push(message)
 		return undefined
 	}
+	const defaultSetStorage = async (items: Record<string, unknown>) => {
+		Object.assign(storageState, items)
+	}
 	const getStorageItems = (keys?: string | string[] | Record<string, unknown> | null) => {
 		if (keys === undefined || keys === null) return { ...storageState }
 		if (Array.isArray(keys)) return Object.fromEntries(keys.map((key) => [key, storageState[key]]))
@@ -37,9 +40,7 @@ function createBrowserMock() {
 		storage: {
 			local: {
 				async get(keys?: string | string[] | Record<string, unknown> | null) { return getStorageItems(keys) },
-				async set(items: Record<string, unknown>) {
-					Object.assign(storageState, items)
-				},
+				set: defaultSetStorage,
 				async remove(keys: string | string[]) {
 					for (const key of Array.isArray(keys) ? keys : [keys]) delete storageState[key]
 				},
@@ -80,9 +81,13 @@ function createBrowserMock() {
 			sentMessages.length = 0
 			browserMock.runtime.lastError = null
 			browserMock.runtime.sendMessage = defaultSendMessage
+			browserMock.storage.local.set = defaultSetStorage
 		},
 		setSendMessage(sendMessage: (message: RuntimeMessage) => Promise<unknown>) {
 			browserMock.runtime.sendMessage = sendMessage
+		},
+		setStorageSet(set: (items: Record<string, unknown>) => Promise<void>) {
+			browserMock.storage.local.set = set
 		},
 	}
 }
@@ -102,7 +107,7 @@ const modulesPromise = loadModules()
 
 describe('unexpected error diagnostics', () => {
 	test('recognizes expected infrastructure errors from unknown thrown values', async () => {
-		const { classifyCaughtError, isExpectedInfrastructureError, isFailedToFetchError, isNewBlockAbort } = await modulesPromise
+		const { classifyCaughtError, createInterceptorInternalError, isExpectedInfrastructureError, isFailedToFetchError, isNewBlockAbort } = await modulesPromise
 
 		assert.equal(isNewBlockAbort(new Error(NEW_BLOCK_ABORT)), true)
 		assert.equal(isNewBlockAbort(NEW_BLOCK_ABORT), true)
@@ -113,8 +118,11 @@ describe('unexpected error diagnostics', () => {
 
 		assert.equal(isFailedToFetchError(new Error('Failed to fetch')), true)
 		assert.equal(isFailedToFetchError('NetworkError when attempting to fetch resource'), true)
-		assert.equal(isFailedToFetchError({ message: 'Fetch request timed out.' }), true)
-		assert.equal(isFailedToFetchError({ message: 'Fetch request aborted.' }), true)
+		assert.equal(isFailedToFetchError(createInterceptorInternalError('Fetch request timed out.', 'fetch_timeout')), true)
+		assert.equal(isFailedToFetchError(createInterceptorInternalError('Fetch request aborted.', 'fetch_aborted')), true)
+		assert.equal(isFailedToFetchError(createInterceptorInternalError('Failed to fetch', 'fetch_transport_failed')), true)
+		assert.equal(isFailedToFetchError({ message: 'Fetch request timed out.' }), false)
+		assert.equal(isFailedToFetchError({ message: 'Fetch request aborted.' }), false)
 		assert.equal(isFailedToFetchError('unrelated error'), false)
 
 		assert.equal(classifyCaughtError(NEW_BLOCK_ABORT), 'newBlockAbort')
@@ -126,20 +134,39 @@ describe('unexpected error diagnostics', () => {
 
 	test('does not report new-block aborts as unexpected errors', async () => {
 		browserMock.reset()
-		const { handleUnexpectedError, getLatestUnexpectedError } = await modulesPromise
+		const { createInterceptorInternalError, getInterceptorErrorDiagnostics, reportUnexpectedError, getLatestUnexpectedError } = await modulesPromise
 
-		await handleUnexpectedError(NEW_BLOCK_ABORT)
-		await handleUnexpectedError(new Error(NEW_BLOCK_ABORT))
+		await reportUnexpectedError(NEW_BLOCK_ABORT)
+		await reportUnexpectedError(new Error(NEW_BLOCK_ABORT))
+		await reportUnexpectedError(createInterceptorInternalError('Fetch request timed out.', 'fetch_timeout'))
 
 		assert.equal(await getLatestUnexpectedError(), undefined)
+		assert.equal((await getInterceptorErrorDiagnostics()).length, 0)
 		assert.equal(browserMock.sentMessages.length, 0)
+	})
+
+	test('reports explicit expected-infrastructure diagnostics when suppression is disabled', async () => {
+		browserMock.reset()
+		const { createInterceptorInternalError, getLatestUnexpectedError, reportUnexpectedError } = await modulesPromise
+
+		await reportUnexpectedError(createInterceptorInternalError('Failed to fetch', 'fetch_transport_failed'), {
+			source: 'popup',
+			code: 'popup_message_listener_failed',
+			suppressExpectedInfrastructure: false,
+		})
+
+		const latestUnexpectedError = await getLatestUnexpectedError()
+		assert.equal(latestUnexpectedError?.data.message, 'Failed to fetch')
+		assert.equal(latestUnexpectedError?.data.source, 'popup')
+		assert.equal(latestUnexpectedError?.data.code, 'popup_message_listener_failed')
+		assert.equal(browserMock.sentMessages.length, 1)
 	})
 
 	test('reports wrapped new-block aborts as unexpected development errors', async () => {
 		browserMock.reset()
-		const { handleUnexpectedError, getLatestUnexpectedError } = await modulesPromise
+		const { reportUnexpectedError, getLatestUnexpectedError } = await modulesPromise
 
-		await handleUnexpectedError(new Error(`Failed to refresh metadata: ${ NEW_BLOCK_ABORT }`))
+		await reportUnexpectedError(new Error(`Failed to refresh metadata: ${ NEW_BLOCK_ABORT }`))
 
 		const latestUnexpectedError = await getLatestUnexpectedError()
 		assert.equal(latestUnexpectedError?.data.message, `Failed to refresh metadata: ${ NEW_BLOCK_ABORT }`)
@@ -150,14 +177,30 @@ describe('unexpected error diagnostics', () => {
 	test('records unexpected errors even when broadcasting the notification fails', async () => {
 		browserMock.reset()
 		browserMock.setSendMessage(async () => { throw new Error('broadcast failed') })
-		const { handleUnexpectedError, getLatestUnexpectedError } = await modulesPromise
+		const { reportUnexpectedError, getLatestUnexpectedError } = await modulesPromise
 
-		await handleUnexpectedError(new Error('root failure'))
+		await reportUnexpectedError(new Error('root failure'))
 
 		const latestUnexpectedError = await getLatestUnexpectedError()
 		assert.equal(latestUnexpectedError?.data.message, 'root failure')
 		assert.equal(latestUnexpectedError?.data.code, 'unexpected_error')
 		assert.equal(browserMock.sentMessages.length, 0)
+	})
+
+	test('broadcasts unexpected errors even when persistence fails', async () => {
+		browserMock.reset()
+		browserMock.setStorageSet(async () => { throw new Error('storage failed') })
+		const { reportUnexpectedError, getLatestUnexpectedError } = await modulesPromise
+
+		await reportUnexpectedError(new Error('root failure'))
+
+		assert.equal(await getLatestUnexpectedError(), undefined)
+		assert.equal(browserMock.sentMessages.length, 1)
+		const [message] = browserMock.sentMessages
+		assert.equal(message?.method, 'popup_UnexpectedErrorOccured')
+		const data = message?.data
+		if (typeof data !== 'object' || data === null || !('code' in data)) throw new Error('missing unexpected error data')
+		assert.equal(data.code, 'unexpected_error_persist_failed')
 	})
 
 	test('preserves caller abort reasons from fetch requests', async () => {
@@ -183,10 +226,10 @@ describe('unexpected error diagnostics', () => {
 
 	test('keeps forwarded InterceptorError diagnostics out of the popup message', async () => {
 		browserMock.reset()
-		const { handleUnexpectedError, getLatestUnexpectedError, GENERIC_UNEXPECTED_ERROR_MESSAGE } = await modulesPromise
+		const { reportUnexpectedError, getLatestUnexpectedError, GENERIC_UNEXPECTED_ERROR_MESSAGE } = await modulesPromise
 		const diagnosticsMessage = 'inpage: Request did not exist anymore\n\nphase: handle background reply\n\nrequestMethod: eth_accounts\n\nrequestId: 17\n\nthrown:\nError: Request did not exist anymore'
 
-		await handleUnexpectedError({ method: 'InterceptorError', params: [diagnosticsMessage] })
+		await reportUnexpectedError({ method: 'InterceptorError', params: [diagnosticsMessage] })
 
 		const latestUnexpectedError = await getLatestUnexpectedError()
 		assert.equal(latestUnexpectedError?.data.message, GENERIC_UNEXPECTED_ERROR_MESSAGE)
@@ -198,15 +241,50 @@ describe('unexpected error diagnostics', () => {
 
 	test('keeps plain unexpected errors unchanged', async () => {
 		browserMock.reset()
-		const { handleUnexpectedError, getLatestUnexpectedError } = await modulesPromise
+		const { getInterceptorErrorDiagnostics, reportUnexpectedError, getLatestUnexpectedError } = await modulesPromise
 
-		await handleUnexpectedError(new Error('plain error'))
+		await reportUnexpectedError(new Error('plain error'))
 
 		const latestUnexpectedError = await getLatestUnexpectedError()
 		assert.equal(latestUnexpectedError?.data.message, 'plain error')
 		assert.equal(latestUnexpectedError?.data.source, 'internal')
 		assert.equal(latestUnexpectedError?.data.code, 'unexpected_error')
 		assert.equal(typeof latestUnexpectedError?.data.debugId, 'string')
+		const diagnostics = await getInterceptorErrorDiagnostics()
+		assert.equal(diagnostics.length, 1)
+		const [diagnostic] = diagnostics
+		assert.equal(diagnostic?.message, 'plain error')
+		assert.equal(diagnostic?.cause, 'plain error')
+		assert.equal(diagnostic?.category, 'unexpected')
+		assert.equal(diagnostic?.severity, 'error')
+		assert.equal(diagnostic?.userVisible, true)
+		assert.equal(diagnostic?.source, 'internal')
+		assert.equal(diagnostic?.code, 'unexpected_error')
+		assert.equal(typeof diagnostic?.debugId, 'string')
+	})
+
+	test('records local recovery diagnostics without notifying the popup', async () => {
+		browserMock.reset()
+		const { getInterceptorErrorDiagnostics, getLatestUnexpectedError, reportLocalRecovery } = await modulesPromise
+
+		await reportLocalRecovery(new Error('decode failed'), {
+			code: 'test_local_recovery',
+			message: 'Continuing after a recovered test failure.',
+			details: { tokenId: 1n },
+		})
+
+		assert.equal(await getLatestUnexpectedError(), undefined)
+		assert.equal(browserMock.sentMessages.length, 0)
+		const diagnostics = await getInterceptorErrorDiagnostics()
+		assert.equal(diagnostics.length, 1)
+		const [diagnostic] = diagnostics
+		assert.equal(diagnostic?.message, 'Continuing after a recovered test failure.')
+		assert.equal(diagnostic?.cause, 'decode failed')
+		assert.equal(diagnostic?.category, 'local_recovery')
+		assert.equal(diagnostic?.severity, 'warning')
+		assert.equal(diagnostic?.userVisible, false)
+		assert.equal(diagnostic?.code, 'test_local_recovery')
+		assert.equal(diagnostic?.details, '{"tokenId":"1"}')
 	})
 
 	test('renders forwarded diagnostics directly from the message string in the existing unexpected error popup', async () => {

--- a/test/tests/unexpectedErrorDiagnostics.test.ts
+++ b/test/tests/unexpectedErrorDiagnostics.test.ts
@@ -287,6 +287,32 @@ describe('unexpected error diagnostics', () => {
 		assert.equal(diagnostic?.details, '{"tokenId":"1"}')
 	})
 
+	test('best-effort local recovery does not block on diagnostic persistence', async () => {
+		browserMock.reset()
+		let storageSetStarted = false
+		let releaseStorageSet: (() => void) | undefined
+		browserMock.setStorageSet(async () => {
+			storageSetStarted = true
+			await new Promise<void>((resolve) => {
+				releaseStorageSet = resolve
+			})
+		})
+		const { getLatestUnexpectedError, reportLocalRecoveryBestEffort } = await modulesPromise
+
+		reportLocalRecoveryBestEffort(new Error('parse failed'), {
+			code: 'test_best_effort_recovery',
+			message: 'Continuing without waiting for diagnostic persistence.',
+		})
+
+		assert.equal(storageSetStarted, false)
+		for (let index = 0; index < 10 && !storageSetStarted; index++) await Promise.resolve()
+		assert.equal(storageSetStarted, true)
+		releaseStorageSet?.()
+		await Promise.resolve()
+		assert.equal(await getLatestUnexpectedError(), undefined)
+		assert.equal(browserMock.sentMessages.length, 0)
+	})
+
 	test('renders forwarded diagnostics directly from the message string in the existing unexpected error popup', async () => {
 		const { UnexpectedError } = await modulesPromise
 		const dom = installDomMock()

--- a/test/tests/unexpectedErrorDiagnostics.test.ts
+++ b/test/tests/unexpectedErrorDiagnostics.test.ts
@@ -269,7 +269,7 @@ describe('unexpected error diagnostics', () => {
 
 		await reportUnexpectedError(new Error('root failure'), {
 			code: 'contextual_failure',
-			message: 'Failed to refresh contextual data: root failure',
+			displayMessage: 'Failed to refresh contextual data: root failure',
 			details: { address: '0xabc' },
 		})
 

--- a/test/tests/unexpectedErrorDiagnostics.test.ts
+++ b/test/tests/unexpectedErrorDiagnostics.test.ts
@@ -4,6 +4,8 @@ import { act } from 'preact/test-utils'
 import { describe, test } from 'bun:test'
 import { installDateMock, installDomMock } from './domMock.js'
 
+const { NEW_BLOCK_ABORT } = await import('../../app/ts/utils/constants.js')
+
 type RuntimeMessage = {
 	method?: string
 	type?: string
@@ -13,6 +15,10 @@ type RuntimeMessage = {
 function createBrowserMock() {
 	const storageState: Record<string, unknown> = {}
 	const sentMessages: RuntimeMessage[] = []
+	const defaultSendMessage = async (message: RuntimeMessage) => {
+		sentMessages.push(message)
+		return undefined
+	}
 	const getStorageItems = (keys?: string | string[] | Record<string, unknown> | null) => {
 		if (keys === undefined || keys === null) return { ...storageState }
 		if (Array.isArray(keys)) return Object.fromEntries(keys.map((key) => [key, storageState[key]]))
@@ -23,10 +29,7 @@ function createBrowserMock() {
 	const browserMock = {
 		runtime: {
 			lastError: null,
-			async sendMessage(message: RuntimeMessage) {
-				sentMessages.push(message)
-				return undefined
-			},
+			sendMessage: defaultSendMessage,
 			getManifest: () => ({ manifest_version: 3 }),
 			onMessage: { addListener: () => undefined, removeListener: () => undefined },
 			onConnect: { addListener: () => undefined, removeListener: () => undefined },
@@ -76,6 +79,10 @@ function createBrowserMock() {
 			for (const key of Object.keys(storageState)) delete storageState[key]
 			sentMessages.length = 0
 			browserMock.runtime.lastError = null
+			browserMock.runtime.sendMessage = defaultSendMessage
+		},
+		setSendMessage(sendMessage: (message: RuntimeMessage) => Promise<unknown>) {
+			browserMock.runtime.sendMessage = sendMessage
 		},
 	}
 }
@@ -85,6 +92,7 @@ const browserMock = createBrowserMock()
 async function loadModules() {
 	return {
 		...await import('../../app/ts/utils/errors.js'),
+		...await import('../../app/ts/utils/requests.js'),
 		...await import('../../app/ts/background/storageVariables.js'),
 		...await import('../../app/ts/components/subcomponents/Error.js'),
 	}
@@ -93,6 +101,86 @@ async function loadModules() {
 const modulesPromise = loadModules()
 
 describe('unexpected error diagnostics', () => {
+	test('recognizes expected infrastructure errors from unknown thrown values', async () => {
+		const { classifyCaughtError, isExpectedInfrastructureError, isFailedToFetchError, isNewBlockAbort } = await modulesPromise
+
+		assert.equal(isNewBlockAbort(new Error(NEW_BLOCK_ABORT)), true)
+		assert.equal(isNewBlockAbort(NEW_BLOCK_ABORT), true)
+		assert.equal(isNewBlockAbort({ message: NEW_BLOCK_ABORT }), true)
+		assert.equal(isNewBlockAbort(new Error(`wrapped ${ NEW_BLOCK_ABORT }`)), false)
+		assert.equal(isNewBlockAbort(new Error('different abort')), false)
+		assert.equal(isNewBlockAbort(undefined), false)
+
+		assert.equal(isFailedToFetchError(new Error('Failed to fetch')), true)
+		assert.equal(isFailedToFetchError('NetworkError when attempting to fetch resource'), true)
+		assert.equal(isFailedToFetchError({ message: 'Fetch request timed out.' }), true)
+		assert.equal(isFailedToFetchError({ message: 'Fetch request aborted.' }), true)
+		assert.equal(isFailedToFetchError('unrelated error'), false)
+
+		assert.equal(classifyCaughtError(NEW_BLOCK_ABORT), 'newBlockAbort')
+		assert.equal(classifyCaughtError(new Error('Failed to fetch')), 'failedToFetch')
+		assert.equal(classifyCaughtError(new Error(`wrapped ${ NEW_BLOCK_ABORT }`)), 'unexpected')
+		assert.equal(isExpectedInfrastructureError(NEW_BLOCK_ABORT), true)
+		assert.equal(isExpectedInfrastructureError(new Error(`wrapped ${ NEW_BLOCK_ABORT }`)), false)
+	})
+
+	test('does not report new-block aborts as unexpected errors', async () => {
+		browserMock.reset()
+		const { handleUnexpectedError, getLatestUnexpectedError } = await modulesPromise
+
+		await handleUnexpectedError(NEW_BLOCK_ABORT)
+		await handleUnexpectedError(new Error(NEW_BLOCK_ABORT))
+
+		assert.equal(await getLatestUnexpectedError(), undefined)
+		assert.equal(browserMock.sentMessages.length, 0)
+	})
+
+	test('reports wrapped new-block aborts as unexpected development errors', async () => {
+		browserMock.reset()
+		const { handleUnexpectedError, getLatestUnexpectedError } = await modulesPromise
+
+		await handleUnexpectedError(new Error(`Failed to refresh metadata: ${ NEW_BLOCK_ABORT }`))
+
+		const latestUnexpectedError = await getLatestUnexpectedError()
+		assert.equal(latestUnexpectedError?.data.message, `Failed to refresh metadata: ${ NEW_BLOCK_ABORT }`)
+		assert.equal(latestUnexpectedError?.data.code, 'wrapped_new_block_abort')
+		assert.equal(browserMock.sentMessages.length, 1)
+	})
+
+	test('records unexpected errors even when broadcasting the notification fails', async () => {
+		browserMock.reset()
+		browserMock.setSendMessage(async () => { throw new Error('broadcast failed') })
+		const { handleUnexpectedError, getLatestUnexpectedError } = await modulesPromise
+
+		await handleUnexpectedError(new Error('root failure'))
+
+		const latestUnexpectedError = await getLatestUnexpectedError()
+		assert.equal(latestUnexpectedError?.data.message, 'root failure')
+		assert.equal(latestUnexpectedError?.data.code, 'unexpected_error')
+		assert.equal(browserMock.sentMessages.length, 0)
+	})
+
+	test('preserves caller abort reasons from fetch requests', async () => {
+		const { fetchWithTimeout } = await modulesPromise
+		const originalFetch = globalThis.fetch
+		globalThis.fetch = async (_resource, init) => {
+			const signal = init?.signal
+			if (!(signal instanceof AbortSignal)) throw new Error('missing abort signal')
+			await new Promise((_resolve, reject) => {
+				signal.addEventListener('abort', () => reject(new DOMException('The user aborted a request.')), { once: true })
+			})
+			throw new Error('unreachable')
+		}
+		try {
+			const requestAbortController = new AbortController()
+			const requestPromise = fetchWithTimeout('https://example.invalid', undefined, 60_000, requestAbortController)
+			requestAbortController.abort(NEW_BLOCK_ABORT)
+			await assert.rejects(requestPromise, (error) => error === NEW_BLOCK_ABORT)
+		} finally {
+			globalThis.fetch = originalFetch
+		}
+	})
+
 	test('keeps forwarded InterceptorError diagnostics out of the popup message', async () => {
 		browserMock.reset()
 		const { handleUnexpectedError, getLatestUnexpectedError, GENERIC_UNEXPECTED_ERROR_MESSAGE } = await modulesPromise
@@ -134,12 +222,18 @@ describe('unexpected error diagnostics', () => {
 				error: {
 					message: diagnosticMessage,
 					timestamp,
+					source: 'inpage',
+					code: 'forwarded',
+					debugId: 'debug-1234',
 				},
 			}), dom.document.body)
 		})
 		assert.equal(dom.document.body.textContent?.includes('inpage: Request did not exist anymore'), true)
 		assert.equal(dom.document.body.textContent?.includes('phase: handle background reply'), true)
 		assert.equal(dom.document.body.textContent?.includes('requestMethod: eth_accounts'), true)
+		assert.equal(dom.document.body.textContent?.includes('source: inpage'), true)
+		assert.equal(dom.document.body.textContent?.includes('code: forwarded'), true)
+		assert.equal(dom.document.body.textContent?.includes('debug: debug-1234'), true)
 
 		await act(() => {
 			render(h(UnexpectedError, {

--- a/test/tests/unexpectedErrorDiagnostics.test.ts
+++ b/test/tests/unexpectedErrorDiagnostics.test.ts
@@ -285,6 +285,38 @@ describe('unexpected error diagnostics', () => {
 		assert.equal(diagnostic?.details, '{"address":"0xabc"}')
 	})
 
+	test('keeps forwarded popup error message as diagnostic cause', async () => {
+		browserMock.reset()
+		const { getInterceptorErrorDiagnostics, getLatestUnexpectedError } = await modulesPromise
+		const { reportUnexpectedErrorInWindow } = await import('../../app/ts/background/popupMessageHandlers.js')
+		const timestamp = new Date('2026-06-23T00:00:00.000Z')
+
+		await withSilencedConsole(async () => await reportUnexpectedErrorInWindow({
+			method: 'popup_UnexpectedErrorOccured',
+			data: {
+				timestamp,
+				message: 'Popup render failed',
+				source: 'popup',
+				code: 'render_error',
+				debugId: 'popup-1234',
+			},
+		}))
+
+		const latestUnexpectedError = await getLatestUnexpectedError()
+		assert.equal(latestUnexpectedError?.data.message, 'Popup render failed')
+		assert.equal(latestUnexpectedError?.data.source, 'popup')
+		assert.equal(latestUnexpectedError?.data.code, 'render_error')
+		assert.equal(latestUnexpectedError?.data.debugId, 'popup-1234')
+		const diagnostics = await getInterceptorErrorDiagnostics()
+		assert.equal(diagnostics.length, 1)
+		const [diagnostic] = diagnostics
+		assert.equal(diagnostic?.message, 'Popup render failed')
+		assert.equal(diagnostic?.cause, 'Popup render failed')
+		assert.equal(diagnostic?.source, 'popup')
+		assert.equal(diagnostic?.code, 'render_error')
+		assert.equal(diagnostic?.debugId, 'popup-1234')
+	})
+
 	test('records local recovery diagnostics without notifying the popup', async () => {
 		browserMock.reset()
 		const { getInterceptorErrorDiagnostics, getLatestUnexpectedError, reportLocalRecovery } = await modulesPromise

--- a/test/tests/unexpectedErrorDiagnostics.test.ts
+++ b/test/tests/unexpectedErrorDiagnostics.test.ts
@@ -263,6 +263,27 @@ describe('unexpected error diagnostics', () => {
 		assert.equal(typeof diagnostic?.debugId, 'string')
 	})
 
+	test('uses metadata message without dropping the original error cause', async () => {
+		browserMock.reset()
+		const { getInterceptorErrorDiagnostics, reportUnexpectedError, getLatestUnexpectedError } = await modulesPromise
+
+		await reportUnexpectedError(new Error('root failure'), {
+			code: 'contextual_failure',
+			message: 'Failed to refresh contextual data: root failure',
+			details: { address: '0xabc' },
+		})
+
+		const latestUnexpectedError = await getLatestUnexpectedError()
+		assert.equal(latestUnexpectedError?.data.message, 'Failed to refresh contextual data: root failure')
+		assert.equal(latestUnexpectedError?.data.code, 'contextual_failure')
+		const diagnostics = await getInterceptorErrorDiagnostics()
+		assert.equal(diagnostics.length, 1)
+		const [diagnostic] = diagnostics
+		assert.equal(diagnostic?.message, 'Failed to refresh contextual data: root failure')
+		assert.equal(diagnostic?.cause, 'root failure')
+		assert.equal(diagnostic?.details, '{"address":"0xabc"}')
+	})
+
 	test('records local recovery diagnostics without notifying the popup', async () => {
 		browserMock.reset()
 		const { getInterceptorErrorDiagnostics, getLatestUnexpectedError, reportLocalRecovery } = await modulesPromise

--- a/test/tests/unexpectedErrorDiagnostics.test.ts
+++ b/test/tests/unexpectedErrorDiagnostics.test.ts
@@ -3,6 +3,7 @@ import { h, render } from 'preact'
 import { act } from 'preact/test-utils'
 import { describe, test } from 'bun:test'
 import { installDateMock, installDomMock } from './domMock.js'
+import { withSilencedConsole } from './consoleSilence.js'
 
 const { NEW_BLOCK_ABORT } = await import('../../app/ts/utils/constants.js')
 
@@ -149,11 +150,11 @@ describe('unexpected error diagnostics', () => {
 		browserMock.reset()
 		const { createInterceptorInternalError, getLatestUnexpectedError, reportUnexpectedError } = await modulesPromise
 
-		await reportUnexpectedError(createInterceptorInternalError('Failed to fetch', 'fetch_transport_failed'), {
+		await withSilencedConsole(async () => await reportUnexpectedError(createInterceptorInternalError('Failed to fetch', 'fetch_transport_failed'), {
 			source: 'popup',
 			code: 'popup_message_listener_failed',
 			suppressExpectedInfrastructure: false,
-		})
+		}))
 
 		const latestUnexpectedError = await getLatestUnexpectedError()
 		assert.equal(latestUnexpectedError?.data.message, 'Failed to fetch')
@@ -166,7 +167,7 @@ describe('unexpected error diagnostics', () => {
 		browserMock.reset()
 		const { reportUnexpectedError, getLatestUnexpectedError } = await modulesPromise
 
-		await reportUnexpectedError(new Error(`Failed to refresh metadata: ${ NEW_BLOCK_ABORT }`))
+		await withSilencedConsole(async () => await reportUnexpectedError(new Error(`Failed to refresh metadata: ${ NEW_BLOCK_ABORT }`)))
 
 		const latestUnexpectedError = await getLatestUnexpectedError()
 		assert.equal(latestUnexpectedError?.data.message, `Failed to refresh metadata: ${ NEW_BLOCK_ABORT }`)
@@ -179,7 +180,7 @@ describe('unexpected error diagnostics', () => {
 		browserMock.setSendMessage(async () => { throw new Error('broadcast failed') })
 		const { reportUnexpectedError, getLatestUnexpectedError } = await modulesPromise
 
-		await reportUnexpectedError(new Error('root failure'))
+		await withSilencedConsole(async () => await reportUnexpectedError(new Error('root failure')))
 
 		const latestUnexpectedError = await getLatestUnexpectedError()
 		assert.equal(latestUnexpectedError?.data.message, 'root failure')
@@ -192,7 +193,7 @@ describe('unexpected error diagnostics', () => {
 		browserMock.setStorageSet(async () => { throw new Error('storage failed') })
 		const { reportUnexpectedError, getLatestUnexpectedError } = await modulesPromise
 
-		await reportUnexpectedError(new Error('root failure'))
+		await withSilencedConsole(async () => await reportUnexpectedError(new Error('root failure')))
 
 		assert.equal(await getLatestUnexpectedError(), undefined)
 		assert.equal(browserMock.sentMessages.length, 1)
@@ -229,7 +230,7 @@ describe('unexpected error diagnostics', () => {
 		const { reportUnexpectedError, getLatestUnexpectedError, GENERIC_UNEXPECTED_ERROR_MESSAGE } = await modulesPromise
 		const diagnosticsMessage = 'inpage: Request did not exist anymore\n\nphase: handle background reply\n\nrequestMethod: eth_accounts\n\nrequestId: 17\n\nthrown:\nError: Request did not exist anymore'
 
-		await reportUnexpectedError({ method: 'InterceptorError', params: [diagnosticsMessage] })
+		await withSilencedConsole(async () => await reportUnexpectedError({ method: 'InterceptorError', params: [diagnosticsMessage] }))
 
 		const latestUnexpectedError = await getLatestUnexpectedError()
 		assert.equal(latestUnexpectedError?.data.message, GENERIC_UNEXPECTED_ERROR_MESSAGE)
@@ -243,7 +244,7 @@ describe('unexpected error diagnostics', () => {
 		browserMock.reset()
 		const { getInterceptorErrorDiagnostics, reportUnexpectedError, getLatestUnexpectedError } = await modulesPromise
 
-		await reportUnexpectedError(new Error('plain error'))
+		await withSilencedConsole(async () => await reportUnexpectedError(new Error('plain error')))
 
 		const latestUnexpectedError = await getLatestUnexpectedError()
 		assert.equal(latestUnexpectedError?.data.message, 'plain error')
@@ -267,11 +268,11 @@ describe('unexpected error diagnostics', () => {
 		browserMock.reset()
 		const { getInterceptorErrorDiagnostics, reportUnexpectedError, getLatestUnexpectedError } = await modulesPromise
 
-		await reportUnexpectedError(new Error('root failure'), {
+		await withSilencedConsole(async () => await reportUnexpectedError(new Error('root failure'), {
 			code: 'contextual_failure',
 			displayMessage: 'Failed to refresh contextual data: root failure',
 			details: { address: '0xabc' },
-		})
+		}))
 
 		const latestUnexpectedError = await getLatestUnexpectedError()
 		assert.equal(latestUnexpectedError?.data.message, 'Failed to refresh contextual data: root failure')
@@ -288,11 +289,11 @@ describe('unexpected error diagnostics', () => {
 		browserMock.reset()
 		const { getInterceptorErrorDiagnostics, getLatestUnexpectedError, reportLocalRecovery } = await modulesPromise
 
-		await reportLocalRecovery(new Error('decode failed'), {
+		await withSilencedConsole(async () => await reportLocalRecovery(new Error('decode failed'), {
 			code: 'test_local_recovery',
 			message: 'Continuing after a recovered test failure.',
 			details: { tokenId: 1n },
-		})
+		}))
 
 		assert.equal(await getLatestUnexpectedError(), undefined)
 		assert.equal(browserMock.sentMessages.length, 0)
@@ -320,9 +321,11 @@ describe('unexpected error diagnostics', () => {
 		})
 		const { getLatestUnexpectedError, reportLocalRecoveryBestEffort } = await modulesPromise
 
-		reportLocalRecoveryBestEffort(new Error('parse failed'), {
-			code: 'test_best_effort_recovery',
-			message: 'Continuing without waiting for diagnostic persistence.',
+		await withSilencedConsole(async () => {
+			reportLocalRecoveryBestEffort(new Error('parse failed'), {
+				code: 'test_best_effort_recovery',
+				message: 'Continuing without waiting for diagnostic persistence.',
+			})
 		})
 
 		assert.equal(storageSetStarted, false)

--- a/test/tests/unexpectedErrorSecurity.test.ts
+++ b/test/tests/unexpectedErrorSecurity.test.ts
@@ -1,5 +1,6 @@
 import * as assert from 'assert'
 import { describe, test } from 'bun:test'
+import { withSilencedConsole } from './consoleSilence.js'
 
 const defineGlobal = (name: PropertyKey, value: unknown) => Object.defineProperty(globalThis, name, { value, configurable: true, writable: true })
 
@@ -75,7 +76,7 @@ describe('unexpected error security', () => {
 		const { storageState, popupMessages } = installBrowserMock()
 		const { getLatestUnexpectedError, handleIterceptorError } = await loadModules()
 
-		await handleIterceptorError({ method: 'InterceptorError', params: ['phishing text'] })
+		await withSilencedConsole(async () => await handleIterceptorError({ method: 'InterceptorError', params: ['phishing text'] }))
 
 		assert.equal(storageState.latestUnexpectedError, undefined)
 		assert.equal(await getLatestUnexpectedError(), undefined)
@@ -86,7 +87,7 @@ describe('unexpected error security', () => {
 		const { popupMessages } = installBrowserMock()
 		const { getLatestUnexpectedError, reportUnexpectedError, GENERIC_UNEXPECTED_ERROR_MESSAGE } = await loadModules()
 
-		await reportUnexpectedError({ arbitrary: 'value' })
+		await withSilencedConsole(async () => await reportUnexpectedError({ arbitrary: 'value' }))
 
 		const latestUnexpectedError = await getLatestUnexpectedError()
 		assert.notEqual(latestUnexpectedError, undefined)
@@ -101,7 +102,7 @@ describe('unexpected error security', () => {
 		installBrowserMock()
 		const { getLatestUnexpectedError, reportUnexpectedError } = await loadModules()
 
-		await reportUnexpectedError(new Error('Trusted extension failure'))
+		await withSilencedConsole(async () => await reportUnexpectedError(new Error('Trusted extension failure')))
 
 		const latestUnexpectedError = await getLatestUnexpectedError()
 		assert.notEqual(latestUnexpectedError, undefined)

--- a/test/tests/unexpectedErrorSecurity.test.ts
+++ b/test/tests/unexpectedErrorSecurity.test.ts
@@ -84,9 +84,9 @@ describe('unexpected error security', () => {
 
 	test('use generic popup copy for unknown thrown values', async () => {
 		const { popupMessages } = installBrowserMock()
-		const { getLatestUnexpectedError, handleUnexpectedError, GENERIC_UNEXPECTED_ERROR_MESSAGE } = await loadModules()
+		const { getLatestUnexpectedError, reportUnexpectedError, GENERIC_UNEXPECTED_ERROR_MESSAGE } = await loadModules()
 
-		await handleUnexpectedError({ arbitrary: 'value' })
+		await reportUnexpectedError({ arbitrary: 'value' })
 
 		const latestUnexpectedError = await getLatestUnexpectedError()
 		assert.notEqual(latestUnexpectedError, undefined)
@@ -99,9 +99,9 @@ describe('unexpected error security', () => {
 
 	test('preserve trusted internal Error messages for popup display', async () => {
 		installBrowserMock()
-		const { getLatestUnexpectedError, handleUnexpectedError } = await loadModules()
+		const { getLatestUnexpectedError, reportUnexpectedError } = await loadModules()
 
-		await handleUnexpectedError(new Error('Trusted extension failure'))
+		await reportUnexpectedError(new Error('Trusted extension failure'))
 
 		const latestUnexpectedError = await getLatestUnexpectedError()
 		assert.notEqual(latestUnexpectedError, undefined)


### PR DESCRIPTION
## Summary
- Treat expected infrastructure churn, including `NEW_BLOCK_ABORT` and fetch abort/transport failures, as suppressible at unexpected-error boundaries.
- Add structured error diagnostics with categories, severity, debug IDs, a bounded diagnostic history, and generic popup copy for untrusted forwarded errors.
- Centralize unexpected-error popup message construction and debug ID generation so UI-side forwarding and background reporting share the same protocol helper.
- Preserve diagnostic causes for popup-forwarded unexpected errors while keeping trusted display text in `displayMessage` metadata.
- Rename unexpected-error reporting around `reportUnexpectedError`, preserve original caught values, and support explicit `displayMessage` metadata for contextual popup/diagnostic text without wrapping the caught error.
- Split local recovery reporting into reliable and best-effort paths, then use best-effort diagnostics in hot fallback paths such as calldata parsing, error decoding, and MV2 content-script injection recovery.
- Add custom lint checks for awaited unexpected-error reporting, message-object/new-error wrappers, simple wrapper aliases, console-only catches, new-block abort guards, raw fetch error wrapping, and signal comparisons.
- Silence expected error-reporting console output in tests so CI failures are easier to scan.
- Merge latest `origin/main` and keep the merged content-script error tests aligned with the new taxonomy.

## Testing
- `bun install --frozen-lockfile`
- `bun test`
- `bun run setup-chrome`
- `bun run typecheck`
- `bun run lint`

## Notes
- `bun test` initially failed after merging `main` because the local root `node_modules` tree still had stale nested `@noble/hashes` installs from the previous lockfile. Refreshing with `bun install --frozen-lockfile` matched the merged lockfile and the full suite passed.
- A later post-merge `bun test` attempt hit a Bun 1.3.13 segmentation fault before executing tests; rerunning `bun test` passed cleanly.
