### PR TITLE
Add project Codex reviewer agent

### DIFF
--- a/.codex/agents/reviewer.toml
+++ b/.codex/agents/reviewer.toml
@@ -1,0 +1,66 @@
+name = "reviewer"
+description = "Read-only final code reviewer for The Interceptor that checks the current worktree diff against origin/main, the stated task intent, validation results, extension behavior, generated-output policy, and long-term maintainability."
+model = "gpt-5.5"
+model_reasoning_effort = "high"
+sandbox_mode = "read-only"
+nickname_candidates = ["Audit", "Inspect", "Review"]
+developer_instructions = """
+Act as a read-only worktree reviewer for The Interceptor browser extension. Do not modify files.
+
+Review the current worktree diff against origin/main using the original user request, acceptance criteria, intentional non-goals, changed-files list, and validation log supplied by the parent agent. Include committed branch changes, staged changes, unstaged changes, and untracked files that are identified as intended for the task. If any of those inputs are missing or vague, state the limitation and continue with a best-effort review.
+
+The Interceptor is a Bun-managed TypeScript browser extension. Most source lives under app/ts, inpage-provider source lives under app/inpage/ts, test coverage lives under test, build/vendor tooling lives under build and scripts, and Chrome/Firefox bundles are produced by setup/build scripts. Treat generated JavaScript and generated extension outputs as build artifacts unless a task explicitly asks to refresh them.
+
+Prioritize:
+
+1. Correctness, security, data-loss, broken builds, and missing requested behavior.
+2. Browser-extension regressions involving MV2/MV3 manifests, content scripts, background script lifecycle, popup/access-window flows, injected inpage messaging, permissions, storage migration, and cross-browser compatibility.
+3. Fixes that only patch the reported symptom locally instead of addressing the root cause at the right codebase level.
+4. Edge cases, failure paths, and contract/API mismatches in JSON-RPC, EIP-1193 provider behavior, transaction/signing flows, simulation stack handling, website access approvals, and network switching.
+5. Validation gaps that create concrete regression risk, especially when required checks were skipped or Chrome bundle/browser-communication behavior was changed.
+6. Naming, terminology, and structure that make the code easy to understand without hidden context.
+7. Code and text duplication that repeats existing behavior or guidance instead of reusing, consolidating, or linking to the canonical source.
+8. Maintainability problems that can cause future mistakes, especially unclear ownership boundaries, brittle special cases, hidden coupling, unnecessary divergence between similar code paths, or edits to generated output instead of TypeScript sources.
+
+Do not raise speculative, preference-only, or style-only findings unless they create concrete readability, correctness, or maintenance risk. Do not rely on hidden conversation context. Base findings on the diff and repository evidence, and put uncertainty in `Review limitations`.
+
+Review method:
+
+- Inspect the worktree diff against origin/main and the relevant changed files.
+- Cross-check each acceptance criterion against the implementation.
+- Search the changed area and nearby/shared modules for existing methods, helpers, components, tests, scripts, documented procedures, generated-output rules, or extension patterns that already cover the same responsibility.
+- Search for analogous call sites, parallel implementations, shared entry points, and related test coverage across the repository when reviewing a bug fix or behavioral change.
+- Check whether the change addresses the underlying cause at the most maintainable layer. Flag narrow one-off patches when the same defect can still occur through another public path, duplicated implementation, or equivalent workflow.
+- Check whether the chosen scope is appropriately broad without being overgeneralized. Prefer shared helpers, central validation, or canonical documentation only when they reduce future drift and make the behavior easier to evolve.
+- Flag new or changed code that duplicates an existing method or reimplements almost the same behavior unless the diff makes a clear, justified distinction.
+- Check changed documentation, instructions, UI copy, and comments for repeated statements of the same guidance; prefer one canonical explanation with links or concise references.
+- Check whether new or changed names clearly describe their domain role, units, lifecycle state, and side effects.
+- Check whether the control flow, data flow, module boundaries, and tests are simple enough for a future maintainer to understand, extend, and change safely without hidden conversation context.
+- Check whether the implementation creates long-term maintenance risk through hard-coded exceptions, inconsistent patterns, duplicated policy, fragile ordering assumptions, or missing ownership of shared behavior.
+- Check whether source changes were made in TypeScript rather than generated JavaScript output, and whether setup/build scripts are used only when generated extension output is intentionally refreshed.
+- Check whether validation matches the repository rules in AGENTS.md. The default final suite for code, tests, configuration, tooling, and repo-instruction changes is `bun test`, `bun run setup-chrome`, `bun run typecheck`, and `bun run lint`, run separately after the full task is complete.
+- If a missing test/check is flagged, explain the exact behavior risk it would catch, including any similar code paths or workflows that would remain unprotected.
+- Put uncertainty under `Review limitations`, not as a finding.
+
+Output:
+
+1. Findings first, grouped by High, Medium, and Low.
+2. For each finding include:
+   - path:line
+   - severity
+   - why it matters for the stated intent
+   - concrete suggested fix
+   - validation that would catch the issue
+3. If no High or Medium issues are found, say so explicitly.
+4. Include `Validation assessment`.
+5. Include `Review limitations`; if none, write `None`.
+6. Include `Review score: <0-100>` with a brief rationale.
+
+Score rubric:
+
+- 90-100: no High/Medium issues, strong validation, low residual risk
+- 75-89: no High issues, minor Medium/Low risk or limited validation
+- 50-74: one or more Medium issues or important validation gaps
+- 25-49: High issue, missing requested behavior, or serious regression risk
+- 0-24: unsafe, unreviewable, or likely broken
+"""

--- a/.codex/config.toml
+++ b/.codex/config.toml
@@ -1,0 +1,3 @@
+[agents]
+max_threads = 3
+max_depth = 1

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,13 +1,110 @@
 # Agent Notes
 
-- After completing a user-requested task that changes code, before handing off, run `bun test`, `bun run setup-chrome`, `bun run typecheck`, and `bun run lint`.
+The Interceptor is a Bun-managed TypeScript browser extension. Main extension source lives in `app/ts`, injected inpage-provider source lives in `app/inpage/ts`, tests live in `test`, build tooling lives in `build` and `scripts`, and extension pages/assets live under `app`.
+
+## Required Validation
+
+- After completing a user-requested task that changes code, tests, configuration, tooling, or repository instructions, run these commands separately and in this order before handing off:
+  ```bash
+  bun test
+  bun run setup-chrome
+  bun run typecheck
+  bun run lint
+  ```
 - Run that full validation suite after the whole task is complete, not after every intermediate edit.
 - Before handing off to the user, those tools should report no errors and no test failures.
-- If any of those tools report an error or test failure, fix the issue before handing off to the user.
-- For a real browser communication check, build the Chrome bundle with `bun run setup-chrome`, install Chromium once with `bun run install-chrome` on Debian/Ubuntu if needed, then run `bun run test:chrome-communication`. That launches Chrome through the repo CDP harness, waits for the MV3 content scripts to register, opens a local HTTP page, approves the real Interceptor access popup, and verifies the page reaches `access-granted`.
+- If any of those tools report an error or test failure, fix the issue and rerun the required validation before handing off.
+- For documentation-only or read-only tasks that cannot affect executable behavior, state which checks were skipped and why.
+
+## Browser Checks
+
+- For a real browser communication check, build the Chrome bundle with `bun run setup-chrome`, install Chromium once with `bun run install-chrome` on Debian/Ubuntu if needed, then run `bun run test:chrome-communication`.
+- `bun run test:chrome-communication` launches Chrome through the repo CDP harness, waits for the MV3 content scripts to register, opens a local HTTP page, approves the real Interceptor access popup, and verifies the page reaches `access-granted`.
 - If Chrome or Chromium is installed outside the standard paths, set `CHROME_BIN=/path/to/chrome` when running `bun run test:chrome-communication` or `bun run benchmark:popup-lifecycle`.
-- Prefer targeted changes that keep the existing architecture intact unless a broader refactor is explicitly requested.
+
+## Final Review Gate
+
+For any task that changes code, tests, configuration, tooling, or repository instructions, after the required validation passes, the main agent must spawn the project-scoped `reviewer` custom agent defined in `.codex/agents/reviewer.toml` and wait for it to complete before responding to the user. Start the reviewer from a clear task summary instead of relying on inherited conversation context.
+
+Give the reviewer a structured request summary that includes:
+
+- A brief verbatim excerpt or exact summary of the original user request.
+- Acceptance criteria derived from the request.
+- Intentional non-goals or exclusions.
+- Implementation summary.
+- Changed files or areas.
+- Validation commands and results, including concrete scope-based reasons for skipped checks.
+- Known risks, tradeoffs, or areas needing close attention.
+
+Send the reviewer a prompt with this shape:
+
+```text
+Use the project-scoped reviewer instructions from .codex/agents/reviewer.toml.
+
+Original user request:
+<brief verbatim excerpt or exact task summary>
+
+Acceptance criteria:
+- <requirement 1>
+- <requirement 2>
+
+Intentional non-goals / exclusions:
+- <anything intentionally not implemented>
+
+Implementation summary:
+- <what changed and why>
+
+Changed files / areas:
+- <file or area list>
+
+Validation:
+- <command>: <passed/failed/skipped>
+- <skip reason, if skipped>
+
+Known risks or areas needing close attention:
+- <risk, tradeoff, or "none known">
+
+Review the current worktree diff against origin/main, including committed branch changes, staged changes, unstaged changes, and untracked files intended for the task. Review the stated acceptance criteria and whether the changed code is named clearly, readable, and easy to understand.
+Do not modify files.
+Return findings grouped by High, Medium, and Low.
+
+Also include:
+- Validation assessment
+- Review limitations, or "None" if there are no limitations
+- Worktree-diff quality score from 0 to 100 using the reviewer rubric
+```
+
+After the reviewer finishes, the main agent must read the full review and decide how to handle every finding:
+
+- Fix all valid High, Medium, and Low issues before completing the task.
+- If a finding is a non-issue, improve the code, tests, names, or local explanation so a future reviewer can understand why the concern does not apply without needing this conversation.
+- If no High, Medium, or Low issues are found, the task may be marked complete.
+- If any High, Medium, or Low issues are fixed, rerun the required checks and repeat the reviewer gate until no valid findings remain.
+
+In the final response to the user, summarize the reviewer feedback received, report the score from each review pass, state which findings were addressed, note any findings considered non-issues and what readability or self-documenting improvements were made, and list the checks run after the final changes.
+
+## Code Style
+
+- Prefer targeted changes that keep the existing extension architecture intact unless a broader refactor is explicitly requested.
 - Do not use TypeScript directive comments such as `// @ts-expect-error`, `// @ts-ignore`, or `// @ts-nocheck`; fix the type problem directly or restructure the code so the types are correct.
 - Avoid type assertions and casting, especially double-cast patterns like `as unknown as SomeType`; prefer proper typing, generic constraints, narrower APIs, or explicit runtime validation when needed.
 - Avoid using `null`; prefer `undefined` for absent values unless an external API or schema explicitly requires `null`.
 - Avoid classes and class-based abstractions; prefer functional programming with plain data, pure functions, and composition.
+- Use single quotes for TypeScript strings unless escaping makes double quotes clearer. Run `bun run lint:quotes` through `bun run lint` to enforce this.
+- Keep error reporting explicit. Await unexpected-error reporting helpers when the surrounding code expects durable reporting before continuing.
+- Do not leave comment-only `catch` blocks or console-error-only catches; handle, propagate, or report the error according to the local pattern.
+- All dependency versions in `package.json` must be exact, with no `^` or `~` ranges.
+
+## Generated Output
+
+- Do not manually edit generated JavaScript under `app/js` or `app/inpage/js`. Change the corresponding TypeScript under `app/ts` or `app/inpage/ts`, then let the setup/build scripts regenerate output.
+- `bun run setup-chrome` runs vendor setup, builds the inpage bundle, builds the Chrome extension output, and writes `app/manifest.json` from `app/manifestV3.json`.
+- `bun run setup-firefox` builds the Firefox extension output and writes `app/manifest.json` from `app/manifestV2.json`.
+- Treat build outputs from `build/` vendor and bundle scripts as generated unless the task explicitly asks to update generated artifacts.
+- Do not commit regenerated output just because validation ran; review the diff and keep only intentional source/config/instruction changes.
+
+## Testing Guidance
+
+- Add or update focused tests when behavior changes, a bug is fixed, or a regression would otherwise be easy to reintroduce.
+- For browser-extension workflow changes, prefer existing test harnesses in `test/tests` and the Chrome benchmark harness in `test/benchmarks` before adding new infrastructure.
+- Use `bun run test:chrome-communication` when changes affect MV3 content-script registration, access approval popups, injected provider communication, or page-to-extension messaging in ways unit tests cannot cover.


### PR DESCRIPTION
## Summary
- Adds project-scoped Codex reviewer configuration in `.codex/config.toml` and `.codex/agents/reviewer.toml`.
- Updates root `AGENTS.md` with The Interceptor-specific validation, generated-output, style, browser-check, and final reviewer-gate guidance.
- Adapts the copied reviewer guidance for this Bun-managed TypeScript browser extension, including MV2/MV3, content script, background, popup/access-window, injected-provider, storage, and cross-browser review priorities.

## Validation
- `bun test`
- `bun run setup-chrome`
- `bun run typecheck`
- `bun run lint`
- TOML parse check for `.codex/config.toml` and `.codex/agents/reviewer.toml`
- `git diff --check`