### PR TITLE
Prune release runtime artifacts

### DIFF
--- a/app/manifestV2.json
+++ b/app/manifestV2.json
@@ -30,6 +30,6 @@
 		"webRequest",
 		"webRequestBlocking"
 	],
-	"web_accessible_resources": ["vendor/*", "js/*", "inpage/*"],
+	"web_accessible_resources": ["inpage/js/inpage.js"],
 	"content_security_policy": "object-src 'self'; script-src 'self'"
 }

--- a/app/manifestV3.json
+++ b/app/manifestV3.json
@@ -25,7 +25,7 @@
 	],
 	"web_accessible_resources": [
 		{
-			"resources": ["vendor/*", "js/*", "inpage/*"],
+			"resources": ["inpage/js/inpage.js"],
 			"matches": ["<all_urls>"]
 		}
 	],

--- a/build/bundler.mts
+++ b/build/bundler.mts
@@ -61,6 +61,10 @@ const forbiddenRuntimeModules = new Set([
 	path.join(vendorDirectory, 'viem', '_esm', 'ens', 'index.js'),
 	path.join(vendorDirectory, 'viem', '_esm', 'accounts', 'index.js'),
 ])
+const requiredRuntimeAssetPaths = new Set([
+	path.join(vendorDirectory, 'webextension-polyfill', 'dist', 'browser-polyfill.js'),
+])
+const addressMetadataImagesDirectory = path.join(vendorDirectory, '@darkflorist', 'address-metadata', 'images')
 const getResolverBasePath = (filePath: string) => filePath.startsWith(`${ vendorDirectory }${ path.sep }`)
 	? path.join(nodeModulesDirectory, path.relative(vendorDirectory, filePath))
 	: filePath
@@ -413,6 +417,7 @@ async function bundleChromeRuntimeEntrypoints() {
 function getRuntimeFiles() {
 	return [
 		path.join(directoryOfThisFile, '..', 'app', 'js'),
+		path.join(directoryOfThisFile, '..', 'app', 'inpage', 'js'),
 		path.join(directoryOfThisFile, '..', 'app', 'vendor'),
 	]
 }
@@ -494,6 +499,48 @@ export function findForbiddenRuntimeModulesInRuntimeFiles() {
 		.map((filePath) => ({ filePath }))
 }
 
+export function shouldKeepRuntimeOutputFile(filePath: string, reachableRuntimeFiles: ReadonlySet<string>) {
+	return reachableRuntimeFiles.has(filePath)
+		|| requiredRuntimeAssetPaths.has(filePath)
+		|| isInsideDirectory(filePath, addressMetadataImagesDirectory)
+}
+
+function removeEmptyChildDirectories(directoryPath: string) {
+	for (const entry of fs.readdirSync(directoryPath, { withFileTypes: true })) {
+		if (!entry.isDirectory()) continue
+		const childDirectoryPath = path.join(directoryPath, entry.name)
+		removeEmptyChildDirectories(childDirectoryPath)
+		if (fs.readdirSync(childDirectoryPath).length === 0) fs.rmdirSync(childDirectoryPath)
+	}
+}
+
+function pruneRuntimeOutputFiles(reachableRuntimeFiles: ReadonlySet<string>) {
+	for (const folder of getRuntimeFiles()) {
+		if (!fs.existsSync(folder)) continue
+		for (const filePath of getFiles(folder)) {
+			if (shouldKeepRuntimeOutputFile(filePath, reachableRuntimeFiles)) continue
+			fs.rmSync(filePath, { force: true })
+		}
+		removeEmptyChildDirectories(folder)
+	}
+}
+
+export function stripSourceMappingUrlComment(text: string) {
+	return text.replace(/(?:\r?\n)?\/\/# sourceMappingURL=.*(?:\r?\n)?$/u, '\n')
+}
+
+function stripSourceMappingUrlCommentsInRuntimeFiles() {
+	for (const folder of getRuntimeFiles()) {
+		if (!fs.existsSync(folder)) continue
+		for (const filePath of getFiles(folder)) {
+			if (path.extname(filePath) !== '.js' && path.extname(filePath) !== '.mjs') continue
+			const text = fs.readFileSync(filePath, 'utf8')
+			const stripped = stripSourceMappingUrlComment(text)
+			if (stripped !== text) fs.writeFileSync(filePath, stripped)
+		}
+	}
+}
+
 export async function replaceImportsInJSFiles() {
 	await bundleChromeRuntimeEntrypoints()
 	for (const folder of getRuntimeFiles()) {
@@ -516,6 +563,8 @@ export async function replaceImportsInJSFiles() {
 	if (forbiddenRuntimeModuleIssues.length > 0) {
 		throw new Error(`Browser-incompatible runtime modules remain after bundling:\n${ formatForbiddenRuntimeModuleIssues(forbiddenRuntimeModuleIssues) }`)
 	}
+	pruneRuntimeOutputFiles(new Set(collectRuntimeDependencyGraph().files))
+	stripSourceMappingUrlCommentsInRuntimeFiles()
 }
 
 if (import.meta.main) {

--- a/test/tests/bundlerImportRewrite.test.ts
+++ b/test/tests/bundlerImportRewrite.test.ts
@@ -2,7 +2,7 @@ import * as assert from 'assert'
 import * as fs from 'node:fs'
 import * as path from 'node:path'
 import { describe, test } from 'bun:test'
-import { findMissingRuntimeImportsInRuntimeFiles, isBrowserIncompatibleRuntimeModule, replaceImport } from '../../build/bundler.mts'
+import { findMissingRuntimeImportsInRuntimeFiles, isBrowserIncompatibleRuntimeModule, replaceImport, shouldKeepRuntimeOutputFile, stripSourceMappingUrlComment } from '../../build/bundler.mts'
 
 const repositoryRoot = process.cwd()
 
@@ -63,6 +63,40 @@ describe('bundler import rewriting', () => {
 		assert.equal(
 			isBrowserIncompatibleRuntimeModule(path.join(repositoryRoot, 'app', 'vendor', 'viem', '_esm', 'utils', 'hash', 'keccak256.js')),
 			false,
+		)
+	})
+
+	test('keeps only reachable runtime modules and required public assets', () => {
+		const reachableFilePath = path.join(repositoryRoot, 'app', 'vendor', 'viem', '_esm', 'utils', 'hash', 'keccak256.js')
+		const reachableRuntimeFiles = new Set([reachableFilePath])
+
+		assert.equal(shouldKeepRuntimeOutputFile(reachableFilePath, reachableRuntimeFiles), true)
+		assert.equal(
+			shouldKeepRuntimeOutputFile(path.join(repositoryRoot, 'app', 'vendor', 'webextension-polyfill', 'dist', 'browser-polyfill.js'), reachableRuntimeFiles),
+			true,
+		)
+		assert.equal(
+			shouldKeepRuntimeOutputFile(path.join(repositoryRoot, 'app', 'vendor', '@darkflorist', 'address-metadata', 'images', 'tokens', '0xdac17f958d2ee523a2206206994597c13d831ec7.png'), reachableRuntimeFiles),
+			true,
+		)
+		assert.equal(
+			shouldKeepRuntimeOutputFile(path.join(repositoryRoot, 'app', 'vendor', 'preact', 'src', 'index.d.ts'), reachableRuntimeFiles),
+			false,
+		)
+		assert.equal(
+			shouldKeepRuntimeOutputFile(path.join(repositoryRoot, 'app', 'js', 'components', 'App.js.map'), reachableRuntimeFiles),
+			false,
+		)
+	})
+
+	test('strips source map comments after pruning maps', () => {
+		assert.equal(
+			stripSourceMappingUrlComment('export const ok = true;\n//# sourceMappingURL=ok.js.map\n'),
+			'export const ok = true;\n',
+		)
+		assert.equal(
+			stripSourceMappingUrlComment('export const ok = true;\n'),
+			'export const ok = true;\n',
 		)
 	})
 


### PR DESCRIPTION
## Summary
- prune generated runtime output to modules reachable from extension entrypoints plus required runtime assets
- keep the webextension polyfill and address metadata image assets needed by extension pages
- narrow MV2/MV3 web-accessible resources to the inpage fallback script only

## Validation
- bun test
- bun run setup-chrome
- bun run typecheck
- bun run lint
- bun run setup-firefox
- CHROME_BIN=/usr/bin/chromium bun run test:chrome-communication

## Artifact check
- generated app size after setup-chrome: ~64 MiB
- generated app/vendor: ~28 MiB
- generated app/js: ~31 MiB
- compressed app tar estimate: 20,063,727 bytes
- source/type/map/package/test-support files under runtime output: 0