### PR TITLE
Harden large state IndexedDB fallback persistence

### DIFF
--- a/app/ts/utils/largeStateStore.ts
+++ b/app/ts/utils/largeStateStore.ts
@@ -1,5 +1,6 @@
 import type * as funtypes from 'funtypes'
 import { serialize } from '../types/wire-types.js'
+import { assertNever } from './typescript.js'
 
 export type LargeStateStorageKey = 'interceptorTransactionStack' | 'popupVisualisation'
 
@@ -117,6 +118,7 @@ function getLegacyDeleteMarkerKey(key: LargeStateStorageKey): LargeStateDeleteMa
 	switch (key) {
 		case 'interceptorTransactionStack': return `${ LARGE_STATE_DELETE_MARKER_PREFIX }interceptorTransactionStack`
 		case 'popupVisualisation': return `${ LARGE_STATE_DELETE_MARKER_PREFIX }popupVisualisation`
+		default: return assertNever(key)
 	}
 }
 

--- a/app/ts/utils/largeStateStore.ts
+++ b/app/ts/utils/largeStateStore.ts
@@ -49,9 +49,20 @@ async function runIndexedDbRequest<T>(mode: IDBTransactionMode, operation: (stor
 		const transaction = db.transaction(LARGE_STATE_STORE_NAME, mode)
 		const store = transaction.objectStore(LARGE_STATE_STORE_NAME)
 		const request = operation(store)
-		request.onsuccess = () => resolve({ kind: 'available', value: request.result })
+		let requestResult: { value: T } | undefined
+		request.onsuccess = () => {
+			requestResult = { value: request.result }
+		}
 		request.onerror = () => reject(request.error ?? new Error(`Large state IndexedDB ${ mode } request failed`))
+		transaction.oncomplete = () => {
+			if (requestResult === undefined) {
+				reject(new Error(`Large state IndexedDB ${ mode } transaction completed before the request succeeded`))
+				return
+			}
+			resolve({ kind: 'available', value: requestResult.value })
+		}
 		transaction.onabort = () => reject(transaction.error ?? new Error(`Large state IndexedDB ${ mode } transaction aborted`))
+		transaction.onerror = () => reject(transaction.error ?? new Error(`Large state IndexedDB ${ mode } transaction failed`))
 	})
 }
 

--- a/app/ts/utils/largeStateStore.ts
+++ b/app/ts/utils/largeStateStore.ts
@@ -193,7 +193,8 @@ export async function setLargeStateValue<T>(key: LargeStateStorageKey, codec: fu
 
 export async function removeLargeStateValue(key: LargeStateStorageKey) {
 	if (!canUseIndexedDb()) {
-		await clearLegacyLocalState(key)
+		await removeLegacyLocalValue(key)
+		await setLegacyLocalDeleted(key)
 		return
 	}
 	const wasRemovedFromIndexedDb = await removeIndexedDbValue(key)

--- a/app/ts/utils/largeStateStore.ts
+++ b/app/ts/utils/largeStateStore.ts
@@ -5,11 +5,21 @@ export type LargeStateStorageKey = 'interceptorTransactionStack' | 'popupVisuali
 
 const LARGE_STATE_DB_NAME = 'interceptorLargeState'
 const LARGE_STATE_STORE_NAME = 'largeState'
+const LARGE_STATE_DELETE_MARKER_PREFIX = 'interceptorLargeStateDeleted:'
 
 type IndexedDbLookup =
 	| { kind: 'available', found: false }
 	| { kind: 'available', found: true, value: unknown }
 	| { kind: 'unavailable' }
+
+type LegacyLocalLookup =
+	| { kind: 'deleted' }
+	| { kind: 'found', value: unknown }
+	| { kind: 'missing' }
+
+type LargeStateDeleteMarkerKey =
+	| 'interceptorLargeStateDeleted:interceptorTransactionStack'
+	| 'interceptorLargeStateDeleted:popupVisualisation'
 
 let indexedDbPromise: Promise<IDBDatabase | undefined> | undefined 
 let indexedDbSource: IDBFactory | undefined 
@@ -103,18 +113,36 @@ async function removeIndexedDbValue(key: LargeStateStorageKey) {
 	}
 }
 
-async function getLegacyLocalValue(key: LargeStateStorageKey) {
-	const localValue = await browser.storage.local.get(key)
-	if (!Object.prototype.hasOwnProperty.call(localValue, key)) return undefined
-	return localValue[key]
+function getLegacyDeleteMarkerKey(key: LargeStateStorageKey): LargeStateDeleteMarkerKey {
+	switch (key) {
+		case 'interceptorTransactionStack': return `${ LARGE_STATE_DELETE_MARKER_PREFIX }interceptorTransactionStack`
+		case 'popupVisualisation': return `${ LARGE_STATE_DELETE_MARKER_PREFIX }popupVisualisation`
+	}
+}
+
+async function getLegacyLocalLookup(key: LargeStateStorageKey): Promise<LegacyLocalLookup> {
+	const deleteMarkerKey = getLegacyDeleteMarkerKey(key)
+	const localValue = await browser.storage.local.get([key, deleteMarkerKey])
+	if (Object.prototype.hasOwnProperty.call(localValue, key)) return { kind: 'found', value: localValue[key] }
+	if (localValue[deleteMarkerKey] === true) return { kind: 'deleted' }
+	return { kind: 'missing' }
 }
 
 async function removeLegacyLocalValue(key: LargeStateStorageKey) {
 	await browser.storage.local.remove(key)
 }
 
+async function clearLegacyLocalState(key: LargeStateStorageKey) {
+	await browser.storage.local.remove([key, getLegacyDeleteMarkerKey(key)])
+}
+
+async function setLegacyLocalDeleted(key: LargeStateStorageKey) {
+	await browser.storage.local.set({ [getLegacyDeleteMarkerKey(key)]: true })
+}
+
 async function setLegacyLocalValue(key: LargeStateStorageKey, value: unknown) {
 	await browser.storage.local.set({ [key]: value })
+	await browser.storage.local.remove(getLegacyDeleteMarkerKey(key))
 }
 
 function parseSerializedValue<T>(codec: funtypes.Codec<T>, value: unknown) {
@@ -123,6 +151,21 @@ function parseSerializedValue<T>(codec: funtypes.Codec<T>, value: unknown) {
 }
 
 export async function getLargeStateValue<T>(key: LargeStateStorageKey, codec: funtypes.Codec<T>): Promise<T | undefined> {
+	const legacyLocalValue = await getLegacyLocalLookup(key)
+	if (legacyLocalValue.kind === 'found') {
+		const parsedLegacyValue = parseSerializedValue(codec, legacyLocalValue.value)
+		if (parsedLegacyValue !== undefined) {
+			const wasMigrated = await setIndexedDbValue(key, legacyLocalValue.value)
+			if (wasMigrated) await clearLegacyLocalState(key)
+			return parsedLegacyValue
+		}
+		await removeLegacyLocalValue(key)
+	}
+	if (legacyLocalValue.kind === 'deleted') {
+		const wasRemoved = await removeIndexedDbValue(key)
+		if (wasRemoved) await clearLegacyLocalState(key)
+		return undefined
+	}
 	const indexedDbValue = await getIndexedDbValue(key)
 	if (indexedDbValue.kind === 'available') {
 		if (indexedDbValue.found) {
@@ -130,22 +173,7 @@ export async function getLargeStateValue<T>(key: LargeStateStorageKey, codec: fu
 			if (parsedIndexedDbValue !== undefined) return parsedIndexedDbValue
 			await removeIndexedDbValue(key)
 		}
-		const legacyLocalValue = await getLegacyLocalValue(key)
-		if (legacyLocalValue === undefined) return undefined
-		const parsedLegacyValue = parseSerializedValue(codec, legacyLocalValue)
-		if (parsedLegacyValue === undefined) {
-			await removeLegacyLocalValue(key)
-			return undefined
-		}
-		const wasMigrated = await setIndexedDbValue(key, legacyLocalValue)
-		if (wasMigrated) await removeLegacyLocalValue(key)
-		return parsedLegacyValue
 	}
-	const localValue = await getLegacyLocalValue(key)
-	if (localValue === undefined) return undefined
-	const parsedLocalValue = parseSerializedValue(codec, localValue)
-	if (parsedLocalValue !== undefined) return parsedLocalValue
-	await removeLegacyLocalValue(key)
 	return undefined
 }
 
@@ -154,7 +182,7 @@ export async function setLargeStateValue<T>(key: LargeStateStorageKey, codec: fu
 	if (canUseIndexedDb()) {
 		const wasStoredInIndexedDb = await setIndexedDbValue(key, serializedValue)
 		if (wasStoredInIndexedDb) {
-			await removeLegacyLocalValue(key)
+			await clearLegacyLocalState(key)
 			return
 		}
 	}
@@ -162,8 +190,17 @@ export async function setLargeStateValue<T>(key: LargeStateStorageKey, codec: fu
 }
 
 export async function removeLargeStateValue(key: LargeStateStorageKey) {
-	if (canUseIndexedDb()) await removeIndexedDbValue(key)
+	if (!canUseIndexedDb()) {
+		await clearLegacyLocalState(key)
+		return
+	}
+	const wasRemovedFromIndexedDb = await removeIndexedDbValue(key)
+	if (wasRemovedFromIndexedDb) {
+		await clearLegacyLocalState(key)
+		return
+	}
 	await removeLegacyLocalValue(key)
+	await setLegacyLocalDeleted(key)
 }
 
 export function estimateSerializedStateBytes<T>(codec: funtypes.Codec<T>, value: T) {

--- a/app/ts/utils/largeStateStore.ts
+++ b/app/ts/utils/largeStateStore.ts
@@ -55,21 +55,41 @@ async function runIndexedDbRequest<T>(mode: IDBTransactionMode, operation: (stor
 	})
 }
 
+function warnIndexedDbRequestFailure(action: string, error: unknown) {
+	console.warn(`IndexedDB ${ action } failed for large state persistence, falling back to storage.local.`)
+	console.warn(error)
+}
+
 async function getIndexedDbValue(key: LargeStateStorageKey): Promise<IndexedDbLookup> {
-	const result = await runIndexedDbRequest('readonly', (store) => store.get(key))
-	if (result.kind === 'unavailable') return result
-	if (result.value === undefined) return { kind: 'available', found: false }
-	return { kind: 'available', found: true, value: result.value }
+	try {
+		const result = await runIndexedDbRequest('readonly', (store) => store.get(key))
+		if (result.kind === 'unavailable') return result
+		if (result.value === undefined) return { kind: 'available', found: false }
+		return { kind: 'available', found: true, value: result.value }
+	} catch (error) {
+		warnIndexedDbRequestFailure('read', error)
+		return { kind: 'unavailable' }
+	}
 }
 
 async function setIndexedDbValue(key: LargeStateStorageKey, value: unknown) {
-	const result = await runIndexedDbRequest('readwrite', (store) => store.put(value, key))
-	return result.kind === 'available'
+	try {
+		const result = await runIndexedDbRequest('readwrite', (store) => store.put(value, key))
+		return result.kind === 'available'
+	} catch (error) {
+		warnIndexedDbRequestFailure('write', error)
+		return false
+	}
 }
 
 async function removeIndexedDbValue(key: LargeStateStorageKey) {
-	const result = await runIndexedDbRequest('readwrite', (store) => store.delete(key))
-	return result.kind === 'available'
+	try {
+		const result = await runIndexedDbRequest('readwrite', (store) => store.delete(key))
+		return result.kind === 'available'
+	} catch (error) {
+		warnIndexedDbRequestFailure('delete', error)
+		return false
+	}
 }
 
 async function getLegacyLocalValue(key: LargeStateStorageKey) {
@@ -106,13 +126,8 @@ export async function getLargeStateValue<T>(key: LargeStateStorageKey, codec: fu
 			await removeLegacyLocalValue(key)
 			return undefined
 		}
-		try {
-			await setIndexedDbValue(key, legacyLocalValue)
-			await removeLegacyLocalValue(key)
-		} catch (error) {
-			console.warn(`Failed to migrate ${ key } to IndexedDB.`)
-			console.warn(error)
-		}
+		const wasMigrated = await setIndexedDbValue(key, legacyLocalValue)
+		if (wasMigrated) await removeLegacyLocalValue(key)
 		return parsedLegacyValue
 	}
 	const localValue = await getLegacyLocalValue(key)

--- a/app/ts/utils/largeStateStore.ts
+++ b/app/ts/utils/largeStateStore.ts
@@ -36,7 +36,7 @@ async function openLargeStateDb() {
 		indexedDbPromise = undefined
 	}
 	if (indexedDbPromise !== undefined) return indexedDbPromise
-	indexedDbPromise = new Promise<IDBDatabase>((resolve, reject) => {
+	const openPromise = new Promise<IDBDatabase>((resolve, reject) => {
 		const request = indexedDB.open(LARGE_STATE_DB_NAME, 1)
 		request.onupgradeneeded = () => {
 			const db = request.result
@@ -45,11 +45,14 @@ async function openLargeStateDb() {
 		request.onsuccess = () => resolve(request.result)
 		request.onerror = () => reject(request.error ?? new Error('Failed to open large state IndexedDB database'))
 		request.onblocked = () => reject(new Error('Large state IndexedDB database open was blocked'))
-	}).catch((error) => {
+	})
+	const retryableOpenPromise = openPromise.catch((error) => {
 		console.warn('IndexedDB unavailable for large state persistence, falling back to storage.local.')
 		console.warn(error)
+		if (indexedDbPromise === retryableOpenPromise) indexedDbPromise = undefined
 		return undefined
 	})
+	indexedDbPromise = retryableOpenPromise
 	return indexedDbPromise
 }
 

--- a/test/tests/largeStateStore.test.ts
+++ b/test/tests/largeStateStore.test.ts
@@ -21,6 +21,7 @@ const staleStack: InterceptorTransactionStack = {
 type StorageGetKeys = string | string[] | Record<string, unknown> | null | undefined
 
 type FakeIndexedDbOptions = {
+	readonly openErrors?: readonly Error[]
 	readonly getError?: Error
 	readonly putError?: Error
 	readonly deleteError?: Error
@@ -151,10 +152,18 @@ function installFakeIndexedDb(indexedDbState: Map<string, unknown>, options: Fak
 			return transaction
 		},
 	}
+	let openAttemptCount = 0
 	const fakeIndexedDb = {
 		open(_name: string, _version?: number) {
 			const request = createFakeRequest(fakeDb)
+			const openError = options.openErrors?.[openAttemptCount]
+			openAttemptCount += 1
 			queueMicrotask(() => {
+				if (openError !== undefined) {
+					request.error = openError
+					request.onerror?.()
+					return
+				}
 				request.onupgradeneeded?.()
 				request.onsuccess?.()
 			})
@@ -213,6 +222,18 @@ describe('large state store helpers', () => {
 
 		assert.equal(indexedDbState.has('interceptorTransactionStack'), false)
 		assert.deepEqual(storageState.interceptorTransactionStack, serializedStack())
+	})
+
+	test('retries IndexedDB open after a transient open failure', async () => {
+		const { indexedDbState, storageState } = installLargeStateEnvironment({ openErrors: [new Error('open failed')] })
+
+		await setLargeStateValue('interceptorTransactionStack', InterceptorTransactionStack, stack)
+		assert.equal(indexedDbState.has('interceptorTransactionStack'), false)
+		assert.deepEqual(storageState.interceptorTransactionStack, serializedStack())
+
+		assert.deepEqual(await getLargeStateValue('interceptorTransactionStack', InterceptorTransactionStack), stack)
+		assert.deepEqual(indexedDbState.get('interceptorTransactionStack'), serializedStack())
+		assert.equal('interceptorTransactionStack' in storageState, false)
 	})
 
 	test('reads storage.local fallback over stale IndexedDB after write failure', async () => {

--- a/test/tests/largeStateStore.test.ts
+++ b/test/tests/largeStateStore.test.ts
@@ -1,7 +1,8 @@
 import * as assert from 'assert'
-import { describe, test } from 'bun:test'
-import { estimateSerializedStateBytes, formatEstimatedBytes } from '../../app/ts/utils/largeStateStore.js'
+import { afterEach, describe, test } from 'bun:test'
+import { estimateSerializedStateBytes, formatEstimatedBytes, getLargeStateValue, removeLargeStateValue, setLargeStateValue } from '../../app/ts/utils/largeStateStore.js'
 import { InterceptorTransactionStack } from '../../app/ts/types/visualizer-types.js'
+import { serialize } from '../../app/ts/types/wire-types.js'
 
 const stack: InterceptorTransactionStack = {
 	operations: [{
@@ -9,6 +10,136 @@ const stack: InterceptorTransactionStack = {
 		blockTimeManipulation: { type: 'AddToTimestamp', deltaToAdd: 11n, deltaUnit: 'Seconds' },
 	}],
 }
+
+type StorageGetKeys = string | string[] | Record<string, unknown> | null | undefined
+
+type FakeIndexedDbOptions = {
+	readonly getError?: Error
+	readonly putError?: Error
+	readonly deleteError?: Error
+	readonly transactionError?: Error
+}
+
+type FakeRequest<T> = {
+	error?: Error
+	result: T
+	onblocked?: () => void
+	onerror?: () => void
+	onsuccess?: () => void
+	onupgradeneeded?: () => void
+}
+
+function createFakeRequest<T>(result: T): FakeRequest<T> {
+	return { result }
+}
+
+function finishFakeRequest<T>(request: FakeRequest<T>, error?: Error) {
+	queueMicrotask(() => {
+		if (error !== undefined) {
+			request.error = error
+			request.onerror?.()
+			return
+		}
+		request.onsuccess?.()
+	})
+}
+
+function createStorageGetResult(keys: StorageGetKeys, storageState: Record<string, unknown>) {
+	if (keys === undefined || keys === null) return { ...storageState }
+	if (Array.isArray(keys)) return Object.fromEntries(keys.filter((key) => key in storageState).map((key) => [key, storageState[key]]))
+	if (typeof keys === 'string') return keys in storageState ? { [keys]: storageState[keys] } : {}
+	return Object.fromEntries(Object.entries(keys).map(([key, defaultValue]) => [key, key in storageState ? storageState[key] : defaultValue]))
+}
+
+function installBrowserStorage(storageState: Record<string, unknown>) {
+	Object.defineProperty(globalThis, 'browser', {
+		value: {
+			storage: {
+				local: {
+					async get(keys?: StorageGetKeys) {
+						return createStorageGetResult(keys, storageState)
+					},
+					async set(items: Record<string, unknown>) {
+						Object.assign(storageState, items)
+					},
+					async remove(keys: string | string[]) {
+						for (const key of Array.isArray(keys) ? keys : [keys]) delete storageState[key]
+					},
+				},
+			},
+		},
+		configurable: true,
+		writable: true,
+	})
+}
+
+function installFakeIndexedDb(indexedDbState: Map<string, unknown>, options: FakeIndexedDbOptions) {
+	let hasLargeStateStore = false
+	const store = {
+		get(key: string) {
+			const request = createFakeRequest(indexedDbState.get(key))
+			finishFakeRequest(request, options.getError)
+			return request
+		},
+		put(value: unknown, key: string) {
+			const request = createFakeRequest(key)
+			if (options.putError === undefined) indexedDbState.set(key, value)
+			finishFakeRequest(request, options.putError)
+			return request
+		},
+		delete(key: string) {
+			const request = createFakeRequest(undefined)
+			if (options.deleteError === undefined) indexedDbState.delete(key)
+			finishFakeRequest(request, options.deleteError)
+			return request
+		},
+	}
+	const fakeDb = {
+		createObjectStore(_name: string) {
+			hasLargeStateStore = true
+			return store
+		},
+		objectStoreNames: {
+			contains(_name: string) {
+				return hasLargeStateStore
+			},
+		},
+		transaction(_storeName: string, _mode: string) {
+			if (options.transactionError !== undefined) throw options.transactionError
+			return {
+				objectStore: () => store,
+			}
+		},
+	}
+	const fakeIndexedDb = {
+		open(_name: string, _version?: number) {
+			const request = createFakeRequest(fakeDb)
+			queueMicrotask(() => {
+				request.onupgradeneeded?.()
+				request.onsuccess?.()
+			})
+			return request
+		},
+	}
+	Object.defineProperty(globalThis, 'indexedDB', { value: fakeIndexedDb, configurable: true, writable: true })
+}
+
+function installLargeStateEnvironment(options: FakeIndexedDbOptions = {}) {
+	const storageState: Record<string, unknown> = {}
+	const indexedDbState = new Map<string, unknown>()
+	installBrowserStorage(storageState)
+	installFakeIndexedDb(indexedDbState, options)
+	return { indexedDbState, storageState }
+}
+
+function serializedStack() {
+	return serialize(InterceptorTransactionStack, stack)
+}
+
+afterEach(() => {
+	Object.defineProperty(globalThis, 'browser', { value: undefined, configurable: true, writable: true })
+	Object.defineProperty(globalThis, 'indexedDB', { value: undefined, configurable: true, writable: true })
+})
 
 describe('large state store helpers', () => {
 	test('estimate serialized bytes for persisted stack state', () => {
@@ -22,5 +153,62 @@ describe('large state store helpers', () => {
 		assert.equal(formatEstimatedBytes(512), '512 B')
 		assert.equal(formatEstimatedBytes(2048), '2.0 KiB')
 		assert.equal(formatEstimatedBytes(2 * 1024 * 1024), '2.00 MiB')
+	})
+
+	test('stores and reads large state from IndexedDB', async () => {
+		const { indexedDbState, storageState } = installLargeStateEnvironment()
+
+		await setLargeStateValue('interceptorTransactionStack', InterceptorTransactionStack, stack)
+		assert.equal('interceptorTransactionStack' in storageState, false)
+		assert.deepEqual(indexedDbState.get('interceptorTransactionStack'), serializedStack())
+
+		assert.deepEqual(await getLargeStateValue('interceptorTransactionStack', InterceptorTransactionStack), stack)
+	})
+
+	test('falls back to storage.local when IndexedDB writes fail', async () => {
+		const { indexedDbState, storageState } = installLargeStateEnvironment({ putError: new Error('put failed') })
+
+		await setLargeStateValue('interceptorTransactionStack', InterceptorTransactionStack, stack)
+
+		assert.equal(indexedDbState.has('interceptorTransactionStack'), false)
+		assert.deepEqual(storageState.interceptorTransactionStack, serializedStack())
+	})
+
+	test('reads legacy storage.local when IndexedDB reads fail', async () => {
+		const { storageState } = installLargeStateEnvironment({ getError: new Error('get failed') })
+		storageState.interceptorTransactionStack = serializedStack()
+
+		const value = await getLargeStateValue('interceptorTransactionStack', InterceptorTransactionStack)
+
+		assert.deepEqual(value, stack)
+	})
+
+	test('keeps legacy storage.local value when IndexedDB migration writes fail', async () => {
+		const { indexedDbState, storageState } = installLargeStateEnvironment({ putError: new Error('put failed') })
+		storageState.interceptorTransactionStack = serializedStack()
+
+		const value = await getLargeStateValue('interceptorTransactionStack', InterceptorTransactionStack)
+
+		assert.deepEqual(value, stack)
+		assert.equal(indexedDbState.has('interceptorTransactionStack'), false)
+		assert.deepEqual(storageState.interceptorTransactionStack, serializedStack())
+	})
+
+	test('removes legacy storage.local value when IndexedDB deletes fail', async () => {
+		const { storageState } = installLargeStateEnvironment({ deleteError: new Error('delete failed') })
+		storageState.interceptorTransactionStack = serializedStack()
+
+		await removeLargeStateValue('interceptorTransactionStack')
+
+		assert.equal('interceptorTransactionStack' in storageState, false)
+	})
+
+	test('falls back to storage.local when IndexedDB transactions fail', async () => {
+		const { storageState } = installLargeStateEnvironment({ transactionError: new Error('transaction failed') })
+		storageState.interceptorTransactionStack = serializedStack()
+
+		const value = await getLargeStateValue('interceptorTransactionStack', InterceptorTransactionStack)
+
+		assert.deepEqual(value, stack)
 	})
 })

--- a/test/tests/largeStateStore.test.ts
+++ b/test/tests/largeStateStore.test.ts
@@ -17,6 +17,7 @@ type FakeIndexedDbOptions = {
 	readonly getError?: Error
 	readonly putError?: Error
 	readonly deleteError?: Error
+	readonly putTransactionAbortAfterRequestSuccess?: Error
 	readonly transactionError?: Error
 }
 
@@ -29,18 +30,50 @@ type FakeRequest<T> = {
 	onupgradeneeded?: () => void
 }
 
+type FakeObjectStore = {
+	delete: (key: string) => FakeRequest<undefined>
+	get: (key: string) => FakeRequest<unknown>
+	put: (value: unknown, key: string) => FakeRequest<string>
+}
+
+type FakeTransaction = {
+	error?: Error
+	onabort?: () => void
+	oncomplete?: () => void
+	onerror?: () => void
+}
+
+type FakeTransactionWithStore = FakeTransaction & {
+	objectStore: () => FakeObjectStore
+}
+
 function createFakeRequest<T>(result: T): FakeRequest<T> {
 	return { result }
 }
 
-function finishFakeRequest<T>(request: FakeRequest<T>, error?: Error) {
+function finishFakeRequest<T>(
+	request: FakeRequest<T>,
+	transaction: FakeTransaction,
+	requestError: Error | undefined,
+	transactionAbortAfterRequestSuccess: Error | undefined,
+	pendingChange?: () => void,
+) {
 	queueMicrotask(() => {
-		if (error !== undefined) {
-			request.error = error
+		if (requestError !== undefined) {
+			request.error = requestError
 			request.onerror?.()
 			return
 		}
 		request.onsuccess?.()
+		queueMicrotask(() => {
+			if (transactionAbortAfterRequestSuccess !== undefined) {
+				transaction.error = transactionAbortAfterRequestSuccess
+				transaction.onabort?.()
+				return
+			}
+			pendingChange?.()
+			transaction.oncomplete?.()
+		})
 	})
 }
 
@@ -75,29 +108,10 @@ function installBrowserStorage(storageState: Record<string, unknown>) {
 
 function installFakeIndexedDb(indexedDbState: Map<string, unknown>, options: FakeIndexedDbOptions) {
 	let hasLargeStateStore = false
-	const store = {
-		get(key: string) {
-			const request = createFakeRequest(indexedDbState.get(key))
-			finishFakeRequest(request, options.getError)
-			return request
-		},
-		put(value: unknown, key: string) {
-			const request = createFakeRequest(key)
-			if (options.putError === undefined) indexedDbState.set(key, value)
-			finishFakeRequest(request, options.putError)
-			return request
-		},
-		delete(key: string) {
-			const request = createFakeRequest(undefined)
-			if (options.deleteError === undefined) indexedDbState.delete(key)
-			finishFakeRequest(request, options.deleteError)
-			return request
-		},
-	}
 	const fakeDb = {
 		createObjectStore(_name: string) {
 			hasLargeStateStore = true
-			return store
+			return undefined
 		},
 		objectStoreNames: {
 			contains(_name: string) {
@@ -106,9 +120,28 @@ function installFakeIndexedDb(indexedDbState: Map<string, unknown>, options: Fak
 		},
 		transaction(_storeName: string, _mode: string) {
 			if (options.transactionError !== undefined) throw options.transactionError
-			return {
+			let store: FakeObjectStore
+			const transaction: FakeTransactionWithStore = {
 				objectStore: () => store,
 			}
+			store = {
+				get(key: string) {
+					const request = createFakeRequest(indexedDbState.get(key))
+					finishFakeRequest(request, transaction, options.getError, undefined)
+					return request
+				},
+				put(value: unknown, key: string) {
+					const request = createFakeRequest(key)
+					finishFakeRequest(request, transaction, options.putError, options.putTransactionAbortAfterRequestSuccess, () => indexedDbState.set(key, value))
+					return request
+				},
+				delete(key: string) {
+					const request = createFakeRequest(undefined)
+					finishFakeRequest(request, transaction, options.deleteError, undefined, () => indexedDbState.delete(key))
+					return request
+				},
+			}
+			return transaction
 		},
 	}
 	const fakeIndexedDb = {
@@ -174,6 +207,15 @@ describe('large state store helpers', () => {
 		assert.deepEqual(storageState.interceptorTransactionStack, serializedStack())
 	})
 
+	test('falls back to storage.local when IndexedDB write transaction aborts after request success', async () => {
+		const { indexedDbState, storageState } = installLargeStateEnvironment({ putTransactionAbortAfterRequestSuccess: new Error('commit failed') })
+
+		await setLargeStateValue('interceptorTransactionStack', InterceptorTransactionStack, stack)
+
+		assert.equal(indexedDbState.has('interceptorTransactionStack'), false)
+		assert.deepEqual(storageState.interceptorTransactionStack, serializedStack())
+	})
+
 	test('reads legacy storage.local when IndexedDB reads fail', async () => {
 		const { storageState } = installLargeStateEnvironment({ getError: new Error('get failed') })
 		storageState.interceptorTransactionStack = serializedStack()
@@ -185,6 +227,17 @@ describe('large state store helpers', () => {
 
 	test('keeps legacy storage.local value when IndexedDB migration writes fail', async () => {
 		const { indexedDbState, storageState } = installLargeStateEnvironment({ putError: new Error('put failed') })
+		storageState.interceptorTransactionStack = serializedStack()
+
+		const value = await getLargeStateValue('interceptorTransactionStack', InterceptorTransactionStack)
+
+		assert.deepEqual(value, stack)
+		assert.equal(indexedDbState.has('interceptorTransactionStack'), false)
+		assert.deepEqual(storageState.interceptorTransactionStack, serializedStack())
+	})
+
+	test('keeps legacy storage.local value when IndexedDB migration transaction aborts after request success', async () => {
+		const { indexedDbState, storageState } = installLargeStateEnvironment({ putTransactionAbortAfterRequestSuccess: new Error('commit failed') })
 		storageState.interceptorTransactionStack = serializedStack()
 
 		const value = await getLargeStateValue('interceptorTransactionStack', InterceptorTransactionStack)

--- a/test/tests/largeStateStore.test.ts
+++ b/test/tests/largeStateStore.test.ts
@@ -162,14 +162,15 @@ function installFakeIndexedDb(indexedDbState: Map<string, unknown>, options: Fak
 		},
 	}
 	Object.defineProperty(globalThis, 'indexedDB', { value: fakeIndexedDb, configurable: true, writable: true })
+	return fakeIndexedDb
 }
 
 function installLargeStateEnvironment(options: FakeIndexedDbOptions = {}) {
 	const storageState: Record<string, unknown> = {}
 	const indexedDbState = new Map<string, unknown>()
 	installBrowserStorage(storageState)
-	installFakeIndexedDb(indexedDbState, options)
-	return { indexedDbState, storageState }
+	const fakeIndexedDb = installFakeIndexedDb(indexedDbState, options)
+	return { fakeIndexedDb, indexedDbState, storageState }
 }
 
 function serializedStack(value: InterceptorTransactionStack = stack) {
@@ -275,6 +276,24 @@ describe('large state store helpers', () => {
 		assert.equal('interceptorTransactionStack' in storageState, false)
 		assert.equal(storageState['interceptorLargeStateDeleted:interceptorTransactionStack'], true)
 		assert.deepEqual(await getLargeStateValue('interceptorTransactionStack', InterceptorTransactionStack), undefined)
+	})
+
+	test('keeps stale IndexedDB hidden when large state is removed during an IndexedDB outage', async () => {
+		const { fakeIndexedDb, indexedDbState, storageState } = installLargeStateEnvironment()
+		indexedDbState.set('interceptorTransactionStack', serializedStack())
+		storageState.interceptorTransactionStack = serializedStack()
+		Object.defineProperty(globalThis, 'indexedDB', { value: undefined, configurable: true, writable: true })
+
+		await removeLargeStateValue('interceptorTransactionStack')
+
+		assert.equal('interceptorTransactionStack' in storageState, false)
+		assert.equal(storageState['interceptorLargeStateDeleted:interceptorTransactionStack'], true)
+
+		Object.defineProperty(globalThis, 'indexedDB', { value: fakeIndexedDb, configurable: true, writable: true })
+
+		assert.deepEqual(await getLargeStateValue('interceptorTransactionStack', InterceptorTransactionStack), undefined)
+		assert.equal(indexedDbState.has('interceptorTransactionStack'), false)
+		assert.equal('interceptorLargeStateDeleted:interceptorTransactionStack' in storageState, false)
 	})
 
 	test('falls back to storage.local when IndexedDB transactions fail', async () => {

--- a/test/tests/largeStateStore.test.ts
+++ b/test/tests/largeStateStore.test.ts
@@ -11,6 +11,13 @@ const stack: InterceptorTransactionStack = {
 	}],
 }
 
+const staleStack: InterceptorTransactionStack = {
+	operations: [{
+		type: 'TimeManipulation',
+		blockTimeManipulation: { type: 'AddToTimestamp', deltaToAdd: 7n, deltaUnit: 'Seconds' },
+	}],
+}
+
 type StorageGetKeys = string | string[] | Record<string, unknown> | null | undefined
 
 type FakeIndexedDbOptions = {
@@ -165,8 +172,8 @@ function installLargeStateEnvironment(options: FakeIndexedDbOptions = {}) {
 	return { indexedDbState, storageState }
 }
 
-function serializedStack() {
-	return serialize(InterceptorTransactionStack, stack)
+function serializedStack(value: InterceptorTransactionStack = stack) {
+	return serialize(InterceptorTransactionStack, value)
 }
 
 afterEach(() => {
@@ -204,6 +211,17 @@ describe('large state store helpers', () => {
 		await setLargeStateValue('interceptorTransactionStack', InterceptorTransactionStack, stack)
 
 		assert.equal(indexedDbState.has('interceptorTransactionStack'), false)
+		assert.deepEqual(storageState.interceptorTransactionStack, serializedStack())
+	})
+
+	test('reads storage.local fallback over stale IndexedDB after write failure', async () => {
+		const { indexedDbState, storageState } = installLargeStateEnvironment({ putError: new Error('put failed') })
+		indexedDbState.set('interceptorTransactionStack', serializedStack(staleStack))
+
+		await setLargeStateValue('interceptorTransactionStack', InterceptorTransactionStack, stack)
+
+		assert.deepEqual(await getLargeStateValue('interceptorTransactionStack', InterceptorTransactionStack), stack)
+		assert.deepEqual(indexedDbState.get('interceptorTransactionStack'), serializedStack(staleStack))
 		assert.deepEqual(storageState.interceptorTransactionStack, serializedStack())
 	})
 
@@ -248,12 +266,15 @@ describe('large state store helpers', () => {
 	})
 
 	test('removes legacy storage.local value when IndexedDB deletes fail', async () => {
-		const { storageState } = installLargeStateEnvironment({ deleteError: new Error('delete failed') })
+		const { indexedDbState, storageState } = installLargeStateEnvironment({ deleteError: new Error('delete failed') })
+		indexedDbState.set('interceptorTransactionStack', serializedStack())
 		storageState.interceptorTransactionStack = serializedStack()
 
 		await removeLargeStateValue('interceptorTransactionStack')
 
 		assert.equal('interceptorTransactionStack' in storageState, false)
+		assert.equal(storageState['interceptorLargeStateDeleted:interceptorTransactionStack'], true)
+		assert.deepEqual(await getLargeStateValue('interceptorTransactionStack', InterceptorTransactionStack), undefined)
 	})
 
 	test('falls back to storage.local when IndexedDB transactions fail', async () => {


### PR DESCRIPTION
## Summary
- Add defensive fallback handling around IndexedDB large-state reads, writes, deletes, transaction commits, and transient open failures so persistence keeps working when IndexedDB is unavailable or a request/transaction fails.
- Treat `storage.local` fallback values as authoritative over stale IndexedDB records after failed writes, then retry migration back to IndexedDB on later reads.
- Add a local delete marker for failed or unavailable IndexedDB deletes so stale IndexedDB records stay hidden until a later delete succeeds.
- Remove legacy `storage.local` values only after IndexedDB writes/migrations/deletes have actually completed successfully.
- Clear failed IndexedDB open attempts from the cache so subsequent operations retry instead of staying on `storage.local` until the global `indexedDB` object changes.
- Expand `largeStateStore` regression coverage for stale IndexedDB records, failed writes, failed transaction commits, failed migrations, failed reads, failed deletes, deletes during IndexedDB outages, and transient open failures.

## Testing
- `bun test test/tests/largeStateStore.test.ts`
- `bun test`
- `bun run setup-chrome`
- `bun run typecheck`
- `bun run lint`
