### PR TITLE
Support ABI v2 tuple/struct parsing and rendering

### DIFF
--- a/app/ts/background/metadataUtils.ts
+++ b/app/ts/background/metadataUtils.ts
@@ -16,6 +16,7 @@ import type { EthereumBytes32 } from '../types/wire-types.js'
 import type { ENSNameHashes } from '../types/ens.js'
 const LOGO_URI_PREFIX = '../vendor/@darkflorist/address-metadata'
 import type { EnrichedEthereumEventWithMetadata, EnrichedEthereumEvents, EnrichedEthereumInputData, EnsEvent, SolidityVariable, TokenEvent, TokenVisualizerResultWithMetadata } from '../types/EnrichedEthereumData.js'
+import type { PureGroupedSolidityType } from '../types/solidityType.js'
 import { promiseAllMapAbortSafe } from '../utils/requests.js'
 import { getFilledInContactEntry } from '../utils/addressBookEntries.js'
 
@@ -186,12 +187,30 @@ export async function identifyAddress(ethereumClientService: EthereumClientServi
 	return entry
 }
 
+const getAddressesForSolidityType = (typeValue: PureGroupedSolidityType): readonly bigint[] => {
+	switch(typeValue.type) {
+		case 'address': return [typeValue.value]
+		case 'address[]': return typeValue.value
+		case 'tuple': return getAddressesForSolidityTypes(typeValue.value)
+		case 'tuple[]': return typeValue.value.flatMap((tupleValue) => getAddressesForSolidityTypes(tupleValue))
+		case 'bool':
+		case 'bool[]':
+		case 'bytes':
+		case 'bytes[]':
+		case 'fixedBytes':
+		case 'fixedBytes[]':
+		case 'signedInteger':
+		case 'signedInteger[]':
+		case 'string':
+		case 'string[]':
+		case 'unsignedInteger':
+		case 'unsignedInteger[]': return []
+		default: assertNever(typeValue)
+	}
+}
+
 export const getAddressesForSolidityTypes = (variables: readonly SolidityVariable[]) => {
-	return variables.flatMap((argumentVariable) => {
-		if (argumentVariable.typeValue.type === 'address') return argumentVariable.typeValue.value
-		if (argumentVariable.typeValue.type === 'address[]') return argumentVariable.typeValue.value
-		return undefined
-	}).filter((address): address is bigint => address !== undefined)
+	return variables.flatMap((argumentVariable) => getAddressesForSolidityType(argumentVariable.typeValue))
 }
 
 export function getAddressesToIdentifyForVisualiserFromTransactions(events: EnrichedEthereumEvents, inputData: readonly EnrichedEthereumInputData[], simulationStateInput: SimulationStateInput) {

--- a/app/ts/components/subcomponents/ParsedInputData.tsx
+++ b/app/ts/components/subcomponents/ParsedInputData.tsx
@@ -7,15 +7,15 @@ import { ViewSelector } from './ViewSelector.js'
 import { SmallAddress } from './address.js'
 import { resolveSignal, type SignalOrValue } from '../../utils/signals.js'
 
-function NoParsedAvailable({ to, renameAddressCallBack }: { to: AddressBookEntry | undefined, renameAddressCallBack: RenameAddressCallBack }) {
+export function NoParsedAvailable({ to, renameAddressCallBack }: { to: AddressBookEntry | undefined, renameAddressCallBack: RenameAddressCallBack }) {
 	if (to?.abi === undefined) {
 		if (to === undefined) return <p class = 'paragraph' style = 'color: var(--subtitle-text-color)'>No ABI available</p>
 		return <p class = 'paragraph' style = 'color: var(--subtitle-text-color)'>No ABI available for&nbsp;
 			<SmallAddress addressBookEntry = { to } renameAddressCallBack = { renameAddressCallBack } />
 		</p>
-	} // We don't have support for parsing struct atm: https://github.com/DarkFlorist/TheInterceptor/issues/737
-	if (to === undefined) return <p class = 'paragraph' style = 'color: var(--subtitle-text-color)'>Unable to parse input data (it probably contains a struct)</p>
-	return <p class = 'paragraph' style = 'color: var(--subtitle-text-color)'>Unable to parse input data (it probably contains a struct) for&nbsp;
+	}
+	if (to === undefined) return <p class = 'paragraph' style = 'color: var(--subtitle-text-color)'>Unable to parse input data with the available ABI</p>
+	return <p class = 'paragraph' style = 'color: var(--subtitle-text-color)'>Unable to parse input data with the available ABI for&nbsp;
 		<SmallAddress addressBookEntry = { to } renameAddressCallBack = { renameAddressCallBack } />
 	</p>
 }

--- a/app/ts/components/subcomponents/solidityType.tsx
+++ b/app/ts/components/subcomponents/solidityType.tsx
@@ -1,6 +1,6 @@
 import type { JSX } from 'preact/jsx-runtime'
 import type { AddressBookEntry } from '../../types/addressBookTypes.js'
-import type { EnrichedGroupedSolidityType, PureGroupedSolidityType } from '../../types/solidityType.js'
+import type { EnrichedGroupedSolidityType, PureGroupedSolidityType, SolidityVariable } from '../../types/solidityType.js'
 import type { RenameAddressCallBack } from '../../types/user-interface-types.js'
 import { checksummedAddress, dataStringWith0xStart } from '../../utils/bigint.js'
 import { assertNever } from '../../utils/typescript.js'
@@ -10,6 +10,8 @@ import { insertBetweenElements } from './misc.js'
 import { resolveSignal, type SignalOrValue } from '../../utils/signals.js'
 
 const textStyle = 'text-overflow: ellipsis; overflow: hidden;'
+const tupleGroupStyle = 'display: inline-flex; flex-wrap: wrap; align-items: center; gap: 0 0.25em; max-width: 100%; min-width: 0;'
+const tupleFieldStyle = 'display: inline-flex; flex-wrap: wrap; align-items: center; gap: 0 0.125em; max-width: 100%; min-width: 0;'
 export const StringElement = ({ text }: { text: string }) => <p class = 'paragraph' style = { textStyle }>{ text }</p>
 
 const JsxArray = ( { array }: { array: JSX.Element[] }) => <>
@@ -17,6 +19,24 @@ const JsxArray = ( { array }: { array: JSX.Element[] }) => <>
 		{ insertBetweenElements(array, <p style = { textStyle } class = 'paragraph'>,&nbsp;</p>) }
 	<StringElement text = ']'/>
 </>
+
+const PureTupleComponent = ({ tuple }: { tuple: readonly SolidityVariable[] }) => <div style = { tupleGroupStyle }>
+	<StringElement text = '{'/>
+		{ insertBetweenElements(tuple.map((variable, index) => <div key = { index } style = { tupleFieldStyle }>
+			<p style = { textStyle } class = 'paragraph'> { `${ variable.paramName } =` }&nbsp;</p>
+			<PureSolidityTypeComponent valueType = { variable.typeValue } />
+		</div>), <p style = { textStyle } class = 'paragraph'>,&nbsp;</p>) }
+	<StringElement text = '}'/>
+</div>
+
+const TupleComponentWithAddressBook = ({ tuple, addressMetaData, renameAddressCallBack }: { tuple: readonly SolidityVariable[], addressMetaData: SignalOrValue<readonly AddressBookEntry[]>, renameAddressCallBack: RenameAddressCallBack }) => <div style = { tupleGroupStyle }>
+	<StringElement text = '{'/>
+		{ insertBetweenElements(tuple.map((variable, index) => <div key = { index } style = { tupleFieldStyle }>
+			<p style = { textStyle } class = 'paragraph'> { `${ variable.paramName } =` }&nbsp;</p>
+			<EnrichedSolidityTypeComponentWithAddressBook valueType = { variable.typeValue } addressMetaData = { addressMetaData } renameAddressCallBack = { renameAddressCallBack } />
+		</div>), <p style = { textStyle } class = 'paragraph'>,&nbsp;</p>) }
+	<StringElement text = '}'/>
+</div>
 
 function PureSolidityTypeComponent( { valueType }: { valueType: PureGroupedSolidityType }) {
 	switch(valueType.type) {
@@ -34,6 +54,8 @@ function PureSolidityTypeComponent( { valueType }: { valueType: PureGroupedSolid
 		case 'unsignedInteger[]':
 		case 'signedInteger[]': return <StringElement text = { `[${ valueType.value.toString() }]` } />
 		case 'string[]': return <StringElement text = { `[${ valueType.value.map((a) => `"${ a }"`) }]` } />
+		case 'tuple': return <PureTupleComponent tuple = { valueType.value } />
+		case 'tuple[]': return <JsxArray array = { valueType.value.map((tuple, index) => <PureTupleComponent key = { index } tuple = { tuple } />) } />
 		default: assertNever(valueType)
 	}
 }
@@ -42,6 +64,8 @@ export function EnrichedSolidityTypeComponentWithAddressBook({ valueType, addres
 	switch(valueType.type) {
 		case 'address': return <SmallAddress addressBookEntry = { getAddressBookEntryOrAFiller(resolveSignal(addressMetaData), valueType.value) } renameAddressCallBack = { renameAddressCallBack } />
 		case 'address[]': return <JsxArray array = { valueType.value.map((value) => <SmallAddress key = { value.toString() } addressBookEntry = { getAddressBookEntryOrAFiller(resolveSignal(addressMetaData), value) } renameAddressCallBack = { renameAddressCallBack } />) }/>
+		case 'tuple': return <TupleComponentWithAddressBook tuple = { valueType.value } addressMetaData = { addressMetaData } renameAddressCallBack = { renameAddressCallBack } />
+		case 'tuple[]': return <JsxArray array = { valueType.value.map((tuple, index) => <TupleComponentWithAddressBook key = { index } tuple = { tuple } addressMetaData = { addressMetaData } renameAddressCallBack = { renameAddressCallBack } />) } />
 		default: return <PureSolidityTypeComponent valueType = { valueType } />
 	}
 }

--- a/app/ts/simulation/parsing.ts
+++ b/app/ts/simulation/parsing.ts
@@ -1,13 +1,12 @@
 import type { EthereumClientService } from './services/EthereumClientService.js'
-import { type EthereumAddress, EthereumData, type EthereumQuantity } from '../types/wire-types.js'
+import type { EthereumAddress, EthereumData, EthereumQuantity } from '../types/wire-types.js'
 import { bytes32String } from '../utils/bigint.js'
 import { APPROVAL_LOG, DEPOSIT_LOG, ENS_ADDRESS_CHANGED, ENS_ADDR_CHANGED, ENS_CONTENT_HASH_CHANGED, ENS_ETHEREUM_NAME_SERVICE, ENS_ETH_REGISTRAR_CONTROLLER, ENS_EXPIRY_EXTENDED, ENS_FUSES_SET, ENS_NAME_CHANGED, ENS_CONTROLLER_NAME_REGISTERED, ENS_BASE_REGISTRAR_NAME_RENEWED, ENS_NAME_UNWRAPPED, ENS_NEW_OWNER, ENS_NEW_RESOLVER, ENS_NEW_TTL, ENS_PUBLIC_RESOLVER, ENS_PUBLIC_RESOLVER_2, ENS_CONTROLLER_NAME_RENEWED, ENS_REGISTRY_WITH_FALLBACK, ENS_REVERSE_CLAIMED, ENS_REVERSE_REGISTRAR, ENS_TEXT_CHANGED, ENS_TEXT_CHANGED_KEY_VALUE, ENS_TOKEN_WRAPPER, ENS_TRANSFER, ERC1155_TRANSFERBATCH_LOG, ERC1155_TRANSFERSINGLE_LOG, ERC721_APPROVAL_FOR_ALL_LOG, TRANSFER_LOG, WITHDRAWAL_LOG, ENS_BASE_REGISTRAR_NAME_REGISTERED, ENS_NAME_WRAPPED } from '../utils/constants.js'
 import { handleApprovalLog, handleDepositLog, handleERC1155TransferBatch, handleERC1155TransferSingle, handleERC20TransferLog, handleEnsAddrChanged, handleEnsAddressChanged, handleEnsContentHashChanged, handleEnsExpiryExtended, handleEnsFusesSet, handleEnsNameChanged, handleEnsNameUnWrapped, handleEnsNewOwner, handleEnsNewResolver, handleEnsNewTtl, handleEnsControllerNameRenewed, handleEnsReverseClaimed, handleEnsTextChanged, handleEnsTextChangedKeyValue, handleEnsTransfer, handleErc721ApprovalForAllLog, handleControllerNameRegistered, handleBaseRegistrarNameRenewed, handleWithdrawalLog, handleBaseRegistrarNameRegistered, handleNameWrapped } from './logHandlers.js'
 import type { AddressBookEntryCategory } from '../types/addressBookTypes.js'
 import { parseEventIfPossible, parseTransactionInputIfPossible } from './services/SimulationModeEthereumClientService.js'
-import { getAbi, extractFunctionArgumentTypes, removeTextBetweenBrackets } from '../utils/abi.js'
-import { SolidityType } from '../types/solidityType.js'
-import { parseSolidityValueByTypePure } from '../utils/solidityTypes.js'
+import { getAbi } from '../utils/abi.js'
+import { parseAbiParametersToSolidityVariables } from '../utils/solidityTypes.js'
 import { identifyAddress } from '../background/metadataUtils.js'
 import { assertNever } from '../utils/typescript.js'
 import type { EthereumEvent } from '../types/ethSimulate-types.js'
@@ -95,23 +94,9 @@ export const parseInputData = async (transaction: { to: EthereumAddress | undefi
 	if (parsed === undefined) return nonParsed
 	if (parsed.fragment.type !== 'function') return nonParsed
 	const functionFragment = parsed.fragment
-	const argTypes = extractFunctionArgumentTypes(parsed.signature)
-	if (argTypes === undefined) return nonParsed
-	if (parsed.args.length !== argTypes.length) return nonParsed
+	if (parsed.args.length !== functionFragment.inputs.length) return nonParsed
 	try {
-		const valuesWithTypes = parsed.args.map((value, index) => {
-			const solidityType = argTypes[index]
-			const paramName = functionFragment.inputs[index]?.name
-			if (paramName === undefined) throw new Error('missing parameter name')
-			if (solidityType === undefined) throw new Error(`unknown solidity type: ${ solidityType }`)
-			const isArray = solidityType.includes('[')
-			const verifiedSolidityType = SolidityType.safeParse(removeTextBetweenBrackets(solidityType))
-			if (verifiedSolidityType.success === false) throw new Error(`unknown solidity type: ${ solidityType }`)
-			if (typeof value === 'object' && value !== null && 'hash' in value) {
-				return { paramName, typeValue: { type: 'fixedBytes' as const, value: EthereumData.parse(value.hash) } }
-			}
-			return { paramName, typeValue: parseSolidityValueByTypePure(verifiedSolidityType.value, value, isArray) }
-		})
+		const valuesWithTypes = parseAbiParametersToSolidityVariables(functionFragment.inputs, parsed.args)
 		return {
 			input: transaction.input,
 			type: 'Parsed' as const,
@@ -138,22 +123,8 @@ export const parseEvents = async (events: readonly EthereumEvent[], ethereumClie
 		if (parsed === undefined) return nonParsed
 		if (parsed.fragment.type !== 'event') return nonParsed
 		const eventFragment = parsed.fragment
-		const argTypes = extractFunctionArgumentTypes(parsed.signature)
-		if (argTypes === undefined) return nonParsed
-		if (parsed.args.length !== argTypes.length) return nonParsed
-		const valuesWithTypes = parsed.args.map((value, index) => {
-			const solidityType = argTypes[index]
-			const paramName = eventFragment.inputs[index]?.name
-			if (paramName === undefined) throw new Error('missing parameter name')
-			if (solidityType === undefined) throw new Error(`unknown solidity type: ${ solidityType }`)
-			const isArray = solidityType.includes('[')
-			const verifiedSolidityType = SolidityType.safeParse(removeTextBetweenBrackets(solidityType))
-			if (verifiedSolidityType.success === false) throw new Error(`unknown solidity type: ${ solidityType }`)
-			if (typeof value === 'object' && value !== null && 'hash' in value) {
-				return { paramName, typeValue: { type: 'fixedBytes' as const, value: EthereumData.parse(value.hash) } }
-			}
-			return { paramName, typeValue: parseSolidityValueByTypePure(verifiedSolidityType.value, value, isArray) }
-		})
+		if (parsed.args.length !== eventFragment.inputs.length) return nonParsed
+		const valuesWithTypes = parseAbiParametersToSolidityVariables(eventFragment.inputs, parsed.args)
 		return {
 			...event,
 			isParsed: 'Parsed' as const,

--- a/app/ts/types/EnrichedEthereumData.ts
+++ b/app/ts/types/EnrichedEthereumData.ts
@@ -1,14 +1,11 @@
 import * as funtypes from 'funtypes'
 import { EthereumAddress, EthereumBytes32, EthereumData, EthereumInput, EthereumQuantity } from './wire-types.js'
-import { PureGroupedSolidityType } from './solidityType.js'
+import { SolidityVariable as SolidityVariableRuntime } from './solidityType.js'
 import { AddressBookEntry, Erc1155Entry, Erc20TokenEntry, Erc721Entry } from './addressBookTypes.js'
 import { MaybeENSLabelHash, MaybeENSNameHash } from './ens.js'
 
-export type SolidityVariable = funtypes.Static<typeof SolidityVariable>
-export const SolidityVariable = funtypes.ReadonlyObject({
-	typeValue: PureGroupedSolidityType,
-	paramName: funtypes.String
-})
+export type SolidityVariable = import('./solidityType.js').SolidityVariable
+export const SolidityVariable = SolidityVariableRuntime
 
 export type EnrichedEthereumInputData = funtypes.Static<typeof EnrichedEthereumInputData>
 export const EnrichedEthereumInputData = funtypes.Union(
@@ -20,7 +17,7 @@ export const EnrichedEthereumInputData = funtypes.Union(
 		input: EthereumInput,
 		type: funtypes.Literal('Parsed'),
 		name: funtypes.String, // eg. 'Transfer'
-		args: funtypes.ReadonlyArray(SolidityVariable), // TODO: add support for structs (abiV2)
+		args: funtypes.ReadonlyArray(SolidityVariableRuntime),
 	}),
 )
 
@@ -30,7 +27,7 @@ export const ParsedEvent = funtypes.ReadonlyObject({
 	isParsed: funtypes.Literal('Parsed'),
 	name: funtypes.String, // eg. 'Transfer'
 	signature: funtypes.String, // eg. 'Transfer(address,address,uint256)'
-	args: funtypes.ReadonlyArray(SolidityVariable), // TODO: add support for structs (abiV2)
+	args: funtypes.ReadonlyArray(SolidityVariableRuntime),
 	address: EthereumAddress,
 	loggersAddressBookEntry: AddressBookEntry,
 	data: EthereumInput,

--- a/app/ts/types/solidityType.ts
+++ b/app/ts/types/solidityType.ts
@@ -16,8 +16,8 @@ const SignedBigIntParser: funtypes.ParsedValue<funtypes.String, bigint>['config'
 export const SignedBigInt = funtypes.String.withParser(SignedBigIntParser)
 export type SignedBigInt = funtypes.Static<typeof SignedBigInt>
 
-export type PureGroupedSolidityType = funtypes.Static<typeof PureGroupedSolidityType>
-export const PureGroupedSolidityType = funtypes.Union(
+export type PureFlatGroupedSolidityType = funtypes.Static<typeof PureFlatGroupedSolidityType>
+const PureFlatGroupedSolidityType = funtypes.Union(
 	funtypes.ReadonlyObject({ type: funtypes.Literal('signedInteger'), value: SignedBigInt }),
 	funtypes.ReadonlyObject({ type: funtypes.Literal('unsignedInteger'), value: EthereumQuantity }),
 	funtypes.ReadonlyObject({ type: funtypes.Literal('bytes'), value: EthereumData }),
@@ -34,6 +34,26 @@ export const PureGroupedSolidityType = funtypes.Union(
 	funtypes.ReadonlyObject({ type: funtypes.Literal('string[]'), value: funtypes.ReadonlyArray(funtypes.String) }),
 	funtypes.ReadonlyObject({ type: funtypes.Literal('address[]'), value: funtypes.ReadonlyArray(EthereumAddress) }),
 )
+
+export type SolidityVariable = {
+	readonly typeValue: PureGroupedSolidityType
+	readonly paramName: string
+}
+
+export type PureGroupedSolidityType = PureFlatGroupedSolidityType
+	| { readonly type: 'tuple', readonly value: readonly SolidityVariable[] }
+	| { readonly type: 'tuple[]', readonly value: readonly (readonly SolidityVariable[])[] }
+
+export const PureGroupedSolidityType: funtypes.Runtype<PureGroupedSolidityType> = funtypes.Lazy(() => funtypes.Union(
+	PureFlatGroupedSolidityType,
+	funtypes.ReadonlyObject({ type: funtypes.Literal('tuple'), value: funtypes.ReadonlyArray(SolidityVariable) }),
+	funtypes.ReadonlyObject({ type: funtypes.Literal('tuple[]'), value: funtypes.ReadonlyArray(funtypes.ReadonlyArray(SolidityVariable)) }),
+))
+
+export const SolidityVariable: funtypes.Runtype<SolidityVariable> = funtypes.Lazy(() => funtypes.ReadonlyObject({
+	typeValue: PureGroupedSolidityType,
+	paramName: funtypes.String
+}))
 
 export type EnrichedGroupedSolidityType = funtypes.Static<typeof EnrichedGroupedSolidityType>
 export const EnrichedGroupedSolidityType = funtypes.Union(

--- a/app/ts/utils/solidityTypes.ts
+++ b/app/ts/utils/solidityTypes.ts
@@ -3,8 +3,9 @@ import { EthereumAddress, EthereumData, EthereumQuantity, NonHexBigInt } from '.
 import * as funtypes from 'funtypes'
 import { identifyAddress } from '../background/metadataUtils.js'
 import type { EthereumClientService } from '../simulation/services/EthereumClientService.js'
-import { type EnrichedGroupedSolidityType, type PureGroupedSolidityType, SignedBigInt, type SolidityType } from '../types/solidityType.js'
+import { type EnrichedGroupedSolidityType, type PureFlatGroupedSolidityType, type PureGroupedSolidityType, SignedBigInt, SolidityType, type SolidityVariable } from '../types/solidityType.js'
 import { promiseAllMapAbortSafe } from './requests.js'
+import type { AbiParameter } from 'viem'
 
 function getSolidityTypeCategory(type: SolidityType) {
 	switch(type) {
@@ -125,8 +126,88 @@ export async function parseSolidityValueByTypeEnriched(ethereumClientService: Et
 
 const SignedIntegerType = funtypes.Union(NonHexBigInt, funtypes.Number, funtypes.BigInt, SignedBigInt)
 const UnsignedIntegerType = funtypes.Union(NonHexBigInt, funtypes.Number, funtypes.BigInt, EthereumQuantity).withConstraint((number) => BigInt(number) >= 0n)
+const removeSingleArraySuffix = (type: string) => type.replace(/\[[^\]]*\]$/, '')
 
-export function parseSolidityValueByTypePure(type: SolidityType, value: unknown, isArray: boolean): PureGroupedSolidityType {
+const hasTupleComponents = (parameter: AbiParameter): parameter is AbiParameter & { readonly components: readonly AbiParameter[] } => {
+	return 'components' in parameter
+}
+
+const hasHashValue = (value: unknown): value is { readonly hash: unknown } => {
+	return typeof value === 'object' && value !== null && 'hash' in value
+}
+
+const isIndexedTopicHash = (value: unknown): value is string => {
+	return typeof value === 'string' && /^0x[a-fA-F0-9]{64}$/.test(value)
+}
+
+const parseIndexedHash = (value: unknown): PureFlatGroupedSolidityType | undefined => {
+	if (hasHashValue(value)) return { type: 'fixedBytes', value: EthereumData.parse(value.hash) }
+	if (isIndexedTopicHash(value)) return { type: 'fixedBytes', value: EthereumData.parse(value) }
+	return undefined
+}
+
+const isIndexedAbiParameter = (parameter: AbiParameter): parameter is AbiParameter & { readonly indexed: true } => {
+	return 'indexed' in parameter && parameter.indexed === true
+}
+
+const getAbiParameterName = (parameter: AbiParameter, fallbackName: string | undefined) => {
+	if (parameter.name !== undefined && parameter.name !== '') return parameter.name
+	if (fallbackName !== undefined) return fallbackName
+	if (parameter.name === '') return ''
+	throw new Error('missing parameter name')
+}
+
+const getTupleComponentValue = (tupleValue: unknown, component: AbiParameter, index: number) => {
+	if (Array.isArray(tupleValue)) return tupleValue[index]
+	if (typeof tupleValue !== 'object' || tupleValue === null) throw new Error('tuple value is not an object or array')
+	if (component.name !== undefined && component.name !== '') {
+		const namedValue = Reflect.get(tupleValue, component.name)
+		if (namedValue !== undefined) return namedValue
+	}
+	return Reflect.get(tupleValue, index)
+}
+
+const parseAbiParameterToSolidityVariable = (parameter: AbiParameter, value: unknown, fallbackName: string | undefined): SolidityVariable => {
+	return {
+		paramName: getAbiParameterName(parameter, fallbackName),
+		typeValue: parseAbiParameterToSolidityValue(parameter, value),
+	}
+}
+
+const parseTupleComponents = (components: readonly AbiParameter[], value: unknown) => {
+	return components.map((component, index) => parseAbiParameterToSolidityVariable(component, getTupleComponentValue(value, component, index), `field${ index }`))
+}
+
+const parseTupleArray = (components: readonly AbiParameter[], value: unknown) => {
+	if (!Array.isArray(value)) throw new Error('tuple array value is not an array')
+	return value.map((tupleValue) => parseTupleComponents(components, tupleValue))
+}
+
+export function parseAbiParameterToSolidityValue(parameter: AbiParameter, value: unknown): PureGroupedSolidityType {
+	const scalarAbiType = removeSingleArraySuffix(parameter.type)
+	const isArray = scalarAbiType !== parameter.type
+	const indexedHash = isIndexedAbiParameter(parameter) ? parseIndexedHash(value) : undefined
+	if (indexedHash !== undefined) return indexedHash
+	if (scalarAbiType === 'tuple') {
+		if (!hasTupleComponents(parameter)) throw new Error(`missing tuple components for ${ parameter.type }`)
+		if (isArray) return { type: 'tuple[]', value: parseTupleArray(parameter.components, value) }
+		return { type: 'tuple', value: parseTupleComponents(parameter.components, value) }
+	}
+	const verifiedSolidityType = SolidityType.safeParse(scalarAbiType)
+	if (verifiedSolidityType.success === false) throw new Error(`unknown solidity type: ${ parameter.type }`)
+	return parseSolidityValueByTypePure(verifiedSolidityType.value, value, isArray)
+}
+
+export function parseAbiParametersToSolidityVariables(parameters: readonly AbiParameter[], values: readonly unknown[]) {
+	if (values.length !== parameters.length) throw new Error('ABI parameter/value length mismatch')
+	return values.map((value, index) => {
+		const parameter = parameters[index]
+		if (parameter === undefined) throw new Error('missing ABI parameter')
+		return parseAbiParameterToSolidityVariable(parameter, value, undefined)
+	})
+}
+
+export function parseSolidityValueByTypePure(type: SolidityType, value: unknown, isArray: boolean): PureFlatGroupedSolidityType {
 	const categorized = getSolidityTypeCategory(type)
 	if (isArray) {
 		switch (categorized) {

--- a/test/tests/metadataAddressCoverage.test.ts
+++ b/test/tests/metadataAddressCoverage.test.ts
@@ -14,6 +14,8 @@ const OPERATOR_ADDRESS = 0x4000000000000000000000000000000000000004n
 const TX_FROM_ADDRESS = 0x5000000000000000000000000000000000000005n
 const TX_TO_ADDRESS = 0x6000000000000000000000000000000000000006n
 const INPUT_ADDRESS = 0x7000000000000000000000000000000000000007n
+const STRUCT_OWNER_ADDRESS = 0x8000000000000000000000000000000000000008n
+const STRUCT_TOKEN_ADDRESS = 0x9000000000000000000000000000000000000009n
 
 const toAddressSet = (addresses: readonly bigint[]) => new Set(addresses.map((address) => addressString(address)))
 const ZERO_BLOCK_TIME_MANIPULATION = { type: 'AddToTimestamp', deltaToAdd: 0n, deltaUnit: 'Seconds' } satisfies SimulationStateInput[number]['blockTimeManipulation']
@@ -186,6 +188,46 @@ describe('getAddressesToIdentifyForVisualiserFromTransactions', () => {
 		assert.equal(addressSet.has(addressString(TO_ADDRESS)), true)
 		assert.equal(addressSet.has(addressString(TOKEN_ADDRESS)), true)
 		assert.equal(addressSet.has(addressString(OPERATOR_ADDRESS)), true)
+		assertCommonAddresses(addresses)
+	})
+
+	test('covers addresses nested in tuple parsed args', () => {
+		const addresses = getAddressesForEvent({
+			type: 'Parsed',
+			address: TOKEN_ADDRESS,
+			isParsed: 'Parsed',
+			name: 'OrderFilled',
+			signature: 'OrderFilled((address,uint256),(address,uint256)[])',
+			args: [
+				{
+					paramName: 'order',
+					typeValue: {
+						type: 'tuple',
+						value: [
+							toAddressArg('owner', STRUCT_OWNER_ADDRESS),
+							{ paramName: 'amount', typeValue: { type: 'unsignedInteger', value: 1n } },
+						],
+					},
+				},
+				{
+					paramName: 'fills',
+					typeValue: {
+						type: 'tuple[]',
+						value: [[
+							toAddressArg('token', STRUCT_TOKEN_ADDRESS),
+							{ paramName: 'amount', typeValue: { type: 'unsignedInteger', value: 2n } },
+						]],
+					},
+				},
+			],
+			loggersAddressBookEntry: { type: 'contract', name: 'Exchange', address: TOKEN_ADDRESS, entrySource: 'User' },
+			data: new Uint8Array(),
+			topics: [],
+		})
+		const addressSet = toAddressSet(addresses)
+		assert.equal(addressSet.has(addressString(STRUCT_OWNER_ADDRESS)), true)
+		assert.equal(addressSet.has(addressString(STRUCT_TOKEN_ADDRESS)), true)
+		assert.equal(addressSet.has(addressString(TOKEN_ADDRESS)), true)
 		assertCommonAddresses(addresses)
 	})
 })

--- a/test/tests/solidityTypeRendering.test.tsx
+++ b/test/tests/solidityTypeRendering.test.tsx
@@ -1,0 +1,146 @@
+import * as assert from 'assert'
+import { h, render } from 'preact'
+import { act } from 'preact/test-utils'
+import { describe, test } from 'bun:test'
+import { NoParsedAvailable } from '../../app/ts/components/subcomponents/ParsedInputData.js'
+import { EnrichedSolidityTypeComponentWithAddressBook } from '../../app/ts/components/subcomponents/solidityType.js'
+import type { AddressBookEntry } from '../../app/ts/types/addressBookTypes.js'
+import type { PureGroupedSolidityType } from '../../app/ts/types/solidityType.js'
+import { installDomMock } from './domMock.js'
+
+type RenderTreeNode = {
+	readonly childNodes?: readonly RenderTreeNode[]
+	readonly style?: { readonly cssText?: string }
+	readonly textContent?: string
+}
+
+const SEAPORT_TOKEN_ADDRESS = 0x6000000000000000000000000000000000000006n
+const CONSIDERATION_RECIPIENT_ADDRESS = 0x7000000000000000000000000000000000000007n
+
+const noopRename = () => undefined
+
+const normalizeRenderedText = (text: string | undefined) => (text ?? '').replace(/\s+/gu, ' ').trim()
+
+const collectNodesWithStyle = (node: RenderTreeNode, styleText: string): readonly RenderTreeNode[] => {
+	const matches = node.style?.cssText?.includes(styleText) === true ? [node] : []
+	for (const child of node.childNodes ?? []) {
+		matches.push(...collectNodesWithStyle(child, styleText))
+	}
+	return matches
+}
+
+const addressMetaData = [
+	{
+		type: 'ERC20',
+		name: 'Seaport Token',
+		symbol: 'SEA',
+		decimals: 18n,
+		address: SEAPORT_TOKEN_ADDRESS,
+		entrySource: 'User',
+	},
+	{
+		type: 'contact',
+		name: 'Fee Recipient',
+		address: CONSIDERATION_RECIPIENT_ADDRESS,
+		entrySource: 'User',
+	},
+] satisfies readonly AddressBookEntry[]
+
+const web3jAbiV2Tuple = {
+	type: 'tuple',
+	value: [
+		{ paramName: 'id', typeValue: { type: 'string', value: 'foo-id' } },
+		{ paramName: 'name', typeValue: { type: 'string', value: 'Example Foo' } },
+	],
+} satisfies PureGroupedSolidityType
+
+const seaportTupleArray = {
+	type: 'tuple[]',
+	value: [
+		[
+			{ paramName: 'itemType', typeValue: { type: 'unsignedInteger', value: 2n } },
+			{ paramName: 'token', typeValue: { type: 'address', value: SEAPORT_TOKEN_ADDRESS } },
+			{ paramName: 'identifier', typeValue: { type: 'unsignedInteger', value: 123n } },
+			{ paramName: 'amount', typeValue: { type: 'unsignedInteger', value: 1n } },
+		],
+		[
+			{ paramName: 'itemType', typeValue: { type: 'unsignedInteger', value: 0n } },
+			{ paramName: 'token', typeValue: { type: 'address', value: 0n } },
+			{ paramName: 'identifier', typeValue: { type: 'unsignedInteger', value: 0n } },
+			{ paramName: 'amount', typeValue: { type: 'unsignedInteger', value: 100n } },
+			{ paramName: 'recipient', typeValue: { type: 'address', value: CONSIDERATION_RECIPIENT_ADDRESS } },
+		],
+	],
+} satisfies PureGroupedSolidityType
+
+describe('Solidity type rendering', () => {
+	test('renders generic unavailable input parser copy after tuple support', async () => {
+		const dom = installDomMock()
+		try {
+			await act(() => {
+				render(h(NoParsedAvailable, {
+					to: {
+						type: 'contract',
+						name: 'Tuple Input Contract',
+						address: 0x9000000000000000000000000000000000000009n,
+						entrySource: 'User',
+						abi: '[]',
+					},
+					renameAddressCallBack: noopRename,
+				}), dom.document.body)
+			})
+
+			const renderedText = normalizeRenderedText(dom.document.body.textContent)
+			assert.equal(renderedText.includes('Unable to parse input data with the available ABI for Tuple Input Contract'), true)
+			assert.equal(renderedText.includes('struct'), false)
+		} finally {
+			dom.restore()
+		}
+	})
+
+	test('renders Web3j ABIv2 struct fields with braces and labels', async () => {
+		const dom = installDomMock()
+		try {
+			await act(() => {
+				render(h(EnrichedSolidityTypeComponentWithAddressBook, {
+					valueType: web3jAbiV2Tuple,
+					addressMetaData: [],
+					renameAddressCallBack: noopRename,
+				}), dom.document.body)
+			})
+
+			const renderedText = normalizeRenderedText(dom.document.body.textContent)
+			assert.equal(renderedText, '{ id = "foo-id", name = "Example Foo"}')
+			assert.equal(collectNodesWithStyle(dom.document.body, 'gap: 0 0.25em').length, 1)
+			assert.equal(collectNodesWithStyle(dom.document.body, 'gap: 0 0.125em').length, 2)
+		} finally {
+			dom.restore()
+		}
+	})
+
+	test('renders Seaport tuple arrays with grouped struct fields and address labels', async () => {
+		const dom = installDomMock()
+		try {
+			await act(() => {
+				render(h(EnrichedSolidityTypeComponentWithAddressBook, {
+					valueType: seaportTupleArray,
+					addressMetaData,
+					renameAddressCallBack: noopRename,
+				}), dom.document.body)
+			})
+
+			const renderedText = normalizeRenderedText(dom.document.body.textContent)
+			assert.equal(renderedText.includes('[{ itemType = 2'), true)
+			assert.equal(renderedText.includes('token = Seaport Token'), true)
+			assert.equal(renderedText.includes('identifier = 123'), true)
+			assert.equal(renderedText.includes('amount = 1}'), true)
+			assert.equal(renderedText.includes('{ itemType = 0'), true)
+			assert.equal(renderedText.includes('amount = 100'), true)
+			assert.equal(renderedText.includes('recipient = Fee Recipient'), true)
+			assert.equal(collectNodesWithStyle(dom.document.body, 'gap: 0 0.25em').length, 2)
+			assert.equal(collectNodesWithStyle(dom.document.body, 'gap: 0 0.125em').length, 9)
+		} finally {
+			dom.restore()
+		}
+	})
+})

--- a/test/tests/solidityTypes.test.ts
+++ b/test/tests/solidityTypes.test.ts
@@ -1,0 +1,435 @@
+import * as assert from 'assert'
+import { describe, test } from 'bun:test'
+import type { Abi, AbiEvent, AbiParameter } from 'viem'
+import { parseAbiParametersToSolidityVariables } from '../../app/ts/utils/solidityTypes.js'
+import { decodeEventLoose } from '../../app/ts/utils/abiRuntime.js'
+import { encodeFunctionCall } from '../../app/ts/utils/abiRuntime.js'
+import { encodeAbiParameters, formatAbiItem, toEventSelector } from '../../app/ts/utils/viem.js'
+import { dataStringWith0xStart } from '../../app/ts/utils/bigint.js'
+import { parseInputData } from '../../app/ts/simulation/parsing.js'
+import { EthereumClientService } from '../../app/ts/simulation/services/EthereumClientService.js'
+import type { IEthereumJSONRpcRequestHandler } from '../../app/ts/simulation/services/EthereumJSONRpcRequestHandler.js'
+import { EthereumData } from '../../app/ts/types/wire-types.js'
+import type { RpcEntry } from '../../app/ts/types/rpc.js'
+
+const OWNER_ADDRESS = 0x1000000000000000000000000000000000000001n
+const TOKEN_ADDRESS = 0x2000000000000000000000000000000000000002n
+const INDEXED_TOPIC_HASH = '0x1234567890abcdef1234567890abcdef1234567890abcdef1234567890abcdef'
+const OFFERER_ADDRESS = '0x3000000000000000000000000000000000000003'
+const ZONE_ADDRESS = '0x4000000000000000000000000000000000000004'
+const RECIPIENT_ADDRESS = '0x5000000000000000000000000000000000000005'
+const SEAPORT_TOKEN_ADDRESS = '0x6000000000000000000000000000000000000006'
+const CONSIDERATION_RECIPIENT_ADDRESS = '0x7000000000000000000000000000000000000007'
+const WEB3J_EVENT_ADDRESS = '0x8000000000000000000000000000000000000008'
+const TUPLE_INPUT_CONTRACT_ADDRESS = 0x9000000000000000000000000000000000000009n
+const TUPLE_INPUT_CONTRACT_ADDRESS_STRING = '0x9000000000000000000000000000000000000009'
+const TEST_RPC_URL = 'https://example.invalid'
+
+const tupleAbiParameters = [
+	{
+		name: 'order',
+		type: 'tuple',
+		components: [
+			{ name: 'owner', type: 'address' },
+			{ name: 'amount', type: 'uint256' },
+		],
+	},
+	{
+		name: 'fills',
+		type: 'tuple[]',
+		components: [
+			{ name: 'token', type: 'address' },
+			{ name: 'amount', type: 'uint256' },
+		],
+	},
+] satisfies readonly AbiParameter[]
+
+const bytes32LikeBytesAbiParameters = [{
+	name: 'payload',
+	type: 'bytes',
+}] satisfies readonly AbiParameter[]
+
+const tupleWithHashFieldAbiParameters = [{
+	name: 'proof',
+	type: 'tuple',
+	components: [
+		{ name: 'hash', type: 'bytes32' },
+	],
+}] satisfies readonly AbiParameter[]
+
+const tupleInputFunctionAbi = [
+	{
+		type: 'function',
+		name: 'fulfill',
+		stateMutability: 'nonpayable',
+		inputs: [
+			{
+				name: 'order',
+				type: 'tuple',
+				components: [
+					{ name: 'owner', type: 'address' },
+					{ name: 'amount', type: 'uint256' },
+				],
+			},
+			{
+				name: 'fills',
+				type: 'tuple[]',
+				components: [
+					{ name: 'token', type: 'address' },
+					{ name: 'amount', type: 'uint256' },
+				],
+			},
+		],
+		outputs: [],
+	},
+] satisfies Abi
+
+const web3jAbiV2ExampleEvent = {
+	type: 'event',
+	name: 'Event',
+	inputs: [
+		{ name: '_address', type: 'address', indexed: true },
+		{
+			name: '_foo',
+			type: 'tuple',
+			components: [
+				{ name: 'id', type: 'string' },
+				{ name: 'name', type: 'string' },
+			],
+		},
+		{
+			name: '_bar',
+			type: 'tuple',
+			components: [
+				{ name: 'id', type: 'uint256' },
+				{ name: 'data', type: 'string' },
+			],
+		},
+	],
+} satisfies AbiEvent
+
+const seaportOrderFulfilledEvent = {
+	type: 'event',
+	name: 'OrderFulfilled',
+	inputs: [
+		{ name: 'orderHash', type: 'bytes32' },
+		{ name: 'offerer', type: 'address' },
+		{ name: 'zone', type: 'address' },
+		{ name: 'recipient', type: 'address' },
+		{
+			name: 'offer',
+			type: 'tuple[]',
+			components: [
+				{ name: 'itemType', type: 'uint8' },
+				{ name: 'token', type: 'address' },
+				{ name: 'identifier', type: 'uint256' },
+				{ name: 'amount', type: 'uint256' },
+			],
+		},
+		{
+			name: 'consideration',
+			type: 'tuple[]',
+			components: [
+				{ name: 'itemType', type: 'uint8' },
+				{ name: 'token', type: 'address' },
+				{ name: 'identifier', type: 'uint256' },
+				{ name: 'amount', type: 'uint256' },
+				{ name: 'recipient', type: 'address' },
+			],
+		},
+	],
+} satisfies AbiEvent
+
+const indexedTupleEvent = {
+	type: 'event',
+	name: 'Order',
+	inputs: [{
+		name: 'order',
+		type: 'tuple',
+		indexed: true,
+		components: [
+			{ name: 'owner', type: 'address' },
+			{ name: 'amount', type: 'uint256' },
+		],
+	}],
+} satisfies AbiEvent
+
+const indexedTupleArrayEvent = {
+	type: 'event',
+	name: 'Orders',
+	inputs: [{
+		name: 'orders',
+		type: 'tuple[]',
+		indexed: true,
+		components: [
+			{ name: 'owner', type: 'address' },
+			{ name: 'amount', type: 'uint256' },
+		],
+	}],
+} satisfies AbiEvent
+
+const toIndexedAddressTopic = (address: string) => `0x${ address.slice(2).padStart(64, '0') }`
+const toAddressHex = (address: bigint) => `0x${ address.toString(16).padStart(40, '0') }`
+
+const installBrowserStorageMock = (storageState: Record<string, unknown>) => {
+	const previousBrowser = globalThis.browser
+	Object.defineProperty(globalThis, 'browser', {
+		value: {
+			storage: {
+				local: {
+					async get(keys?: string | string[] | Record<string, unknown> | null) {
+						if (keys === undefined || keys === null) return { ...storageState }
+						if (Array.isArray(keys)) return Object.fromEntries(keys.map((key) => [key, storageState[key]]))
+						if (typeof keys === 'string') return { [keys]: storageState[keys] }
+						return Object.fromEntries(Object.entries(keys).map(([key, defaultValue]) => [key, key in storageState ? storageState[key] : defaultValue]))
+					},
+					async set(items: Record<string, unknown>) {
+						Object.assign(storageState, items)
+					},
+					async remove(keys: string | string[]) {
+						for (const key of Array.isArray(keys) ? keys : [keys]) delete storageState[key]
+					},
+				},
+			},
+		},
+		configurable: true,
+		writable: true,
+	})
+	return () => {
+		Object.defineProperty(globalThis, 'browser', { value: previousBrowser, configurable: true, writable: true })
+	}
+}
+
+const testRpcEntry = {
+	name: 'Ethereum',
+	chainId: 1n,
+	httpsRpc: TEST_RPC_URL,
+	currencyName: 'Ether',
+	currencyTicker: 'ETH',
+	primary: true,
+	minimized: false,
+} satisfies RpcEntry
+
+const createTestEthereumClientService = () => {
+	const requestHandler = {
+		rpcUrl: TEST_RPC_URL,
+		clearCache: () => undefined,
+		getChainId: async () => 1n,
+		jsonRpcRequest: async (rpcRequest: { readonly method: string }) => {
+			throw new Error(`Unexpected RPC request during parseInputData test: ${ rpcRequest.method }`)
+		},
+	} satisfies IEthereumJSONRpcRequestHandler
+	return new EthereumClientService(requestHandler, async () => undefined, async () => undefined, testRpcEntry)
+}
+
+const encodeEventData = (event: AbiEvent, values: readonly unknown[]) => {
+	const unindexedInputs = event.inputs.filter((input) => input.indexed !== true)
+	const unindexedValues = values.filter((_value, index) => event.inputs[index]?.indexed !== true)
+	return encodeAbiParameters(unindexedInputs, unindexedValues)
+}
+
+const parseDecodedEvent = (event: AbiEvent, values: readonly unknown[], indexedTopics: readonly string[]) => {
+	const selector = toEventSelector(formatAbiItem(event))
+	const decoded = decodeEventLoose([event], { data: encodeEventData(event, values), topics: [selector, ...indexedTopics] })
+	if (decoded === undefined) throw new Error('failed to decode event')
+	return parseAbiParametersToSolidityVariables(event.inputs, decoded.args)
+}
+
+const parseDecodedIndexedEvent = (event: AbiEvent) => {
+	const selector = toEventSelector(formatAbiItem(event))
+	const decoded = decodeEventLoose([event], { data: '0x', topics: [selector, INDEXED_TOPIC_HASH] })
+	if (decoded === undefined) throw new Error('failed to decode indexed tuple event')
+	return parseAbiParametersToSolidityVariables(event.inputs, decoded.args)
+}
+
+const assertIndexedTupleHash = (event: AbiEvent, paramName: string) => {
+	const variables = parseDecodedIndexedEvent(event)
+	const variable = variables[0]
+	assert.equal(variable?.paramName, paramName)
+	assert.equal(variable?.typeValue.type, 'fixedBytes')
+	if (variable?.typeValue.type !== 'fixedBytes') throw new Error('expected indexed tuple to parse as fixedBytes')
+	assert.equal(dataStringWith0xStart(variable.typeValue.value), INDEXED_TOPIC_HASH)
+}
+
+describe('parseAbiParametersToSolidityVariables', () => {
+	test('parses tuple and tuple array ABI parameters recursively', () => {
+		const variables = parseAbiParametersToSolidityVariables(tupleAbiParameters, [
+			{
+				owner: '0x1000000000000000000000000000000000000001',
+				amount: 5n,
+			},
+			[
+				['0x2000000000000000000000000000000000000002', 7n],
+			],
+		])
+
+		assert.deepEqual(variables, [
+			{
+				paramName: 'order',
+				typeValue: {
+					type: 'tuple',
+					value: [
+						{ paramName: 'owner', typeValue: { type: 'address', value: OWNER_ADDRESS } },
+						{ paramName: 'amount', typeValue: { type: 'unsignedInteger', value: 5n } },
+					],
+				},
+			},
+			{
+				paramName: 'fills',
+				typeValue: {
+					type: 'tuple[]',
+					value: [[
+						{ paramName: 'token', typeValue: { type: 'address', value: TOKEN_ADDRESS } },
+						{ paramName: 'amount', typeValue: { type: 'unsignedInteger', value: 7n } },
+					]],
+				},
+			},
+		])
+	})
+
+	test('parses decoded indexed tuple event args as topic hashes', () => {
+		assertIndexedTupleHash(indexedTupleEvent, 'order')
+		assertIndexedTupleHash(indexedTupleArrayEvent, 'orders')
+	})
+
+	test('keeps non-indexed 32-byte bytes values as bytes', () => {
+		const variables = parseAbiParametersToSolidityVariables(bytes32LikeBytesAbiParameters, [INDEXED_TOPIC_HASH])
+		const variable = variables[0]
+		assert.equal(variable?.paramName, 'payload')
+		assert.equal(variable?.typeValue.type, 'bytes')
+		if (variable?.typeValue.type !== 'bytes') throw new Error('expected non-indexed bytes to parse as bytes')
+		assert.equal(dataStringWith0xStart(variable.typeValue.value), INDEXED_TOPIC_HASH)
+	})
+
+	test('keeps non-indexed tuple objects with hash fields as tuples', () => {
+		const variables = parseAbiParametersToSolidityVariables(tupleWithHashFieldAbiParameters, [{ hash: INDEXED_TOPIC_HASH }])
+		const variable = variables[0]
+		assert.equal(variable?.paramName, 'proof')
+		assert.equal(variable?.typeValue.type, 'tuple')
+		if (variable?.typeValue.type !== 'tuple') throw new Error('expected non-indexed hash field object to parse as tuple')
+		const hashField = variable.typeValue.value[0]
+		assert.equal(hashField?.paramName, 'hash')
+		assert.equal(hashField?.typeValue.type, 'fixedBytes')
+		if (hashField?.typeValue.type !== 'fixedBytes') throw new Error('expected hash field to parse as fixedBytes')
+		assert.equal(dataStringWith0xStart(hashField.typeValue.value), INDEXED_TOPIC_HASH)
+	})
+
+	test('parses tuple and tuple array function calldata through parseInputData', async () => {
+		const storageState: Record<string, unknown> = {
+			userAddressBookEntriesV3: [
+				{
+					type: 'contract',
+					name: 'Tuple Input Contract',
+					address: TUPLE_INPUT_CONTRACT_ADDRESS_STRING,
+					entrySource: 'User',
+					abi: JSON.stringify(tupleInputFunctionAbi),
+				},
+			],
+		}
+		const restoreBrowser = installBrowserStorageMock(storageState)
+		try {
+			const input = encodeFunctionCall(tupleInputFunctionAbi, 'fulfill', [
+				{ owner: toAddressHex(OWNER_ADDRESS), amount: 5n },
+				[{ token: toAddressHex(TOKEN_ADDRESS), amount: 7n }],
+			])
+			const parsedInputData = await parseInputData({
+				to: TUPLE_INPUT_CONTRACT_ADDRESS,
+				value: 0n,
+				input: EthereumData.parse(input),
+			}, createTestEthereumClientService(), undefined)
+
+			assert.equal(parsedInputData.type, 'Parsed')
+			if (parsedInputData.type !== 'Parsed') throw new Error('expected calldata to parse')
+			assert.equal(parsedInputData.name, 'fulfill')
+			assert.deepEqual(parsedInputData.args, [
+				{
+					paramName: 'order',
+					typeValue: {
+						type: 'tuple',
+						value: [
+							{ paramName: 'owner', typeValue: { type: 'address', value: OWNER_ADDRESS } },
+							{ paramName: 'amount', typeValue: { type: 'unsignedInteger', value: 5n } },
+						],
+					},
+				},
+				{
+					paramName: 'fills',
+					typeValue: {
+						type: 'tuple[]',
+						value: [[
+							{ paramName: 'token', typeValue: { type: 'address', value: TOKEN_ADDRESS } },
+							{ paramName: 'amount', typeValue: { type: 'unsignedInteger', value: 7n } },
+						]],
+					},
+				},
+			])
+		} finally {
+			restoreBrowser()
+		}
+	})
+
+	test('parses Web3j ABIv2 example event struct parameters after log decoding', () => {
+		const variables = parseDecodedEvent(
+			web3jAbiV2ExampleEvent,
+			[
+				WEB3J_EVENT_ADDRESS,
+				{ id: 'foo-id', name: 'Example Foo' },
+				{ id: 15n, data: 'Example Bar' },
+			],
+			[toIndexedAddressTopic(WEB3J_EVENT_ADDRESS)],
+		)
+
+		assert.deepEqual(variables, [
+			{ paramName: '_address', typeValue: { type: 'address', value: BigInt(WEB3J_EVENT_ADDRESS) } },
+			{
+				paramName: '_foo',
+				typeValue: {
+					type: 'tuple',
+					value: [
+						{ paramName: 'id', typeValue: { type: 'string', value: 'foo-id' } },
+						{ paramName: 'name', typeValue: { type: 'string', value: 'Example Foo' } },
+					],
+				},
+			},
+			{
+				paramName: '_bar',
+				typeValue: {
+					type: 'tuple',
+					value: [
+						{ paramName: 'id', typeValue: { type: 'unsignedInteger', value: 15n } },
+						{ paramName: 'data', typeValue: { type: 'string', value: 'Example Bar' } },
+					],
+				},
+			},
+		])
+	})
+
+	test('parses OpenSea Seaport OrderFulfilled tuple array event args after log decoding', () => {
+		const variables = parseDecodedEvent(
+			seaportOrderFulfilledEvent,
+			[
+				INDEXED_TOPIC_HASH,
+				OFFERER_ADDRESS,
+				ZONE_ADDRESS,
+				RECIPIENT_ADDRESS,
+				[[2n, SEAPORT_TOKEN_ADDRESS, 123n, 1n]],
+				[[0n, '0x0000000000000000000000000000000000000000', 0n, 100n, CONSIDERATION_RECIPIENT_ADDRESS]],
+			],
+			[],
+		)
+
+		assert.equal(variables[4]?.paramName, 'offer')
+		assert.equal(variables[4]?.typeValue.type, 'tuple[]')
+		if (variables[4]?.typeValue.type !== 'tuple[]') throw new Error('expected Seaport offer to parse as tuple[]')
+		const offerToken = variables[4].typeValue.value[0]?.[1]
+		assert.equal(offerToken?.paramName, 'token')
+		assert.deepEqual(offerToken?.typeValue, { type: 'address', value: BigInt(SEAPORT_TOKEN_ADDRESS) })
+
+		assert.equal(variables[5]?.paramName, 'consideration')
+		assert.equal(variables[5]?.typeValue.type, 'tuple[]')
+		if (variables[5]?.typeValue.type !== 'tuple[]') throw new Error('expected Seaport consideration to parse as tuple[]')
+		const considerationRecipient = variables[5].typeValue.value[0]?.[4]
+		assert.equal(considerationRecipient?.paramName, 'recipient')
+		assert.deepEqual(considerationRecipient?.typeValue, { type: 'address', value: BigInt(CONSIDERATION_RECIPIENT_ADDRESS) })
+	})
+})


### PR DESCRIPTION
## Summary
- Fixes #737 by parsing function inputs and event args from ABI parameters instead of signature strings, enabling recursive `tuple` and `tuple[]` support for Solidity structs.
- Handles indexed tuple event args as topic hashes while preserving non-indexed bytes and tuple values as their decoded types.
- Recurses through nested tuple values for address metadata discovery so addresses inside structs are identified for the visualizer.
- Renders tuple/struct fields and tuple arrays with visible labels, braces, values, and address labels so decoded structs stay readable in the UI.
- Updates stale parse-failure fallback copy now that struct inputs are supported.

## Online examples covered
- Web3j ABIv2 struct event example with `Foo` and `Bar` tuple parameters.
- OpenSea Seaport `OrderFulfilled` tuple arrays for `SpentItem[]` and `ReceivedItem[]`.

## Testing
- `bun test` (352 tests passed)
- `bun run setup-chrome`
- `bun run typecheck`
- `bun run lint`
- Not run: `bun run test:chrome-communication` (not required; this change does not touch content-script registration, access approval, injected provider communication, or page-to-extension messaging)
