### PR TITLE
Support EIP-7702 delegation rescue flows

### DIFF
--- a/app/ts/background/windows/confirmTransaction.ts
+++ b/app/ts/background/windows/confirmTransaction.ts
@@ -11,15 +11,8 @@ import { getHtmlFile, sendPopupMessageToOpenWindows } from '../backgroundUtils.j
 import { appendPendingTransactionOrMessage, clearPendingTransactions, getInterceptorTransactionStack, getPendingTransactionsAndMessages, getRpcConnectionStatus, removePendingTransactionOrMessage, updateInterceptorTransactionStack, updatePendingTransactionOrMessage } from '../storageVariables.js'
 import { type InterceptedRequest, type UniqueRequestIdentifier, doesUniqueRequestIdentifiersMatch, getUniqueRequestIdentifierString, silenceChromeUnCaughtPromise } from '../../utils/requests.js'
 import { replyToInterceptedRequest } from '../messageSending.js'
-import {
-	stringToBytes,
-	keccak256,
-	recoverAddress,
-	parseTransaction as parseSerializedTransaction,
-	serializeTransaction,
-} from '../../utils/viem.js'
-import { dataStringWith0xStart, stringToUint8Array } from '../../utils/bigint.js'
-import { EthereumAddress, EthereumBytes32, EthereumQuantity, serialize } from '../../types/wire-types.js'
+import { stringToBytes, keccak256 } from '../../utils/viem.js'
+import { EthereumBytes32, EthereumQuantity, serialize } from '../../types/wire-types.js'
 import type { PopupOrTabId, Website } from '../../types/websiteAccessTypes.js'
 import { JsonRpcResponseError, reportUnexpectedError, isExpectedInfrastructureError, reportLocalRecovery } from '../../utils/errors.js'
 import type { PendingTransactionOrSignableMessage, PopupPendingTransactionOrSignableMessage } from '../../types/accessRequest.js'
@@ -34,6 +27,7 @@ import { POPUP_PERFORMANCE_MARKS, markPerformance } from '../../utils/popupPerfo
 import type { TokenPriceService } from '../../simulation/services/priceEstimator.js'
 import { closePopupOrTabById, getPopupOrTabById, openPopupOrTab, tryFocusingTabOrWindow } from '../../utils/popupOrTab.js'
 import { getDesiredMaxFeePerGasForBaseFee, getTransactionFeesForBaseFee, hasExplicitMaxFeePerGas } from '../../utils/transactionFees.js'
+import { parseSendRawTransaction } from '../../utils/sendRawTransactionParsing.js'
 
 const pendingConfirmationSemaphore = new Semaphore(1)
 
@@ -249,70 +243,9 @@ const formRejectMessage = (code: number, errorString: string) => {
 	}
 }
 
-const isSerializedEip1559Transaction = (transaction: `0x${ string }`): transaction is `0x02${ string }` => transaction.startsWith('0x02')
-const recoverSerializedEip1559TransactionAddress = async (serializedTransaction: `0x02${ string }`) => {
-	const parsedTransaction = parseSerializedTransaction(serializedTransaction)
-	if (parsedTransaction.type !== 'eip1559') throw new Error('Expected EIP-1559 transaction')
-	if (parsedTransaction.chainId === undefined || parsedTransaction.gas === undefined || parsedTransaction.maxFeePerGas === undefined || parsedTransaction.maxPriorityFeePerGas === undefined || parsedTransaction.nonce === undefined || parsedTransaction.r === undefined || parsedTransaction.s === undefined) {
-		throw new Error('Serialized transaction is missing required signature fields')
-	}
-	const unsignedTransaction = serializeTransaction({
-		type: 'eip1559',
-		chainId: Number(parsedTransaction.chainId),
-		nonce: parsedTransaction.nonce,
-		maxFeePerGas: parsedTransaction.maxFeePerGas,
-		maxPriorityFeePerGas: parsedTransaction.maxPriorityFeePerGas,
-		gas: parsedTransaction.gas,
-		to: parsedTransaction.to,
-		value: parsedTransaction.value,
-		data: parsedTransaction.data,
-		accessList: parsedTransaction.accessList,
-	})
-	return await recoverAddress({
-		hash: keccak256(unsignedTransaction),
-		signature: {
-			r: parsedTransaction.r,
-			s: parsedTransaction.s,
-			yParity: parsedTransaction.yParity ?? 0,
-		},
-	})
-}
-
 export const formSendRawTransaction = async(ethereumClientService: EthereumClientService, sendRawTransactionParams: SendRawTransactionParams, website: Website, created: Date, transactionIdentifier: EthereumQuantity): Promise<WebsiteCreatedEthereumUnsignedTransaction> => {
-	const serializedTransaction = dataStringWith0xStart(sendRawTransactionParams.params[0])
-	const parsedTransaction = parseSerializedTransaction(serializedTransaction)
-	if (parsedTransaction.type !== 'eip1559') throw new Error('No support for non-1559 transactions')
-	if (!isSerializedEip1559Transaction(serializedTransaction)) throw new Error('Expected serialized EIP-1559 transaction')
-	const from = await recoverSerializedEip1559TransactionAddress(serializedTransaction)
-	if (parsedTransaction.gas === undefined) throw new Error('Unable to parse gas from serialized transaction')
-	if (parsedTransaction.nonce === undefined) throw new Error('Unable to parse nonce from serialized transaction')
-	const transactionDetails = {
-		from: EthereumAddress.parse(from),
-		input: stringToUint8Array(parsedTransaction.data ?? '0x'),
-		gas: parsedTransaction.gas,
-		value: parsedTransaction.value,
-		...(parsedTransaction.to === undefined || parsedTransaction.to === null ? {} : { to: EthereumAddress.parse(parsedTransaction.to) }),
-		...(parsedTransaction.maxPriorityFeePerGas === undefined ? {} : { maxPriorityFeePerGas: parsedTransaction.maxPriorityFeePerGas }),
-		...(parsedTransaction.maxFeePerGas === undefined ? {} : { maxFeePerGas: parsedTransaction.maxFeePerGas }),
-	}
-
-	if (transactionDetails.maxFeePerGas === undefined) throw new Error('No support for non-1559 transactions')
-
-	const transaction = {
-		type: '1559' as const,
-		from: transactionDetails.from,
-		chainId: ethereumClientService.getChainId(),
-		nonce: BigInt(parsedTransaction.nonce),
-		maxFeePerGas: transactionDetails.maxFeePerGas,
-		maxPriorityFeePerGas: transactionDetails.maxPriorityFeePerGas ? transactionDetails.maxPriorityFeePerGas : 0n,
-		to: transactionDetails.to === undefined ? null : transactionDetails.to,
-		value: transactionDetails.value ? transactionDetails.value : 0n,
-		input: transactionDetails.input,
-		accessList: [],
-		gas: transactionDetails.gas,
-	}
 	return {
-		transaction,
+		transaction: await parseSendRawTransaction(sendRawTransactionParams.params[0], ethereumClientService.getChainId()),
 		website,
 		created,
 		originalRequestParameters: sendRawTransactionParams,
@@ -338,8 +271,7 @@ export const formEthSendTransaction = async(ethereumClientService: EthereumClien
 	const getFeePerGas = async (gasLimit: bigint) => {
 		return getTransactionFeesForBaseFee(parentBaseFeePerGas, maxPriorityFeePerGas, transactionDetails.maxFeePerGas, await balancePromise, value, gasLimit)
 	}
-	const transactionWithoutGas = {
-		type: '1559' as const,
+	const transactionWithoutGasBase = {
 		from,
 		chainId: ethereumClientService.getChainId(),
 		nonce: await transactionCountPromise,
@@ -350,6 +282,22 @@ export const formEthSendTransaction = async(ethereumClientService: EthereumClien
 		input: getInputFieldFromDataOrInput(transactionDetails),
 		accessList: [],
 	}
+	const authorizationList = transactionDetails.authorizationList?.map((authorization) => ({
+		chainId: authorization.chainId,
+		address: authorization.address,
+		nonce: authorization.nonce,
+		...(authorization.authority === undefined ? {} : { authority: authorization.authority }),
+	}))
+	const transactionWithoutGas = transactionDetails.type === '7702' || authorizationList !== undefined
+		? {
+			...transactionWithoutGasBase,
+			type: '7702' as const,
+			authorizationList: authorizationList ?? [],
+		}
+		: {
+			...transactionWithoutGasBase,
+			type: '1559' as const,
+		}
 	const extraParams = {
 		website,
 		created,

--- a/app/ts/background/windows/confirmTransaction.ts
+++ b/app/ts/background/windows/confirmTransaction.ts
@@ -244,9 +244,9 @@ const formRejectMessage = (code: number, errorString: string) => {
 	}
 }
 
-export const formSendRawTransaction = async(ethereumClientService: EthereumClientService, sendRawTransactionParams: SendRawTransactionParams, website: Website, created: Date, transactionIdentifier: EthereumQuantity): Promise<WebsiteCreatedEthereumUnsignedTransaction> => {
+export const formSendRawTransaction = async(_ethereumClientService: EthereumClientService, sendRawTransactionParams: SendRawTransactionParams, website: Website, created: Date, transactionIdentifier: EthereumQuantity): Promise<WebsiteCreatedEthereumUnsignedTransaction> => {
 	return {
-		transaction: await parseSendRawTransaction(sendRawTransactionParams.params[0], ethereumClientService.getChainId()),
+		transaction: await parseSendRawTransaction(sendRawTransactionParams.params[0]),
 		website,
 		created,
 		originalRequestParameters: sendRawTransactionParams,

--- a/app/ts/background/windows/confirmTransaction.ts
+++ b/app/ts/background/windows/confirmTransaction.ts
@@ -28,6 +28,7 @@ import type { TokenPriceService } from '../../simulation/services/priceEstimator
 import { closePopupOrTabById, getPopupOrTabById, openPopupOrTab, tryFocusingTabOrWindow } from '../../utils/popupOrTab.js'
 import { getDesiredMaxFeePerGasForBaseFee, getTransactionFeesForBaseFee, hasExplicitMaxFeePerGas } from '../../utils/transactionFees.js'
 import { parseSendRawTransaction } from '../../utils/sendRawTransactionParsing.js'
+import { normalizeEip7702AuthorizationList } from '../../utils/eip7702Authorization.js'
 
 const pendingConfirmationSemaphore = new Semaphore(1)
 
@@ -282,12 +283,7 @@ export const formEthSendTransaction = async(ethereumClientService: EthereumClien
 		input: getInputFieldFromDataOrInput(transactionDetails),
 		accessList: [],
 	}
-	const authorizationList = transactionDetails.authorizationList?.map((authorization) => ({
-		chainId: authorization.chainId,
-		address: authorization.address,
-		nonce: authorization.nonce,
-		...(authorization.authority === undefined ? {} : { authority: authorization.authority }),
-	}))
+	const authorizationList = transactionDetails.authorizationList === undefined ? undefined : await normalizeEip7702AuthorizationList(transactionDetails.authorizationList)
 	const transactionWithoutGas = transactionDetails.type === '7702' || authorizationList !== undefined
 		? {
 			...transactionWithoutGasBase,

--- a/app/ts/components/simulationExplaining/Transactions.tsx
+++ b/app/ts/components/simulationExplaining/Transactions.tsx
@@ -96,9 +96,9 @@ function CompactDelegationAddress({ addressBookEntry }: { addressBookEntry: Addr
 	</div>
 }
 
-function DelegationNotice({ signer, authorizationList, addressMetadata, renameAddressCallBack }: {
-	signer: AddressBookEntry
-	authorizationList: readonly { address: bigint }[]
+function DelegationNotice({ defaultSigner, authorizationList, addressMetadata, renameAddressCallBack }: {
+	defaultSigner: AddressBookEntry
+	authorizationList: readonly { address: bigint, authority?: bigint }[]
 	addressMetadata: ReadonlySignal<readonly AddressBookEntry[]>
 	renameAddressCallBack: RenameAddressCallBack
 }) {
@@ -114,22 +114,25 @@ function DelegationNotice({ signer, authorizationList, addressMetadata, renameAd
 			</a>
 			<p class = 'paragraph delegation-flow-title'>Delegated execution</p>
 		</div>
-		<div class = 'delegation-flow-row'>
-			<button type = 'button' class = 'delegation-flow-address-button' onClick = { () => renameAddressCallBack(signer) }>
-				<CompactDelegationAddress addressBookEntry = { signer } />
-			</button>
-			<div class = 'delegation-flow-connector'>
-				<p class = 'paragraph delegation-flow-label'>delegated to</p>
-				<DelegationFlowArrow />
-			</div>
-			<div class = 'delegation-flow-targets'>
-				{ authorizationList.map((authorization, index) => {
-					const entry = getAddressBookEntryOrAFiller(addressMetadata.value, authorization.address)
-					return <button type = 'button' class = 'delegation-flow-address-button' key = { `${ authorization.address.toString() }-${ index }` } onClick = { () => renameAddressCallBack(entry) }>
-						<CompactDelegationAddress addressBookEntry = { entry } />
+		<div class = 'delegation-flow-column'>
+			{ authorizationList.map((authorization, index) => {
+				const signer = authorization.authority === undefined ? defaultSigner : getAddressBookEntryOrAFiller(addressMetadata.value, authorization.authority)
+				const entry = getAddressBookEntryOrAFiller(addressMetadata.value, authorization.address)
+				return <div class = 'delegation-flow-row' key = { `${ authorization.address.toString() }-${ authorization.authority?.toString() ?? defaultSigner.address.toString() }-${ index }` }>
+					<button type = 'button' class = 'delegation-flow-address-button' onClick = { () => renameAddressCallBack(signer) }>
+						<CompactDelegationAddress addressBookEntry = { signer } />
 					</button>
-				}) }
-			</div>
+					<div class = 'delegation-flow-connector'>
+						<p class = 'paragraph delegation-flow-label'>{ authorization.address === 0n ? 'cleared delegate' : 'delegated to' }</p>
+						<DelegationFlowArrow />
+					</div>
+					<div class = 'delegation-flow-targets'>
+						<button type = 'button' class = 'delegation-flow-address-button' onClick = { () => renameAddressCallBack(entry) }>
+						<CompactDelegationAddress addressBookEntry = { entry } />
+						</button>
+					</div>
+				</div>
+			}) }
 		</div>
 	</div>
 }
@@ -140,14 +143,14 @@ function getDelegationNotice(
 	renameAddressCallBack: RenameAddressCallBack
 ) {
 	if (transaction.type === '7702' && transaction.authorizationList.length > 0) return <DelegationNotice
-		signer = { transaction.from }
+		defaultSigner = { transaction.from }
 		authorizationList = { transaction.authorizationList }
 		addressMetadata = { addressMetadata }
 		renameAddressCallBack = { renameAddressCallBack }
 	/>
 	if (transaction.delegationAddress === undefined) return undefined
 	return <DelegationNotice
-		signer = { transaction.from }
+		defaultSigner = { transaction.from }
 		authorizationList = { [{ address: transaction.delegationAddress.address }] }
 		addressMetadata = { addressMetadata }
 		renameAddressCallBack = { renameAddressCallBack }

--- a/app/ts/simulation/SimulationStackExtraction.ts
+++ b/app/ts/simulation/SimulationStackExtraction.ts
@@ -44,7 +44,7 @@ export const getSimulatedStackV1 = (simulationState: ResolvedSimulationState, ad
 	const simulatedTransactions = simulationState.value.simulatedBlocks.flatMap((simulatedBlock) => simulatedBlock.simulatedTransactions).map((transaction) => {
 		const ethLogs = transaction.ethSimulateV1CallResult.status === 'failure' ? [] : transaction.ethSimulateV1CallResult.logs.filter((log) => log.address === ETHEREUM_LOGS_LOGGER_ADDRESS)
 		const ethBalanceAfter = transaction.tokenBalancesAfter.filter((x) => x.token === ETHEREUM_LOGS_LOGGER_ADDRESS)
-		const maxPriorityFeePerGas = transaction.preSimulationTransaction.signedTransaction.type === '1559' ? transaction.preSimulationTransaction.signedTransaction.maxPriorityFeePerGas : 0n
+		const maxPriorityFeePerGas = 'maxPriorityFeePerGas' in transaction.preSimulationTransaction.signedTransaction ? transaction.preSimulationTransaction.signedTransaction.maxPriorityFeePerGas : 0n
 		return {
 			...transaction.preSimulationTransaction.signedTransaction,
 			...transaction.ethSimulateV1CallResult,

--- a/app/ts/simulation/services/SimulationModeEthereumClientService.ts
+++ b/app/ts/simulation/services/SimulationModeEthereumClientService.ts
@@ -6,7 +6,7 @@ import { CANNOT_SIMULATE_OFF_LEGACY_BLOCK, ERROR_INTERCEPTOR_GAS_ESTIMATION_FAIL
 import type { SimulatedTransaction, SimulationState, TokenBalancesAfter, PreSimulationTransaction, SimulationStateBlock, SimulationStateInput, SimulationStateInputMinimalData, SimulationStateInputMinimalDataBlock, BlockTimeManipulationDeltaUnit, ExecutionSimulatedTransaction, ExecutionSimulationState, ResolvedExecutionSimulationState, ResolvedSimulationInput, ResolvedSimulationState } from '../../types/visualizer-types.js'
 import type { Abi } from 'viem'
 import { privateKeyToAccount, stringToBytes, keccak256, hashMessage, hashTypedData } from '../../utils/viem.js'
-import { EthereumUnsignedTransactionToUnsignedTransaction, type IUnsignedTransaction1559, rlpEncode, serializeSignedTransactionToBytes } from '../../utils/ethereum.js'
+import { EthereumUnsignedTransactionToUnsignedTransaction, type IUnsignedTransaction1559, type IUnsignedTransaction7702, rlpEncode, serializeSignedTransactionToBytes } from '../../utils/ethereum.js'
 import type { EthGetLogsResponse, EthGetLogsRequest, EthTransactionReceiptResponse, PartialEthereumTransaction, EthGetFeeHistoryResponse, FeeHistory } from '../../types/JsonRpc-types.js'
 import { handleERC1155TransferBatch, handleERC1155TransferSingle } from '../logHandlers.js'
 import { assertNever, modifyObject } from '../../utils/typescript.js'
@@ -260,12 +260,27 @@ export const getSimulatedTransactionCount = async (ethereumClientService: Ethere
 	return (await ethereumClientService.getTransactionCount(address, blockNumToUseForChain, requestAbortController)) + addedTransactions
 }
 
-type Simulated1559BlockCall = Pick<IUnsignedTransaction1559, 'from' | 'chainId' | 'nonce' | 'maxFeePerGas' | 'maxPriorityFeePerGas' | 'to' | 'value' | 'input'> & Partial<Pick<IUnsignedTransaction1559, 'gasLimit' | 'accessList'>>
+type Simulated1559BlockCall = Pick<IUnsignedTransaction1559, 'type' | 'from' | 'chainId' | 'nonce' | 'maxFeePerGas' | 'maxPriorityFeePerGas' | 'to' | 'value' | 'input'> & Partial<Pick<IUnsignedTransaction1559, 'gasLimit' | 'accessList'>>
+type Simulated7702BlockCall = Pick<IUnsignedTransaction7702, 'type' | 'from' | 'chainId' | 'nonce' | 'maxFeePerGas' | 'maxPriorityFeePerGas' | 'to' | 'value' | 'input' | 'authorizationList'> & Partial<Pick<IUnsignedTransaction7702, 'gasLimit' | 'accessList'>>
+type SimulatedBlockCall = Simulated1559BlockCall | Simulated7702BlockCall
 
-const createSimulated1559BlockCall = (transaction: Simulated1559BlockCall): SimulateBlockCalls['calls'][number] => {
+const createSimulatedBlockCall = (transaction: SimulatedBlockCall): SimulateBlockCalls['calls'][number] => {
 	const { gasLimit, maxFeePerGas, accessList, ...transactionWithoutOptionalGasFields } = transaction
+	if (transactionWithoutOptionalGasFields.type === '7702') {
+		const { authorizationList, ...transactionWithoutOptionalAuthorizationMetadata } = transactionWithoutOptionalGasFields
+		return {
+			...transactionWithoutOptionalAuthorizationMetadata,
+			authorizationList: authorizationList.map((authorization) => ({
+				chainId: authorization.chainId,
+				address: authorization.address,
+				nonce: authorization.nonce,
+			})),
+			accessList: accessList ?? [],
+			...(maxFeePerGas === 0n ? {} : { maxFeePerGas }),
+			...(gasLimit === undefined ? {} : { gas: gasLimit }),
+		}
+	}
 	return {
-		type: '1559' as const,
 		...transactionWithoutOptionalGasFields,
 		accessList: accessList ?? [],
 		...(maxFeePerGas === 0n ? {} : { maxFeePerGas }),
@@ -277,7 +292,7 @@ const simulateBlockCallWithPreparedInputContext = async (
 	ethereumClientService: EthereumClientService,
 	requestAbortController: AbortController | undefined,
 	context: PreparedSimulationExecutionContext | undefined,
-	transaction: Simulated1559BlockCall,
+	transaction: SimulatedBlockCall,
 	extraOverrides: StateOverrides = {},
 	simulateWithZeroBaseFee = false,
 ) => {
@@ -289,7 +304,7 @@ const simulateBlockCallWithPreparedInputContext = async (
 	const blockStateCalls: readonly SimulateBlockCalls[] = [
 		...(context?.prepared.request.params[0].blockStateCalls ?? []),
 		{
-			calls: [createSimulated1559BlockCall(transaction)],
+			calls: [createSimulatedBlockCall(transaction)],
 			blockOverrides: {
 				...(previousBlockOverride ?? { feeRecipient: parentBlock.miner }),
 				baseFeePerGas: simulateWithZeroBaseFee ? 0n : baseFeePerGas,
@@ -307,7 +322,7 @@ const simulateBlockCallOnTopOfSimulationInput = async (
 	ethereumClientService: EthereumClientService,
 	requestAbortController: AbortController | undefined,
 	simulationStateInput: SimulationStateInputMinimalData | undefined,
-	transaction: Simulated1559BlockCall,
+	transaction: SimulatedBlockCall,
 	extraOverrides: StateOverrides = {},
 	simulateWithZeroBaseFee = false,
 ) => {
@@ -332,8 +347,7 @@ export const simulateEstimateGas = async (ethereumClientService: EthereumClientS
 	const simulatedBlockIncrement = blockDelta === undefined ? currentState.simulatedBlocks.length || 0 : blockDelta
 	const maxGas = simulationGasLeft(currentState.simulatedBlocks[simulatedBlockIncrement] || undefined, block)
 
-	const estimateGasTransaction = {
-		type: '1559' as const,
+	const estimateGasTransactionBase = {
 		from: sendAddress,
 		chainId: ethereumClientService.getChainId(),
 		nonce: await transactionCount,
@@ -347,6 +361,22 @@ export const simulateEstimateGas = async (ethereumClientService: EthereumClientS
 		input: getInputFieldFromDataOrInput(data),
 		accessList: []
 	}
+	const authorizationList = data.authorizationList?.map((authorization) => ({
+		chainId: authorization.chainId,
+		address: authorization.address,
+		nonce: authorization.nonce,
+		...(authorization.authority === undefined ? {} : { authority: authorization.authority }),
+	}))
+	const estimateGasTransaction = data.type === '7702' || authorizationList !== undefined
+		? {
+			...estimateGasTransactionBase,
+			type: '7702' as const,
+			authorizationList: authorizationList ?? [],
+		}
+		: {
+			...estimateGasTransactionBase,
+			type: '1559' as const,
+		}
 	try {
 		const lastResult = await simulateBlockCallOnTopOfSimulationInput(ethereumClientService, requestAbortController, currentState.simulationStateInput, estimateGasTransaction, {}, true)
 		if (lastResult === undefined) return { error: { code: ERROR_INTERCEPTOR_GAS_ESTIMATION_FAILED, message: 'ETH Simulate Failed to estimate gas', data: '0x' } }
@@ -1236,8 +1266,7 @@ export const simulateEstimateGasFromInput = async (
 	if (fallbackBlock === null) throw new Error('The latest block is null')
 	const simulatedBlockIncrement = blockDelta === undefined ? context?.executionBlocks.length ?? 0 : blockDelta
 	const maxGas = max(fallbackBlock.gasLimit * 1023n / 1024n - transactionQueueTotalGasLimitFromInput(context?.prepared.rpcBlocks[simulatedBlockIncrement]), 0n)
-	const estimateGasTransaction = {
-		type: '1559' as const,
+	const estimateGasTransactionBase = {
 		from: sendAddress,
 		chainId: ethereumClientService.getChainId(),
 		nonce: await transactionCount,
@@ -1249,6 +1278,22 @@ export const simulateEstimateGasFromInput = async (
 		input: getInputFieldFromDataOrInput(data),
 		accessList: []
 	}
+	const authorizationList = data.authorizationList?.map((authorization) => ({
+		chainId: authorization.chainId,
+		address: authorization.address,
+		nonce: authorization.nonce,
+		...(authorization.authority === undefined ? {} : { authority: authorization.authority }),
+	}))
+	const estimateGasTransaction = data.type === '7702' || authorizationList !== undefined
+		? {
+			...estimateGasTransactionBase,
+			type: '7702' as const,
+			authorizationList: authorizationList ?? [],
+		}
+		: {
+			...estimateGasTransactionBase,
+			type: '1559' as const,
+		}
 	try {
 		const lastResult = await simulateBlockCallWithPreparedInputContext(ethereumClientService, requestAbortController, context, estimateGasTransaction, {}, true)
 		if (lastResult === undefined) return { error: { code: ERROR_INTERCEPTOR_GAS_ESTIMATION_FAILED, message: 'ETH Simulate Failed to estimate gas', data: '0x' } }

--- a/app/ts/simulation/services/SimulationModeEthereumClientService.ts
+++ b/app/ts/simulation/services/SimulationModeEthereumClientService.ts
@@ -23,6 +23,7 @@ import { getSimulationInputHash } from '../../utils/simulationFingerprint.js'
 import { decodeCallDataLoose, decodeEventLoose, decodeFunctionOutput, encodeFunctionCall, type AbiLike } from '../../utils/abiRuntime.js'
 import { Erc20ABI, Erc1155ABI } from '../../utils/abi.js'
 import { getDesiredMaxFeePerGasForBaseFee, getTransactionFeesForBaseFee, hasExplicitMaxFeePerGas } from '../../utils/transactionFees.js'
+import { normalizeEip7702AuthorizationList } from '../../utils/eip7702Authorization.js'
 
 type SuccessfulExecutionSimulationState = Extract<ExecutionSimulationState, { success: true }>
 
@@ -264,6 +265,27 @@ type Simulated1559BlockCall = Pick<IUnsignedTransaction1559, 'type' | 'from' | '
 type Simulated7702BlockCall = Pick<IUnsignedTransaction7702, 'type' | 'from' | 'chainId' | 'nonce' | 'maxFeePerGas' | 'maxPriorityFeePerGas' | 'to' | 'value' | 'input' | 'authorizationList'> & Partial<Pick<IUnsignedTransaction7702, 'gasLimit' | 'accessList'>>
 type SimulatedBlockCall = Simulated1559BlockCall | Simulated7702BlockCall
 
+type IUnsigned7702Authorization = IUnsignedTransaction7702['authorizationList'][number]
+type ISigned7702Authorization = IUnsigned7702Authorization & {
+	readonly yParity: 'even' | 'odd'
+	readonly r: bigint
+	readonly s: bigint
+}
+
+const has7702AuthorizationSignature = (authorization: IUnsigned7702Authorization): authorization is ISigned7702Authorization => {
+	return authorization.r !== undefined && authorization.s !== undefined && authorization.yParity !== undefined
+}
+
+const hasPartial7702AuthorizationSignature = (authorization: IUnsigned7702Authorization) => {
+	return authorization.r !== undefined || authorization.s !== undefined || authorization.yParity !== undefined
+}
+
+const mockSign7702Authorization = (authorization: IUnsigned7702Authorization): ISigned7702Authorization => {
+	if (has7702AuthorizationSignature(authorization)) return authorization
+	if (hasPartial7702AuthorizationSignature(authorization)) throw new Error('EIP-7702 authorization signature is missing required fields')
+	return { ...authorization, r: 0n, s: 0n, yParity: 'even' }
+}
+
 const createSimulatedBlockCall = (transaction: SimulatedBlockCall): SimulateBlockCalls['calls'][number] => {
 	const { gasLimit, maxFeePerGas, accessList, ...transactionWithoutOptionalGasFields } = transaction
 	if (transactionWithoutOptionalGasFields.type === '7702') {
@@ -336,6 +358,10 @@ const simulateBlockCallOnTopOfSimulationInput = async (
 	)
 }
 
+const normalizeEstimateGasAuthorizationList = async (data: PartialEthereumTransaction) => {
+	return data.authorizationList === undefined ? undefined : await normalizeEip7702AuthorizationList(data.authorizationList)
+}
+
 export const simulateEstimateGas = async (ethereumClientService: EthereumClientService, requestAbortController: AbortController | undefined, simulationState: ResolvedSimulationState, data: PartialEthereumTransaction, blockDelta: number | undefined = undefined): Promise<{ error: ErrorWithCodeAndOptionalData } | { gas: bigint }> => {
 	if (simulationState.kind === 'passthrough') return { gas: await ethereumClientService.estimateGas(data, requestAbortController) }
 	const currentState = simulationState.value
@@ -361,12 +387,7 @@ export const simulateEstimateGas = async (ethereumClientService: EthereumClientS
 		input: getInputFieldFromDataOrInput(data),
 		accessList: []
 	}
-	const authorizationList = data.authorizationList?.map((authorization) => ({
-		chainId: authorization.chainId,
-		address: authorization.address,
-		nonce: authorization.nonce,
-		...(authorization.authority === undefined ? {} : { authority: authorization.authority }),
-	}))
+	const authorizationList = await normalizeEstimateGasAuthorizationList(data)
 	const estimateGasTransaction = data.type === '7702' || authorizationList !== undefined
 		? {
 			...estimateGasTransactionBase,
@@ -408,7 +429,7 @@ export const mockSignTransaction = (transaction: EthereumUnsignedTransaction) : 
 	}
 	if (unsignedTransaction.type === '7702') {
 		const signatureParams = { r: 0n, s: 0n, yParity: 'even' as const }
-		const authorizationList = unsignedTransaction.authorizationList.map((element) => ({ ...element, ...signatureParams }))
+		const authorizationList = unsignedTransaction.authorizationList.map(mockSign7702Authorization)
 		const hash = EthereumQuantity.parse(keccak256(serializeSignedTransactionToBytes({ ...unsignedTransaction, ...signatureParams, authorizationList })))
 		if (transaction.type !== '7702') throw new Error('types do not match')
 		return { ...transaction, ...signatureParams, hash, authorizationList }
@@ -723,9 +744,16 @@ const subtractMaxGasCost = (balance: bigint, value: bigint, gasLimit: bigint, ma
 	return balance > maxCost ? balance - maxCost : 0n
 }
 
-const usesInterceptorFilledMaxFeePerGas = (transaction: PreSimulationTransaction) => {
+type FeeMarketSignedTransaction = Extract<EthereumSendableSignedTransaction, { type: '1559' | '7702' }>
+type FeeMarketPreSimulationTransaction = PreSimulationTransaction & { readonly signedTransaction: FeeMarketSignedTransaction }
+
+const isFeeMarketPreSimulationTransaction = (transaction: PreSimulationTransaction): transaction is FeeMarketPreSimulationTransaction => {
+	return transaction.signedTransaction.type === '1559' || transaction.signedTransaction.type === '7702'
+}
+
+const usesInterceptorFilledMaxFeePerGas = (transaction: PreSimulationTransaction): transaction is FeeMarketPreSimulationTransaction => {
 	return transaction.originalRequestParameters.method === 'eth_sendTransaction'
-		&& transaction.signedTransaction.type === '1559'
+		&& isFeeMarketPreSimulationTransaction(transaction)
 		&& !hasExplicitMaxFeePerGas(transaction.originalRequestParameters.params[0].maxFeePerGas)
 }
 
@@ -735,7 +763,6 @@ const getBaseFeeAdjustedTransaction = (
 	balance: bigint,
 ) => {
 	if (!usesInterceptorFilledMaxFeePerGas(transaction)) return transaction
-	if (transaction.signedTransaction.type !== '1559') return transaction
 	const feePerGas = getTransactionFeesForBaseFee(
 		parentBaseFeePerGas,
 		transaction.signedTransaction.maxPriorityFeePerGas,
@@ -800,7 +827,7 @@ export const getBaseFeeAdjustmentBalances = async (
 	for (const transaction of currentBlock.transactions) {
 		if (!usesInterceptorFilledMaxFeePerGas(transaction)) {
 			if (transaction.originalRequestParameters.method === 'eth_sendTransaction'
-				&& transaction.signedTransaction.type === '1559'
+				&& isFeeMarketPreSimulationTransaction(transaction)
 				&& hasExplicitMaxFeePerGas(transaction.originalRequestParameters.params[0].maxFeePerGas)
 			) {
 				const conservativeBalance = conservativeBalances.get(transaction.signedTransaction.from)
@@ -816,7 +843,6 @@ export const getBaseFeeAdjustmentBalances = async (
 			adjustedTransactions.push(getBaseFeeAdjustedTransactionWithBalances(parentBlock, transaction, balances))
 			continue
 		}
-		if (transaction.signedTransaction.type !== '1559') throw new Error('Expected 1559 transaction for interceptor-filled max fee per gas')
 		const desiredMaxFeePerGas = getDesiredMaxFeePerGasForBaseFee(parentBaseFeePerGas, transaction.signedTransaction.maxPriorityFeePerGas)
 		const conservativeBalance = conservativeBalances.get(transaction.signedTransaction.from)
 		const balance = conservativeBalance !== undefined && canAffordMaxGasCost(conservativeBalance, transaction.signedTransaction.value, transaction.signedTransaction.gas, desiredMaxFeePerGas)
@@ -824,7 +850,7 @@ export const getBaseFeeAdjustmentBalances = async (
 			: await getBalanceBeforeSimulationInputTransaction(ethereumClientService, requestAbortController, parentBlock, simulationInputBeforeBlock, currentBlock, adjustedTransactions, transaction.signedTransaction.from)
 		balances.set(transaction.transactionIdentifier, balance)
 		const adjustedTransaction = getBaseFeeAdjustedTransactionWithBalances(parentBlock, transaction, balances)
-		if (adjustedTransaction.signedTransaction.type !== '1559') throw new Error('Expected 1559 transaction after base fee adjustment')
+		if (!isFeeMarketPreSimulationTransaction(adjustedTransaction)) throw new Error('Expected fee-market transaction after base fee adjustment')
 		conservativeBalances.set(transaction.signedTransaction.from, subtractMaxGasCost(balance, transaction.signedTransaction.value, transaction.signedTransaction.gas, adjustedTransaction.signedTransaction.maxFeePerGas))
 		adjustedTransactions.push(adjustedTransaction)
 	}
@@ -1278,12 +1304,7 @@ export const simulateEstimateGasFromInput = async (
 		input: getInputFieldFromDataOrInput(data),
 		accessList: []
 	}
-	const authorizationList = data.authorizationList?.map((authorization) => ({
-		chainId: authorization.chainId,
-		address: authorization.address,
-		nonce: authorization.nonce,
-		...(authorization.authority === undefined ? {} : { authority: authorization.authority }),
-	}))
+	const authorizationList = await normalizeEstimateGasAuthorizationList(data)
 	const estimateGasTransaction = data.type === '7702' || authorizationList !== undefined
 		? {
 			...estimateGasTransactionBase,

--- a/app/ts/types/JsonRpc-types.ts
+++ b/app/ts/types/JsonRpc-types.ts
@@ -1,5 +1,5 @@
 import * as funtypes from 'funtypes'
-import { EthereumAddress, EthereumBlockHeader, EthereumBlockHeaderWithTransactionHashes, EthereumBlockTag, EthereumBytes256, EthereumBytes32, EthereumData, EthereumInput, EthereumQuantity, LiteralConverterParserFactory } from './wire-types.js'
+import { EthereumAddress, EthereumBlockHeader, EthereumBlockHeaderWithTransactionHashes, EthereumBlockTag, EthereumBytes256, EthereumBytes32, EthereumData, EthereumInput, EthereumQuantity, EthereumSignatureParity, LiteralConverterParserFactory } from './wire-types.js'
 import { areEqualUint8Arrays } from '../utils/typed-arrays.js'
 import { EthSimulateV1Params } from './ethSimulate-types.js'
 import { OldSignTypedDataParams, PersonalSignParams, SignTypedDataParams } from './jsonRpc-signing-types.js'
@@ -61,6 +61,13 @@ export const EthBalanceChanges = funtypes.ReadonlyArray(
 
 export type PartialEthereumTransaction = funtypes.Static<typeof PartialEthereumTransaction>
 export const PartialEthereumTransaction = funtypes.ReadonlyPartial({
+	type: funtypes.Union(
+		funtypes.Literal('0x0').withParser(LiteralConverterParserFactory('0x0', 'legacy' as const)),
+		funtypes.Literal('0x1').withParser(LiteralConverterParserFactory('0x1', '2930' as const)),
+		funtypes.Literal('0x2').withParser(LiteralConverterParserFactory('0x2', '1559' as const)),
+		funtypes.Literal('0x3').withParser(LiteralConverterParserFactory('0x3', '4844' as const)),
+		funtypes.Literal('0x4').withParser(LiteralConverterParserFactory('0x4', '7702' as const)),
+	),
 	from: EthereumAddress,
 	gas: EthereumQuantity,
 	value: EthereumQuantity,
@@ -70,6 +77,16 @@ export const PartialEthereumTransaction = funtypes.ReadonlyPartial({
 	maxFeePerGas: funtypes.Union(EthereumQuantity, funtypes.Null), // etherscan sets this field to null, remove this if etherscan fixes this
 	data: EthereumData,
 	input: EthereumData,
+	authorizationList: funtypes.ReadonlyArray(funtypes.ReadonlyObject({
+		chainId: EthereumQuantity,
+		address: EthereumAddress,
+		nonce: EthereumQuantity,
+	}).And(funtypes.ReadonlyPartial({
+		authority: EthereumAddress,
+		r: EthereumQuantity,
+		s: EthereumQuantity,
+		yParity: EthereumSignatureParity,
+	}))),
 }).withConstraint((PartialEthereumTransaction) => {
 	if (PartialEthereumTransaction.input !== undefined && PartialEthereumTransaction.data !== undefined) {
 		return areEqualUint8Arrays(PartialEthereumTransaction.input, PartialEthereumTransaction.data)

--- a/app/ts/types/JsonRpc-types.ts
+++ b/app/ts/types/JsonRpc-types.ts
@@ -82,7 +82,6 @@ export const PartialEthereumTransaction = funtypes.ReadonlyPartial({
 		address: EthereumAddress,
 		nonce: EthereumQuantity,
 	}).And(funtypes.ReadonlyPartial({
-		authority: EthereumAddress,
 		r: EthereumQuantity,
 		s: EthereumQuantity,
 		yParity: EthereumSignatureParity,

--- a/app/ts/types/visualizer-types.ts
+++ b/app/ts/types/visualizer-types.ts
@@ -306,7 +306,9 @@ export const TransactionWithAddressBookEntries = funtypes.Intersect(
 				r: EthereumQuantity,
 				s: EthereumQuantity,
 				yParity: funtypes.Union(funtypes.Literal('even'), funtypes.Literal('odd')),
-			})),
+			}).And(funtypes.ReadonlyPartial({
+				authority: EthereumAddress,
+			}))),
 		}),
 		funtypes.ReadonlyObject({
 			type: funtypes.Literal('4844'),

--- a/app/ts/types/wire-types.ts
+++ b/app/ts/types/wire-types.ts
@@ -295,7 +295,9 @@ const EthereumUnsignedTransaction7702 = funtypes.Intersect(
 			chainId: EthereumQuantity,
 			address: EthereumAddress,
 			nonce: EthereumQuantity,
-		}))
+		}).And(funtypes.ReadonlyPartial({
+			authority: EthereumAddress,
+		})))
 	}).asReadonly(),
 	funtypes.Partial({
 		accessList: EthereumAccessList,
@@ -380,7 +382,9 @@ const OptionalEthereumUnsignedTransaction7702 = funtypes.Intersect(
 			chainId: EthereumQuantity,
 			address: EthereumAddress,
 			nonce: EthereumQuantity,
-		}))
+		}).And(funtypes.ReadonlyPartial({
+			authority: EthereumAddress,
+		})))
 	}).asReadonly(),
 	funtypes.Partial({
 		gas: EthereumQuantity,
@@ -478,7 +482,9 @@ const EthereumSignedTransaction7702 = funtypes.Intersect(
 			r: EthereumQuantity,
 			s: EthereumQuantity,
 			yParity: EthereumSignatureParity
-		}))
+		}).And(funtypes.ReadonlyPartial({
+			authority: EthereumAddress,
+		})))
 	}).asReadonly(),
 	funtypes.Partial({
 		accessList: EthereumAccessList,

--- a/app/ts/types/wire-types.ts
+++ b/app/ts/types/wire-types.ts
@@ -224,6 +224,27 @@ export const EthereumAccessList = funtypes.ReadonlyArray(
 )
 export type EthereumAccessList = funtypes.Static<typeof EthereumAccessList>
 
+const EthereumEip7702AuthorizationBase = funtypes.ReadonlyObject({
+	chainId: EthereumQuantity,
+	address: EthereumAddress,
+	nonce: EthereumQuantity,
+})
+
+const EthereumUnsignedEip7702Authorization = EthereumEip7702AuthorizationBase.And(funtypes.ReadonlyPartial({
+	authority: EthereumAddress,
+	r: EthereumQuantity,
+	s: EthereumQuantity,
+	yParity: EthereumSignatureParity,
+}))
+
+const EthereumSignedEip7702Authorization = EthereumEip7702AuthorizationBase.And(funtypes.ReadonlyObject({
+	r: EthereumQuantity,
+	s: EthereumQuantity,
+	yParity: EthereumSignatureParity,
+}).And(funtypes.ReadonlyPartial({
+	authority: EthereumAddress,
+})))
+
 type EthereumUnsignedTransactionLegacy = funtypes.Static<typeof EthereumUnsignedTransactionLegacy>
 const EthereumUnsignedTransactionLegacy = funtypes.Intersect(
 	funtypes.ReadonlyObject({
@@ -291,13 +312,7 @@ const EthereumUnsignedTransaction7702 = funtypes.Intersect(
 		value: EthereumQuantity,
 		input: EthereumInput,
 		chainId: EthereumQuantity,
-		authorizationList: funtypes.ReadonlyArray(funtypes.ReadonlyObject({
-			chainId: EthereumQuantity,
-			address: EthereumAddress,
-			nonce: EthereumQuantity,
-		}).And(funtypes.ReadonlyPartial({
-			authority: EthereumAddress,
-		})))
+		authorizationList: funtypes.ReadonlyArray(EthereumUnsignedEip7702Authorization)
 	}).asReadonly(),
 	funtypes.Partial({
 		accessList: EthereumAccessList,
@@ -378,13 +393,7 @@ const OptionalEthereumUnsignedTransaction7702 = funtypes.Intersect(
 		value: EthereumQuantity,
 		input: EthereumInput,
 		chainId: EthereumQuantity,
-		authorizationList: funtypes.ReadonlyArray(funtypes.ReadonlyObject({
-			chainId: EthereumQuantity,
-			address: EthereumAddress,
-			nonce: EthereumQuantity,
-		}).And(funtypes.ReadonlyPartial({
-			authority: EthereumAddress,
-		})))
+		authorizationList: funtypes.ReadonlyArray(EthereumUnsignedEip7702Authorization)
 	}).asReadonly(),
 	funtypes.Partial({
 		gas: EthereumQuantity,
@@ -475,16 +484,7 @@ const EthereumSignedTransaction7702 = funtypes.Intersect(
 		value: EthereumQuantity,
 		input: EthereumInput,
 		chainId: EthereumQuantity,
-		authorizationList: funtypes.ReadonlyArray(funtypes.ReadonlyObject({
-			chainId: EthereumQuantity,
-			address: EthereumAddress,
-			nonce: EthereumQuantity,
-			r: EthereumQuantity,
-			s: EthereumQuantity,
-			yParity: EthereumSignatureParity
-		}).And(funtypes.ReadonlyPartial({
-			authority: EthereumAddress,
-		})))
+		authorizationList: funtypes.ReadonlyArray(EthereumSignedEip7702Authorization)
 	}).asReadonly(),
 	funtypes.Partial({
 		accessList: EthereumAccessList,

--- a/app/ts/utils/eip7702Authorization.ts
+++ b/app/ts/utils/eip7702Authorization.ts
@@ -1,0 +1,84 @@
+import { EthereumAddress } from '../types/wire-types.js'
+import { addressString, bytes32String } from './bigint.js'
+import { recoverAuthorizationAddress } from './viem.js'
+
+export type Eip7702Authorization = {
+	readonly chainId: bigint
+	readonly address: bigint
+	readonly nonce: bigint
+	readonly authority?: bigint
+	readonly r?: bigint
+	readonly s?: bigint
+	readonly yParity?: 'even' | 'odd'
+}
+
+type Eip7702AuthorizationBase = {
+	readonly chainId: bigint
+	readonly address: bigint
+	readonly nonce: bigint
+}
+
+type UnsignedNormalizedEip7702Authorization = Eip7702AuthorizationBase & {
+	readonly authority?: bigint
+	readonly r?: undefined
+	readonly s?: undefined
+	readonly yParity?: undefined
+}
+
+type SignedEip7702Authorization = Eip7702Authorization & {
+	readonly r: bigint
+	readonly s: bigint
+	readonly yParity: 'even' | 'odd'
+}
+
+type SignedNormalizedEip7702Authorization = SignedEip7702Authorization & {
+	readonly authority: bigint
+}
+
+export type NormalizedEip7702Authorization = UnsignedNormalizedEip7702Authorization | SignedNormalizedEip7702Authorization
+
+const hasAuthorizationSignature = (authorization: Eip7702Authorization): authorization is SignedEip7702Authorization => {
+	return authorization.r !== undefined && authorization.s !== undefined && authorization.yParity !== undefined
+}
+
+const hasPartialAuthorizationSignature = (authorization: Eip7702Authorization) => {
+	return authorization.r !== undefined || authorization.s !== undefined || authorization.yParity !== undefined
+}
+
+const maximumSafeAuthorizationNumber = BigInt(Number.MAX_SAFE_INTEGER)
+
+const toSafeAuthorizationNumber = (value: bigint, fieldName: 'chainId' | 'nonce') => {
+	if (value < 0n || value > maximumSafeAuthorizationNumber) throw new Error(`EIP-7702 authorization ${ fieldName } exceeds the maximum safe integer`)
+	return Number(value)
+}
+
+export const recoverEip7702AuthorizationAuthority = async (authorization: SignedEip7702Authorization): Promise<bigint> => {
+	return EthereumAddress.parse(await recoverAuthorizationAddress({
+		authorization: {
+			chainId: toSafeAuthorizationNumber(authorization.chainId, 'chainId'),
+			address: addressString(authorization.address),
+			nonce: toSafeAuthorizationNumber(authorization.nonce, 'nonce'),
+			r: bytes32String(authorization.r),
+			s: bytes32String(authorization.s),
+			yParity: authorization.yParity === 'even' ? 0 : 1,
+		},
+	}))
+}
+
+export const normalizeEip7702Authorization = async (authorization: Eip7702Authorization): Promise<NormalizedEip7702Authorization> => {
+	const base = {
+		chainId: authorization.chainId,
+		address: authorization.address,
+		nonce: authorization.nonce,
+	}
+	if (hasAuthorizationSignature(authorization)) return { ...authorization, authority: await recoverEip7702AuthorizationAuthority(authorization) }
+	if (hasPartialAuthorizationSignature(authorization)) throw new Error('EIP-7702 authorization signature is missing required fields')
+	if (authorization.authority !== undefined) return { ...base, authority: authorization.authority }
+	return base
+}
+
+export const normalizeEip7702AuthorizationList = async (
+	authorizationList: readonly Eip7702Authorization[]
+): Promise<readonly NormalizedEip7702Authorization[]> => {
+	return await Promise.all(authorizationList.map(normalizeEip7702Authorization))
+}

--- a/app/ts/utils/ethereum.ts
+++ b/app/ts/utils/ethereum.ts
@@ -99,6 +99,7 @@ export interface IUnsignedTransaction7702 {
 		chainId: bigint
 		address: bigint
 		nonce: bigint
+		authority?: bigint
 	}[]
 }
 
@@ -121,6 +122,7 @@ type ISignedTransaction7702 = {
 		chainId: bigint,
 		address: bigint,
 		nonce: bigint,
+		authority?: bigint,
 		yParity: 'even' | 'odd',
 		r: bigint,
 		s: bigint

--- a/app/ts/utils/ethereum.ts
+++ b/app/ts/utils/ethereum.ts
@@ -96,10 +96,13 @@ export interface IUnsignedTransaction7702 {
 		readonly storageKeys: readonly bigint[]
 	}[]
 	readonly authorizationList: readonly {
-		chainId: bigint
-		address: bigint
-		nonce: bigint
-		authority?: bigint
+		readonly chainId: bigint
+		readonly address: bigint
+		readonly nonce: bigint
+		readonly authority?: bigint
+		readonly yParity?: 'even' | 'odd'
+		readonly r?: bigint
+		readonly s?: bigint
 	}[]
 }
 

--- a/app/ts/utils/sendRawTransactionParsing.ts
+++ b/app/ts/utils/sendRawTransactionParsing.ts
@@ -30,11 +30,9 @@ const parseToAddress = (address: `0x${ string }` | null | undefined) => {
 	return address === undefined || address === null ? null : EthereumAddress.parse(address)
 }
 
-const requireActiveChainId = (transactionChainId: number | undefined, activeChainId: bigint) => {
+const parseRequiredChainId = (transactionChainId: number | undefined) => {
 	if (transactionChainId === undefined) throw new Error('Serialized transaction is missing chainId')
-	const chainId = BigInt(transactionChainId)
-	if (chainId !== activeChainId) throw new Error(`Serialized transaction chainId ${ chainId } does not match active chainId ${ activeChainId }`)
-	return chainId
+	return BigInt(transactionChainId)
 }
 
 const parseAuthorizationParity = (yParity: number): 'even' | 'odd' => {
@@ -62,7 +60,7 @@ const parseSignedAuthorization = (authorization: {
 	}
 }
 
-export const parseSendRawTransaction = async (serializedTransactionBytes: Uint8Array, activeChainId: bigint): Promise<EthereumUnsignedTransaction> => {
+export const parseSendRawTransaction = async (serializedTransactionBytes: Uint8Array): Promise<EthereumUnsignedTransaction> => {
 	const serializedTransaction = dataStringWith0xStart(serializedTransactionBytes)
 	const parsedTransaction = parseSerializedTransaction(serializedTransaction)
 
@@ -70,7 +68,7 @@ export const parseSendRawTransaction = async (serializedTransactionBytes: Uint8A
 		if (parsedTransaction.gas === undefined || parsedTransaction.maxFeePerGas === undefined || parsedTransaction.maxPriorityFeePerGas === undefined || parsedTransaction.nonce === undefined || parsedTransaction.r === undefined || parsedTransaction.s === undefined || parsedTransaction.yParity === undefined) {
 			throw new Error('Serialized EIP-1559 transaction is missing required fields')
 		}
-		const chainId = requireActiveChainId(parsedTransaction.chainId, activeChainId)
+		const chainId = parseRequiredChainId(parsedTransaction.chainId)
 		const unsignedTransaction = serializeTransaction({
 			type: 'eip1559',
 			chainId: Number(parsedTransaction.chainId),
@@ -107,7 +105,7 @@ export const parseSendRawTransaction = async (serializedTransactionBytes: Uint8A
 		if (parsedTransaction.gas === undefined || parsedTransaction.maxFeePerGas === undefined || parsedTransaction.maxPriorityFeePerGas === undefined || parsedTransaction.nonce === undefined || parsedTransaction.r === undefined || parsedTransaction.s === undefined || parsedTransaction.yParity === undefined) {
 			throw new Error('Serialized EIP-7702 transaction is missing required fields')
 		}
-		const chainId = requireActiveChainId(parsedTransaction.chainId, activeChainId)
+		const chainId = parseRequiredChainId(parsedTransaction.chainId)
 		const authorizationList = await normalizeEip7702AuthorizationList((parsedTransaction.authorizationList ?? []).map(parseSignedAuthorization))
 		const unsignedTransaction = serializeTransaction({
 			type: 'eip7702',

--- a/app/ts/utils/sendRawTransactionParsing.ts
+++ b/app/ts/utils/sendRawTransactionParsing.ts
@@ -1,11 +1,11 @@
 import type { EthereumUnsignedTransaction } from '../types/wire-types.js'
-import { EthereumAddress } from '../types/wire-types.js'
+import { EthereumAddress, EthereumBytes32 } from '../types/wire-types.js'
 import { dataStringWith0xStart, stringToUint8Array } from './bigint.js'
+import { normalizeEip7702AuthorizationList } from './eip7702Authorization.js'
 import {
 	keccak256,
 	parseTransaction as parseSerializedTransaction,
 	recoverAddress,
-	recoverAuthorizationAddress,
 	serializeTransaction,
 } from './viem.js'
 
@@ -19,6 +19,49 @@ const recoverParsedTransactionAddress = async (
 	})
 }
 
+const parseAccessList = (accessList: readonly { readonly address: `0x${ string }`, readonly storageKeys: readonly `0x${ string }`[] }[] | undefined) => {
+	return (accessList ?? []).map((accessListEntry) => ({
+		address: EthereumAddress.parse(accessListEntry.address),
+		storageKeys: accessListEntry.storageKeys.map(EthereumBytes32.parse),
+	}))
+}
+
+const parseToAddress = (address: `0x${ string }` | null | undefined) => {
+	return address === undefined || address === null ? null : EthereumAddress.parse(address)
+}
+
+const requireActiveChainId = (transactionChainId: number | undefined, activeChainId: bigint) => {
+	if (transactionChainId === undefined) throw new Error('Serialized transaction is missing chainId')
+	const chainId = BigInt(transactionChainId)
+	if (chainId !== activeChainId) throw new Error(`Serialized transaction chainId ${ chainId } does not match active chainId ${ activeChainId }`)
+	return chainId
+}
+
+const parseAuthorizationParity = (yParity: number): 'even' | 'odd' => {
+	if (yParity === 0) return 'even'
+	if (yParity === 1) return 'odd'
+	throw new Error(`Unsupported EIP-7702 authorization yParity ${ yParity }`)
+}
+
+const parseSignedAuthorization = (authorization: {
+	readonly chainId: number
+	readonly address: `0x${ string }`
+	readonly nonce: number
+	readonly r?: `0x${ string }`
+	readonly s?: `0x${ string }`
+	readonly yParity?: number
+}) => {
+	if (authorization.r === undefined || authorization.s === undefined || authorization.yParity === undefined) throw new Error('Serialized EIP-7702 authorization is missing required signature fields')
+	return {
+		chainId: BigInt(authorization.chainId),
+		address: EthereumAddress.parse(authorization.address),
+		nonce: BigInt(authorization.nonce),
+		r: BigInt(authorization.r),
+		s: BigInt(authorization.s),
+		yParity: parseAuthorizationParity(authorization.yParity),
+	}
+}
+
 export const parseSendRawTransaction = async (serializedTransactionBytes: Uint8Array, activeChainId: bigint): Promise<EthereumUnsignedTransaction> => {
 	const serializedTransaction = dataStringWith0xStart(serializedTransactionBytes)
 	const parsedTransaction = parseSerializedTransaction(serializedTransaction)
@@ -27,6 +70,7 @@ export const parseSendRawTransaction = async (serializedTransactionBytes: Uint8A
 		if (parsedTransaction.gas === undefined || parsedTransaction.maxFeePerGas === undefined || parsedTransaction.maxPriorityFeePerGas === undefined || parsedTransaction.nonce === undefined || parsedTransaction.r === undefined || parsedTransaction.s === undefined || parsedTransaction.yParity === undefined) {
 			throw new Error('Serialized EIP-1559 transaction is missing required fields')
 		}
+		const chainId = requireActiveChainId(parsedTransaction.chainId, activeChainId)
 		const unsignedTransaction = serializeTransaction({
 			type: 'eip1559',
 			chainId: Number(parsedTransaction.chainId),
@@ -47,15 +91,15 @@ export const parseSendRawTransaction = async (serializedTransactionBytes: Uint8A
 		return {
 			type: '1559',
 			from: EthereumAddress.parse(from),
-			chainId: activeChainId,
+			chainId,
 			nonce: BigInt(parsedTransaction.nonce),
 			maxFeePerGas: parsedTransaction.maxFeePerGas,
 			maxPriorityFeePerGas: parsedTransaction.maxPriorityFeePerGas,
 			gas: parsedTransaction.gas,
-			to: parsedTransaction.to === undefined ? null : EthereumAddress.parse(parsedTransaction.to),
+			to: parseToAddress(parsedTransaction.to),
 			value: parsedTransaction.value ?? 0n,
 			input: stringToUint8Array(parsedTransaction.data ?? '0x'),
-			accessList: [],
+			accessList: parseAccessList(parsedTransaction.accessList),
 		}
 	}
 
@@ -63,12 +107,8 @@ export const parseSendRawTransaction = async (serializedTransactionBytes: Uint8A
 		if (parsedTransaction.gas === undefined || parsedTransaction.maxFeePerGas === undefined || parsedTransaction.maxPriorityFeePerGas === undefined || parsedTransaction.nonce === undefined || parsedTransaction.r === undefined || parsedTransaction.s === undefined || parsedTransaction.yParity === undefined) {
 			throw new Error('Serialized EIP-7702 transaction is missing required fields')
 		}
-		const authorizationList = await Promise.all((parsedTransaction.authorizationList ?? []).map(async (authorization) => ({
-			chainId: BigInt(authorization.chainId),
-			address: EthereumAddress.parse(authorization.address),
-			nonce: BigInt(authorization.nonce),
-			authority: EthereumAddress.parse(await recoverAuthorizationAddress({ authorization })),
-		})))
+		const chainId = requireActiveChainId(parsedTransaction.chainId, activeChainId)
+		const authorizationList = await normalizeEip7702AuthorizationList((parsedTransaction.authorizationList ?? []).map(parseSignedAuthorization))
 		const unsignedTransaction = serializeTransaction({
 			type: 'eip7702',
 			chainId: Number(parsedTransaction.chainId),
@@ -90,15 +130,15 @@ export const parseSendRawTransaction = async (serializedTransactionBytes: Uint8A
 		return {
 			type: '7702',
 			from: EthereumAddress.parse(from),
-			chainId: activeChainId,
+			chainId,
 			nonce: BigInt(parsedTransaction.nonce),
 			maxFeePerGas: parsedTransaction.maxFeePerGas,
 			maxPriorityFeePerGas: parsedTransaction.maxPriorityFeePerGas,
 			gas: parsedTransaction.gas,
-			to: parsedTransaction.to === undefined ? null : EthereumAddress.parse(parsedTransaction.to),
+			to: parseToAddress(parsedTransaction.to),
 			value: parsedTransaction.value ?? 0n,
 			input: stringToUint8Array(parsedTransaction.data ?? '0x'),
-			accessList: [],
+			accessList: parseAccessList(parsedTransaction.accessList),
 			authorizationList,
 		}
 	}

--- a/app/ts/utils/sendRawTransactionParsing.ts
+++ b/app/ts/utils/sendRawTransactionParsing.ts
@@ -1,0 +1,107 @@
+import type { EthereumUnsignedTransaction } from '../types/wire-types.js'
+import { EthereumAddress } from '../types/wire-types.js'
+import { dataStringWith0xStart, stringToUint8Array } from './bigint.js'
+import {
+	keccak256,
+	parseTransaction as parseSerializedTransaction,
+	recoverAddress,
+	recoverAuthorizationAddress,
+	serializeTransaction,
+} from './viem.js'
+
+const recoverParsedTransactionAddress = async (
+	serializedUnsignedTransaction: `0x${ string }`,
+	signature: { r: `0x${ string }`, s: `0x${ string }`, yParity: number }
+) => {
+	return await recoverAddress({
+		hash: keccak256(serializedUnsignedTransaction),
+		signature,
+	})
+}
+
+export const parseSendRawTransaction = async (serializedTransactionBytes: Uint8Array, activeChainId: bigint): Promise<EthereumUnsignedTransaction> => {
+	const serializedTransaction = dataStringWith0xStart(serializedTransactionBytes)
+	const parsedTransaction = parseSerializedTransaction(serializedTransaction)
+
+	if (parsedTransaction.type === 'eip1559') {
+		if (parsedTransaction.gas === undefined || parsedTransaction.maxFeePerGas === undefined || parsedTransaction.maxPriorityFeePerGas === undefined || parsedTransaction.nonce === undefined || parsedTransaction.r === undefined || parsedTransaction.s === undefined || parsedTransaction.yParity === undefined) {
+			throw new Error('Serialized EIP-1559 transaction is missing required fields')
+		}
+		const unsignedTransaction = serializeTransaction({
+			type: 'eip1559',
+			chainId: Number(parsedTransaction.chainId),
+			nonce: parsedTransaction.nonce,
+			maxFeePerGas: parsedTransaction.maxFeePerGas,
+			maxPriorityFeePerGas: parsedTransaction.maxPriorityFeePerGas,
+			gas: parsedTransaction.gas,
+			to: parsedTransaction.to,
+			value: parsedTransaction.value,
+			data: parsedTransaction.data,
+			accessList: parsedTransaction.accessList,
+		})
+		const from = await recoverParsedTransactionAddress(unsignedTransaction, {
+			r: parsedTransaction.r,
+			s: parsedTransaction.s,
+			yParity: parsedTransaction.yParity,
+		})
+		return {
+			type: '1559',
+			from: EthereumAddress.parse(from),
+			chainId: activeChainId,
+			nonce: BigInt(parsedTransaction.nonce),
+			maxFeePerGas: parsedTransaction.maxFeePerGas,
+			maxPriorityFeePerGas: parsedTransaction.maxPriorityFeePerGas,
+			gas: parsedTransaction.gas,
+			to: parsedTransaction.to === undefined ? null : EthereumAddress.parse(parsedTransaction.to),
+			value: parsedTransaction.value ?? 0n,
+			input: stringToUint8Array(parsedTransaction.data ?? '0x'),
+			accessList: [],
+		}
+	}
+
+	if (parsedTransaction.type === 'eip7702') {
+		if (parsedTransaction.gas === undefined || parsedTransaction.maxFeePerGas === undefined || parsedTransaction.maxPriorityFeePerGas === undefined || parsedTransaction.nonce === undefined || parsedTransaction.r === undefined || parsedTransaction.s === undefined || parsedTransaction.yParity === undefined) {
+			throw new Error('Serialized EIP-7702 transaction is missing required fields')
+		}
+		const authorizationList = await Promise.all((parsedTransaction.authorizationList ?? []).map(async (authorization) => ({
+			chainId: BigInt(authorization.chainId),
+			address: EthereumAddress.parse(authorization.address),
+			nonce: BigInt(authorization.nonce),
+			authority: EthereumAddress.parse(await recoverAuthorizationAddress({ authorization })),
+		})))
+		const unsignedTransaction = serializeTransaction({
+			type: 'eip7702',
+			chainId: Number(parsedTransaction.chainId),
+			nonce: parsedTransaction.nonce,
+			maxFeePerGas: parsedTransaction.maxFeePerGas,
+			maxPriorityFeePerGas: parsedTransaction.maxPriorityFeePerGas,
+			gas: parsedTransaction.gas,
+			to: parsedTransaction.to,
+			value: parsedTransaction.value,
+			data: parsedTransaction.data,
+			accessList: parsedTransaction.accessList,
+			authorizationList: parsedTransaction.authorizationList ?? [],
+		})
+		const from = await recoverParsedTransactionAddress(unsignedTransaction, {
+			r: parsedTransaction.r,
+			s: parsedTransaction.s,
+			yParity: parsedTransaction.yParity,
+		})
+		return {
+			type: '7702',
+			from: EthereumAddress.parse(from),
+			chainId: activeChainId,
+			nonce: BigInt(parsedTransaction.nonce),
+			maxFeePerGas: parsedTransaction.maxFeePerGas,
+			maxPriorityFeePerGas: parsedTransaction.maxPriorityFeePerGas,
+			gas: parsedTransaction.gas,
+			to: parsedTransaction.to === undefined ? null : EthereumAddress.parse(parsedTransaction.to),
+			value: parsedTransaction.value ?? 0n,
+			input: stringToUint8Array(parsedTransaction.data ?? '0x'),
+			accessList: [],
+			authorizationList,
+		}
+	}
+
+	throw new Error('No support for non-1559 and non-7702 raw transactions')
+}

--- a/app/ts/utils/viem.ts
+++ b/app/ts/utils/viem.ts
@@ -19,6 +19,7 @@ export {
 	toEventSelector,
 	toFunctionSelector,
 	recoverAddress,
+	recoverAuthorizationAddress,
 	hashMessage,
 	hashStruct,
 	hashTypedData,

--- a/docs/eip-7702-rescue-plan.md
+++ b/docs/eip-7702-rescue-plan.md
@@ -1,0 +1,46 @@
+# EIP-7702 Delegation Rescue Plan
+
+## Recommended Rescue Flow
+
+Build the first rescue path around a sponsored type-4 transaction and the existing Bouquet private bundle flow.
+
+1. Detect that the compromised account currently has EIP-7702 delegation code.
+2. Have the compromised account sign an EIP-7702 authorization whose delegate address is `0x0000000000000000000000000000000000000000`.
+3. Have a separate funded sponsor account submit a type-4 transaction containing that authorization list.
+4. Put the sponsored clear-delegation transaction first in a private Bouquet bundle.
+5. Put the normal funding transaction and victim-signed token rescue transfers after it in the same bundle.
+6. Optionally drain leftover ETH from the compromised account at the end of the bundle.
+
+This avoids sending ETH to a delegated compromised account before the hostile delegation is removed. The sponsored type-4 transaction pays gas from the sponsor while changing the compromised account's delegation, and the private bundle keeps the later funding and sweep transactions from being exposed independently.
+
+## Interceptor Feature Plan
+
+Interceptor should be able to inspect, simulate, and export the rescue bundle components. It should not be responsible for holding private keys or submitting bundles.
+
+Required Interceptor features:
+
+1. Accept EIP-7702 `authorizationList` values on `eth_sendTransaction` requests.
+2. Preserve authorization list delegate targets when building simulated type-4 transactions.
+3. Support serialized type-4 transactions passed through `eth_sendRawTransaction`.
+4. Recover the type-4 transaction sender from raw transactions for simulation stack bookkeeping.
+5. Recover authorization authority addresses from signed authorizations when available, so sponsored transactions can show the compromised account separately from the sponsor.
+6. Include 7702 transaction data in simulation stack exports so Bouquet can import and plan around it.
+7. Continue showing already-delegated senders detected from `eth_getCode` as a separate signal from newly included authorization lists.
+
+Out of scope for Interceptor:
+
+1. Signing victim authorizations.
+2. Managing sponsor or victim private keys.
+3. Constructing and submitting private bundles.
+4. Auditing or deploying a rescue delegate contract.
+
+## Bouquet Follow-Up
+
+Bouquet should add a rescue mode that:
+
+1. Imports Interceptor stacks containing type-4 transactions.
+2. Signs or imports clear-delegation authorizations.
+3. Inserts the sponsored clear-delegation transaction before funding and token sweep transactions.
+4. Accounts for the victim authorization nonce increment before victim-signed follow-up transactions.
+5. Submits the complete ordered bundle privately.
+

--- a/docs/eip-7702-rescue-plan.md
+++ b/docs/eip-7702-rescue-plan.md
@@ -43,4 +43,3 @@ Bouquet should add a rescue mode that:
 3. Inserts the sponsored clear-delegation transaction before funding and token sweep transactions.
 4. Accounts for the victim authorization nonce increment before victim-signed follow-up transactions.
 5. Submits the complete ordered bundle privately.
-

--- a/test/tests/SimulationModeEthereumClientService.test.ts
+++ b/test/tests/SimulationModeEthereumClientService.test.ts
@@ -6,14 +6,15 @@ import { EthereumClientService } from '../../app/ts/simulation/services/Ethereum
 import { EthereumSignedTransactionToSignedTransaction, EthereumUnsignedTransactionToUnsignedTransaction, serializeSignedTransactionToBytes, serializeUnsignedTransactionToBytes } from '../../app/ts/utils/ethereum.js'
 import { bytes32String, dataStringWith0xStart } from '../../app/ts/utils/bigint.js'
 import { EthereumSignatureParity, EthereumSignedTransaction, EthereumSignedTransaction1559, EthereumSignedTransactionWithBlockData, EthereumUnsignedTransaction } from '../../app/ts/types/wire-types.js'
-import { createExecutionSimulationState, createSimulationState, getBaseFeeAdjustedTransactions, getBaseFeeAdjustmentBalances, getSimulatedBalanceFromInput, getSimulatedBlockByHashFromInput, getSimulatedBlockFromInput, getSimulatedBlockNumberFromInput, getSimulatedCodeFromInput, getSimulatedLogs, getSimulatedTransactionByHashFromInput, getSimulatedTransactionReceipt, groupEthSimulateV1ResultByInputBlocks, mockSignTransaction, simulateEstimateGasFromInput, simulatedCallFromInput } from '../../app/ts/simulation/services/SimulationModeEthereumClientService.js'
+import { createExecutionSimulationState, createSimulationState, getBaseFeeAdjustedTransactions, getBaseFeeAdjustmentBalances, getSimulatedBalanceFromInput, getSimulatedBlockByHashFromInput, getSimulatedBlockFromInput, getSimulatedBlockNumberFromInput, getSimulatedCodeFromInput, getSimulatedLogs, getSimulatedTransactionByHashFromInput, getSimulatedTransactionReceipt, groupEthSimulateV1ResultByInputBlocks, mockSignTransaction, simulateEstimateGas, simulateEstimateGasFromInput, simulatedCallFromInput } from '../../app/ts/simulation/services/SimulationModeEthereumClientService.js'
 import { EthTransactionReceiptResponse, JsonRpcResponse, type EthereumJsonRpcRequest } from '../../app/ts/types/JsonRpc-types.js'
 import type { EthSimulateV1Result } from '../../app/ts/types/ethSimulate-types.js'
-import { toResolvedExecutionSimulationState, toResolvedSimulationInput } from '../../app/ts/types/visualizer-types.js'
+import { toResolvedExecutionSimulationState, toResolvedSimulationInput, toResolvedSimulationState } from '../../app/ts/types/visualizer-types.js'
 import { Multicall3ABI } from '../../app/ts/utils/constants.js'
 import { decodeFunctionDataStrict, encodeAbiValues, encodeFunctionCall, encodeFunctionReturn } from '../../app/ts/utils/abiRuntime.js'
 import { eth_getBlockByNumber_goerli_8443561_false, eth_getBlockByNumber_goerli_8443561_true, eth_simulateV1_dummy_call_result, eth_simulateV1_dummy_call_result_2calls, eth_simulateV1_get_eth_balance_multicall } from '../RPCResponses.js'
 import { JsonRpcResponseError } from '../../app/ts/utils/errors.js'
+import { privateKeyToAccount } from '../../app/ts/utils/viem.js'
 
 function parseRequest<T>(data: string): T {
 	const jsonRpcResponse = JsonRpcResponse.parse(JSON.parse(data))
@@ -92,7 +93,12 @@ const zeroBytes256 = `0x${'0'.repeat(512)}`
 		public rejectOmittedGas = false
 		public balance = 0n
 		public ethGetBalanceCalls: EthereumJsonRpcRequest[] = []
-		public readonly ethSimulateV1Calls: { blockStateCallCount: number, aggregate3BalanceQueryCount: number | undefined, lastCallGas: bigint | undefined }[] = []
+		public readonly ethSimulateV1Calls: {
+			blockStateCallCount: number,
+			aggregate3BalanceQueryCount: number | undefined,
+			lastCallGas: bigint | undefined,
+			lastCallAuthorizationList: readonly { chainId: bigint, address: bigint, nonce: bigint }[] | undefined
+		}[] = []
 
 		public clearCache = () => undefined
 
@@ -114,6 +120,7 @@ const zeroBytes256 = `0x${'0'.repeat(512)}`
 					const lastCall = rpcRequest.params[0]?.blockStateCalls.at(-1)?.calls[0]
 					const lastCallInput = lastCall?.input
 					const lastCallGas = lastCall?.gas
+					const lastCallAuthorizationList = lastCall?.authorizationList
 					const aggregate3BalanceQueryCount = lastCallInput !== undefined && dataStringWith0xStart(lastCallInput).startsWith('0x82ad56cb')
 						? (() => {
 							const decoded = decodeFunctionDataStrict(Multicall3ABI, dataStringWith0xStart(lastCallInput))
@@ -122,7 +129,7 @@ const zeroBytes256 = `0x${'0'.repeat(512)}`
 						})()
 						: undefined
 					const blockStateCallCount = rpcRequest.params[0]?.blockStateCalls.length ?? 0
-					this.ethSimulateV1Calls.push({ blockStateCallCount, aggregate3BalanceQueryCount, lastCallGas })
+					this.ethSimulateV1Calls.push({ blockStateCallCount, aggregate3BalanceQueryCount, lastCallGas, lastCallAuthorizationList })
 					if (this.rejectOmittedGas && lastCallGas === undefined) {
 						throw new JsonRpcResponseError({ jsonrpc: '2.0', id: 1, error: { code: -32000, message: 'gas required' } })
 					}
@@ -167,6 +174,11 @@ const zeroBytes256 = `0x${'0'.repeat(512)}`
 			input: new Uint8Array(0),
 			chainId: 1n,
 		} as const
+		const example7702Transaction = {
+			...exampleTransaction,
+			type: '7702',
+			authorizationList: [],
+		} as const
 
 		const createSimulationStateInput = () => [{
 			stateOverrides: {},
@@ -192,6 +204,31 @@ const zeroBytes256 = `0x${'0'.repeat(512)}`
 			assert.equal(signed.s, 0n)
 			if (!('yParity' in signed)) throw new Error('yParity missing')
 			if (signed.type === '1559') assert.equal(signed.yParity, 'even')
+		})
+
+		test('mockSignTransaction preserves signed 7702 authorization tuples', async () => {
+			const signedAuthorization = {
+				chainId: 5n,
+				address: 0x000000009b1d0af20d8c6d0a44e162d11f9b8f00n,
+				nonce: 3n,
+				authority: 0x0000000000000000000000000000000000000004n,
+				r: 0x11n,
+				s: 0x22n,
+				yParity: 'odd' as const,
+			}
+			const signed = mockSignTransaction({
+				...example7702Transaction,
+				authorizationList: [signedAuthorization],
+			})
+
+			assert.equal(signed.type, '7702')
+			if (signed.type !== '7702') throw new Error('wrong transaction type')
+			const [authorization] = signed.authorizationList
+			if (authorization === undefined) throw new Error('authorization missing')
+			assert.equal(authorization.r, signedAuthorization.r)
+			assert.equal(authorization.s, signedAuthorization.s)
+			assert.equal(authorization.yParity, signedAuthorization.yParity)
+			assert.equal(authorization.authority, signedAuthorization.authority)
 		})
 
 		test('recoverAddress should fail for mocked transaction', async () => {
@@ -534,6 +571,43 @@ const zeroBytes256 = `0x${'0'.repeat(512)}`
 			assert.equal(requestHandler.ethSimulateV1Calls.length, 0)
 		})
 
+		test('getBaseFeeAdjustedTransactions adjusts type-7702 fee-market transactions', async () => {
+			requestHandler.balance = 50n
+			requestHandler.ethGetBalanceCalls.length = 0
+			requestHandler.ethSimulateV1Calls.length = 0
+			const parentBlock = await ethereum.getBlock(undefined)
+			const transaction = {
+				signedTransaction: mockSignTransaction({
+					...example7702Transaction,
+					nonce: 0n,
+					maxFeePerGas: 999n,
+					maxPriorityFeePerGas: 100n,
+					gas: 10n,
+					value: 0n,
+				}),
+				website: { websiteOrigin: 'test', icon: undefined, title: undefined },
+				created: new Date(),
+				originalRequestParameters: { method: 'eth_sendTransaction', params: [{ type: '7702', authorizationList: [] }]},
+				transactionIdentifier: 26n,
+			} as const
+			const currentBlock = {
+				stateOverrides: {},
+				transactions: [transaction],
+				signedMessages: [],
+				blockTimeManipulation: { type: 'AddToTimestamp', deltaToAdd: 12n, deltaUnit: 'Seconds' },
+				simulateWithZeroBaseFee: false,
+			} as const
+
+			const { balances, transactions: adjusted } = await getBaseFeeAdjustmentBalances(ethereum, undefined, parentBlock, [], currentBlock)
+			assert.deepEqual(adjusted, getBaseFeeAdjustedTransactions(parentBlock, currentBlock.transactions, balances))
+			const adjustedTransaction = adjusted[0]?.signedTransaction
+			if (adjustedTransaction === undefined || adjustedTransaction.type !== '7702') throw new Error('missing adjusted 7702 transaction')
+			assert.equal(adjustedTransaction.maxFeePerGas, 5n)
+			assert.equal(adjustedTransaction.maxPriorityFeePerGas, 5n)
+			assert.equal(requestHandler.ethGetBalanceCalls.length, 1)
+			assert.equal(requestHandler.ethSimulateV1Calls.length, 0)
+		})
+
 		test('getBaseFeeAdjustedTransactions skips prefix simulation when conservative balance can afford desired fees', async () => {
 			requestHandler.balance = 100_000n
 			requestHandler.ethGetBalanceCalls.length = 0
@@ -609,6 +683,50 @@ const zeroBytes256 = `0x${'0'.repeat(512)}`
 			assert.equal(requestHandler.ethSimulateV1Calls.length, 0)
 		})
 
+		test('getBaseFeeAdjustmentBalances tracks explicit type-7702 max fee in conservative balance', async () => {
+			requestHandler.balance = 100_000n
+			requestHandler.ethGetBalanceCalls.length = 0
+			requestHandler.ethSimulateV1Calls.length = 0
+			const parentBlock = await ethereum.getBlock(undefined)
+			const makeTransaction = (nonce: bigint, identifier: bigint, maxFeePerGas: bigint | undefined) => ({
+				signedTransaction: mockSignTransaction({
+					...example7702Transaction,
+					nonce,
+					maxFeePerGas: maxFeePerGas ?? 999n,
+					maxPriorityFeePerGas: 100n,
+					gas: 10n,
+					value: 0n,
+				}),
+				website: { websiteOrigin: 'test', icon: undefined, title: undefined },
+				created: new Date(),
+				originalRequestParameters: { method: 'eth_sendTransaction', params: maxFeePerGas === undefined ? [{ type: '7702', authorizationList: [] }] : [{ type: '7702', authorizationList: [], maxFeePerGas }]},
+				transactionIdentifier: identifier,
+			} as const)
+			const currentBlock = {
+				stateOverrides: {},
+				transactions: [
+					makeTransaction(0n, 27n, undefined),
+					makeTransaction(1n, 28n, 200n),
+					makeTransaction(2n, 29n, undefined),
+				],
+				signedMessages: [],
+				blockTimeManipulation: { type: 'AddToTimestamp', deltaToAdd: 12n, deltaUnit: 'Seconds' },
+				simulateWithZeroBaseFee: false,
+			} as const
+
+			const { transactions: adjusted } = await getBaseFeeAdjustmentBalances(ethereum, undefined, parentBlock, [], currentBlock)
+			assert.equal(adjusted.length, 3)
+			const firstAdjusted = adjusted[0]?.signedTransaction
+			const secondAdjusted = adjusted[1]?.signedTransaction
+			const thirdAdjusted = adjusted[2]?.signedTransaction
+			if (firstAdjusted?.type !== '7702' || secondAdjusted?.type !== '7702' || thirdAdjusted?.type !== '7702') throw new Error('wrong transaction type')
+			assert.equal(firstAdjusted.maxFeePerGas, 284n)
+			assert.equal(secondAdjusted.maxFeePerGas, 200n)
+			assert.equal(thirdAdjusted.maxFeePerGas, 284n)
+			assert.equal(requestHandler.ethGetBalanceCalls.length, 1)
+			assert.equal(requestHandler.ethSimulateV1Calls.length, 0)
+		})
+
 		test('simulateEstimateGasFromInput omits gas when input gas is omitted', async () => {
 			requestHandler.ethSimulateV1Calls.length = 0
 			const estimateGas = await simulateEstimateGasFromInput(ethereum, undefined, [], {
@@ -633,6 +751,96 @@ const zeroBytes256 = `0x${'0'.repeat(512)}`
 			})
 			if ('error' in estimateGas) throw new Error(`estimate gas unexpectedly failed: ${ estimateGas.message }`)
 			assert.equal(requestHandler.ethSimulateV1Calls.at(-1)?.lastCallGas, explicitGas)
+		})
+
+		test('simulateEstimateGasFromInput validates and projects signed 7702 authorizations', async () => {
+			requestHandler.ethSimulateV1Calls.length = 0
+			const victim = privateKeyToAccount('0x0000000000000000000000000000000000000000000000000000000000000002')
+			const clearDelegationAuthorization = await victim.signAuthorization({
+				address: '0x0000000000000000000000000000000000000000',
+				chainId: 5,
+				nonce: 3,
+			})
+			const estimateGas = await simulateEstimateGasFromInput(ethereum, undefined, [], {
+				type: '7702',
+				from: exampleTransaction.from,
+				to: exampleTransaction.to,
+				value: exampleTransaction.value,
+				input: exampleTransaction.input,
+				authorizationList: [{
+					chainId: BigInt(clearDelegationAuthorization.chainId),
+					address: BigInt(clearDelegationAuthorization.address),
+					nonce: BigInt(clearDelegationAuthorization.nonce),
+					authority: 0x0000000000000000000000000000000000000004n,
+					r: BigInt(clearDelegationAuthorization.r),
+					s: BigInt(clearDelegationAuthorization.s),
+					yParity: clearDelegationAuthorization.yParity === 0 ? 'even' : 'odd',
+				}],
+			})
+
+			if ('error' in estimateGas) throw new Error(`estimate gas unexpectedly failed: ${ estimateGas.message }`)
+			const [authorization] = requestHandler.ethSimulateV1Calls.at(-1)?.lastCallAuthorizationList ?? []
+			if (authorization === undefined) throw new Error('authorization missing')
+			assert.deepEqual(authorization, {
+				chainId: BigInt(clearDelegationAuthorization.chainId),
+				address: BigInt(clearDelegationAuthorization.address),
+				nonce: BigInt(clearDelegationAuthorization.nonce),
+			})
+			assert.equal('authority' in authorization, false)
+			assert.equal('r' in authorization, false)
+			assert.equal('s' in authorization, false)
+			assert.equal('yParity' in authorization, false)
+		})
+
+		test('simulateEstimateGasFromInput rejects partial signed 7702 authorizations', async () => {
+			await assert.rejects(
+				async () => await simulateEstimateGasFromInput(ethereum, undefined, [], {
+					type: '7702',
+					from: exampleTransaction.from,
+					to: exampleTransaction.to,
+					value: exampleTransaction.value,
+					input: exampleTransaction.input,
+					authorizationList: [{
+						chainId: 5n,
+						address: 0n,
+						nonce: 3n,
+						authority: 0x0000000000000000000000000000000000000004n,
+						r: 0x11n,
+						s: 0x22n,
+					}],
+				}),
+				/EIP-7702 authorization signature is missing required fields/
+			)
+		})
+
+		test('simulateEstimateGas rejects partial signed 7702 authorizations', async () => {
+			await assert.rejects(
+				async () => await simulateEstimateGas(ethereum, undefined, toResolvedSimulationState({
+					success: true,
+					simulationStateInput: [],
+					simulatedBlocks: [],
+					blockNumber,
+					blockTimestamp: new Date('2024-01-01T00:00:00.000Z'),
+					baseFeePerGas: 1n,
+					simulationConductedTimestamp: new Date('2024-01-01T00:00:00.000Z'),
+					rpcNetwork,
+				}), {
+					type: '7702',
+					from: exampleTransaction.from,
+					to: exampleTransaction.to,
+					value: exampleTransaction.value,
+					input: exampleTransaction.input,
+					authorizationList: [{
+						chainId: 5n,
+						address: 0n,
+						nonce: 3n,
+						authority: 0x0000000000000000000000000000000000000004n,
+						r: 0x11n,
+						s: 0x22n,
+					}],
+				}),
+				/EIP-7702 authorization signature is missing required fields/
+			)
 		})
 
 		test('simulatedCallFromInput omits gas when gasLimit is omitted', async () => {

--- a/test/tests/eip7702RescueTransactionParsing.test.ts
+++ b/test/tests/eip7702RescueTransactionParsing.test.ts
@@ -214,6 +214,9 @@ describe('EIP-7702 rescue transaction parsing', () => {
 				}],
 			}],
 		})
+		const [parsedAuthorization] = params.params[0].authorizationList ?? []
+		if (parsedAuthorization === undefined) throw new Error('Expected authorization to be parsed')
+		assert.equal('authority' in parsedAuthorization, false)
 		const restoreGlobals = installExtensionImportGlobals()
 		try {
 			const { formEthSendTransaction } = await import('../../app/ts/background/windows/confirmTransaction.js')
@@ -292,7 +295,7 @@ describe('EIP-7702 rescue transaction parsing', () => {
 		})
 		const signedTransaction = await sponsor.signTransaction({
 			type: 'eip7702',
-			chainId: 1,
+			chainId: 5,
 			nonce: 7,
 			maxFeePerGas: 2n,
 			maxPriorityFeePerGas: 1n,
@@ -307,12 +310,12 @@ describe('EIP-7702 rescue transaction parsing', () => {
 			authorizationList: [clearDelegationAuthorization],
 		})
 
-		const transaction = await parseSendRawTransaction(stringToUint8Array(signedTransaction), 1n)
+		const transaction = await parseSendRawTransaction(stringToUint8Array(signedTransaction))
 
 		assert.equal(transaction.type, '7702')
 		if (transaction.type !== '7702') throw new Error('Expected a 7702 transaction')
 		assert.equal(transaction.from, EthereumAddress.parse(sponsor.address))
-		assert.equal(transaction.chainId, 1n)
+		assert.equal(transaction.chainId, 5n)
 		assert.equal(transaction.nonce, 7n)
 		assert.deepEqual(transaction.accessList, [{
 			address: EthereumAddress.parse(accessListAddress),
@@ -332,7 +335,7 @@ describe('EIP-7702 rescue transaction parsing', () => {
 		const sponsor = privateKeyToAccount('0x0000000000000000000000000000000000000000000000000000000000000001')
 		const signedTransaction = await sponsor.signTransaction({
 			type: 'eip1559',
-			chainId: 1,
+			chainId: 5,
 			nonce: 7,
 			maxFeePerGas: 2n,
 			maxPriorityFeePerGas: 1n,
@@ -346,12 +349,12 @@ describe('EIP-7702 rescue transaction parsing', () => {
 			}],
 		})
 
-		const transaction = await parseSendRawTransaction(stringToUint8Array(signedTransaction), 1n)
+		const transaction = await parseSendRawTransaction(stringToUint8Array(signedTransaction))
 
 		assert.equal(transaction.type, '1559')
 		if (transaction.type !== '1559') throw new Error('Expected a 1559 transaction')
 		assert.equal(transaction.from, EthereumAddress.parse(sponsor.address))
-		assert.equal(transaction.chainId, 1n)
+		assert.equal(transaction.chainId, 5n)
 		assert.equal(transaction.nonce, 7n)
 		assert.deepEqual(transaction.accessList, [{
 			address: EthereumAddress.parse(accessListAddress),
@@ -359,50 +362,4 @@ describe('EIP-7702 rescue transaction parsing', () => {
 		}])
 	})
 
-	test('rejects raw EIP-1559 transactions for a different active chain', async () => {
-		const sponsor = privateKeyToAccount('0x0000000000000000000000000000000000000000000000000000000000000001')
-		const signedTransaction = await sponsor.signTransaction({
-			type: 'eip1559',
-			chainId: 1,
-			nonce: 7,
-			maxFeePerGas: 2n,
-			maxPriorityFeePerGas: 1n,
-			gas: 50_000n,
-			to: recipientAddress,
-			value: 0n,
-			data: '0x',
-		})
-
-		await assert.rejects(
-			async () => await parseSendRawTransaction(stringToUint8Array(signedTransaction), 2n),
-			/does not match active chainId/
-		)
-	})
-
-	test('rejects raw EIP-7702 transactions for a different active chain', async () => {
-		const sponsor = privateKeyToAccount('0x0000000000000000000000000000000000000000000000000000000000000001')
-		const victim = privateKeyToAccount('0x0000000000000000000000000000000000000000000000000000000000000002')
-		const clearDelegationAuthorization = await victim.signAuthorization({
-			address: zeroAddress,
-			chainId: 1,
-			nonce: 5,
-		})
-		const signedTransaction = await sponsor.signTransaction({
-			type: 'eip7702',
-			chainId: 1,
-			nonce: 7,
-			maxFeePerGas: 2n,
-			maxPriorityFeePerGas: 1n,
-			gas: 50_000n,
-			to: recipientAddress,
-			value: 0n,
-			data: '0x',
-			authorizationList: [clearDelegationAuthorization],
-		})
-
-		await assert.rejects(
-			async () => await parseSendRawTransaction(stringToUint8Array(signedTransaction), 2n),
-			/does not match active chainId/
-		)
-	})
 })

--- a/test/tests/eip7702RescueTransactionParsing.test.ts
+++ b/test/tests/eip7702RescueTransactionParsing.test.ts
@@ -1,13 +1,115 @@
 import * as assert from 'assert'
 import { describe, test } from 'bun:test'
-import { SendTransactionParams } from '../../app/ts/types/JsonRpc-types.js'
-import { EthereumAddress } from '../../app/ts/types/wire-types.js'
+import { type EthereumJsonRpcRequest, SendTransactionParams } from '../../app/ts/types/JsonRpc-types.js'
+import { EthereumAddress, EthereumBlockHeader, EthereumBytes32, EthereumQuantity, serialize } from '../../app/ts/types/wire-types.js'
 import { privateKeyToAccount } from '../../app/ts/utils/viem.js'
 import { stringToUint8Array } from '../../app/ts/utils/bigint.js'
 import { parseSendRawTransaction } from '../../app/ts/utils/sendRawTransactionParsing.js'
+import { EthereumClientService } from '../../app/ts/simulation/services/EthereumClientService.js'
+import type { RpcEntry } from '../../app/ts/types/rpc.js'
+import { normalizeEip7702AuthorizationList } from '../../app/ts/utils/eip7702Authorization.js'
 
 const zeroAddress = '0x0000000000000000000000000000000000000000'
 const recipientAddress = '0x0000000000000000000000000000000000000002'
+const accessListAddress = '0x0000000000000000000000000000000000000003'
+const accessListStorageKey = '0x0000000000000000000000000000000000000000000000000000000000000042'
+
+const rpcNetwork: RpcEntry = {
+	name: 'Test Chain',
+	chainId: 1n,
+	httpsRpc: 'https://example.invalid',
+	currencyName: 'Ether',
+	currencyTicker: 'ETH',
+	primary: true,
+	minimized: true,
+}
+
+function makeFakeBlock(number: bigint) {
+	return {
+		author: 0n,
+		difficulty: 0n,
+		extraData: new Uint8Array(),
+		gasLimit: 30_000_000n,
+		gasUsed: 21_000n,
+		hash: 0x1234n + number,
+		logsBloom: 0n,
+		miner: 0n,
+		mixHash: 0n,
+		nonce: 0n,
+		number,
+		parentHash: 0x1n,
+		receiptsRoot: 0n,
+		sha3Uncles: 0n,
+		stateRoot: 0n,
+		timestamp: new Date('2024-01-01T00:00:00.000Z'),
+		size: 0n,
+		totalDifficulty: 0n,
+		uncles: [],
+		baseFeePerGas: 1n,
+		transactionsRoot: 0n,
+		transactions: [],
+		withdrawals: [],
+		withdrawalsRoot: 0n,
+	}
+}
+
+const createEip7702TransactionParsingRequestHandler = () => ({
+	rpcUrl: rpcNetwork.httpsRpc,
+	clearCache: () => undefined,
+	getChainId: async () => rpcNetwork.chainId,
+	jsonRpcRequest: async (rpcRequest: EthereumJsonRpcRequest) => {
+		switch (rpcRequest.method) {
+			case 'eth_getBlockByNumber':
+				return serialize(EthereumBlockHeader, makeFakeBlock(1n))
+			case 'eth_getTransactionCount':
+				return serialize(EthereumQuantity, 7n)
+			case 'eth_getBalance':
+				return serialize(EthereumQuantity, 10n ** 18n)
+			default:
+				throw new Error(`Unexpected RPC method: ${ rpcRequest.method }`)
+		}
+	},
+})
+
+type SignedAuthorizationForRpc = {
+	readonly chainId: number
+	readonly address: `0x${ string }`
+	readonly nonce: number
+	readonly yParity: number
+	readonly r: `0x${ string }`
+	readonly s: `0x${ string }`
+}
+
+const signedAuthorizationToRpc = (authorization: SignedAuthorizationForRpc) => ({
+	chainId: `0x${ authorization.chainId.toString(16) }`,
+	address: authorization.address,
+	nonce: `0x${ authorization.nonce.toString(16) }`,
+	yParity: authorization.yParity === 0 ? '0x0' : '0x1',
+	r: authorization.r,
+	s: authorization.s,
+})
+
+function restoreGlobalProperty(key: 'browser' | 'chrome', descriptor: PropertyDescriptor | undefined) {
+	if (descriptor === undefined) {
+		Reflect.deleteProperty(globalThis, key)
+		return
+	}
+	Object.defineProperty(globalThis, key, descriptor)
+}
+
+function installExtensionImportGlobals() {
+	const browserDescriptor = Object.getOwnPropertyDescriptor(globalThis, 'browser')
+	const chromeDescriptor = Object.getOwnPropertyDescriptor(globalThis, 'chrome')
+	Object.defineProperty(globalThis, 'chrome', {
+		value: { runtime: { id: 'test-extension' } },
+		configurable: true,
+		writable: true,
+	})
+	return () => {
+		restoreGlobalProperty('browser', browserDescriptor)
+		restoreGlobalProperty('chrome', chromeDescriptor)
+	}
+}
 
 describe('EIP-7702 rescue transaction parsing', () => {
 	test('parses eth_sendTransaction authorization lists', () => {
@@ -37,7 +139,247 @@ describe('EIP-7702 rescue transaction parsing', () => {
 		assert.equal(authorization.yParity, 'even')
 	})
 
+	test('formEthSendTransaction recovers authorization authority from signed tuples', async () => {
+		const sponsor = privateKeyToAccount('0x0000000000000000000000000000000000000000000000000000000000000001')
+		const victim = privateKeyToAccount('0x0000000000000000000000000000000000000000000000000000000000000002')
+		const clearDelegationAuthorization = await victim.signAuthorization({
+			address: zeroAddress,
+			chainId: 1,
+			nonce: 5,
+		})
+		const params = SendTransactionParams.parse({
+			method: 'eth_sendTransaction',
+			params: [{
+				type: '0x4',
+				from: sponsor.address,
+				to: recipientAddress,
+				value: '0x0',
+				gas: '0xc350',
+				maxFeePerGas: '0x2',
+				maxPriorityFeePerGas: '0x1',
+				authorizationList: [signedAuthorizationToRpc(clearDelegationAuthorization)],
+			}],
+		})
+		const restoreGlobals = installExtensionImportGlobals()
+		try {
+			const { formEthSendTransaction } = await import('../../app/ts/background/windows/confirmTransaction.js')
+			const transaction = await formEthSendTransaction(
+				new EthereumClientService(createEip7702TransactionParsingRequestHandler(), async () => undefined, async () => undefined, rpcNetwork),
+				undefined,
+				EthereumAddress.parse(sponsor.address),
+				{ websiteOrigin: 'test', icon: undefined, title: undefined },
+				params,
+				new Date('2024-01-01T00:00:00.000Z'),
+				1n,
+				false,
+			)
+
+			assert.equal(transaction.success, true)
+			if (transaction.success === false) throw new Error('transaction creation unexpectedly failed')
+			assert.equal(transaction.transaction.type, '7702')
+			if (transaction.transaction.type !== '7702') throw new Error('Expected a 7702 transaction')
+			const [authorization] = transaction.transaction.authorizationList
+			if (authorization === undefined) throw new Error('Expected authorization to be parsed')
+			assert.equal(authorization.authority, EthereumAddress.parse(victim.address))
+			assert.equal(authorization.r, BigInt(clearDelegationAuthorization.r))
+			assert.equal(authorization.s, BigInt(clearDelegationAuthorization.s))
+			assert.equal(authorization.yParity, clearDelegationAuthorization.yParity === 0 ? 'even' : 'odd')
+		} finally {
+			restoreGlobals()
+		}
+	})
+
+	test('formEthSendTransaction recovers signed authorization authority over supplied authority', async () => {
+		const sponsor = privateKeyToAccount('0x0000000000000000000000000000000000000000000000000000000000000001')
+		const victim = privateKeyToAccount('0x0000000000000000000000000000000000000000000000000000000000000002')
+		const suppliedAuthority = '0x0000000000000000000000000000000000000004'
+		const clearDelegationAuthorization = await victim.signAuthorization({
+			address: zeroAddress,
+			chainId: 1,
+			nonce: 5,
+		})
+		const params = SendTransactionParams.parse({
+			method: 'eth_sendTransaction',
+			params: [{
+				type: '0x4',
+				from: sponsor.address,
+				to: recipientAddress,
+				value: '0x0',
+				gas: '0xc350',
+				maxFeePerGas: '0x2',
+				maxPriorityFeePerGas: '0x1',
+				authorizationList: [{
+					...signedAuthorizationToRpc(clearDelegationAuthorization),
+					authority: suppliedAuthority,
+				}],
+			}],
+		})
+		const restoreGlobals = installExtensionImportGlobals()
+		try {
+			const { formEthSendTransaction } = await import('../../app/ts/background/windows/confirmTransaction.js')
+			const transaction = await formEthSendTransaction(
+				new EthereumClientService(createEip7702TransactionParsingRequestHandler(), async () => undefined, async () => undefined, rpcNetwork),
+				undefined,
+				EthereumAddress.parse(sponsor.address),
+				{ websiteOrigin: 'test', icon: undefined, title: undefined },
+				params,
+				new Date('2024-01-01T00:00:00.000Z'),
+				1n,
+				false,
+			)
+
+			assert.equal(transaction.success, true)
+			if (transaction.success === false) throw new Error('transaction creation unexpectedly failed')
+			if (transaction.transaction.type !== '7702') throw new Error('Expected a 7702 transaction')
+			const [authorization] = transaction.transaction.authorizationList
+			if (authorization === undefined) throw new Error('Expected authorization to be parsed')
+			assert.equal(authorization.authority, EthereumAddress.parse(victim.address))
+			assert.equal(authorization.r, BigInt(clearDelegationAuthorization.r))
+			assert.equal(authorization.s, BigInt(clearDelegationAuthorization.s))
+			assert.equal(authorization.yParity, clearDelegationAuthorization.yParity === 0 ? 'even' : 'odd')
+		} finally {
+			restoreGlobals()
+		}
+	})
+
+	test('normalizing partial signed authorizations rejects supplied authority fallback', async () => {
+		await assert.rejects(
+			async () => await normalizeEip7702AuthorizationList([{
+				chainId: 1n,
+				address: 0n,
+				nonce: 5n,
+				authority: 0x0000000000000000000000000000000000000004n,
+				r: 1n,
+				s: 2n,
+			}]),
+			/EIP-7702 authorization signature is missing required fields/
+		)
+	})
+
+	test('normalizing signed authorizations rejects unsafe chain id and nonce values', async () => {
+		const unsafeValue = BigInt(Number.MAX_SAFE_INTEGER) + 1n
+		await assert.rejects(
+			async () => await normalizeEip7702AuthorizationList([{
+				chainId: unsafeValue,
+				address: 0n,
+				nonce: 5n,
+				r: 1n,
+				s: 2n,
+				yParity: 'even',
+			}]),
+			/EIP-7702 authorization chainId exceeds the maximum safe integer/
+		)
+		await assert.rejects(
+			async () => await normalizeEip7702AuthorizationList([{
+				chainId: 1n,
+				address: 0n,
+				nonce: unsafeValue,
+				r: 1n,
+				s: 2n,
+				yParity: 'even',
+			}]),
+			/EIP-7702 authorization nonce exceeds the maximum safe integer/
+		)
+	})
+
 	test('parses raw EIP-7702 transactions and recovers authorization authority', async () => {
+		const sponsor = privateKeyToAccount('0x0000000000000000000000000000000000000000000000000000000000000001')
+		const victim = privateKeyToAccount('0x0000000000000000000000000000000000000000000000000000000000000002')
+		const clearDelegationAuthorization = await victim.signAuthorization({
+			address: zeroAddress,
+			chainId: 1,
+			nonce: 5,
+		})
+		const signedTransaction = await sponsor.signTransaction({
+			type: 'eip7702',
+			chainId: 1,
+			nonce: 7,
+			maxFeePerGas: 2n,
+			maxPriorityFeePerGas: 1n,
+			gas: 50_000n,
+			to: recipientAddress,
+			value: 0n,
+			data: '0x',
+			accessList: [{
+				address: accessListAddress,
+				storageKeys: [accessListStorageKey],
+			}],
+			authorizationList: [clearDelegationAuthorization],
+		})
+
+		const transaction = await parseSendRawTransaction(stringToUint8Array(signedTransaction), 1n)
+
+		assert.equal(transaction.type, '7702')
+		if (transaction.type !== '7702') throw new Error('Expected a 7702 transaction')
+		assert.equal(transaction.from, EthereumAddress.parse(sponsor.address))
+		assert.equal(transaction.chainId, 1n)
+		assert.equal(transaction.nonce, 7n)
+		assert.deepEqual(transaction.accessList, [{
+			address: EthereumAddress.parse(accessListAddress),
+			storageKeys: [EthereumBytes32.parse(accessListStorageKey)],
+		}])
+		const [authorization] = transaction.authorizationList
+		if (authorization === undefined) throw new Error('Expected authorization to be parsed')
+		assert.equal(authorization.address, 0n)
+		assert.equal(authorization.nonce, 5n)
+		assert.equal(authorization.authority, EthereumAddress.parse(victim.address))
+		assert.equal(authorization.r, BigInt(clearDelegationAuthorization.r))
+		assert.equal(authorization.s, BigInt(clearDelegationAuthorization.s))
+		assert.equal(authorization.yParity, clearDelegationAuthorization.yParity === 0 ? 'even' : 'odd')
+	})
+
+	test('parses raw EIP-1559 transactions with signed chain and access list', async () => {
+		const sponsor = privateKeyToAccount('0x0000000000000000000000000000000000000000000000000000000000000001')
+		const signedTransaction = await sponsor.signTransaction({
+			type: 'eip1559',
+			chainId: 1,
+			nonce: 7,
+			maxFeePerGas: 2n,
+			maxPriorityFeePerGas: 1n,
+			gas: 50_000n,
+			to: recipientAddress,
+			value: 0n,
+			data: '0x',
+			accessList: [{
+				address: accessListAddress,
+				storageKeys: [accessListStorageKey],
+			}],
+		})
+
+		const transaction = await parseSendRawTransaction(stringToUint8Array(signedTransaction), 1n)
+
+		assert.equal(transaction.type, '1559')
+		if (transaction.type !== '1559') throw new Error('Expected a 1559 transaction')
+		assert.equal(transaction.from, EthereumAddress.parse(sponsor.address))
+		assert.equal(transaction.chainId, 1n)
+		assert.equal(transaction.nonce, 7n)
+		assert.deepEqual(transaction.accessList, [{
+			address: EthereumAddress.parse(accessListAddress),
+			storageKeys: [EthereumBytes32.parse(accessListStorageKey)],
+		}])
+	})
+
+	test('rejects raw EIP-1559 transactions for a different active chain', async () => {
+		const sponsor = privateKeyToAccount('0x0000000000000000000000000000000000000000000000000000000000000001')
+		const signedTransaction = await sponsor.signTransaction({
+			type: 'eip1559',
+			chainId: 1,
+			nonce: 7,
+			maxFeePerGas: 2n,
+			maxPriorityFeePerGas: 1n,
+			gas: 50_000n,
+			to: recipientAddress,
+			value: 0n,
+			data: '0x',
+		})
+
+		await assert.rejects(
+			async () => await parseSendRawTransaction(stringToUint8Array(signedTransaction), 2n),
+			/does not match active chainId/
+		)
+	})
+
+	test('rejects raw EIP-7702 transactions for a different active chain', async () => {
 		const sponsor = privateKeyToAccount('0x0000000000000000000000000000000000000000000000000000000000000001')
 		const victim = privateKeyToAccount('0x0000000000000000000000000000000000000000000000000000000000000002')
 		const clearDelegationAuthorization = await victim.signAuthorization({
@@ -58,16 +400,9 @@ describe('EIP-7702 rescue transaction parsing', () => {
 			authorizationList: [clearDelegationAuthorization],
 		})
 
-		const transaction = await parseSendRawTransaction(stringToUint8Array(signedTransaction), 1n)
-
-		assert.equal(transaction.type, '7702')
-		if (transaction.type !== '7702') throw new Error('Expected a 7702 transaction')
-		assert.equal(transaction.from, EthereumAddress.parse(sponsor.address))
-		assert.equal(transaction.nonce, 7n)
-		const [authorization] = transaction.authorizationList
-		if (authorization === undefined) throw new Error('Expected authorization to be parsed')
-		assert.equal(authorization.address, 0n)
-		assert.equal(authorization.nonce, 5n)
-		assert.equal(authorization.authority, EthereumAddress.parse(victim.address))
+		await assert.rejects(
+			async () => await parseSendRawTransaction(stringToUint8Array(signedTransaction), 2n),
+			/does not match active chainId/
+		)
 	})
 })

--- a/test/tests/eip7702RescueTransactionParsing.test.ts
+++ b/test/tests/eip7702RescueTransactionParsing.test.ts
@@ -1,0 +1,73 @@
+import * as assert from 'assert'
+import { describe, test } from 'bun:test'
+import { SendTransactionParams } from '../../app/ts/types/JsonRpc-types.js'
+import { EthereumAddress } from '../../app/ts/types/wire-types.js'
+import { privateKeyToAccount } from '../../app/ts/utils/viem.js'
+import { stringToUint8Array } from '../../app/ts/utils/bigint.js'
+import { parseSendRawTransaction } from '../../app/ts/utils/sendRawTransactionParsing.js'
+
+const zeroAddress = '0x0000000000000000000000000000000000000000'
+const recipientAddress = '0x0000000000000000000000000000000000000002'
+
+describe('EIP-7702 rescue transaction parsing', () => {
+	test('parses eth_sendTransaction authorization lists', () => {
+		const parsed = SendTransactionParams.parse({
+			method: 'eth_sendTransaction',
+			params: [{
+				type: '0x4',
+				from: '0x0000000000000000000000000000000000000001',
+				to: recipientAddress,
+				value: '0x0',
+				authorizationList: [{
+					chainId: '0x1',
+					address: zeroAddress,
+					nonce: '0x5',
+					yParity: '0x0',
+					r: '0x1',
+					s: '0x2',
+				}],
+			}],
+		})
+
+		assert.equal(parsed.params[0].type, '7702')
+		const [authorization] = parsed.params[0].authorizationList ?? []
+		if (authorization === undefined) throw new Error('Expected authorization to be parsed')
+		assert.equal(authorization.address, 0n)
+		assert.equal(authorization.nonce, 5n)
+		assert.equal(authorization.yParity, 'even')
+	})
+
+	test('parses raw EIP-7702 transactions and recovers authorization authority', async () => {
+		const sponsor = privateKeyToAccount('0x0000000000000000000000000000000000000000000000000000000000000001')
+		const victim = privateKeyToAccount('0x0000000000000000000000000000000000000000000000000000000000000002')
+		const clearDelegationAuthorization = await victim.signAuthorization({
+			address: zeroAddress,
+			chainId: 1,
+			nonce: 5,
+		})
+		const signedTransaction = await sponsor.signTransaction({
+			type: 'eip7702',
+			chainId: 1,
+			nonce: 7,
+			maxFeePerGas: 2n,
+			maxPriorityFeePerGas: 1n,
+			gas: 50_000n,
+			to: recipientAddress,
+			value: 0n,
+			data: '0x',
+			authorizationList: [clearDelegationAuthorization],
+		})
+
+		const transaction = await parseSendRawTransaction(stringToUint8Array(signedTransaction), 1n)
+
+		assert.equal(transaction.type, '7702')
+		if (transaction.type !== '7702') throw new Error('Expected a 7702 transaction')
+		assert.equal(transaction.from, EthereumAddress.parse(sponsor.address))
+		assert.equal(transaction.nonce, 7n)
+		const [authorization] = transaction.authorizationList
+		if (authorization === undefined) throw new Error('Expected authorization to be parsed')
+		assert.equal(authorization.address, 0n)
+		assert.equal(authorization.nonce, 5n)
+		assert.equal(authorization.authority, EthereumAddress.parse(victim.address))
+	})
+})

--- a/test/tests/importSimulationStack.test.tsx
+++ b/test/tests/importSimulationStack.test.tsx
@@ -4,7 +4,8 @@ import { h, render } from 'preact'
 import { act } from 'preact/test-utils'
 import { signal } from '@preact/signals'
 import { installDomMock } from './domMock.js'
-import { InterceptorSimulationExport } from '../../app/ts/types/visualizer-types.js'
+import { InterceptorSimulationExport, InterceptorTransactionStack } from '../../app/ts/types/visualizer-types.js'
+import { NEW_BLOCK_ABORT } from '../../app/ts/utils/constants.js'
 
 const storageState: Record<string, unknown> = {}
 let runtimeSendMessage = async (_message: unknown) => undefined
@@ -100,6 +101,78 @@ const exportPayload = {
 }
 
 const exportString = JSON.stringify(InterceptorSimulationExport.serialize(exportPayload))
+const expectedInfrastructureEthereum = {
+	getBlock: async () => { throw NEW_BLOCK_ABORT },
+}
+
+const create7702ExportPayload = () => ({
+	name: 'Interceptor Simulation Export' as const,
+	version: '1.0.0' as const,
+	eth_simulateV1: {
+		method: 'eth_simulateV1' as const,
+		params: [{
+			blockStateCalls: [],
+			traceTransfers: true,
+			validation: true,
+		}, 'latest' as const],
+	},
+	interceptorSimulateStack: {
+		operations: [{
+			type: 'Transaction' as const,
+			preSimulationTransaction: {
+				signedTransaction: {
+					type: '7702' as const,
+					from: 0x1111111111111111111111111111111111111111n,
+					nonce: 7n,
+					maxFeePerGas: 2n,
+					maxPriorityFeePerGas: 1n,
+					gas: 50_000n,
+					to: 0x2222222222222222222222222222222222222222n,
+					value: 0n,
+					input: new Uint8Array(),
+					chainId: 1n,
+					hash: 0xabcden,
+					r: 3n,
+					s: 4n,
+					yParity: 'odd' as const,
+					authorizationList: [{
+						chainId: 1n,
+						address: 0x3333333333333333333333333333333333333333n,
+						nonce: 5n,
+						authority: 0x4444444444444444444444444444444444444444n,
+						r: 6n,
+						s: 7n,
+						yParity: 'even' as const,
+					}],
+				},
+				website: { websiteOrigin: 'https://example.com', icon: undefined, title: 'Example' },
+				created: new Date('2024-01-01T00:00:00.000Z'),
+				originalRequestParameters: {
+					method: 'eth_sendTransaction' as const,
+					params: [{
+						type: '7702' as const,
+						from: 0x1111111111111111111111111111111111111111n,
+						to: 0x2222222222222222222222222222222222222222n,
+						value: 0n,
+						gas: 50_000n,
+						maxFeePerGas: 2n,
+						maxPriorityFeePerGas: 1n,
+						input: new Uint8Array(),
+						authorizationList: [{
+							chainId: 1n,
+							address: 0x3333333333333333333333333333333333333333n,
+							nonce: 5n,
+							r: 6n,
+							s: 7n,
+							yParity: 'even' as const,
+						}],
+					}],
+				},
+				transactionIdentifier: 77n,
+			},
+		}],
+	},
+})
 
 function resetEnvironment() {
 	for (const key of Object.keys(storageState)) delete storageState[key]
@@ -144,6 +217,31 @@ describe('import simulation stack', () => {
 		assert.equal(reply.ok, false)
 		assert.match(reply.message, /quota/i)
 		assert.match(reply.message, /simulation stack/i)
+	})
+
+	test('preserves EIP-7702 authorization signatures when importing an exported stack', async () => {
+		const modules = await modulesPromise
+		resetEnvironment()
+		const serializedExport = InterceptorSimulationExport.serialize(create7702ExportPayload())
+		const parsedExport = InterceptorSimulationExport.parse(serializedExport)
+
+		const reply = await modules.importSimulationStack(expectedInfrastructureEthereum as never, {} as never, { method: 'popup_importSimulationStack', data: parsedExport })
+
+		assert.equal(reply.type, 'ImportSimulationStackReply')
+		assert.equal(reply.ok, true)
+		const storedStack = InterceptorTransactionStack.parse(storageState.interceptorTransactionStack)
+		const [operation] = storedStack.operations
+		if (operation === undefined || operation.type !== 'Transaction') throw new Error('Expected imported transaction operation')
+		assert.notEqual(operation.preSimulationTransaction.transactionIdentifier, 77n)
+		const transaction = operation.preSimulationTransaction.signedTransaction
+		assert.equal(transaction.type, '7702')
+		if (transaction.type !== '7702') throw new Error('Expected imported type-7702 transaction')
+		const [authorization] = transaction.authorizationList
+		if (authorization === undefined) throw new Error('Expected imported authorization')
+		assert.equal(authorization.authority, 0x4444444444444444444444444444444444444444n)
+		assert.equal(authorization.yParity, 'even')
+		assert.equal(authorization.r, 6n)
+		assert.equal(authorization.s, 7n)
 	})
 
 	test('keeps the modal open and shows the returned import error', async () => {

--- a/test/tests/transactionImportanceBlockDelegation.test.tsx
+++ b/test/tests/transactionImportanceBlockDelegation.test.tsx
@@ -303,6 +303,19 @@ describe('TransactionImportanceBlock delegation notice', () => {
 		dom.restore()
 	})
 
+	test('labels zero-address authorizations as delegate clears', async () => {
+		const dom = await renderImportanceBlock(
+			create7702Transaction({ status: 'Transaction Succeeded', authorizationAddresses: [0n] }),
+			[senderEntry],
+		)
+
+		assert.equal(dom.document.body.textContent?.includes('Delegated execution'), true)
+		assert.equal(dom.document.body.textContent?.includes('cleared delegate'), true)
+		assert.equal(dom.document.body.textContent?.includes('delegated to'), false)
+
+		dom.restore()
+	})
+
 	test('shows the delegated transfer flow together with the executed send outcome', async () => {
 		const dom = await renderImportanceBlock(
 			create7702Transaction({


### PR DESCRIPTION
## Intent

This PR prepares Interceptor for EIP-7702 rescue workflows where a compromised EOA already has delegated code. The intended recovery path is to inspect and simulate a sponsored type-4 transaction that clears the compromised account's delegation before any rescue funding or token sweep transactions are bundled privately by Bouquet.

Interceptor is not taking custody of keys or submitting rescue bundles in this change. Its role is to correctly parse, preserve, simulate, display, and export the EIP-7702 transaction data that Bouquet/Lunaria can use in the broader rescue flow.

## Summary

- Added a documented rescue plan in `docs/eip-7702-rescue-plan.md`, including the recommended sponsored clear-delegation transaction followed by private bundle funding and sweep steps.
- Added support for EIP-7702 `authorizationList` data on `eth_sendTransaction` requests.
- Added raw type-4 transaction parsing for `eth_sendRawTransaction`, including sponsor sender recovery and authorization authority recovery.
- Preserved 7702 authorization data through gas estimation, simulation block calls, simulation stack handling, and export paths.
- Updated the transaction explanation UI to show sponsored delegation changes with the recovered authority account and to label zero-address authorizations as delegation clears.
- Added focused regression coverage for 7702 send-transaction parsing and signed raw 7702 transaction parsing.

## Testing

- `bun test`
- `bun run setup-chrome`
- `bun run typecheck`
- `bun run lint`
