### PR TITLE
Standardize popup async query states

### DIFF
--- a/app/ts/AddressBook.tsx
+++ b/app/ts/AddressBook.tsx
@@ -15,6 +15,8 @@ import type { ChainEntry, RpcEntries } from './types/rpc.js'
 import { ChainSelector } from './components/subcomponents/ChainSelector.js'
 import { noReplyExpectingBrowserRuntimeOnMessageListener } from './utils/browser.js'
 import { addressEditEntry } from './components/ui-utils.js'
+import { createAsyncActionRunner, useAsyncState } from './utils/preact-utilities.js'
+import { AsyncActionButton } from './components/subcomponents/AsyncAction.js'
 
 type Modals =  { page: 'noModal' }
 	| { page: 'addNewAddress', state: Signal<ModifyAddressWindowState> }
@@ -47,10 +49,15 @@ type ConfirmaddressBookEntryToBeRemovedParams = {
 }
 
 function ConfirmaddressBookEntryToBeRemoved(param: ConfirmaddressBookEntryToBeRemovedParams) {
-	const remove = () => {
-		param.removeEntry(param.addressBookEntry)
-		param.close()
-	}
+	const { value: removeAddressState, waitFor: waitForRemoveAddress, reset: resetRemoveAddress } = useAsyncState<void>()
+	const remove = createAsyncActionRunner(
+		{ value: removeAddressState, waitFor: waitForRemoveAddress, reset: resetRemoveAddress },
+		async () => {
+			param.removeEntry(param.addressBookEntry)
+			param.close()
+		}
+	)
+
 	return <>
 		<div class = 'modal-background'> </div>
 		<div class = 'modal-card'>
@@ -78,7 +85,13 @@ function ConfirmaddressBookEntryToBeRemoved(param: ConfirmaddressBookEntryToBeRe
 				</div>
 			</section>
 			<footer class = 'modal-card-foot window-footer' style = 'border-bottom-left-radius: unset; border-bottom-right-radius: unset; border-top: unset; padding: 10px;'>
-				<button class = 'button is-success is-primary' onClick = { remove }> { 'Remove' } </button>
+				<AsyncActionButton
+					class = 'button is-success is-primary'
+					state = { removeAddressState.value.state }
+					onClick = { remove }
+					text = 'Remove'
+					pendingText = 'Removing...'
+				/>
 				<button class = 'button is-warning is-danger' onClick = { param.close }>Cancel</button>
 			</footer>
 		</div>

--- a/app/ts/background/backgroundUtils.ts
+++ b/app/ts/background/backgroundUtils.ts
@@ -136,6 +136,10 @@ export async function requestPopupSimulationMetadata() {
 	return reply?.method === 'popup_requestSimulationMetadata' ? reply : undefined
 }
 
+export function getMissingPopupReplyErrorMessage(actionDescription: string) {
+	return `${ actionDescription } failed because the background page did not return a reply.`
+}
+
 export async function requestPopupAbiAndNameFromBlockExplorer(data: PopupRequestByMethod<'popup_requestAbiAndNameFromBlockExplorer'>['data']) {
 	const reply = await sendPopupMessageWithReply({ method: 'popup_requestAbiAndNameFromBlockExplorer', data })
 	return reply?.method === 'popup_requestAbiAndNameFromBlockExplorer' ? reply : undefined
@@ -144,6 +148,16 @@ export async function requestPopupAbiAndNameFromBlockExplorer(data: PopupRequest
 export async function requestPopupIdentifyAddress(data: PopupRequestByMethod<'popup_requestIdentifyAddress'>['data']) {
 	const reply = await sendPopupMessageWithReply({ method: 'popup_requestIdentifyAddress', data })
 	return reply?.method === 'popup_requestIdentifyAddress' ? reply : undefined
+}
+
+export async function requestPopupSimulateGovernanceContractExecution(data: PopupRequestByMethod<'popup_simulateGovernanceContractExecution'>['data']) {
+	const reply = await sendPopupMessageWithReply({ method: 'popup_simulateGovernanceContractExecution', data })
+	return reply?.method === 'popup_simulateExecutionReply' ? reply : undefined
+}
+
+export async function requestPopupSimulateGnosisSafeTransaction(data: PopupRequestByMethod<'popup_simulateGnosisSafeTransaction'>['data']) {
+	const reply = await sendPopupMessageWithReply({ method: 'popup_simulateGnosisSafeTransaction', data })
+	return reply?.method === 'popup_simulateExecutionReply' ? reply : undefined
 }
 
 export async function requestIsMainPopupWindowOpen() {

--- a/app/ts/background/popupMessageHandlers.ts
+++ b/app/ts/background/popupMessageHandlers.ts
@@ -2,7 +2,7 @@ import { changeActiveAddressAndChain, changeActiveRpc, getUpdatedSimulationState
 import { getSettings, setUseTabsInsteadOfPopup, setPage, setUseSignersAddressAsActiveAddress, updateWebsiteAccess, exportSettingsAndAddressBook, importSettingsAndAddressBook, getMakeCurrentAddressRich, getUseTabsInsteadOfPopup, getMetamaskCompatibilityMode, setMetamaskCompatibilityMode, getPage, setPreSimulationBlockTimeManipulation, getPreSimulationBlockTimeManipulation, getFixedAddressRichList, getWebsiteAccess, setMakeCurrentAddressRich, setFixedMakeMeRichList } from './settings.js'
 import { getPendingTransactionsAndMessages, getCurrentTabId, getTabState, saveCurrentTabId, setRpcList, getRpcList, getPrimaryRpcForChain, getRpcConnectionStatus, updateUserAddressBookEntries, getPopupVisualisationState, setIdsOfOpenedTabs, getIdsOfOpenedTabs, updatePendingTransactionOrMessage, addEnsLabelHash, addEnsNodeHash, updateInterceptorTransactionStack, getLatestUnexpectedError, getInterceptorTransactionStack, getChainChangeConfirmationPromise, getFetchSimulationStackRequestPromise, getPendingAccessRequests } from './storageVariables.js'
 import { parseEvents, parseInputData } from '../simulation/parsing.js'
-import { type ChangeActiveAddress, type ModifyMakeMeRich, type ChangePage, type RemoveTransaction, type RequestAccountsFromSigner, type TransactionConfirmation, type InterceptorAccess, type ChangeInterceptorAccess, type ChainChangeConfirmation, type EnableSimulationMode, type ChangeActiveChain, type AddOrEditAddressBookEntry, type GetAddressBookData, type RemoveAddressBookEntry, type InterceptorAccessRefresh, type InterceptorAccessChangeAddress, type Settings, type ChangeSettings, type ImportSettings, type ImportSettingsReply, type SetRpcList, type UpdateHomePage, type SimulateGovernanceContractExecution, type ChangeAddOrModifyAddressWindowState, type OpenWebPage, type DisableInterceptor, type SetEnsNameForHash, UpdateConfirmTransactionDialog, UpdateConfirmTransactionDialogPendingTransactions, SimulateExecutionReply, type BlockOrAllowExternalRequests, type RemoveWebsiteAccess, type AllowOrPreventAddressAccessForWebsite, type RemoveWebsiteAddressAccess, type ForceSetGasLimitForTransaction, type RetrieveWebsiteAccess, type ChangePreSimulationBlockTimeManipulation, type SetTransactionOrMessageBlockTimeManipulator, type FetchSimulationStackRequestConfirmation, type ImportSimulationStack, type PopupReadyAndListeningPage } from '../types/interceptor-messages.js'
+import { type ChangeActiveAddress, type ModifyMakeMeRich, type ChangePage, type RemoveTransaction, type RequestAccountsFromSigner, type TransactionConfirmation, type InterceptorAccess, type ChangeInterceptorAccess, type ChainChangeConfirmation, type EnableSimulationMode, type ChangeActiveChain, type AddOrEditAddressBookEntry, type GetAddressBookData, type RemoveAddressBookEntry, type InterceptorAccessRefresh, type InterceptorAccessChangeAddress, type Settings, type ChangeSettings, type ImportSettings, type ImportSettingsReply, type SetRpcList, type UpdateHomePage, type SimulateGovernanceContractExecution, type ChangeAddOrModifyAddressWindowState, type OpenWebPage, type DisableInterceptor, type SetEnsNameForHash, UpdateConfirmTransactionDialog, UpdateConfirmTransactionDialogPendingTransactions, type BlockOrAllowExternalRequests, type RemoveWebsiteAccess, type AllowOrPreventAddressAccessForWebsite, type RemoveWebsiteAddressAccess, type ForceSetGasLimitForTransaction, type RetrieveWebsiteAccess, type ChangePreSimulationBlockTimeManipulation, type SetTransactionOrMessageBlockTimeManipulator, type FetchSimulationStackRequestConfirmation, type ImportSimulationStack, type PopupReadyAndListeningPage } from '../types/interceptor-messages.js'
 import { formEthSendTransaction, formSendRawTransaction, resolvePendingTransactionOrMessage, updateConfirmTransactionView, setGasLimitForTransaction, toPopupPendingTransactionOrSignableMessage } from './windows/confirmTransaction.js'
 import { askForSignerAccountsFromSignerIfNotAvailable, getAddressMetadataForAccess, requestAddressChange, resolveInterceptorAccess } from './windows/interceptorAccess.js'
 import { resolveChainChange } from './windows/changeChain.js'
@@ -44,6 +44,7 @@ import { updateFetchSimulationStackRequestWithPendingRequest } from './windows/f
 import { estimateSerializedStateBytes, formatEstimatedBytes } from '../utils/largeStateStore.js'
 import { POPUP_PERFORMANCE_MARKS, markPerformance } from '../utils/popupPerformance.js'
 import { bumpPopupRefreshGeneration } from './popupRefreshGeneration.js'
+import { serializeSimulateExecutionReply } from '../types/simulateExecutionReply.js'
 
 type TimestampedPopupVisualisation = {
 	data: {
@@ -641,18 +642,22 @@ export async function simulateGovernanceContractExecutionOnPass(ethereum: Ethere
 	const transaction = pendingTransactions.find((tx) => tx.type === 'Transaction' && tx.transactionIdentifier === request.data.transactionIdentifier)
 	if (transaction === undefined || transaction.type !== 'Transaction') throw new Error(`Could not find transactionIdentifier: ${ request.data.transactionIdentifier }`)
 	const governanceContractExecutionVisualisation = await simulateGovernanceContractExecution(transaction, ethereum, tokenPriceService)
-	await sendPopupMessageToOpenWindows(serialize(SimulateExecutionReply, {
+	const reply = {
 		method: 'popup_simulateExecutionReply' as const,
 		data: { ...governanceContractExecutionVisualisation, transactionOrMessageIdentifier: request.data.transactionIdentifier }
-	}))
+	}
+	await sendPopupMessageToOpenWindows(serializeSimulateExecutionReply(reply))
+	return reply
 }
 
 export async function simulateGnosisSafeTransactionOnPass(ethereum: EthereumClientService, tokenPriceService: TokenPriceService, gnosisSafeMessage: VisualizedPersonalSignRequestSafeTx) {
 	const gnosisTransactionExecutionVisualisation = await simulateGnosisSafeMetaTransaction(gnosisSafeMessage, await getCurrentSimulationInput(), ethereum, tokenPriceService)
-	await sendPopupMessageToOpenWindows(serialize(SimulateExecutionReply, {
+	const reply = {
 		method: 'popup_simulateExecutionReply' as const,
 		data: { ...gnosisTransactionExecutionVisualisation, transactionOrMessageIdentifier: gnosisSafeMessage.messageIdentifier }
-	}))
+	}
+	await sendPopupMessageToOpenWindows(serializeSimulateExecutionReply(reply))
+	return reply
 }
 
 const getErrorIfAnyWithIncompleteAddressBookEntry = async (ethereum: EthereumClientService, incompleteAddressBookEntry: IncompleteAddressBookEntry) => {

--- a/app/ts/components/pages/AddNewAddress.tsx
+++ b/app/ts/components/pages/AddNewAddress.tsx
@@ -3,7 +3,7 @@ import { useEffect } from 'preact/hooks'
 import type { AddAddressParam } from '../../types/user-interface-types.js'
 import { ErrorCheckBox, ErrorText } from '../subcomponents/Error.js'
 import { checksummedAddress, stringToAddress } from '../../utils/bigint.js'
-import { requestPopupAbiAndNameFromBlockExplorer, requestPopupIdentifyAddress, sendPopupMessageToBackgroundPage } from '../../background/backgroundUtils.js'
+import { getMissingPopupReplyErrorMessage, requestPopupAbiAndNameFromBlockExplorer, requestPopupIdentifyAddress, sendPopupMessageToBackgroundPage } from '../../background/backgroundUtils.js'
 import { AddressIcon } from '../subcomponents/address.js'
 import { assertUnreachable, modifyObject } from '../../utils/typescript.js'
 import { type ComponentChildren, createRef } from 'preact'
@@ -18,6 +18,8 @@ import { type Signal, useComputed, useSignal, useSignalEffect } from '@preact/si
 import { noReplyExpectingBrowserRuntimeOnMessageListener } from '../../utils/browser.js'
 import { DropDownMenu } from '../subcomponents/DropDownMenu.js'
 import { NonHexBigInt } from '../../types/wire-types.js'
+import { AsyncActionButton } from '../subcomponents/AsyncAction.js'
+import { type AsyncStates, useAsyncState } from '../../utils/preact-utilities.js'
 
 export function mergeAddressWindowErrorState(
 	currentErrorState: ModifyAddressWindowState['errorState'],
@@ -48,6 +50,8 @@ const readableAddressType = {
 	ERC1155: 'ERC1155',
 	contract: 'contract',
 }
+
+export const BLOCK_EXPLORER_REPLY_MISSING_ERROR = getMissingPopupReplyErrorMessage('Fetching ABI from the block explorer')
 
 type IncompleteAddressIconParams = {
 	addressInput: string | undefined,
@@ -107,6 +111,7 @@ type RenderinCompleteAddressBookParams = {
 	modifyAddressWindowState: Signal<ModifyAddressWindowState>
 	rpcEntries: Signal<RpcEntries>
 	canFetchFromEtherScan: Signal<boolean>
+	blockExplorerLookupState: AsyncStates
 	fetchAbiAndNameFromBlockExplorer: () => Promise<void>
 }
 
@@ -157,7 +162,7 @@ export async function updateModifyAddressWindowState(
 	}
 }
 
-function RenderIncompleteAddressBookEntry({ modifyAddressWindowState, rpcEntries, canFetchFromEtherScan, fetchAbiAndNameFromBlockExplorer }: RenderinCompleteAddressBookParams) {
+function RenderIncompleteAddressBookEntry({ modifyAddressWindowState, rpcEntries, canFetchFromEtherScan, blockExplorerLookupState, fetchAbiAndNameFromBlockExplorer }: RenderinCompleteAddressBookParams) {
 	const Text = (param: { text: ComponentChildren }) => {
 		return <p class = 'paragraph' style = 'color: var(--subtitle-text-color); text-overflow: ellipsis; overflow: hidden; width: 100%'>
 			{ param.text }
@@ -237,7 +242,14 @@ function RenderIncompleteAddressBookEntry({ modifyAddressWindowState, rpcEntries
 					<CellElement element = { <>
 						<AbiInput abiInput = { modifyAddressWindowState.value.incompleteAddressBookEntry.abi } setAbiInput = { setAbi } disabled = { false }/>
 						<div style = 'padding-left: 5px'/>
-						<button class = 'btn btn--outline is-small' disabled = { stringToAddress(modifyAddressWindowState.value.incompleteAddressBookEntry.address) === undefined || !canFetchFromEtherScan.value || !blockExplorerAvailable.value } onClick = { async  () => { fetchAbiAndNameFromBlockExplorer() } }> Fetch from Block Explorer</button>
+						<AsyncActionButton
+							class = 'btn btn--outline is-small'
+							state = { blockExplorerLookupState }
+							text = 'Fetch from Block Explorer'
+							pendingText = 'Fetching...'
+							disabled = { stringToAddress(modifyAddressWindowState.value.incompleteAddressBookEntry.address) === undefined || !canFetchFromEtherScan.value || !blockExplorerAvailable.value }
+							onClick = { fetchAbiAndNameFromBlockExplorer }
+						/>
 					</> }/>
 				</span>
 			</div>
@@ -262,6 +274,8 @@ export function AddNewAddress(param: AddAddressParam) {
 	const onChainInformationVerifiedByUser = useSignal<boolean>(false)
 	const canFetchFromEtherScan = useSignal<boolean>(false)
 	const lastCheckedAddress = useSignal<bigint>(0n)
+	const { value: blockExplorerLookup, waitFor: waitForBlockExplorerLookup, reset: resetBlockExplorerLookup } = useAsyncState<void>()
+	const isBlockExplorerLookupPending = useComputed(() => blockExplorerLookup.value.state === 'pending')
 
 	useEffect(() => {
 		const popupMessageListener = (msg: unknown): false => {
@@ -309,9 +323,11 @@ export function AddNewAddress(param: AddAddressParam) {
 		if (param.modifyAddressWindowState.value !== undefined) {
 			canFetchFromEtherScan.value = stringToAddress(param.modifyAddressWindowState.value.incompleteAddressBookEntry.address) !== undefined
 		}
+		resetBlockExplorerLookup()
 	}, [
 		param.modifyAddressWindowState.value.windowStateId,
 		param.modifyAddressWindowState.value.incompleteAddressBookEntry.address,
+		param.modifyAddressWindowState.value.incompleteAddressBookEntry.chainId,
 		param.activeAddress,
 	])
 
@@ -397,32 +413,44 @@ export function AddNewAddress(param: AddAddressParam) {
 	async function fetchAbiAndNameFromBlockExplorer() {
 		const address = stringToAddress(param.modifyAddressWindowState.value.incompleteAddressBookEntry.address)
 		if (address === undefined) return
-		canFetchFromEtherScan.value = false
-		const reply = await requestPopupAbiAndNameFromBlockExplorer({
-			address,
-			chainId: param.modifyAddressWindowState.value.incompleteAddressBookEntry.chainId
-		})
-		canFetchFromEtherScan.value = true
-		if (reply === undefined) return
-		if (!reply.data.success) {
-			const error = reply.data.error
+		const requestedChainId = param.modifyAddressWindowState.peek().incompleteAddressBookEntry.chainId
+		const isCurrentLookup = () => {
+			const currentEntry = param.modifyAddressWindowState.peek().incompleteAddressBookEntry
+			return stringToAddress(currentEntry.address) === address && currentEntry.chainId === requestedChainId
+		}
+		waitForBlockExplorerLookup(async () => {
+			const reply = await requestPopupAbiAndNameFromBlockExplorer({
+				address,
+				chainId: requestedChainId,
+			})
+			if (!isCurrentLookup()) return
+			if (reply === undefined) {
+				await updateModifyAddressWindowState(
+					param.modifyAddressWindowState,
+					previousState => modifyObject(previousState, { errorState: { blockEditing: false, message: BLOCK_EXPLORER_REPLY_MISSING_ERROR } })
+				)
+				return
+			}
+			if (!reply.data.success) {
+				const error = reply.data.error
+				await updateModifyAddressWindowState(
+					param.modifyAddressWindowState,
+					previousState => modifyObject(previousState, { errorState: { blockEditing: false, message: error } })
+				)
+				return
+			}
+			const { abi, contractName } = reply.data
 			await updateModifyAddressWindowState(
 				param.modifyAddressWindowState,
-				previousState => modifyObject(previousState, { errorState: { blockEditing: false, message: error } })
+				previousState => modifyObject(previousState, {
+					incompleteAddressBookEntry: modifyObject(previousState.incompleteAddressBookEntry, {
+						abi,
+						name: previousState.incompleteAddressBookEntry.name === undefined ? contractName : previousState.incompleteAddressBookEntry.name
+					}),
+					errorState: undefined
+				})
 			)
-			return
-		}
-		const { abi, contractName } = reply.data
-		await updateModifyAddressWindowState(
-			param.modifyAddressWindowState,
-			previousState => modifyObject(previousState, {
-				incompleteAddressBookEntry: modifyObject(previousState.incompleteAddressBookEntry, {
-					abi,
-					name: previousState.incompleteAddressBookEntry.name === undefined ? contractName : previousState.incompleteAddressBookEntry.name
-				}),
-				errorState: undefined
-			})
-		)
+		})
 	}
 
 	const showOnChainVerificationErrorBox = useComputed(() => {
@@ -434,6 +462,7 @@ export function AddNewAddress(param: AddAddressParam) {
 		return !areInputsValid.value
 			|| (param.modifyAddressWindowState.value.errorState?.blockEditing)
 			|| (showOnChainVerificationErrorBox.value && !onChainInformationVerifiedByUser.value)
+			|| isBlockExplorerLookupPending.value
 	})
 
 	function getCardTitle() {
@@ -458,7 +487,7 @@ export function AddNewAddress(param: AddAddressParam) {
 				<div class = 'card-header-title'>
 					<p class = 'paragraph'> { getCardTitle() } </p>
 				</div>
-				<button class = 'card-header-icon' aria-label = 'close' onClick = { param.close }>
+				<button class = 'card-header-icon' aria-label = 'close' onClick = { param.close } disabled = { isBlockExplorerLookupPending.value }>
 					<XMarkIcon />
 				</button>
 			</header>
@@ -469,6 +498,7 @@ export function AddNewAddress(param: AddAddressParam) {
 							modifyAddressWindowState = { param.modifyAddressWindowState }
 							rpcEntries = { param.rpcEntries }
 							canFetchFromEtherScan = { canFetchFromEtherScan }
+							blockExplorerLookupState = { blockExplorerLookup.value.state }
 							fetchAbiAndNameFromBlockExplorer = { fetchAbiAndNameFromBlockExplorer }
 						/>
 					</div>
@@ -486,11 +516,11 @@ export function AddNewAddress(param: AddAddressParam) {
 				</div>
 			</section>
 			<footer class = 'modal-card-foot window-footer' style = 'border-bottom-left-radius: unset; border-bottom-right-radius: unset; border-top: unset; padding: 10px;'>
-				{ param.setActiveAddressAndInformAboutIt === undefined || param.modifyAddressWindowState.value.incompleteAddressBookEntry === undefined || activeAddress.value === stringToAddress(param.modifyAddressWindowState.value.incompleteAddressBookEntry.address) ? <></> : <button class = 'button is-success is-primary' onClick = { createAndSwitch } disabled = { !areInputsValid.value }>
+				{ param.setActiveAddressAndInformAboutIt === undefined || param.modifyAddressWindowState.value.incompleteAddressBookEntry === undefined || activeAddress.value === stringToAddress(param.modifyAddressWindowState.value.incompleteAddressBookEntry.address) ? <></> : <button class = 'button is-success is-primary' onClick = { createAndSwitch } disabled = { !areInputsValid.value || isBlockExplorerLookupPending.value }>
 					{ param.modifyAddressWindowState.value.incompleteAddressBookEntry.addingAddress ? 'Create and switch' : 'Modify and switch' }
 				</button> }
 				<button class = 'button is-success is-primary' onClick = { modifyOrAddEntry } disabled = { isSubmitButtonDisabled.value }> { param.modifyAddressWindowState.value.incompleteAddressBookEntry.addingAddress ? 'Create' : 'Modify' } </button>
-				<button class = 'button is-primary' style = 'background-color: var(--negative-color)' onClick = { param.close }>Cancel</button>
+				<button class = 'button is-primary' style = 'background-color: var(--negative-color)' onClick = { param.close } disabled = { isBlockExplorerLookupPending.value }>Cancel</button>
 			</footer>
 		</div>
 	</> )

--- a/app/ts/components/pages/ChangeChain.tsx
+++ b/app/ts/components/pages/ChangeChain.tsx
@@ -3,10 +3,12 @@ import { useSignal } from '@preact/signals'
 import { ErrorComponent } from '../subcomponents/Error.js'
 import { MessageToPopup } from '../../types/interceptor-messages.js'
 import { sendPopupMessageToBackgroundPage, sendPopupReadyAndListening } from '../../background/backgroundUtils.js'
+import { AsyncActionButton } from '../subcomponents/AsyncAction.js'
 import { tryFocusingTabOrWindow } from '../ui-utils.js'
 import type { PendingChainChangeConfirmationPromise } from '../../types/user-interface-types.js'
 import { noReplyExpectingBrowserRuntimeOnMessageListener } from '../../utils/browser.js'
 import { sanitizeStoredWebsiteIcon } from '../../utils/websiteIcons.js'
+import { createAsyncActionRunner, useAsyncState } from '../../utils/preact-utilities.js'
 
 export function getChangeChainActionState(params: { hasSupportedRpc: boolean, simulationMode: boolean }) {
 	if (params.hasSupportedRpc) return {
@@ -28,6 +30,8 @@ export function getChangeChainActionState(params: { hasSupportedRpc: boolean, si
 
 export function ChangeChain() {
 	const chainChangeData = useSignal<PendingChainChangeConfirmationPromise | undefined>(undefined)
+	const { value: approveChainChangeState, waitFor: waitForApproveChainChangeState, reset: resetApproveChainChangeState } = useAsyncState<void>()
+	const { value: rejectChainChangeState, waitFor: waitForRejectChainChangeState, reset: resetRejectChainChangeState } = useAsyncState<void>()
 
 	useEffect(() => {
 		function popupMessageListener(msg: unknown): false {
@@ -44,17 +48,21 @@ export function ChangeChain() {
 
 	useEffect(() => { void sendPopupReadyAndListening('changeChain') }, [])
 
-	async function approve() {
+	async function changeChain(accept: boolean) {
 		if (chainChangeData.value === undefined) return
 		await tryFocusingTabOrWindow({ type: 'tab', id: chainChangeData.value.request.uniqueRequestIdentifier.requestSocket.tabId })
-		await sendPopupMessageToBackgroundPage({ method: 'popup_changeChainDialog', data: { accept: true, uniqueRequestIdentifier: chainChangeData.value.request.uniqueRequestIdentifier, rpcNetwork: chainChangeData.value.rpcNetwork } })
+		await sendPopupMessageToBackgroundPage({ method: 'popup_changeChainDialog', data: { accept, uniqueRequestIdentifier: chainChangeData.value.request.uniqueRequestIdentifier, rpcNetwork: chainChangeData.value.rpcNetwork } })
 	}
 
-	async function reject() {
-		if (chainChangeData.value === undefined) return
-		await tryFocusingTabOrWindow({ type: 'tab', id: chainChangeData.value.request.uniqueRequestIdentifier.requestSocket.tabId })
-		await sendPopupMessageToBackgroundPage({ method: 'popup_changeChainDialog', data: { accept: false, uniqueRequestIdentifier: chainChangeData.value.request.uniqueRequestIdentifier, rpcNetwork: chainChangeData.value.rpcNetwork } })
-	}
+	const reject = createAsyncActionRunner(
+		{ value: rejectChainChangeState, waitFor: waitForRejectChainChangeState, reset: resetRejectChainChangeState },
+		async () => { await changeChain(false) }
+	)
+
+	const approve = createAsyncActionRunner(
+		{ value: approveChainChangeState, waitFor: waitForApproveChainChangeState, reset: resetApproveChainChangeState },
+		async () => { await changeChain(true) }
+	)
 
 	if (chainChangeData.value === undefined) return <main></main>
 	const actionState = getChangeChainActionState({
@@ -100,19 +108,23 @@ export function ChangeChain() {
 						</div>
 					</div>
 					<div style = 'overflow: auto; display: flex; justify-content: space-around; width: 100%; height: 40px;'>
-						<button
+						<AsyncActionButton
 							class = { 'button is-danger' }
 							style = { 'flex-grow: 1; margin-left: 5px; margin-right: 5px;' }
+							state = { rejectChainChangeState.value.state }
+							text = { `Don't change` }
+							pendingText = 'Not changing...'
 							onClick = { reject } >
-							Don't change
-						</button>
-						<button
+						</AsyncActionButton>
+						<AsyncActionButton
 							class = { 'button is-primary' }
 							disabled = { actionState.approveDisabled }
 							style = 'flex-grow: 1; margin-left: 5px; margin-right: 5px;'
+							state = { approveChainChangeState.value.state }
+							text = { actionState.approveButtonText }
+							pendingText = 'Changing chain...'
 							onClick = { approve }>
-							{ actionState.approveButtonText }
-						</button>
+						</AsyncActionButton>
 					</div>
 				</div>
 			</div>

--- a/app/ts/components/pages/ConfirmTransaction.tsx
+++ b/app/ts/components/pages/ConfirmTransaction.tsx
@@ -38,6 +38,8 @@ import type { Website } from '../../types/websiteAccessTypes.js'
 import { dataStringWith0xStart } from '../../utils/bigint.js'
 import { browserStorageLocalGet2 } from '../../utils/storageUtils.js'
 import { reportUnexpectedError } from '../../utils/errors.js'
+import { type AsyncStates, useAsyncState } from '../../utils/preact-utilities.js'
+import { AsyncActionButton } from '../subcomponents/AsyncAction.js'
 
 type UnderTransactionsParams = {
 	pendingTransactionsAndSignableMessages: ReadonlySignal<PendingTransactionOrSignableMessage[]>
@@ -523,25 +525,32 @@ type ModalState =
 	{ page: 'noModal' }
 
 type RejectButtonParams = {
-	onClick: () => void
+	onClick: () => void | Promise<void>
+	state: AsyncStates
 }
-const RejectButton = ({ onClick }: RejectButtonParams) => {
+const RejectButton = ({ onClick, state }: RejectButtonParams) => {
 	return <div style = 'display: flex;'>
-		<button class = 'button is-primary is-danger button-overflow dialog-button-left' onClick = { onClick } >
-			{ 'Reject' }
-		</button>
+		<AsyncActionButton
+			class = 'button is-primary is-danger button-overflow dialog-button-left'
+			state = { state }
+			text = { 'Reject' }
+			pendingText = { 'Rejecting...' }
+			onClick = { onClick }
+		/>
 	</div>
 }
 
 type ButtonsParams = {
 	currentPendingTransactionOrSignableMessage: PendingTransactionOrSignableMessage | undefined
 	reject: () => void
+	rejectButtonState: AsyncStates
 	approve: () => void
-	confirmDisabled: ReadonlySignal<boolean>
+	approveButtonState: AsyncStates
+	confirmDisabled: boolean
 }
-function Buttons({ currentPendingTransactionOrSignableMessage, reject, approve, confirmDisabled }: ButtonsParams) {
-	if (currentPendingTransactionOrSignableMessage === undefined) return <RejectButton onClick = { reject }/>
-	if (currentPendingTransactionOrSignableMessage.transactionOrMessageCreationStatus !== 'Simulated') return <RejectButton onClick = { reject }/>
+function Buttons({ currentPendingTransactionOrSignableMessage, reject, rejectButtonState, approve, approveButtonState, confirmDisabled }: ButtonsParams) {
+	if (currentPendingTransactionOrSignableMessage === undefined) return <RejectButton onClick = { reject } state = { rejectButtonState }/>
+	if (currentPendingTransactionOrSignableMessage.transactionOrMessageCreationStatus !== 'Simulated') return <RejectButton onClick = { reject } state = { rejectButtonState }/>
 
 	const signerName = currentPendingTransactionOrSignableMessage.type === 'Transaction' ? currentPendingTransactionOrSignableMessage.popupVisualisation.data.signerName : currentPendingTransactionOrSignableMessage.visualizedPersonalSignRequest.signerName
 	const identify = () => {
@@ -551,23 +560,34 @@ function Buttons({ currentPendingTransactionOrSignableMessage, reject, approve, 
 		return identifyTransaction(lastTx)
 	}
 	const identified = identify()
-	if (identified === undefined) return <RejectButton onClick = { reject }/>
+	if (identified === undefined) return <RejectButton onClick = { reject } state = { rejectButtonState }/>
 
 	return <div style = 'display: flex; flex-direction: row;'>
-		<button class = 'button is-primary is-danger button-overflow dialog-button-left' onClick = { reject } >
-			{ identified.rejectAction }
-		</button>
-		<button class = 'button is-primary button-overflow dialog-button-right' onClick = { approve } disabled = { confirmDisabled }>
-			{ currentPendingTransactionOrSignableMessage.approvalStatus.status === 'WaitingForSigner' ? <>
-				<span> <Spinner height = '1em' color = 'var(--text-color)' /> Waiting for <SignersLogoName signerName = { signerName } /> </span>
-				</> : <>
-					{ currentPendingTransactionOrSignableMessage.simulationMode
-						? `${ identified.simulationAction }!`
-						: <SignerLogoText signerName = { signerName } text = { identified.signingAction } />
-					}
-				</>
+		<AsyncActionButton
+			class = 'button is-primary is-danger button-overflow dialog-button-left'
+			state = { rejectButtonState }
+			text = { identified.rejectAction }
+			pendingText = 'Rejecting...'
+			onClick = { reject }
+		/>
+		<AsyncActionButton
+			class = 'button is-primary button-overflow dialog-button-right'
+			state = { approveButtonState }
+			text = { currentPendingTransactionOrSignableMessage.approvalStatus.status === 'WaitingForSigner' 
+				? <><span> <Spinner height = '1em' color = 'var(--text-color)' /> Waiting for <SignersLogoName signerName = { signerName } /> </span></>
+				: currentPendingTransactionOrSignableMessage.simulationMode
+					? `${ identified.simulationAction }!`
+					: <SignerLogoText signerName = { signerName } text = { identified.signingAction } />
 			}
-		</button>
+			pendingText = { currentPendingTransactionOrSignableMessage.approvalStatus.status === 'WaitingForSigner'
+				? 'Waiting for signer...'
+				: currentPendingTransactionOrSignableMessage.simulationMode
+					? `${ identified.simulationAction }...`
+					: `Sign with ${ signerName }...`
+			}
+			onClick = { approve }
+			disabled = { confirmDisabled }
+		/>
 	</div>
 }
 
@@ -703,7 +723,7 @@ export function ConfirmTransaction() {
 		}
 	}, [])
 
-	async function approve() {
+	async function approveTransaction() {
 		if (currentPendingTransactionOrSignableMessage.value === undefined) throw new Error('dialogState is not set')
 		pendingTransactionAddedNotification.value = false
 		const currentWindow = await browser.windows.getCurrent()
@@ -712,7 +732,7 @@ export function ConfirmTransaction() {
 		const deliveryError = await sendConfirmDialogMessage({ method: 'popup_confirmDialog', data: { uniqueRequestIdentifier: currentPendingTransactionOrSignableMessage.value.uniqueRequestIdentifier, action: 'accept' } })
 		if (deliveryError !== undefined) unexpectedError.value = deliveryError
 	}
-	async function reject() {
+	async function rejectTransaction() {
 		if (currentPendingTransactionOrSignableMessage.value === undefined) throw new Error('dialogState is not set')
 		pendingTransactionAddedNotification.value = false
 		const currentWindow = await browser.windows.getCurrent()
@@ -739,6 +759,16 @@ export function ConfirmTransaction() {
 			errorString: getPossibleErrorString(),
 		} })
 		if (deliveryError !== undefined) unexpectedError.value = deliveryError
+	}
+	const { value: rejectButtonState, waitFor: waitForRejectTransaction, reset: resetRejectButton } = useAsyncState<void>()
+	const { value: approveButtonState, waitFor: waitForApproveTransaction, reset: resetApproveButton } = useAsyncState<void>()
+	const reject = () => {
+		resetRejectButton()
+		waitForRejectTransaction(rejectTransaction)
+	}
+	const approve = () => {
+		resetApproveButton()
+		waitForApproveTransaction(approveTransaction)
 	}
 	const refreshMetadata = async () => {
 		if (currentPendingTransactionOrSignableMessage.value === undefined) return
@@ -910,12 +940,14 @@ export function ConfirmTransaction() {
 						</div>
 						<nav class = 'window-footer popup-button-row' style = 'position: sticky; bottom: 0; width: 100%;'>
 							<CheckBoxes currentPendingTransactionOrSignableMessage = { currentPendingTransactionOrSignableMessage } forceSend = { forceSend } />
-							<Buttons
-								currentPendingTransactionOrSignableMessage = { currentPendingTransactionOrSignableMessage.value }
-								reject = { reject }
-								approve = { approve }
-								confirmDisabled = { isConfirmDisabled }
-							/>
+					<Buttons
+						currentPendingTransactionOrSignableMessage = { currentPendingTransactionOrSignableMessage.value }
+						reject = { reject }
+						rejectButtonState = { rejectButtonState.value.state }
+						approve = { approve }
+						approveButtonState = { approveButtonState.value.state }
+						confirmDisabled = { isConfirmDisabled.value }
+					/>
 						</nav>
 					</div>
 				</div>

--- a/app/ts/components/pages/ConfirmTransaction.tsx
+++ b/app/ts/components/pages/ConfirmTransaction.tsx
@@ -117,7 +117,7 @@ export function getConfirmDialogDeliveryErrorMessage(error: unknown) {
 export async function sendConfirmDialogMessage(message: TransactionConfirmation): Promise<CaughtError | undefined> {
 	try {
 		await sendPopupMessageToBackgroundPageWithoutUnexpectedErrorReport(message)
-	} catch(error) {
+	} catch (error) {
 		const errorMessage = await reportUnexpectedError(error, {
 			source: 'confirmTransaction',
 			code: 'confirm_dialog_delivery_failed',

--- a/app/ts/components/pages/FetchSimulationStack.tsx
+++ b/app/ts/components/pages/FetchSimulationStack.tsx
@@ -16,6 +16,8 @@ import { CenterToPageTextSpinner } from '../subcomponents/Spinner.js'
 import { ETHEREUM_LOGS_LOGGER_ADDRESS } from '../../utils/constants.js'
 import { SimulationStackRows } from '../simulationExplaining/Transactions.js'
 import { sanitizeStoredWebsiteIcon } from '../../utils/websiteIcons.js'
+import { useAsyncState } from '../../utils/preact-utilities.js'
+import { AsyncActionButton } from '../subcomponents/AsyncAction.js'
 
 type ModalState =
 	{ page: 'modifyAddress', state: Signal<ModifyAddressWindowState> } |
@@ -28,6 +30,8 @@ export function FetchSimulationStack() {
 	const completeVisualizedSimulation = useSignal<CompleteVisualizedSimulation>(createPassthroughCompleteVisualizedSimulation())
 	const simulationMetadata = useSignal<SimulationMetadata | undefined>(undefined)
 	const rpcEntries = useSignal<RpcEntries>([])
+	const { value: rejectRequestState, waitFor: waitForRejectRequest } = useAsyncState<void>()
+	const { value: allowRequestState, waitFor: waitForAllowRequest } = useAsyncState<void>()
 
 	function renameAddressCallBack(entry: AddressBookEntry) {
 		modalState.value = { page: 'modifyAddress', state: new Signal(addressEditEntry(entry)) }
@@ -83,6 +87,13 @@ export function FetchSimulationStack() {
 		if (changeRequest.value === undefined) return
 		await tryFocusingTabOrWindow({ type: 'tab', id: changeRequest.value.uniqueRequestIdentifier.requestSocket.tabId })
 		await sendPopupMessageToBackgroundPage({ method: 'popup_fetchSimulationStackRequestConfirmation', data: { accept: false, uniqueRequestIdentifier: changeRequest.value.uniqueRequestIdentifier, simulationStackVersion: changeRequest.value?.simulationStackVersion } })
+	}
+
+	const allowRequest = () => {
+		void waitForAllowRequest(() => approve())
+	}
+	const rejectRequest = () => {
+		void waitForRejectRequest(() => reject())
 	}
 
 	const simulationStackResults = useComputed<SimulationAndVisualisationResults | undefined>(() => {
@@ -191,19 +202,23 @@ export function FetchSimulationStack() {
 							</div>
 						</div>
 						<div style = 'overflow: auto; display: flex; justify-content: space-around; width: 100%; height: 40px;'>
-							<button
+							<AsyncActionButton
 								class = { 'button is-danger' }
 								style = { 'flex-grow: 1; margin-left: 5px; margin-right: 5px;' }
-								onClick = { reject } >
-								Don't allow
-							</button>
-							<button
+								state = { rejectRequestState.value.state }
+								text = { 'Don' + '\u0027' + 't allow' }
+								pendingText = 'Rejecting request...'
+								onClick = { rejectRequest }
+							/>
+							<AsyncActionButton
 								class = { 'button is-primary' }
-								disabled = { false }
 								style = 'flex-grow: 1; margin-left: 5px; margin-right: 5px;'
-								onClick = { approve }>
-								Allow
-							</button>
+								state = { allowRequestState.value.state }
+								disabled = { false }
+								text = 'Allow'
+								pendingText = 'Allowing request...'
+								onClick = { allowRequest }
+							/>
 						</div>
 					</div>
 				</div>

--- a/app/ts/components/pages/Home.tsx
+++ b/app/ts/components/pages/Home.tsx
@@ -23,6 +23,8 @@ import { DEFAULT_BLOCK_MANIPULATION } from '../../simulation/services/Simulation
 import type { EnrichedRichListElement } from '../../types/interceptor-reply-messages.js'
 import { Spinner } from '../subcomponents/Spinner.js'
 import { useResetSimulation } from '../hooks/useResetSimulation.js'
+import { useAsyncState } from '../../utils/preact-utilities.js'
+import { AsyncActionButton } from '../subcomponents/AsyncAction.js'
 
 function scheduleAfterPaint(callback: () => void) {
 	if (typeof globalThis.requestAnimationFrame === 'function' && typeof globalThis.cancelAnimationFrame === 'function') {
@@ -60,9 +62,17 @@ function SignerExplanation(param: SignerExplanationParams) {
 function FirstCardHeader(param: FirstCardParams) {
 	const tabIconReason = useComputed(() => param.tabIconDetails.value.iconReason)
 	const signerName = useComputed(() => param.tabState.value?.signerName ?? 'NoSignerDetected')
+	const { value: setSimulatingState, waitFor: waitForSetSimulating } = useAsyncState<void>()
+	const { value: setSigningState, waitFor: waitForSetSigning } = useAsyncState<void>()
 
-	function enableSimulationMode(enabled: boolean ) {
-		sendPopupMessageToBackgroundPage( { method: 'popup_enableSimulationMode', data: enabled } )
+	async function enableSimulationMode(enabled: boolean ) {
+		await sendPopupMessageToBackgroundPage( { method: 'popup_enableSimulationMode', data: enabled } )
+	}
+	const enableSimulating = () => {
+		void waitForSetSimulating(() => enableSimulationMode(true))
+	}
+	const enableSigning = () => {
+		void waitForSetSigning(() => enableSimulationMode(false))
 	}
 
 	return <>
@@ -74,20 +84,24 @@ function FirstCardHeader(param: FirstCardParams) {
 			</div>
 			<div>
 				<div class = 'buttons has-addons' style = 'border-style: solid; border-color: var(--primary-color); border-radius: 6px; padding: 1px; border-width: 1px; display: inline-flex; margin-bottom: 0;' >
-					<button
+					<AsyncActionButton
 						class = { `button is-primary ${ param.simulationMode.value ? '' : 'is-outlined' }` }
 						style = { `margin-bottom: 0px; ${ param.simulationMode.value ? 'opacity: 1;' : 'border-style: none;' }` }
+						state = { setSimulatingState.value.state }
 						disabled = { param.simulationMode.value }
-						onClick = { () => enableSimulationMode(true) }>
-						Simulating
-					</button>
-					<button
+						pendingText = 'Switching to simulating mode...'
+						text = 'Simulating'
+						onClick = { enableSimulating }
+					/>
+					<AsyncActionButton
 						class = { `button is-primary ${ param.simulationMode.value ? 'is-outlined' : ''}` }
 						style = { `margin-bottom: 0px; ${ param.simulationMode.value ? 'border-style: none;' : 'opacity: 1;' }` }
+						state = { setSigningState.value.state }
 						disabled = { !param.simulationMode.value }
-						onClick = { () => enableSimulationMode(false) }>
-						<SignerLogoText signerName = { signerName } text = { 'Signing' } />
-					</button>
+						text = { <SignerLogoText signerName = { signerName } text = 'Signing' /> }
+						pendingText = 'Switching to signing mode...'
+						onClick = { enableSigning }
+					/>
 				</div>
 			</div>
 			<RpcSelector rpcEntries = { param.rpcEntries } rpcNetwork = { param.rpcNetwork } changeRpc = { param.changeActiveRpc }/>
@@ -102,15 +116,27 @@ type InterceptorDisabledButtonParams = {
 }
 
 function InterceptorDisabledButton({ disableInterceptorToggle, interceptorDisabled, website }: InterceptorDisabledButtonParams) {
-	return <button disabled = { website.value === undefined } class = { `button is-small ${ interceptorDisabled.value ? 'is-success' : 'is-primary' }` } onClick = { () => disableInterceptorToggle(!interceptorDisabled.value) } >
-		{ interceptorDisabled.value ? <>
+	const { value: disableButtonState, waitFor: waitForDisableInterceptor } = useAsyncState<void>()
+	const toggleInterceptor = () => {
+		void waitForDisableInterceptor(async () => {
+			disableInterceptorToggle(!interceptorDisabled.value)
+		})
+	}
+
+	return <AsyncActionButton
+		disabled = { website.value === undefined }
+		state = { disableButtonState.value.state }
+		class = { `button is-small ${ interceptorDisabled.value ? 'is-success' : 'is-primary' }` }
+		text = { interceptorDisabled.value ? <>
 			<span class = 'icon'> <img src = { ICON_ACTIVE } width = '24' height = '24'/> </span>
 			<span> Enable</span>
 		</> : <>
 			<span class = 'icon'> <img src = { ICON_INTERCEPTOR_DISABLED } width = '24' height = '24'/> </span>
 			<span> Disable</span>
 		</> }
-	</button>
+		pendingText = { interceptorDisabled.value ? 'Enabling interceptor...' : 'Disabling interceptor...' }
+		onClick = { toggleInterceptor }
+	/>
 }
 
 type RichListParams = {
@@ -189,7 +215,12 @@ function FirstCard(param: FirstCardParams) {
 	const timeSelectorAbsoluteTime = useSignal<Date | undefined>(undefined)
 	const timeSelectorDeltaValue = useSignal<bigint>(12n)
 	const timeSelectorDeltaUnit = useSignal<DeltaUnit>('Seconds')
+	const { value: connectToSignerButtonState, waitFor: waitForConnectToSigner } = useAsyncState<void>()
 	const signerAvailable = useComputed(() => isSignerAvailable(param.tabState.value))
+
+	const connectToSigner = () => {
+		void waitForConnectToSigner(() => sendPopupMessageToBackgroundPage({ method: 'popup_requestAccountsFromSigner', data: true }))
+	}
 
 	const timeSelectorOnChange = () => {
 		const blockTimeManipulation = getTimeManipulatorFromSignals(timeSelectorMode.value, timeSelectorAbsoluteTime.value, timeSelectorDeltaValue.value, timeSelectorDeltaUnit.value)
@@ -249,12 +280,16 @@ function FirstCard(param: FirstCardParams) {
 				{ !param.simulationMode.value ? <>
 					{ (param.tabState.value?.signerAccounts.length === 0 && param.tabIconDetails.value.icon !== ICON_NOT_ACTIVE && param.tabIconDetails.value.icon !== ICON_NOT_ACTIVE_WITH_SHIELD) ?
 						<div style = 'margin-top: 5px'>
-							<button class = 'button is-primary' onClick = { () => sendPopupMessageToBackgroundPage({ method: 'popup_requestAccountsFromSigner', data: true }) } >
-								<SignerLogoText
+							<AsyncActionButton
+								class = 'button is-primary'
+								state = { connectToSignerButtonState.value.state }
+								text = { <SignerLogoText
 									signerName = { param.tabState.value?.signerName ?? 'NoSignerDetected' }
 									text = { `Connect to ${ getPrettySignerName(param.tabState.value?.signerName ?? 'NoSignerDetected') }` }
-								/>
-							</button>
+								/> }
+								pendingText = { `Connecting to ${ getPrettySignerName(param.tabState.value?.signerName ?? 'NoSignerDetected') }` }
+								onClick = { connectToSigner }
+							/>
 						</div>
 						: <p style = 'color: var(--subtitle-text-color);' class = 'subtitle is-7'> { ` You can change active address by changing it directly from ${ getPrettySignerName(param.tabState.value?.signerName ?? 'NoSignerDetected') }` } </p>
 					}
@@ -291,13 +326,23 @@ type SimulationResultsHeaderParams = {
 }
 
 function SimulationResultsHeader(param: SimulationResultsHeaderParams) {
+	const { value: clearSimulationState, waitFor: waitForClearSimulation } = useAsyncState<void>()
+	const openStack = () => { param.openSimulationStack?.() }
+	const resetSimulation = param.resetSimulation
+	const clearSimulation = () => {
+		if (resetSimulation === undefined) return
+		void waitForClearSimulation(async () => {
+			resetSimulation()
+		})
+	}
+
 	return <div style = 'display: grid; grid-template-columns: minmax(0, 1fr) auto; gap: 8px; align-items: start; padding-left: 10px; padding-right: 10px' >
 		<div class = 'log-cell' style = 'justify-content: left; align-items: center; gap: 8px; flex-wrap: wrap; min-width: 0;'>
 			<p class = 'h1' style = 'margin: 0;'> Simulation Results </p>
 		</div>
 		<div class = 'log-cell' style = 'justify-content: right; align-items: center; gap: 6px; flex-wrap: wrap; max-width: 300px;'>
 			{ param.openSimulationStack === undefined ? <></> :
-				<button class = 'btn btn--outline is-small' onClick = { () => param.openSimulationStack?.() } title = 'Open simulation stack details in a new tab' aria-label = 'Open simulation stack details in a new tab'>
+				<button class = 'btn btn--outline is-small' onClick = { openStack } title = 'Open simulation stack details in a new tab' aria-label = 'Open simulation stack details in a new tab'>
 					<span style = { { marginRight: '0.25rem', fontSize: '1rem', width: '1em', height: '1em' } }>
 						<OpenInNewIcon/>
 					</span>
@@ -305,12 +350,19 @@ function SimulationResultsHeader(param: SimulationResultsHeaderParams) {
 				</button>
 			}
 			{ param.disableReset === undefined || param.resetSimulation === undefined ? <></> :
-				<button class = 'btn is-small is-danger' disabled = { param.disableReset.value } onClick = { param.resetSimulation } title = 'Clear simulation stack' aria-label = 'Clear simulation stack'>
-					<span style = { { marginRight: '0.25rem', fontSize: '1rem', width: '1em', height: '1em' } }>
-						<BroomIcon />
-					</span>
-					<span>Clear</span>
-				</button>
+				<AsyncActionButton
+					class = 'btn is-small is-danger'
+					state = { clearSimulationState.value.state }
+					disabled = { param.disableReset.value }
+					onClick = { clearSimulation }
+					text = { <>
+						<span style = { { marginRight: '0.25rem', fontSize: '1rem', width: '1em', height: '1em' } }>
+							<BroomIcon />
+						</span>
+						<span>Clear</span>
+					</> }
+					pendingText = 'Clearing...'
+				/>
 			}
 		</div>
 	</div>
@@ -319,15 +371,16 @@ function SimulationResultsHeader(param: SimulationResultsHeaderParams) {
 function RichAddressesTitleCard({ numberOfAddressesMadeRich, openSimulationStack }: { numberOfAddressesMadeRich: number, openSimulationStack?: () => void }) {
 	if (numberOfAddressesMadeRich === 0) return <></>
 	const actionLabel = 'Open rich address state in the full simulation stack'
+	const openStack = () => { openSimulationStack?.() }
 	return <section class = 'card' style = 'margin: 10px;'>
 		<header
 			class = { `card-header stack-card-header${ openSimulationStack === undefined ? '' : ' stack-row-link-header' }` }
-			onClick = { openSimulationStack }
+			onClick = { openStack }
 			onKeyDown = { (event) => {
 				if (openSimulationStack === undefined || (event.key !== 'Enter' && event.key !== ' ')) return
 				if (event.target !== event.currentTarget) return
 				event.preventDefault()
-				openSimulationStack()
+				openStack()
 			} }
 			role = { openSimulationStack === undefined ? undefined : 'button' }
 			tabIndex = { openSimulationStack === undefined ? undefined : 0 }
@@ -367,7 +420,7 @@ function PopupVisualisation(param: SimulationStateParam) {
 			<SimulationResultsHeader openSimulationStack = { param.openSimulationStack } />
 			{ isEmpty.value ?
 				<div style = 'padding: 10px'><DinoSays text = { 'Give me some transactions to munch on!' } /></div>
-			: <RichAddressesTitleCard numberOfAddressesMadeRich = { param.numberOfAddressesMadeRich.value } openSimulationStack = { () => param.openSimulationStack() } /> }
+			: <RichAddressesTitleCard numberOfAddressesMadeRich = { param.numberOfAddressesMadeRich.value } openSimulationStack = { param.openSimulationStack } /> }
 		</div>
 	}
 
@@ -376,10 +429,10 @@ function PopupVisualisation(param: SimulationStateParam) {
 	return <div>
 		<SimulationResultsHeader openSimulationStack = { param.openSimulationStack } disableReset = { param.disableReset } resetSimulation = { param.resetSimulation } />
 
-		{ resolvedResults.visualizedSimulationState.success === false ? <>
-			<ErrorComponent text = { `Failed to simulate the stack due to error: "${ resolvedResults.visualizedSimulationState.jsonRpcError.error.message }". Please modify the stack to make it simutable.` }/>
-			<RichAddressesTitleCard numberOfAddressesMadeRich = { param.numberOfAddressesMadeRich.value } openSimulationStack = { () => param.openSimulationStack() } />
-			<TransactionsAndSignedMessages
+			{ resolvedResults.visualizedSimulationState.success === false ? <>
+				<ErrorComponent text = { `Failed to simulate the stack due to error: "${ resolvedResults.visualizedSimulationState.jsonRpcError.error.message }". Please modify the stack to make it simutable.` }/>
+				<RichAddressesTitleCard numberOfAddressesMadeRich = { param.numberOfAddressesMadeRich.value } openSimulationStack = { param.openSimulationStack } />
+				<TransactionsAndSignedMessages
 				simulationAndVisualisationResults = { param.simulationAndVisualisationResults }
 				removeTransactionOrSignedMessage = { param.removeTransactionOrSignedMessage }
 				activeAddress = { param.activeSimulationAddress }
@@ -394,7 +447,7 @@ function PopupVisualisation(param: SimulationStateParam) {
 				<div style = 'padding: 10px'><DinoSays text = { 'Give me some transactions to munch on!' } /></div>
 			: <>
 				<div class = { param.simulationResultState.value === 'invalid' || param.simulationUpdatingState.value === 'failed' ? 'blur' : '' }>
-					<RichAddressesTitleCard numberOfAddressesMadeRich = { param.numberOfAddressesMadeRich.value } openSimulationStack = { () => param.openSimulationStack() } />
+					<RichAddressesTitleCard numberOfAddressesMadeRich = { param.numberOfAddressesMadeRich.value } openSimulationStack = { param.openSimulationStack } />
 					<TransactionsAndSignedMessages
 						simulationAndVisualisationResults = { param.simulationAndVisualisationResults }
 						removeTransactionOrSignedMessage = { param.removeTransactionOrSignedMessage }

--- a/app/ts/components/pages/ImportSimulationStack.tsx
+++ b/app/ts/components/pages/ImportSimulationStack.tsx
@@ -2,10 +2,12 @@ import { useEffect } from 'preact/hooks'
 import { Notice } from '../subcomponents/Error.js'
 import { type ComponentChildren, createRef } from 'preact'
 import { XMarkIcon } from '../subcomponents/icons.js'
-import { type Signal, useComputed, useSignal } from '@preact/signals'
+import { type Signal, useComputed } from '@preact/signals'
 import { isJSON } from '../../utils/json.js'
-import { sendPopupMessageWithReply } from '../../background/backgroundUtils.js'
+import { getMissingPopupReplyErrorMessage, sendPopupMessageWithReply } from '../../background/backgroundUtils.js'
 import { InterceptorSimulationExport } from '../../types/visualizer-types.js'
+import { AsyncActionButton } from '../subcomponents/AsyncAction.js'
+import { useAsyncState } from '../../utils/preact-utilities.js'
 
 type SimulationInputParams = {
 	input: Signal<string>
@@ -33,10 +35,11 @@ type ImportSimulationStackParam = {
 }
 
 export function ImportSimulationStack(param: ImportSimulationStackParam) {
-	const importError = useSignal<string | undefined>(undefined)
-	const isImporting = useSignal(false)
+	const { value: importRequestState, waitFor: waitForImport } = useAsyncState<void>()
+	const isImporting = useComputed(() => importRequestState.value.state === 'pending')
+	const importError = useComputed(() => importRequestState.value.state === 'rejected' ? importRequestState.value.error.message : undefined)
 
-	const isSubmitButtonDisabled = useComputed(() => errorString.value !== undefined || param.simulationInput.value.trim().length === 0 || isImporting.value )
+	const isSubmitButtonDisabled = useComputed(() => errorString.value !== undefined || param.simulationInput.value.trim().length === 0 || isImporting.value)
 	const isValid = useComputed(() => errorString.value === undefined)
 
 	const errorString = useComputed(() => {
@@ -54,24 +57,14 @@ export function ImportSimulationStack(param: ImportSimulationStackParam) {
 		</p>
 	}
 
-	const importStack = async () => {
+	const importStack = () => {
 		const trimmed = param.simulationInput.value.trim()
-		importError.value = undefined
-		isImporting.value = true
-		try {
+		waitForImport(async () => {
 			const reply = await sendPopupMessageWithReply({ method: 'popup_importSimulationStack', data: InterceptorSimulationExport.parse(JSON.parse(trimmed)) })
-			if (reply === undefined) {
-				importError.value = 'Import failed because the background page did not return a reply.'
-				return
-			}
-			if (!reply.ok) {
-				importError.value = reply.message
-				return
-			}
+			if (reply === undefined) throw new Error(getMissingPopupReplyErrorMessage('Importing the simulation stack'))
+			if (!reply.ok) throw new Error(reply.message)
 			param.close()
-		} finally {
-			isImporting.value = false
-		}
+		})
 	}
 
 	return ( <>
@@ -86,7 +79,7 @@ export function ImportSimulationStack(param: ImportSimulationStackParam) {
 				<div class = 'card-header-title'>
 					<p class = 'paragraph'> { 'Import Interceptor Simulation Stack' } </p>
 				</div>
-				<button class = 'card-header-icon' aria-label = 'close' onClick = { param.close }>
+				<button class = 'card-header-icon' aria-label = 'close' onClick = { param.close } disabled = { isImporting.value }>
 					<XMarkIcon />
 				</button>
 			</header>
@@ -110,7 +103,7 @@ export function ImportSimulationStack(param: ImportSimulationStackParam) {
 				</div>
 			</section>
 			<footer class = 'modal-card-foot window-footer' style = 'border-bottom-left-radius: unset; border-bottom-right-radius: unset; border-top: unset; padding: 10px;'>
-				<button class = 'button is-success is-primary' onClick = { importStack } disabled = { isSubmitButtonDisabled.value }> { isImporting.value ? 'Importing...' : 'Import' } </button>
+				<AsyncActionButton class = 'button is-success is-primary' state = { importRequestState.value.state } text = 'Import' pendingText = 'Importing...' onClick = { importStack } disabled = { isSubmitButtonDisabled.value } />
 			</footer>
 		</div>
 	</> )

--- a/app/ts/components/pages/InterceptorAccess.tsx
+++ b/app/ts/components/pages/InterceptorAccess.tsx
@@ -19,6 +19,8 @@ import { ChevronIcon } from '../subcomponents/icons.js'
 import { noReplyExpectingBrowserRuntimeOnMessageListener } from '../../utils/browser.js'
 import { sendPopupReadyAndListening } from '../../background/backgroundUtils.js'
 import { sanitizeStoredWebsiteIcon } from '../../utils/websiteIcons.js'
+import { AsyncActionButton } from '../subcomponents/AsyncAction.js'
+import { useAsyncState } from '../../utils/preact-utilities.js'
 
 function Title({ icon, title} : {icon: string | undefined, title: string}) {
 	const websiteIcon = sanitizeStoredWebsiteIcon(icon)
@@ -140,30 +142,63 @@ type AccessRequestParam = {
 }
 
 function AccessRequests(param: AccessRequestParam) {
+
+	const AccessRequestActions = ({ accessRequest, reject, approve, informationChangedRecently }: {
+		accessRequest: PendingAccessRequest
+		reject: (accessRequestId: string) => void
+		approve: (accessRequestId: string) => void
+		informationChangedRecently: ReadonlySignal<boolean>
+	}) => {
+		const { value: rejectState, waitFor: waitForReject } = useAsyncState<void>()
+		const { value: approveState, waitFor: waitForApprove } = useAsyncState<void>()
+		const disabled = informationChangedRecently.value
+		const onReject = () => {
+			void waitForReject(async () => {
+				reject(accessRequest.accessRequestId)
+			})
+		}
+		const onApprove = () => {
+			void waitForApprove(async () => {
+				approve(accessRequest.accessRequestId)
+			})
+		}
+
+		return <nav class = 'popup-button-row'>
+			<div style = 'display: flex; flex-direction: row;'>
+		<AsyncActionButton
+				class = 'button is-primary is-danger'
+				state = { rejectState.value.state }
+					text = 'Deny Access'
+					pendingText = 'Denying access...'
+					onClick = { onReject }
+					disabled = { disabled }
+				/>
+			<AsyncActionButton
+				class = 'button is-primary'
+				state = { approveState.value.state }
+					text = 'Grant Access'
+					pendingText = 'Granting access...'
+					onClick = { onApprove }
+					disabled = { disabled }
+				/>
+			</div>
+			</nav>
+	}
+
 	return <> { param.pendingAccessRequests.map((pendingRequest) => <>
 		<div class = 'card' style = 'margin-bottom: 10px;'>
 			<AccessRequestHeader { ...pendingRequest.website } />
 			<div class = 'card-content' style = 'padding-bottom: 5px;'>
 				<AccessRequest
-					renameAddressCallBack =  { (entry: AddressBookEntry) => param.renameAddressCallBack(pendingRequest.accessRequestId, entry) }
-					accessRequest = { pendingRequest }
+						renameAddressCallBack =  { (entry: AddressBookEntry) => param.renameAddressCallBack(pendingRequest.accessRequestId, entry) }
+						accessRequest = { pendingRequest }
 					changeActiveAddress = { () => param.changeActiveAddress(pendingRequest.accessRequestId) }
-					refreshActiveAddress = { () => param.refreshActiveAddress(pendingRequest.accessRequestId) }
-				/>
-			</div>
-
-			<nav class = 'popup-button-row'>
-				<div style = 'display: flex; flex-direction: row;'>
-					<button class = 'button is-primary is-danger' style = 'flex-grow: 1; margin-left: 5px; margin-right: 5px;' onClick = { () => param.reject(pendingRequest.accessRequestId) } disabled = { param.informationChangedRecently.value }>
-						Deny Access
-					</button>
-					<button class = 'button is-primary' style = 'flex-grow: 1; margin-left: 5px; margin-right: 5px;' onClick = { () => param.approve(pendingRequest.accessRequestId) } disabled = { param.informationChangedRecently.value }>
-						Grant Access
-					</button>
+						refreshActiveAddress = { () => param.refreshActiveAddress(pendingRequest.accessRequestId) }
+					/>
 				</div>
-			</nav>
-		</div>
-	</>) } </>
+				<AccessRequestActions accessRequest = { pendingRequest } reject = { param.reject } approve = { param.approve } informationChangedRecently = { param.informationChangedRecently } />
+			</div>
+		</>) } </>
 }
 
 const DISABLED_DELAY_MS = 500

--- a/app/ts/components/pages/InterceptorAccessList.tsx
+++ b/app/ts/components/pages/InterceptorAccessList.tsx
@@ -9,6 +9,8 @@ import { modifyObject } from '../../utils/typescript.js'
 import type { AddressBookEntry } from '../../types/addressBookTypes.js'
 import { XMarkIcon } from '../subcomponents/icons.js'
 import { sanitizeStoredWebsiteIcon } from '../../utils/websiteIcons.js'
+import { AsyncActionButton } from '../subcomponents/AsyncAction.js'
+import { createAsyncActionRunner, useAsyncState } from '../../utils/preact-utilities.js'
 
 interface ModifiedAddressAccess {
 	address: bigint,
@@ -36,6 +38,7 @@ interface AccessChanges {
 export function InterceptorAccessList(param: InterceptorAccessListParams) {
 	const editableAccessList = useSignal<readonly EditableAccess[] | undefined>(undefined)
 	const metadata = useSignal<Map<string, AddressBookEntry>>(new Map())
+	const { value: saveChangesState, waitFor: waitForSaveChangesState, reset: resetSaveChangesState } = useAsyncState<void>()
 
 	function updateEditableAccessList(newList: WebsiteAccessArray | undefined) {
 		if (newList === undefined) { editableAccessList.value = undefined; return }
@@ -167,7 +170,7 @@ export function InterceptorAccessList(param: InterceptorAccessListParams) {
 		return false
 	}
 
-	function saveChanges() {
+	async function saveChanges() {
 		if (!areThereChanges()) return param.goHome()
 		if (editableAccessList.value === undefined) return param.goHome()
 		const changedEntry = (editable: EditableAccess) => {
@@ -308,7 +311,13 @@ export function InterceptorAccessList(param: InterceptorAccessListParams) {
 
 			<footer class = 'modal-card-foot window-footer' style = 'border-bottom-left-radius: unset; border-bottom-right-radius: unset; border-top: unset; padding: 10px;'>
 				<button class = 'button is-primary' style = 'background-color: var(--negative-color)' onClick = { param.goHome }>Cancel</button>
-				<button class = 'button is-success is-primary' onClick = { saveChanges }> { areThereChanges() ? 'Save Changes' : 'Close' } </button>
+					<AsyncActionButton
+						class = 'button is-success is-primary'
+						state = { saveChangesState.value.state }
+						onClick = { createAsyncActionRunner({ value: saveChangesState, waitFor: waitForSaveChangesState, reset: resetSaveChangesState }, saveChanges) }
+						text = { areThereChanges() ? 'Save Changes' : 'Close' }
+						pendingText = 'Saving...'
+					/>
 			</footer>
 		</div>
 	</> )

--- a/app/ts/components/pages/SettingsView.tsx
+++ b/app/ts/components/pages/SettingsView.tsx
@@ -14,6 +14,8 @@ import { useComputed, useSignal } from '@preact/signals'
 import { serialize } from '../../types/wire-types.js'
 import { noReplyExpectingBrowserRuntimeOnMessageListener } from '../../utils/browser.js'
 import { resolveSignal, type SignalOrValue } from '../../utils/signals.js'
+import { useAsyncState } from '../../utils/preact-utilities.js'
+import { AsyncActionButton } from '../subcomponents/AsyncAction.js'
 
 type CheckBoxSettingParam = {
 	text: string
@@ -88,7 +90,8 @@ function ImportExport() {
 			throw new Error('error on importing settings')
 		}
 	}
-	const exportSettings = async () => await sendPopupMessageToBackgroundPage({ method: 'popup_get_export_settings' })
+	const { value: exportSettingsState, waitFor: waitForExportSettings } = useAsyncState<void>()
+	const exportSettings = () => void waitForExportSettings(async () => { await sendPopupMessageToBackgroundPage({ method: 'popup_get_export_settings' }) })
 
 	return <>
 		{ settingsReply.value !== undefined && settingsReply.value.data.success === false ?
@@ -106,9 +109,13 @@ function ImportExport() {
 					Import settings
 					<input type = 'file' accept = '.json' onInput = { importSettings } style = 'position: absolute; width: 100%; height: 100%; opacity: 0;' />
 				</label>
-				<button class = 'button is-primary settings-import-export-button' onClick = { exportSettings }>
-					Export settings
-				</button>
+				<AsyncActionButton
+					class = 'button is-primary settings-import-export-button'
+					state = { exportSettingsState.value.state }
+					text = 'Export settings'
+					pendingText = 'Exporting settings...'
+					onClick = { exportSettings }
+				/>
 			</div>
 		</div>
 	</>
@@ -201,15 +208,24 @@ export function SettingsView() {
 const RpcListings = () => {
 	const rpcEntries = useRpcConnectionsList()
 	const latestEntry = useComputed(() => rpcEntries.value[0])
+	const { value: resetRpcListState, waitFor: waitForResetDefaultRpcs } = useAsyncState<void>()
+	const loadDefaultRpcs = () => void waitForResetDefaultRpcs(() => sendPopupMessageToBackgroundPage({ method: 'popup_set_rpc_list', data: defaultRpcs }))
 
-	const loadDefaultRpcs = () => sendPopupMessageToBackgroundPage({ method: 'popup_set_rpc_list', data: defaultRpcs })
+	
 
 	if (rpcEntries.value.length < 2 && latestEntry.value !== undefined) {
 		return (
 			<>
 				<aside class = 'report' style = { { display: 'grid', height: '9rem', textAlign: 'center', rowGap: '0.5rem'} }>
 					<p style = { { color: 'var(--disabled-text-color)' } }>Interceptor requires at least 1 active RPC connection to work, do you want to reset to the default list instead?</p>
-					<button class = 'btn btn--outline' style = 'font-weight: 600' onClick = { loadDefaultRpcs }>Yes, load the default RPC list</button>
+				<AsyncActionButton
+					class = 'btn btn--outline'
+					style = 'font-weight: 600'
+					state = { resetRpcListState.value.state }
+					text = 'Yes, load the default RPC list'
+					pendingText = 'Loading default RPC list'
+					onClick = { loadDefaultRpcs }
+						/>
 				</aside>
 				<ul class = 'grid' style = '--gap-y: 0.5rem'>
 						<RpcSummary info = { latestEntry } />

--- a/app/ts/components/pages/SimulationStackPage.tsx
+++ b/app/ts/components/pages/SimulationStackPage.tsx
@@ -22,6 +22,8 @@ import { getSimulationStackTargetElementIdFromHash } from '../../utils/simulatio
 import { SmallAddress, getActiveAddressEntry } from '../subcomponents/address.js'
 import type { EnrichedRichListElement } from '../../types/interceptor-reply-messages.js'
 import { createUnexpectedErrorPopupMessage } from '../../utils/unexpectedErrorPopupMessage.js'
+import { useAsyncState } from '../../utils/preact-utilities.js'
+import { AsyncActionButton } from '../subcomponents/AsyncAction.js'
 
 type ModalState =
 	{ page: 'modifyAddress', state: Signal<ModifyAddressWindowState> } |
@@ -49,11 +51,25 @@ function SimulationStackToolbar({ openImportSimulation, resetSimulation, disable
 	resetSimulation: () => void
 	disableReset: Signal<boolean>
 }) {
+	const { value: exportSimulationStackState, waitFor: waitForExportSimulationStack } = useAsyncState<void>()
+	const { value: clearSimulationStackState, waitFor: waitForClearSimulationStack } = useAsyncState<void>()
+
 	const exportSimulationStack = async () => {
 		const reply = await requestPopupInterceptorSimulationInput()
 		if (reply === undefined) return
 		await clipboardCopy(reply.ethSimulateV1InputString)
 	}
+
+	const exportStack = () => {
+		void waitForExportSimulationStack(exportSimulationStack)
+	}
+
+	const clearStack = () => {
+		void waitForClearSimulationStack(async () => {
+			resetSimulation()
+		})
+	}
+
 	return <header class = 'simulation-stack-page-header'>
 		<div class = 'simulation-stack-page-title'>
 			<h1>Simulation Stack</h1>
@@ -66,26 +82,33 @@ function SimulationStackToolbar({ openImportSimulation, resetSimulation, disable
 				</span>
 				<span>Import</span>
 			</button>
-			<button
+			<AsyncActionButton
 				class = 'btn btn--outline'
 				type = 'button'
-				onClick = { exportSimulationStack }
-				title = 'Export simulation stack'
-				aria-label = 'Export simulation stack'
-				data-hint-clickable-hide-timer-ms = { 1500 }
-				data-hint = 'Interceptor Simulation input copied!'
-			>
-				<span style = { { marginRight: '0.25rem', fontSize: '1rem', width: '1em', height: '1em' } }>
-					<ExportIcon/>
-				</span>
-				<span>Export</span>
-			</button>
-			<button class = 'btn btn--destructive' type = 'button' disabled = { disableReset.value } onClick = { resetSimulation } title = 'Clear simulation stack' aria-label = 'Clear simulation stack'>
-				<span style = { { marginRight: '0.25rem', fontSize: '1rem', width: '1em', height: '1em' } }>
-					<BroomIcon />
-				</span>
-				<span>Clear</span>
-			</button>
+				state = { exportSimulationStackState.value.state }
+				onClick = { exportStack }
+				text = { <>
+					<span style = { { marginRight: '0.25rem', fontSize: '1rem', width: '1em', height: '1em' } }>
+						<ExportIcon/>
+					</span>
+					<span>Export</span>
+				</> }
+				pendingText = 'Exporting simulation stack...'
+			/>
+			<AsyncActionButton
+				class = 'btn btn--destructive'
+				type = 'button'
+				state = { clearSimulationStackState.value.state }
+				disabled = { disableReset.value }
+				onClick = { clearStack }
+				text = { <>
+					<span style = { { marginRight: '0.25rem', fontSize: '1rem', width: '1em', height: '1em' } }>
+						<BroomIcon />
+					</span>
+					<span>Clear</span>
+				</> }
+				pendingText = 'Clearing simulation stack...'
+			/>
 		</div>
 	</header>
 }

--- a/app/ts/components/pages/WebsiteAccess.tsx
+++ b/app/ts/components/pages/WebsiteAccess.tsx
@@ -20,6 +20,8 @@ import { noReplyExpectingBrowserRuntimeOnMessageListener } from '../../utils/bro
 import { addressEditEntry } from '../ui-utils.js'
 import type { OptionalSignal } from '../../utils/OptionalSignal.js'
 import { sanitizeStoredWebsiteIcon } from '../../utils/websiteIcons.js'
+import { AsyncActionButton } from '../subcomponents/AsyncAction.js'
+import { useAsyncState } from '../../utils/preact-utilities.js'
 
 const URL_HASH_KEY = 'origin'
 const URL_HASH_PREFIX = `#${ URL_HASH_KEY }:`
@@ -442,6 +444,11 @@ const AdvancedSettings = ({ websiteAccess }: { websiteAccess: OptionalSignal<Web
 }
 
 const BlockRequestSetting = ({ websiteAccess }: { websiteAccess: OptionalSignal<WebsiteAccess> }) => {
+	const { value: unblockWebsiteRequestState, waitFor: waitForUnblockWebsiteRequest } = useAsyncState<void>()
+	const unblockWebsiteRequest = () => {
+		void waitForUnblockWebsiteRequest(() => setWebsiteExternalRequestBlocking(false))
+	}
+
 	const setWebsiteExternalRequestBlocking = async (shouldBlock: boolean) => {
 		if (!websiteAccess.deepValue) return
 		sendPopupMessageToBackgroundPage({ method: 'popup_blockOrAllowExternalRequests', data: { website: websiteAccess.deepValue.website, shouldBlock } })
@@ -461,11 +468,18 @@ const BlockRequestSetting = ({ websiteAccess }: { websiteAccess: OptionalSignal<
 			<section class = 'flexy' style = { { flex: 1, '--pad-y': 0 } }>
 				<div style = { { contain: 'inline-size', flex: '1 20ch', marginBottom: '0.5rem' } }>
 					<h1 style = { { color: 'var(--text-color)', whiteSpace: 'nowrap' } }>Block External Request</h1>
-					<p style = { { color: 'var(--disabled-text-color)', fontSize: '0.875rem' } }>The Interceptor can block network requests from this domain, effectively preventing the website from connecting to external domains and services.</p>
+				<p style = { { color: 'var(--disabled-text-color)', fontSize: '0.875rem' } }>The Interceptor can block network requests from this domain, effectively preventing the website from connecting to external domains and services.</p>
 				</div>
 				<aside>
 					{ requestBlockMode.value === 'block-all' ? (
-						<button type='button' class = 'btn btn--primary' onClick = { () => setWebsiteExternalRequestBlocking(false) }><span style = { { whiteSpace: 'nowrap' } }>Unblock Requests</span></button>
+						<AsyncActionButton
+							class = 'btn btn--primary'
+							type = 'button'
+							state = { unblockWebsiteRequestState.value.state }
+							text = { <span style = { { whiteSpace: 'nowrap' } }>Unblock Requests</span> }
+							pendingText = { <span style = { { whiteSpace: 'nowrap' } }>Unblocking Requests</span> }
+							onClick = { unblockWebsiteRequest }
+						/>
 					) : (
 						<Modal>
 							<Modal.Open class = 'btn btn--destructive'><span style = { { whiteSpace: 'nowrap' } }>Block Requests</span></Modal.Open>
@@ -489,6 +503,8 @@ const BlockRequestSetting = ({ websiteAccess }: { websiteAccess: OptionalSignal<
 }
 
 const DisableProtectionSetting = ({ websiteAccess }: { websiteAccess: OptionalSignal<WebsiteAccess> }) => {
+	const { value: enableProtectionState, waitFor: waitForEnableProtection } = useAsyncState<void>()
+	const enableProtection = () => { void waitForEnableProtection(() => disableWebsiteProtection(false)) }
 
 	const disableWebsiteProtection = async (shouldDisable = true) => {
 		if (!websiteAccess.deepValue) return
@@ -513,7 +529,14 @@ const DisableProtectionSetting = ({ websiteAccess }: { websiteAccess: OptionalSi
 				</div>
 				<aside>
 					{ isInterceptorDisabled.value ? (
-						<button type='button' class = 'btn btn--primary' onClick = { () => disableWebsiteProtection(false) }><span style = { { whiteSpace: 'nowrap' } }>Enable Protection</span></button>
+						<AsyncActionButton
+							class = 'btn btn--primary'
+							type = 'button'
+							state = { enableProtectionState.value.state }
+							text = { <span style = { { whiteSpace: 'nowrap' } }>Enable Protection</span> }
+							pendingText = { <span style = { { whiteSpace: 'nowrap' } }>Enabling Protection</span> }
+							onClick = { enableProtection }
+						/>
 					) : (
 						<Modal>
 							<Modal.Open class = 'btn btn--destructive'><span style = { { whiteSpace: 'nowrap' } }>Disable Protection</span></Modal.Open>

--- a/app/ts/components/simulationExplaining/SimulationSummary.tsx
+++ b/app/ts/components/simulationExplaining/SimulationSummary.tsx
@@ -21,6 +21,8 @@ import { ChevronIcon, XMarkIcon } from '../subcomponents/icons.js'
 import { TransactionInput } from '../subcomponents/ParsedInputData.js'
 import { sendPopupMessageToBackgroundPage } from '../../background/backgroundUtils.js'
 import { IntegerInput } from '../subcomponents/AutosizingInput.js'
+import { AsyncActionButton } from '../subcomponents/AsyncAction.js'
+import { createAsyncActionRunner, useAsyncState } from '../../utils/preact-utilities.js'
 import { useOptionalSignal } from '../../utils/OptionalSignal.js'
 import { type ReadonlySignal, type Signal, useComputed, useSignal } from '@preact/signals'
 import type { SignalOrValue } from '../../utils/signals.js'
@@ -826,12 +828,17 @@ type GasLimitEditorParams = {
 
 export function GasLimitEditor({ transactionIdentifier, initialGasLimit, isRawTransaction }: GasLimitEditorParams) {
 	const gasLimit = useOptionalSignal<bigint>(initialGasLimit)
+	const { value: forceSetGasLimitState, waitFor: waitForForceSetGasLimit, reset: resetForceSetGasLimit } = useAsyncState<void>()
 
 	async function forceSetGasLimitForTransaction() {
 		const gas = gasLimit.deepPeek()
 		if (gas === undefined || gas === initialGasLimit) return
 		await sendPopupMessageToBackgroundPage({ method: 'popup_forceSetGasLimitForTransaction', data: { gasLimit: gas, transactionIdentifier } })
 	}
+	const forceSetGasLimit = createAsyncActionRunner(
+		{ value: forceSetGasLimitState, waitFor: waitForForceSetGasLimit, reset: resetForceSetGasLimit },
+		forceSetGasLimitForTransaction
+	)
 
 	return <>
 		<span style = 'padding: 2px; background: rgba(255, 255, 255, 0.1); border-bottom: 1.5px solid var(--text-color);'>
@@ -843,7 +850,14 @@ export function GasLimitEditor({ transactionIdentifier, initialGasLimit, isRawTr
 			/>
 		</span>
 		&nbsp;gas&nbsp;
-		<button disabled = { isRawTransaction || gasLimit.deepValue === initialGasLimit } class = 'button is-primary is-small' onClick = { forceSetGasLimitForTransaction }>Change</button>
+		<AsyncActionButton
+			disabled = { isRawTransaction || gasLimit.deepValue === initialGasLimit }
+			class = 'button is-primary is-small'
+			state = { forceSetGasLimitState.value.state }
+			text = 'Change'
+			pendingText = 'Saving...'
+			onClick = { forceSetGasLimit }
+		/>
 	</>
 }
 

--- a/app/ts/components/simulationExplaining/customExplainers/GnosisSafeVisualizer.tsx
+++ b/app/ts/components/simulationExplaining/customExplainers/GnosisSafeVisualizer.tsx
@@ -1,5 +1,5 @@
 import { type Signal, type ReadonlySignal, useComputed, useSignal } from '@preact/signals'
-import { sendPopupMessageToBackgroundPage } from '../../../background/backgroundUtils.js'
+import { getMissingPopupReplyErrorMessage, requestPopupSimulateGnosisSafeTransaction } from '../../../background/backgroundUtils.js'
 import { MessageToPopup, SimulateExecutionReply } from '../../../types/interceptor-messages.js'
 import type { VisualizedPersonalSignRequestSafeTx } from '../../../types/personal-message-definitions.js'
 import type { RenameAddressCallBack } from '../../../types/user-interface-types.js'
@@ -8,19 +8,23 @@ import { ErrorComponent } from '../../subcomponents/Error.js'
 import { SmallAddress } from '../../subcomponents/address.js'
 import type { EditEnsNamedHashCallBack } from '../../subcomponents/ens.js'
 import { Transaction } from '../Transactions.js'
-import { useEffect } from 'preact/hooks'
+import { useEffect, useRef } from 'preact/hooks'
+import { AsyncActionButton } from '../../subcomponents/AsyncAction.js'
+import { type AsyncStates, useAsyncState } from '../../../utils/preact-utilities.js'
 
 type ShowSuccessOrFailureParams = {
-	gnosisSafeMessage: VisualizedPersonalSignRequestSafeTx
 	activeAddress: ReadonlySignal<bigint | undefined>
 	simulateExecutionReply: Signal<SimulateExecutionReply | undefined>
+	gnosisSimulationState: AsyncStates
+	requestErrorText: string | undefined
+	requestToSimulate: () => void
 	renameAddressCallBack: RenameAddressCallBack
 	editEnsNamedHashCallBack: EditEnsNamedHashCallBack
 }
 
-const requestToSimulate = (gnosisSafeMessage: VisualizedPersonalSignRequestSafeTx) => sendPopupMessageToBackgroundPage({ method: 'popup_simulateGnosisSafeTransaction', data: { gnosisSafeMessage } })
+const GNOSIS_SIMULATION_REPLY_MISSING_ERROR = getMissingPopupReplyErrorMessage('Simulating Gnosis Safe execution')
 
-const ShowSuccessOrFailure = ({ simulateExecutionReply, activeAddress, renameAddressCallBack, editEnsNamedHashCallBack, gnosisSafeMessage }: ShowSuccessOrFailureParams) => {
+const ShowSuccessOrFailure = ({ simulateExecutionReply, activeAddress, renameAddressCallBack, editEnsNamedHashCallBack, gnosisSimulationState, requestErrorText, requestToSimulate }: ShowSuccessOrFailureParams) => {
 	const errorText = useComputed(() => simulateExecutionReply.value?.data.success === false ? simulateExecutionReply.value.data.errorMessage : undefined)
 	const rpcErrorText = useComputed(() => simulateExecutionReply.value?.data.success === true && simulateExecutionReply.value.data.result.visualizedSimulationState.success === false ? JSON.stringify(simulateExecutionReply.value.data.result.visualizedSimulationState.jsonRpcError, undefined, 4) : undefined)
 	const simTx = useComputed(() => {
@@ -51,30 +55,36 @@ const ShowSuccessOrFailure = ({ simulateExecutionReply, activeAddress, renameAdd
 	})
 
 	if (simulateExecutionReply.value === undefined) {
-		return <div style = 'display: flex; justify-content: center;'>
-			<button
-				class = { 'button is-primary' }
-				onClick = { () => requestToSimulate(gnosisSafeMessage) }
-				disabled = { false }
-			>
-				Simulate execution
-			</button>
+		return <div style = 'display: grid; row-gap: 10px;'>
+			{ requestErrorText === undefined ? <></> : <ErrorComponent text = { requestErrorText }/> }
+			<div style = 'display: flex; justify-content: center;'>
+				<AsyncActionButton
+					class = 'button is-primary'
+					state = { gnosisSimulationState }
+					text = 'Simulate execution'
+					pendingText = 'Simulating...'
+					onClick = { requestToSimulate }
+				/>
+			</div>
 		</div>
 	}
 
 	if (simulateExecutionReply.value.data.success === false) {
-		return <div style = 'display: grid; grid-template-rows: max-content' >
+		return <div style = 'display: grid; grid-template-rows: max-content; row-gap: 10px;' >
+			{ requestErrorText === undefined ? <></> : <ErrorComponent text = { requestErrorText }/> }
 			<ErrorComponent text = { errorText }/>
 		</div>
 	}
 	if (simulateExecutionReply.value.data.result.visualizedSimulationState.success === false) {
-		return <div style = 'display: grid; grid-template-rows: max-content' >
+		return <div style = 'display: grid; grid-template-rows: max-content; row-gap: 10px;' >
+			{ requestErrorText === undefined ? <></> : <ErrorComponent text = { requestErrorText }/> }
 			<ErrorComponent text = { rpcErrorText }/>
 		</div>
 	}
 	if (simTx.value === undefined || activeAddress.value === undefined) return <></>
 
-	return <div style = 'display: grid; grid-template-rows: max-content' >
+	return <div style = 'display: grid; grid-template-rows: max-content; row-gap: 10px;' >
+		{ requestErrorText === undefined ? <></> : <ErrorComponent text = { requestErrorText }/> }
 		<Transaction
 			simTx = { simTx.value }
 			simulationAndVisualisationResults = { results.value }
@@ -97,6 +107,12 @@ type GnosisSafeVisualizerParams = {
 export function GnosisSafeVisualizer(param: GnosisSafeVisualizerParams) {
 	const simulateExecutionReply = useSignal<SimulateExecutionReply | undefined>(undefined)
 	const activeAddress = useSignal<bigint | undefined>(undefined)
+	const { value: gnosisSimulationRequest, waitFor: waitForGnosisSimulation, reset: resetGnosisSimulationRequest } = useAsyncState<void>()
+	const requestErrorText = useComputed(() => gnosisSimulationRequest.value.state === 'rejected' ? gnosisSimulationRequest.value.error.message : undefined)
+	const currentMessageIdentifier = useRef(param.gnosisSafeMessage.messageIdentifier)
+	currentMessageIdentifier.current = param.gnosisSafeMessage.messageIdentifier
+
+	const isReplyForCurrentMessage = (reply: SimulateExecutionReply) => reply.data.transactionOrMessageIdentifier === currentMessageIdentifier.current
 
 	useEffect(() => {
 		const popupMessageListener = (msg: unknown): false => {
@@ -107,7 +123,8 @@ export function GnosisSafeVisualizer(param: GnosisSafeVisualizerParams) {
 			if (parsed.method !== 'popup_simulateExecutionReply') return false
 			const { role: _role, ...popupSimulateExecutionReply } = parsed
 			const reply = SimulateExecutionReply.parse(popupSimulateExecutionReply)
-			if (reply.data.transactionOrMessageIdentifier !== param.gnosisSafeMessage.messageIdentifier) return false
+			if (!isReplyForCurrentMessage(reply)) return false
+			resetGnosisSimulationRequest()
 			simulateExecutionReply.value = reply
 			return false
 		}
@@ -118,7 +135,17 @@ export function GnosisSafeVisualizer(param: GnosisSafeVisualizerParams) {
 	useEffect(() => {
 		activeAddress.value = param.activeAddress
 		simulateExecutionReply.value = undefined
+		resetGnosisSimulationRequest()
 	}, [param.activeAddress, param.gnosisSafeMessage.messageIdentifier])
+
+	const requestToSimulate = () => {
+		waitForGnosisSimulation(async () => {
+			const reply = await requestPopupSimulateGnosisSafeTransaction({ gnosisSafeMessage: param.gnosisSafeMessage })
+			if (reply === undefined) throw new Error(GNOSIS_SIMULATION_REPLY_MISSING_ERROR)
+			if (param.gnosisSafeMessage.messageIdentifier !== currentMessageIdentifier.current || !isReplyForCurrentMessage(reply)) return
+			simulateExecutionReply.value = reply
+		})
+	}
 
 	if (activeAddress.value === undefined) return <></>
 	return <>
@@ -132,8 +159,10 @@ export function GnosisSafeVisualizer(param: GnosisSafeVisualizerParams) {
 		<div class = 'notification dashed-notification'>
 			<legend class = 'paragraph'>Outcome of the message, should the multisig approve it</legend>
 			<ShowSuccessOrFailure
-				gnosisSafeMessage = { param.gnosisSafeMessage }
 				simulateExecutionReply = { simulateExecutionReply }
+				gnosisSimulationState = { gnosisSimulationRequest.value.state }
+				requestErrorText = { requestErrorText.value }
+				requestToSimulate = { requestToSimulate }
 				renameAddressCallBack = { param.renameAddressCallBack }
 				editEnsNamedHashCallBack = { param.editEnsNamedHashCallBack }
 				activeAddress = { activeAddress }
@@ -141,7 +170,13 @@ export function GnosisSafeVisualizer(param: GnosisSafeVisualizerParams) {
 		</div>
 		{ simulateExecutionReply.value === undefined ? <></> :
 			<div class = 'log-cell' style = 'justify-content: right; margin-top: 10px;'>
-				<button class = { 'button is-primary is-small' } onClick = { () => requestToSimulate(param.gnosisSafeMessage) }>Refresh simulation</button>
+				<AsyncActionButton
+					class = 'button is-primary is-small'
+					state = { gnosisSimulationRequest.value.state }
+					text = 'Refresh simulation'
+					pendingText = 'Simulating...'
+					onClick = { requestToSimulate }
+				/>
 			</div>
 		}
 	</>

--- a/app/ts/components/simulationExplaining/customExplainers/GovernanceVoteVisualizer.tsx
+++ b/app/ts/components/simulationExplaining/customExplainers/GovernanceVoteVisualizer.tsx
@@ -1,18 +1,19 @@
 import { type Signal, type ReadonlySignal, useComputed, useSignal } from '@preact/signals'
-import { sendPopupMessageToBackgroundPage } from '../../../background/backgroundUtils.js'
+import { getMissingPopupReplyErrorMessage, requestPopupSimulateGovernanceContractExecution } from '../../../background/backgroundUtils.js'
 import type { AddressBookEntry } from '../../../types/addressBookTypes.js'
 import { MessageToPopup, type GovernanceVoteInputParameters, SimulateExecutionReply } from '../../../types/interceptor-messages.js'
 import type { RenameAddressCallBack } from '../../../types/user-interface-types.js'
 import type { SimulatedAndVisualizedTransaction } from '../../../types/visualizer-types.js'
-import type { EthereumQuantity } from '../../../types/wire-types.js'
 import { checksummedAddress, dataStringWith0xStart } from '../../../utils/bigint.js'
 import { noReplyExpectingBrowserRuntimeOnMessageListener } from '../../../utils/browser.js'
 import { ErrorComponent } from '../../subcomponents/Error.js'
 import type { EditEnsNamedHashCallBack } from '../../subcomponents/ens.js'
 import { CellElement } from '../../ui-utils.js'
 import { Transaction } from '../Transactions.js'
-import { useEffect } from 'preact/hooks'
+import { useEffect, useRef } from 'preact/hooks'
 import { resolveSignal, type SignalOrValue } from '../../../utils/signals.js'
+import { AsyncActionButton } from '../../subcomponents/AsyncAction.js'
+import { type AsyncStates, useAsyncState } from '../../../utils/preact-utilities.js'
 
 type MissingAbiParams = {
 	errorMessage: string
@@ -82,13 +83,16 @@ type ShowSuccessOrFailureParams = {
 	simTx: Signal<SimulatedAndVisualizedTransaction | undefined>
 	activeAddress: ReadonlySignal<bigint | undefined>
 	simulateExecutionReply: Signal<SimulateExecutionReply | undefined>
+	governanceSimulationState: AsyncStates
+	requestErrorText: string | undefined
+	simulateGovernanceVote: () => void
 	renameAddressCallBack: RenameAddressCallBack
 	editEnsNamedHashCallBack: EditEnsNamedHashCallBack
 }
 
-const simulateGovernanceVote = (transactionIdentifier: EthereumQuantity) => sendPopupMessageToBackgroundPage({ method: 'popup_simulateGovernanceContractExecution', data: { transactionIdentifier } })
+const GOVERNANCE_SIMULATION_REPLY_MISSING_ERROR = getMissingPopupReplyErrorMessage('Simulating governance execution')
 
-const ShowSuccessOrFailure = ({ simulateExecutionReply, simTx, activeAddress, renameAddressCallBack, editEnsNamedHashCallBack }: ShowSuccessOrFailureParams) => {
+const ShowSuccessOrFailure = ({ simulateExecutionReply, simTx, activeAddress, renameAddressCallBack, editEnsNamedHashCallBack, governanceSimulationState, requestErrorText, simulateGovernanceVote }: ShowSuccessOrFailureParams) => {
 	const missingAbiText = 'The governance contract is missing an ABI. Add an ABI to simulate execution of this proposal.'
 	const errorText = useComputed(() => simulateExecutionReply.value?.data.success === false ? simulateExecutionReply.value.data.errorMessage : undefined)
 	const rpcErrorText = useComputed(() => simulateExecutionReply.value?.data.success === true && simulateExecutionReply.value.data.result.visualizedSimulationState.success === false ? JSON.stringify(simulateExecutionReply.value.data.result.visualizedSimulationState.jsonRpcError, undefined, 4) : undefined)
@@ -121,15 +125,18 @@ const ShowSuccessOrFailure = ({ simulateExecutionReply, simTx, activeAddress, re
 
 	if (simTx.value === undefined || activeAddress.value === undefined) return <></>
 	if (simulateExecutionReply.value === undefined) {
-		return <div style = 'display: flex; justify-content: center;'>
+		return <div style = 'display: grid; row-gap: 10px;'>
+			{ requestErrorText === undefined ? <></> : <ErrorComponent text = { requestErrorText }/> }
 			{ simTx.value.transaction.to !== undefined && 'abi' in simTx.value.transaction.to && simTx.value.transaction.to.abi !== undefined ?
-				<button
-					class = { 'button is-primary' }
-					onClick = { () => simulateGovernanceVote(simTx.value!.transactionIdentifier) }
-					disabled = { false }
-				>
-					Simulate execution on a passing vote
-				</button>
+				<div style = 'display: flex; justify-content: center;'>
+					<AsyncActionButton
+						class = 'button is-primary'
+						state = { governanceSimulationState }
+						text = 'Simulate execution on a passing vote'
+						pendingText = 'Simulating...'
+						onClick = { simulateGovernanceVote }
+					/>
+				</div>
 			: <> <MissingAbi
 					errorMessage = { missingAbiText }
 					addressBookEntry = { simTx.value.transaction.to }
@@ -139,7 +146,8 @@ const ShowSuccessOrFailure = ({ simulateExecutionReply, simTx, activeAddress, re
 		</div>
 	}
 	if (simulateExecutionReply.value.data.success === false) {
-		return <div style = 'display: grid; grid-template-rows: max-content' >
+		return <div style = 'display: grid; grid-template-rows: max-content; row-gap: 10px;' >
+			{ requestErrorText === undefined ? <></> : <ErrorComponent text = { requestErrorText }/> }
 			{ simulateExecutionReply.value.data.errorType === 'MissingAbi' ? <MissingAbi
 				errorMessage = { missingAbiText }
 				addressBookEntry = { simulateExecutionReply.value.data.errorAddressBookEntry }
@@ -148,13 +156,15 @@ const ShowSuccessOrFailure = ({ simulateExecutionReply, simTx, activeAddress, re
 		</div>
 	}
 	if (simulateExecutionReply.value.data.result.visualizedSimulationState.success === false) {
-		return <div style = 'display: grid; grid-template-rows: max-content' >
+		return <div style = 'display: grid; grid-template-rows: max-content; row-gap: 10px;' >
+			{ requestErrorText === undefined ? <></> : <ErrorComponent text = { requestErrorText }/> }
 			<ErrorComponent text = { rpcErrorText }/>
 		</div>
 	}
 	if (govSimTx.value === undefined) return <></>
 
-	return <div style = 'display: grid; grid-template-rows: max-content' >
+	return <div style = 'display: grid; grid-template-rows: max-content; row-gap: 10px;' >
+		{ requestErrorText === undefined ? <></> : <ErrorComponent text = { requestErrorText }/> }
 		<Transaction
 			simTx = { govSimTx.value }
 			simulationAndVisualisationResults = { results.value }
@@ -180,6 +190,12 @@ export function GovernanceVoteVisualizer(param: GovernanceVoteVisualizerParams) 
 	const governanceVoteInputParameters = useSignal<GovernanceVoteInputParameters | undefined>(undefined)
 	const simTx = useSignal<SimulatedAndVisualizedTransaction | undefined>(undefined)
 	const activeAddress = useSignal<bigint | undefined>(undefined)
+	const { value: governanceSimulationRequest, waitFor: waitForGovernanceSimulation, reset: resetGovernanceSimulationRequest } = useAsyncState<void>()
+	const requestErrorText = useComputed(() => governanceSimulationRequest.value.state === 'rejected' ? governanceSimulationRequest.value.error.message : undefined)
+	const currentTransactionIdentifier = useRef(param.simTx.transactionIdentifier)
+	currentTransactionIdentifier.current = param.simTx.transactionIdentifier
+
+	const isReplyForCurrentTransaction = (reply: SimulateExecutionReply) => reply.data.transactionOrMessageIdentifier === currentTransactionIdentifier.current
 
 	useEffect(() => {
 		const popupMessageListener = (msg: unknown): false => {
@@ -190,7 +206,8 @@ export function GovernanceVoteVisualizer(param: GovernanceVoteVisualizerParams) 
 			if (parsed.method !== 'popup_simulateExecutionReply') return false
 			const { role: _role, ...popupSimulateExecutionReply } = parsed
 			const reply = SimulateExecutionReply.parse(popupSimulateExecutionReply)
-			if (reply.data.transactionOrMessageIdentifier !== param.simTx.transactionIdentifier) return false
+			if (!isReplyForCurrentTransaction(reply)) return false
+			resetGovernanceSimulationRequest()
 			simulateExecutionReply.value = reply
 			return false
 		}
@@ -203,31 +220,52 @@ export function GovernanceVoteVisualizer(param: GovernanceVoteVisualizerParams) 
 		simTx.value = param.simTx
 		activeAddress.value = param.activeAddress.value
 		simulateExecutionReply.value = undefined
+		resetGovernanceSimulationRequest()
 	}, [param.simTx.transactionIdentifier, param.governanceVoteInputParameters, param.activeAddress.value])
+
+	const simulateGovernanceVote = () => {
+		const transactionIdentifier = simTx.value?.transactionIdentifier
+		if (transactionIdentifier === undefined) return
+		waitForGovernanceSimulation(async () => {
+			const reply = await requestPopupSimulateGovernanceContractExecution({ transactionIdentifier })
+			if (reply === undefined) throw new Error(GOVERNANCE_SIMULATION_REPLY_MISSING_ERROR)
+			if (transactionIdentifier !== currentTransactionIdentifier.current || !isReplyForCurrentTransaction(reply)) return
+			simulateExecutionReply.value = reply
+		})
+	}
 
 	if (governanceVoteInputParameters.value === undefined || simTx.value === undefined || activeAddress.value === undefined) return <></>
 	return <>
 	<VotePanel inputParams = { governanceVoteInputParameters } />
 
 		<div style = 'display: grid; grid-template-rows: max-content max-content'>
-			<span class = 'log-table' style = 'padding-bottom: 10px; grid-template-columns: auto auto;'>
-				<div class = 'log-cell'>
-					<p class = 'paragraph'>Simulation of this proposal's outcome should the vote pass:</p>
-				</div>
-				<div class = 'log-cell' style = 'justify-content: right;'>
-					{ simulateExecutionReply.value === undefined ? <></> :
-						<button class = { 'button is-primary is-small' } onClick = { () => simulateGovernanceVote(simTx.value!.transactionIdentifier) }>Refresh</button>
-					}
-				</div>
-			</span>
+				<span class = 'log-table' style = 'padding-bottom: 10px; grid-template-columns: auto auto;'>
+					<div class = 'log-cell'>
+						<p class = 'paragraph'>Simulation of this proposal's outcome should the vote pass:</p>
+					</div>
+					<div class = 'log-cell' style = 'justify-content: right;'>
+						{ simulateExecutionReply.value === undefined ? <></> :
+							<AsyncActionButton
+								class = 'button is-primary is-small'
+								state = { governanceSimulationRequest.value.state }
+								text = 'Refresh'
+								pendingText = 'Simulating...'
+								onClick = { simulateGovernanceVote }
+							/>
+						}
+					</div>
+				</span>
 		</div>
 
-		<div class = 'notification dashed-notification'>
-			<ShowSuccessOrFailure
-				simulateExecutionReply = { simulateExecutionReply }
-				renameAddressCallBack = { param.renameAddressCallBack }
-				editEnsNamedHashCallBack = { param.editEnsNamedHashCallBack }
-				simTx = { simTx }
+			<div class = 'notification dashed-notification'>
+				<ShowSuccessOrFailure
+					simulateExecutionReply = { simulateExecutionReply }
+					governanceSimulationState = { governanceSimulationRequest.value.state }
+					requestErrorText = { requestErrorText.value }
+					simulateGovernanceVote = { simulateGovernanceVote }
+					renameAddressCallBack = { param.renameAddressCallBack }
+					editEnsNamedHashCallBack = { param.editEnsNamedHashCallBack }
+					simTx = { simTx }
 				activeAddress = { activeAddress }
 			/>
 		</div>

--- a/app/ts/components/subcomponents/AsyncAction.tsx
+++ b/app/ts/components/subcomponents/AsyncAction.tsx
@@ -1,0 +1,69 @@
+import type { ComponentChildren, JSX } from 'preact'
+import type { AsyncStates } from '../../utils/preact-utilities.js'
+import { Spinner } from './Spinner.js'
+import { XMarkIcon } from './icons.js'
+
+type AsyncStatusIconProps = {
+	state: AsyncStates
+	size?: string
+}
+
+function SpinnerIcon({ size = '1em' }: { size?: string }) {
+	return (
+		<span aria-hidden = 'true' style = { { display: 'inline-flex', alignItems: 'center', justifyContent: 'center', width: size, height: size, lineHeight: 0 } }>
+			<Spinner height = { size } color = 'currentColor' />
+		</span>
+	)
+}
+
+function CheckIcon({ size = '1em' }: { size?: string }) {
+	return (
+		<span aria-hidden = 'true' style = { { color: 'var(--positive-color, currentColor)', display: 'inline-flex', alignItems: 'center', justifyContent: 'center', width: size, height: size, lineHeight: 0 } }>
+			<svg width = '1em' height = '1em' viewBox = '0 0 16 16' fill = 'none' xmlns = 'http://www.w3.org/2000/svg'>
+				<path d = 'M3 8.5L6.5 12L13 4.5' stroke = 'currentColor' stroke-width = '2' stroke-linecap = 'round' stroke-linejoin = 'round' />
+			</svg>
+		</span>
+	)
+}
+
+export function AsyncStatusIcon({ state, size = '1em' }: AsyncStatusIconProps) {
+	switch (state) {
+		case 'inactive': return <></>
+		case 'pending': return <SpinnerIcon size = { size } />
+		case 'rejected': return <span aria-hidden = 'true' style = { { color: 'var(--negative-color)', display: 'inline-flex', alignItems: 'center', justifyContent: 'center', width: size, height: size, lineHeight: 0 } }><XMarkIcon /></span>
+		case 'resolved': return <CheckIcon size = { size } />
+	}
+}
+
+type AsyncActionButtonProps = {
+	state: AsyncStates
+	text: ComponentChildren
+	pendingText: ComponentChildren
+	onClick: () => void | Promise<void>
+	disabled?: boolean
+	class?: string
+	style?: JSX.CSSProperties | string
+	type?: 'button' | 'submit' | 'reset'
+}
+
+export function AsyncActionButton(props: AsyncActionButtonProps) {
+	const pending = props.state === 'pending'
+	return (
+		<button
+			type = { props.type ?? 'button' }
+			class = { props.class }
+			style = { props.style }
+			onClick = { props.onClick }
+			disabled = { props.disabled || pending }
+			aria-busy = { pending }
+		>
+			{ pending
+				? <span style = { { display: 'inline-flex', alignItems: 'center', gap: '0.5em' } }>
+					<AsyncStatusIcon state = 'pending' />
+					<span>{ props.pendingText }</span>
+				</span>
+				: props.text
+			}
+		</button>
+	)
+}

--- a/app/ts/components/subcomponents/ConfigureRpcConnection.tsx
+++ b/app/ts/components/subcomponents/ConfigureRpcConnection.tsx
@@ -1,7 +1,7 @@
 import { createContext, type ComponentChildren } from 'preact'
 import { useComputed, useSignal, useSignalEffect } from '@preact/signals'
 import { useContext, useRef } from 'preact/hooks'
-import { type AsyncStates, useAsyncState } from '../../utils/preact-utilities.js'
+import { useAsyncState } from '../../utils/preact-utilities.js'
 import { TextInput } from './TextField.js'
 import { RpcEntry } from '../../types/rpc.js'
 import { sendPopupMessageToBackgroundPage } from '../../background/backgroundUtils.js'
@@ -10,10 +10,10 @@ import { getChainName } from '../../utils/constants.js'
 import { useRpcConnectionsList } from '../pages/SettingsView.js'
 import { EthereumJSONRpcRequestHandler } from '../../simulation/services/EthereumJSONRpcRequestHandler.js'
 import { type EthSimulateV1Params, EthSimulateV1Result } from '../../types/ethSimulate-types.js'
-import { XMarkIcon } from './icons.js'
 import { JsonRpcResponseError } from '../../utils/errors.js'
 import { EthereumQuantity } from '../../types/wire-types.js'
 import { isBrowserFetchTransportError } from '../../utils/caughtErrors.js'
+import { AsyncStatusIcon } from './AsyncAction.js'
 
 type RpcProbeResult = {
 	chainId: bigint
@@ -323,30 +323,8 @@ const RpcUrlField = ({ defaultValue }: { defaultValue?: string }) => {
 		}
 	})
 
-	return <TextInput ref = { inputRef } label = 'RPC URL *' name = 'httpsRpc' defaultValue = { defaultValue } onInput = { (e) => deferredQueryAnRpcUrl(e.currentTarget.value) } statusIcon = { <StatusIcon state = { rpcQuery.value.state } /> } style = '--area: 1 / span 2' required autoComplete = 'off' autoFocus = { defaultValue === undefined } readOnly = { defaultValue !== undefined } />
+	return <TextInput ref = { inputRef } label = 'RPC URL *' name = 'httpsRpc' defaultValue = { defaultValue } onInput = { (e) => deferredQueryAnRpcUrl(e.currentTarget.value) } statusIcon = { <AsyncStatusIcon state = { rpcQuery.value.state } /> } style = '--area: 1 / span 2' required autoComplete = 'off' autoFocus = { defaultValue === undefined } readOnly = { defaultValue !== undefined } />
 }
-
-const StatusIcon = ({ state }: { state: AsyncStates }) => {
-	switch (state) {
-		case 'inactive': return <></>
-		case 'pending': return <SpinnerIcon />
-		case 'rejected': return <i style = {{ color: 'var(--negative-color)' }} ><XMarkIcon /></i>
-		case 'resolved': return <CheckIcon />
-	}
-}
-
-const SpinnerIcon = () => (
-	<svg class = 'spin' width = '1em' height = '1em' viewBox = '0 0 16 16' fill = 'none' xmlns = 'http://www.w3.org/2000/svg'>
-		<circle cx = '8' cy = '8' r = '6.5' stroke = 'var(--text-color, currentColor)' stroke-opacity = '.5' stroke-width = '3' />
-		<path d = 'M8 0a8 8 0 1 0 8 8h-3a5 5 0 1 1-5-5z' fill = 'var(--text-color, currentColor)' fill-opacity = '.4' />
-	</svg>
-)
-
-const CheckIcon = () => (
-	<svg width = '1em' height = '1em' viewBox = '0 0 16 16' fill = 'none' xmlns = 'http://www.w3.org/2000/svg' >
-		<path d = 'M15 3L5.64686 12.5524L1 7.84615' stroke = 'var(--positive-color, currentColor)' strokeWidth = { 2 } />
-	</svg>
-)
 
 const Trash = () => (
 	<svg xmlns = 'http://www.w3.org/2000/svg' width = '1em' height = '1em' viewBox = '0 0 32 32'><path fill = 'currentColor' d = 'M15 4c-.522 0-1.06.185-1.438.563S13 5.478 13 6v1H7v2h1v16c0 1.645 1.355 3 3 3h12c1.645 0 3-1.355 3-3V9h1V7h-6V6c0-.522-.185-1.06-.563-1.438C20.06 4.186 19.523 4 19 4zm0 2h4v1h-4zm-5 3h14v16c0 .555-.445 1-1 1H11c-.555 0-1-.445-1-1zm2 3v11h2V12zm4 0v11h2V12zm4 0v11h2V12z' /></svg>

--- a/app/ts/types/interceptor-messages.ts
+++ b/app/ts/types/interceptor-messages.ts
@@ -1,8 +1,7 @@
 import * as funtypes from 'funtypes'
 import { PendingChainChangeConfirmationPromise, PendingFetchSimulationStackRequestPromise, RpcConnectionStatus, TabIconDetails, TabState } from './user-interface-types.js'
 import { EthereumAddress, EthereumBlockHeaderWithTransactionHashes, EthereumBytes32, EthereumData, EthereumQuantity, EthereumSignedTransactionWithBlockData, NonHexBigInt, OptionalEthereumAddress } from './wire-types.js'
-import { ModifyAddressWindowState, CompleteVisualizedSimulation, NamedTokenId, SimulationState, TokenPriceEstimate, VisualizedSimulationState, BlockTimeManipulation, BlockTimeManipulationWithNoDelay, InterceptorSimulationExport } from './visualizer-types.js'
-import { VisualizedPersonalSignRequestSafeTx } from './personal-message-definitions.js'
+import { ModifyAddressWindowState, CompleteVisualizedSimulation, BlockTimeManipulation, BlockTimeManipulationWithNoDelay, InterceptorSimulationExport } from './visualizer-types.js'
 import { UniqueRequestIdentifier, WebsiteSocket } from '../utils/requests.js'
 import { EthGetFeeHistoryResponse, EthGetLogsResponse, EthGetStorageAtParams, EthTransactionReceiptResponse, GetBlockReturn, SendRawTransactionParams, SendTransactionParams, SimulationStackVersion, WalletAddEthereumChain } from './JsonRpc-types.js'
 import { AddressBookEntries, AddressBookEntry, ChainIdWithUniversal } from './addressBookTypes.js'
@@ -15,6 +14,8 @@ import { OldSignTypedDataParams, PersonalSignParams, SignTypedDataParams } from 
 import { GetSimulationStackReplyV1, GetSimulationStackReplyV2 } from './simulationStackTypes.js'
 import { EnrichedRichListElement, PopupMessageReplyRequests, UnexpectedErrorOccured } from './interceptor-reply-messages.js'
 import { ErrorWithCodeAndOptionalData } from './error.js'
+import { SimulateExecutionReply as SharedSimulateExecutionReply, SimulateExecutionReplyData as SharedSimulateExecutionReplyData } from './simulateExecutionReply.js'
+import { SimulateGnosisSafeTransaction as SharedSimulateGnosisSafeTransaction, SimulateGovernanceContractExecution as SharedSimulateGovernanceContractExecution } from './simulateExecutionRequests.js'
 import { EthSimulateV1Result } from './ethSimulate-types.js'
 
 type WalletSwitchEthereumChainReplyParams = funtypes.Static<typeof WalletSwitchEthereumChainReplyParams>
@@ -714,53 +715,17 @@ export const GovernanceVoteInputParameters = funtypes.ReadonlyObject({
 	voter: funtypes.Union(funtypes.Undefined, EthereumAddress),
 })
 
-export type SimulateExecutionReplyData = funtypes.Static<typeof SimulateExecutionReplyData>
-export const SimulateExecutionReplyData = funtypes.Union(
-	funtypes.ReadonlyObject({
-		success: funtypes.Literal(false),
-		errorType: funtypes.Literal('Other'),
-		transactionOrMessageIdentifier: EthereumQuantity,
-		errorMessage: funtypes.String,
-	}),
-	funtypes.ReadonlyObject({
-		success: funtypes.Literal(false),
-		errorType: funtypes.Literal('MissingAbi'),
-		transactionOrMessageIdentifier: EthereumQuantity,
-		errorMessage: funtypes.String,
-		errorAddressBookEntry: AddressBookEntry,
-	}),
-	funtypes.ReadonlyObject({
-		success: funtypes.Literal(true),
-		transactionOrMessageIdentifier: EthereumQuantity,
-		result: funtypes.ReadonlyObject({
-			namedTokenIds: funtypes.ReadonlyArray(NamedTokenId),
-			addressBookEntries: funtypes.ReadonlyArray(AddressBookEntry),
-			visualizedSimulationState: VisualizedSimulationState,
-			tokenPriceEstimates: funtypes.ReadonlyArray(TokenPriceEstimate),
-			simulationState: funtypes.Union(SimulationState),
-		})
-	})
-)
+export type SimulateExecutionReplyData = funtypes.Static<typeof SharedSimulateExecutionReplyData>
+export const SimulateExecutionReplyData = SharedSimulateExecutionReplyData
 
-export type SimulateExecutionReply = funtypes.Static<typeof SimulateExecutionReply>
-export const SimulateExecutionReply = funtypes.ReadonlyObject({
-	method: funtypes.Literal('popup_simulateExecutionReply'),
-	data: SimulateExecutionReplyData
-}).asReadonly()
+export type SimulateExecutionReply = funtypes.Static<typeof SharedSimulateExecutionReply>
+export const SimulateExecutionReply = SharedSimulateExecutionReply
 
-export type SimulateGovernanceContractExecution = funtypes.Static<typeof SimulateGovernanceContractExecution>
-export const SimulateGovernanceContractExecution = funtypes.ReadonlyObject({
-	method: funtypes.Literal('popup_simulateGovernanceContractExecution'),
-	data: funtypes.ReadonlyObject({ transactionIdentifier: EthereumQuantity })
-})
+export type SimulateGovernanceContractExecution = funtypes.Static<typeof SharedSimulateGovernanceContractExecution>
+export const SimulateGovernanceContractExecution = SharedSimulateGovernanceContractExecution
 
-type SimulateGnosisSafeTransaction = funtypes.Static<typeof SimulateGnosisSafeTransaction>
-const SimulateGnosisSafeTransaction = funtypes.ReadonlyObject({
-	method: funtypes.Literal('popup_simulateGnosisSafeTransaction'),
-	data: funtypes.ReadonlyObject({
-		gnosisSafeMessage: VisualizedPersonalSignRequestSafeTx,
-	})
-})
+export type SimulateGnosisSafeTransaction = funtypes.Static<typeof SharedSimulateGnosisSafeTransaction>
+export const SimulateGnosisSafeTransaction = SharedSimulateGnosisSafeTransaction
 
 type SettingsOpenedReply = funtypes.Static<typeof SettingsOpenedReply>
 const SettingsOpenedReply = funtypes.ReadonlyObject({

--- a/app/ts/types/interceptor-reply-messages.ts
+++ b/app/ts/types/interceptor-reply-messages.ts
@@ -6,6 +6,8 @@ import { CompleteVisualizedSimulation, InterceptorSimulationExport, NamedTokenId
 import { EthereumAddress, EthereumQuantity, EthereumTimestamp } from './wire-types.js'
 import { PopupPendingTransactionOrSignableMessage } from './accessRequest.js'
 import { RpcConnectionStatus } from './user-interface-types.js'
+import { SimulateExecutionReply as PopupSimulateExecutionReply } from './simulateExecutionReply.js'
+import { SimulateGnosisSafeTransaction as RequestSimulateGnosisSafeTransaction, SimulateGovernanceContractExecution as RequestSimulateGovernanceContractExecution } from './simulateExecutionRequests.js'
 
 export type UnexpectedErrorOccured = funtypes.Static<typeof UnexpectedErrorOccured>
 export const UnexpectedErrorOccured = funtypes.ReadonlyObject({
@@ -174,6 +176,8 @@ type PopupRequestsRepliesMap = {
 	popup_requestSimulationMetadata: typeof RequestSimulationMetadataReply
 	popup_requestAbiAndNameFromBlockExplorer: typeof RequestAbiAndNameFromBlockExplorerReply
 	popup_requestIdentifyAddress: typeof RequestIdentifyAddressReply
+	popup_simulateGovernanceContractExecution: typeof PopupSimulateExecutionReply
+	popup_simulateGnosisSafeTransaction: typeof PopupSimulateExecutionReply
 	popup_isMainPopupWindowOpen: typeof RequestIsMainWindowOpen
 	popup_isSimulationVisualizerOpen: typeof RequestIsSimulationVisualizerOpen
 	popup_readyAndListening: typeof PopupReadyAndListeningReply
@@ -190,6 +194,8 @@ export const PopupRequestsReplies: PopupRequestsRepliesMap = {
 	popup_requestSimulationMetadata: RequestSimulationMetadataReply,
 	popup_requestAbiAndNameFromBlockExplorer: RequestAbiAndNameFromBlockExplorerReply,
 	popup_requestIdentifyAddress: RequestIdentifyAddressReply,
+	popup_simulateGovernanceContractExecution: PopupSimulateExecutionReply,
+	popup_simulateGnosisSafeTransaction: PopupSimulateExecutionReply,
 	popup_isMainPopupWindowOpen: RequestIsMainWindowOpen,
 	popup_isSimulationVisualizerOpen: RequestIsSimulationVisualizerOpen,
 	popup_readyAndListening: PopupReadyAndListeningReply,
@@ -208,6 +214,8 @@ export const RequestAbiAndNameFromBlockExplorer = funtypes.ReadonlyObject({
 export const PopupMessageReplyRequests = funtypes.Union(
 	RequestAbiAndNameFromBlockExplorer,
 	RequestIdentifyAddress,
+	RequestSimulateGovernanceContractExecution,
+	RequestSimulateGnosisSafeTransaction,
 	funtypes.ReadonlyObject({ method: funtypes.Literal('popup_requestMakeMeRichData') }),
 	funtypes.ReadonlyObject({ method: funtypes.Literal('popup_requestActiveAddresses') }),
 	funtypes.ReadonlyObject({ method: funtypes.Literal('popup_requestSimulationMode') }),
@@ -245,6 +253,7 @@ export type PopupReplyOption =
 	| RequestSimulationMetadataReply
 	| RequestAbiAndNameFromBlockExplorerReply
 	| RequestIdentifyAddressReply
+	| funtypes.Static<typeof PopupSimulateExecutionReply>
 	| RequestIsMainWindowOpen
 	| RequestIsSimulationVisualizerOpen
 	| PopupReadyAndListeningReply
@@ -261,6 +270,7 @@ export const PopupReplyOption: funtypes.Codec<PopupReplyOption> = funtypes.Union
 	RequestSimulationMetadataReply,
 	RequestAbiAndNameFromBlockExplorerReply,
 	RequestIdentifyAddressReply,
+	PopupSimulateExecutionReply,
 	RequestIsMainWindowOpen,
 	RequestIsSimulationVisualizerOpen,
 	PopupReadyAndListeningReply,

--- a/app/ts/types/simulateExecutionReply.ts
+++ b/app/ts/types/simulateExecutionReply.ts
@@ -1,0 +1,42 @@
+import * as funtypes from 'funtypes'
+import { AddressBookEntry } from './addressBookTypes.js'
+import { NamedTokenId, SimulationState, TokenPriceEstimate, VisualizedSimulationState } from './visualizer-types.js'
+import { EthereumQuantity, serialize } from './wire-types.js'
+
+export type SimulateExecutionReplyData = funtypes.Static<typeof SimulateExecutionReplyData>
+export const SimulateExecutionReplyData = funtypes.Union(
+	funtypes.ReadonlyObject({
+		success: funtypes.Literal(false),
+		errorType: funtypes.Literal('Other'),
+		transactionOrMessageIdentifier: EthereumQuantity,
+		errorMessage: funtypes.String,
+	}),
+	funtypes.ReadonlyObject({
+		success: funtypes.Literal(false),
+		errorType: funtypes.Literal('MissingAbi'),
+		transactionOrMessageIdentifier: EthereumQuantity,
+		errorMessage: funtypes.String,
+		errorAddressBookEntry: AddressBookEntry,
+	}),
+	funtypes.ReadonlyObject({
+		success: funtypes.Literal(true),
+		transactionOrMessageIdentifier: EthereumQuantity,
+		result: funtypes.ReadonlyObject({
+			namedTokenIds: funtypes.ReadonlyArray(NamedTokenId),
+			addressBookEntries: funtypes.ReadonlyArray(AddressBookEntry),
+			visualizedSimulationState: VisualizedSimulationState,
+			tokenPriceEstimates: funtypes.ReadonlyArray(TokenPriceEstimate),
+			simulationState: funtypes.Union(SimulationState),
+		}),
+	}),
+)
+
+export type SimulateExecutionReply = funtypes.Static<typeof SimulateExecutionReply>
+export const SimulateExecutionReply = funtypes.ReadonlyObject({
+	method: funtypes.Literal('popup_simulateExecutionReply'),
+	data: SimulateExecutionReplyData,
+}).asReadonly()
+
+export function serializeSimulateExecutionReply(reply: SimulateExecutionReply) {
+	return serialize(SimulateExecutionReply, reply)
+}

--- a/app/ts/types/simulateExecutionRequests.ts
+++ b/app/ts/types/simulateExecutionRequests.ts
@@ -1,0 +1,17 @@
+import * as funtypes from 'funtypes'
+import { VisualizedPersonalSignRequestSafeTx } from './personal-message-definitions.js'
+import { EthereumQuantity } from './wire-types.js'
+
+export type SimulateGovernanceContractExecution = funtypes.Static<typeof SimulateGovernanceContractExecution>
+export const SimulateGovernanceContractExecution = funtypes.ReadonlyObject({
+	method: funtypes.Literal('popup_simulateGovernanceContractExecution'),
+	data: funtypes.ReadonlyObject({ transactionIdentifier: EthereumQuantity }),
+})
+
+export type SimulateGnosisSafeTransaction = funtypes.Static<typeof SimulateGnosisSafeTransaction>
+export const SimulateGnosisSafeTransaction = funtypes.ReadonlyObject({
+	method: funtypes.Literal('popup_simulateGnosisSafeTransaction'),
+	data: funtypes.ReadonlyObject({
+		gnosisSafeMessage: VisualizedPersonalSignRequestSafeTx,
+	}),
+})

--- a/app/ts/utils/preact-utilities.ts
+++ b/app/ts/utils/preact-utilities.ts
@@ -5,7 +5,12 @@ type Resolved<T> = { state: 'resolved', value: T }
 type Rejected = { state: 'rejected', error: Error }
 type AsyncProperty<T> = Inactive | Pending | Resolved<T> | Rejected
 type AsyncState<T> = { value: Signal<AsyncProperty<T>>, waitFor: (resolver: () => Promise<T>) => void, reset: () => void }
+export type AsyncActionContext<T> = { value: Signal<AsyncProperty<T>>, waitFor: (resolver: () => Promise<T>) => void, reset: () => void }
 export type AsyncStates = AsyncState<unknown>['value']['value']['state']
+
+export function createAsyncActionRunner<T>(asyncAction: AsyncActionContext<T>, resolver: () => Promise<T>) {
+	return () => { void asyncAction.waitFor(resolver) }
+}
 
 export function useAsyncState<T>(): AsyncState<T> {
 	function getCaptureAndCancelOthers() {

--- a/readme.md
+++ b/readme.md
@@ -49,5 +49,31 @@ Then depending on your browser:
 - Firefox: Browse to `about:debugging` and click `Load Temporary Add-on` and point to `\app\manifest.json`.
 - Brave: Browse to `brave://extensions/` and click `Load unpacked` and point to `\app\manifest.json`.
 
+## Async popup button pattern
+
+Use `AsyncActionButton` for popup buttons that send a background message and need pending/retry/error UI while waiting for a reply.
+
+Use this pattern when the click:
+- sends a popup message via `sendPopupMessageToBackgroundPage`,
+- waits for a background reply or error path,
+- and expects the UI state to refresh after the result.
+
+Preferred pattern:
+```tsx
+const actionState = useAsyncState<void>()
+const action = createAsyncActionRunner(actionState, async () => {
+	await sendPopupMessageToBackgroundPage({ method: '...' })
+})
+
+<AsyncActionButton
+	state = { actionState.value.state }
+	text = 'Action'
+	pendingText = 'Applying...'
+	onClick = { action }
+/>
+```
+
+Do not use direct `void actionState.waitFor(...)` call sites for these async button flows.
+
 # Contact Us!
 You can reach us [Dark Florist](https://www.dark.florist/) via [Discord](https://discord.gg/b66SwRZAbu) and twitter [@DarkFlorist](https://twitter.com/DarkFlorist)!

--- a/test/tests/contentScriptsUpdating.test.ts
+++ b/test/tests/contentScriptsUpdating.test.ts
@@ -144,6 +144,18 @@ describe('content script injection strategy errors', () => {
 		assert.equal(await getLatestUnexpectedError(), undefined)
 	})
 
+	test('keeps invalid-tab manifest v2 injection failures ignored', async () => {
+		const { getCommittedListener } = installBrowserMock({ executeScriptError: new Error('Invalid tab ID: 42') })
+		const { updateContentScriptInjectionStrategyManifestV2, getLatestUnexpectedError } = await loadModules()
+
+		await updateContentScriptInjectionStrategyManifestV2()
+		await withSilencedConsole(async () => {
+			await getCommittedListener()(committedDetails)
+		})
+
+		assert.equal(await getLatestUnexpectedError(), undefined)
+	})
+
 	test('records manifest v2 injection failures as local recovery diagnostics', async () => {
 		const { getCommittedListener } = installBrowserMock({ executeScriptError: new Error('executeScript failed') })
 		const { updateContentScriptInjectionStrategyManifestV2, getInterceptorErrorDiagnostics, getLatestUnexpectedError } = await loadModules()

--- a/test/tests/importSimulationStack.test.tsx
+++ b/test/tests/importSimulationStack.test.tsx
@@ -115,6 +115,8 @@ type TestDomNode = {
 	readonly childNodes?: readonly TestDomNode[]
 	readonly textContent?: string | null
 	readonly l?: Record<string, (event: unknown) => unknown>
+	readonly attributes?: Record<string, string | undefined>
+	disabled?: boolean
 }
 
 function collectElements(node: TestDomNode | null | undefined, tagName: string, results: TestDomNode[] = []) {
@@ -127,6 +129,26 @@ async function clickElement(element: { l?: Record<string, (event: unknown) => un
 	const clickHandler = element.l === undefined ? undefined : Object.entries(element.l).find(([key]) => key.startsWith('Click'))?.[1]
 	if (clickHandler === undefined) throw new Error('Expected click handler')
 	await clickHandler({ currentTarget: element })
+}
+
+function isDisabled(element: TestDomNode | undefined) {
+	if (element === undefined) return false
+	return 'disabled' in element || element.attributes?.disabled !== undefined
+}
+
+function createDeferred<T>() {
+	let resolvePromise: (value: T | PromiseLike<T>) => void = () => undefined
+	const promise = new Promise<T>((resolve) => {
+		resolvePromise = resolve
+	})
+	return { promise, resolve: resolvePromise }
+}
+
+async function settleAsyncUpdates() {
+	await Promise.resolve()
+	await Promise.resolve()
+	await new Promise((resolve) => setTimeout(resolve, 0))
+	await Promise.resolve()
 }
 
 describe('import simulation stack', () => {
@@ -166,10 +188,82 @@ describe('import simulation stack', () => {
 
 		await act(async () => {
 			await clickElement(importButton)
+			await settleAsyncUpdates()
 		})
 
 		assert.equal(closeCount, 0)
 		assert.match(dom.document.body.textContent, /Quota exceeded while saving the imported stack\./)
+		dom.restore()
+	})
+
+	test('shows import progress and disables modal controls while waiting for the reply', async () => {
+		const modules = await modulesPromise
+		resetEnvironment()
+		const dom = installDomMock()
+		const deferredReply = createDeferred<unknown>()
+		let closeCount = 0
+		runtimeSendMessage = async () => deferredReply.promise
+
+		await act(() => {
+			render(h(modules.ImportSimulationStack, {
+				close: () => { closeCount += 1 },
+				simulationInput: signal(exportString),
+			}), dom.document.body)
+		})
+
+		const buttons = collectElements(dom.document.body, 'button')
+		const closeButton = buttons.find((button) => button.textContent?.includes('Import') !== true)
+		const importButton = buttons.find((button) => button.textContent?.includes('Import'))
+		const textareas = collectElements(dom.document.body, 'textarea')
+		const textarea = textareas[0]
+		assert.ok(importButton)
+		assert.ok(closeButton)
+		assert.ok(textarea)
+
+		await act(async () => {
+			await clickElement(importButton)
+			await settleAsyncUpdates()
+		})
+
+		assert.match(importButton.textContent ?? '', /Importing\.\.\./)
+		assert.equal(isDisabled(importButton), true)
+		assert.equal(isDisabled(closeButton), true)
+		assert.equal(isDisabled(textarea), true)
+		assert.equal(closeCount, 0)
+
+		await act(async () => {
+			deferredReply.resolve({ type: 'ImportSimulationStackReply', ok: true })
+			await deferredReply.promise
+			await settleAsyncUpdates()
+		})
+
+		assert.equal(closeCount, 1)
+		dom.restore()
+	})
+
+	test('shows a missing-reply import error', async () => {
+		const modules = await modulesPromise
+		resetEnvironment()
+		const dom = installDomMock()
+		runtimeSendMessage = async () => undefined
+
+		await act(() => {
+			render(h(modules.ImportSimulationStack, {
+				close: () => undefined,
+				simulationInput: signal(exportString),
+			}), dom.document.body)
+		})
+
+		const buttons = collectElements(dom.document.body, 'button')
+		const importButton = buttons.find((button) => button.textContent?.includes('Import'))
+		assert.ok(importButton)
+
+		await act(async () => {
+			await clickElement(importButton)
+			await settleAsyncUpdates()
+		})
+
+		assert.match(dom.document.body.textContent, /Importing the simulation stack failed because the background page did not return a reply\./)
 		dom.restore()
 	})
 
@@ -193,6 +287,7 @@ describe('import simulation stack', () => {
 
 		await act(async () => {
 			await clickElement(importButton)
+			await settleAsyncUpdates()
 		})
 
 		assert.equal(closeCount, 1)

--- a/test/tests/messageSendingPortLifecycle.test.ts
+++ b/test/tests/messageSendingPortLifecycle.test.ts
@@ -39,4 +39,17 @@ describe('background messageSending port lifecycle', () => {
 			sendSubscriptionReplyOrCallBackToPort(port, { type: 'result', method: 'accountsChanged', result: [] })
 		})
 	})
+
+	test('ignores invalid tab target errors after posting to a content-script port', () => {
+		installBrowserMock()
+		const port = {
+			postMessage() {
+				throw new Error('Invalid tab ID: 12')
+			},
+		} as unknown as browser.runtime.Port
+
+		assert.doesNotThrow(() => {
+			sendSubscriptionReplyOrCallBackToPort(port, { type: 'result', method: 'accountsChanged', result: [] })
+		})
+	})
 })

--- a/test/tests/popupAsyncActionUi.test.tsx
+++ b/test/tests/popupAsyncActionUi.test.tsx
@@ -1,0 +1,742 @@
+import * as assert from 'assert'
+import { afterEach, describe, test } from 'bun:test'
+import { signal } from '@preact/signals'
+import { h, render } from 'preact'
+import { act } from 'preact/test-utils'
+import { type GovernanceVoteInputParameters, SimulateExecutionReply } from '../../app/ts/types/interceptor-messages.js'
+import { PopupRequestsReplies } from '../../app/ts/types/interceptor-reply-messages.js'
+import type { VisualizedPersonalSignRequestSafeTx } from '../../app/ts/types/personal-message-definitions.js'
+import type { SimulatedAndVisualizedTransaction } from '../../app/ts/types/visualizer-types.js'
+import { serialize } from '../../app/ts/types/wire-types.js'
+import { installDomMock } from './domMock.js'
+
+let runtimeSendMessage = async (_message: unknown) => undefined
+const runtimeMessageListeners: Array<(message: unknown) => unknown> = []
+
+function installBrowser() {
+	Object.defineProperty(globalThis, 'browser', {
+		value: {
+			runtime: {
+				lastError: null,
+				getManifest: () => ({ manifest_version: 3 }),
+				sendMessage: async (message: unknown) => await runtimeSendMessage(message),
+				onMessage: {
+					addListener: (listener: (message: unknown) => unknown) => { runtimeMessageListeners.push(listener) },
+					removeListener: (listener: (message: unknown) => unknown) => {
+						const index = runtimeMessageListeners.indexOf(listener)
+						if (index !== -1) runtimeMessageListeners.splice(index, 1)
+					},
+				},
+				onConnect: { addListener: () => undefined, removeListener: () => undefined },
+			},
+			storage: {
+				local: {
+					async get() { return {} },
+					async set() { return undefined },
+					async remove() { return undefined },
+				},
+			},
+			tabs: {
+				async query() { return [] },
+				async get() { return undefined },
+				async update() { return undefined },
+				onUpdated: { addListener: () => undefined, removeListener: () => undefined },
+				onRemoved: { addListener: () => undefined, removeListener: () => undefined },
+			},
+			windows: {
+				async get() { return undefined },
+				async update() { return undefined },
+			},
+			action: {
+				async setIcon() { return undefined },
+				async setTitle() { return undefined },
+				async setBadgeText() { return undefined },
+				async setBadgeBackgroundColor() { return undefined },
+			},
+			browserAction: {
+				async setIcon() { return undefined },
+				async setTitle() { return undefined },
+				async setBadgeText() { return undefined },
+				async setBadgeBackgroundColor() { return undefined },
+			},
+		},
+		configurable: true,
+		writable: true,
+	})
+	Object.defineProperty(globalThis, 'chrome', { value: { runtime: { id: 'test-extension' } }, configurable: true, writable: true })
+}
+
+installBrowser()
+
+afterEach(() => {
+	runtimeSendMessage = async (_message: unknown) => undefined
+	runtimeMessageListeners.splice(0, runtimeMessageListeners.length)
+})
+
+async function loadModules() {
+	return {
+		...await import('../../app/ts/components/pages/AddNewAddress.js'),
+		...await import('../../app/ts/components/simulationExplaining/customExplainers/GovernanceVoteVisualizer.js'),
+		...await import('../../app/ts/components/simulationExplaining/customExplainers/GnosisSafeVisualizer.js'),
+	}
+}
+
+const modulesPromise = loadModules()
+
+type TestDomNode = {
+	readonly tagName?: string
+	readonly childNodes?: readonly TestDomNode[]
+	readonly textContent?: string | null
+	readonly l?: Record<string, (event: unknown) => unknown>
+	readonly attributes?: Record<string, string | undefined>
+	disabled?: boolean
+}
+
+function collectElements(node: TestDomNode | null | undefined, tagName: string, results: TestDomNode[] = []) {
+	if (node?.tagName === tagName.toUpperCase()) results.push(node)
+	for (const child of node?.childNodes ?? []) collectElements(child, tagName, results)
+	return results
+}
+
+async function clickElement(element: { l?: Record<string, (event: unknown) => unknown> }) {
+	const clickHandler = element.l === undefined ? undefined : Object.entries(element.l).find(([key]) => key.startsWith('Click'))?.[1]
+	if (clickHandler === undefined) throw new Error('Expected click handler')
+	await clickHandler({ currentTarget: element })
+}
+
+function isDisabled(element: TestDomNode | undefined) {
+	if (element === undefined) return false
+	return 'disabled' in element || element.attributes?.disabled !== undefined
+}
+
+function createDeferred<T>() {
+	let resolvePromise: (value: T | PromiseLike<T>) => void = () => undefined
+	let rejectPromise: (reason?: unknown) => void = () => undefined
+	const promise = new Promise<T>((resolve, reject) => {
+		resolvePromise = resolve
+		rejectPromise = reject
+	})
+	return { promise, resolve: resolvePromise, reject: rejectPromise }
+}
+
+function createSimulationFailureReply(transactionOrMessageIdentifier: bigint, errorMessage: string) {
+	return serialize(SimulateExecutionReply, {
+		method: 'popup_simulateExecutionReply' as const,
+		data: {
+			success: false as const,
+			errorType: 'Other' as const,
+			transactionOrMessageIdentifier,
+			errorMessage,
+		},
+	})
+}
+
+function createSimulationFailureBroadcast(transactionOrMessageIdentifier: bigint, errorMessage: string) {
+	return { role: 'all' as const, ...createSimulationFailureReply(transactionOrMessageIdentifier, errorMessage) }
+}
+
+function createAbiLookupFailureReply(error: string) {
+	return PopupRequestsReplies.popup_requestAbiAndNameFromBlockExplorer.serialize({
+		method: 'popup_requestAbiAndNameFromBlockExplorer',
+		data: {
+			success: false as const,
+			error,
+		},
+	})
+}
+
+async function emitRuntimeMessage(message: unknown) {
+	for (const listener of [...runtimeMessageListeners]) {
+		await listener(message)
+	}
+}
+
+function getRuntimeMethod(message: unknown) {
+	if (typeof message !== 'object' || message === null || !('method' in message)) return undefined
+	const method = Reflect.get(message, 'method')
+	return typeof method === 'string' ? method : undefined
+}
+
+async function settleAsyncUpdates() {
+	await Promise.resolve()
+	await Promise.resolve()
+	await new Promise((resolve) => setTimeout(resolve, 0))
+	await Promise.resolve()
+}
+
+const ASYNC_CHANNEL_CLOSED_ERROR = 'A listener indicated an asynchronous response by returning true, but the message channel closed before a response was received'
+
+function createGovernanceVoteInputParameters(proposalId: bigint): GovernanceVoteInputParameters {
+	return {
+		proposalId,
+		support: true,
+		reason: undefined,
+		params: undefined,
+		signature: undefined,
+		voter: undefined,
+	}
+}
+
+function createGovernanceTransactionFixture(transactionIdentifier: bigint): SimulatedAndVisualizedTransaction {
+	const governanceTransactionFixture = {
+		transactionIdentifier,
+		transaction: {
+			to: {
+				type: 'contract',
+				name: 'Governance',
+				address: 0x1n,
+				entrySource: 'User',
+				abi: '[]',
+				chainId: 1n,
+			},
+		},
+	} satisfies Pick<SimulatedAndVisualizedTransaction, 'transactionIdentifier' | 'transaction'>
+
+	// GovernanceVoteVisualizer only reads transactionIdentifier and transaction.to in these tests.
+	return governanceTransactionFixture as SimulatedAndVisualizedTransaction
+}
+
+const gnosisSignerAddress = {
+	type: 'contact' as const,
+	name: 'Signer',
+	address: 0x2n,
+	entrySource: 'User' as const,
+	chainId: 1n,
+}
+
+const zeroAddressEntry = {
+	type: 'contact' as const,
+	name: '0x0 Address',
+	address: 0n,
+	entrySource: 'Interceptor' as const,
+	chainId: 1n,
+}
+
+function createGnosisSafeMessageFixture(messageIdentifier: bigint): VisualizedPersonalSignRequestSafeTx {
+	return {
+		activeAddress: gnosisSignerAddress,
+		rpcNetwork: {
+			name: 'Ethereum Mainnet',
+			chainId: 1n,
+			httpsRpc: 'https://rpc.example',
+			currencyName: 'Ether',
+			currencyTicker: 'ETH',
+			primary: true,
+			minimized: false,
+		},
+		simulationMode: true,
+		signerName: 'NoSignerDetected',
+		quarantineReasons: [],
+		quarantine: false,
+		account: gnosisSignerAddress,
+		website: { websiteOrigin: 'https://safe.example', icon: undefined, title: undefined },
+		created: new Date('2024-01-01T00:00:00.000Z'),
+		rawMessage: '{}',
+		stringifiedMessage: '{}',
+		messageIdentifier,
+		method: 'eth_signTypedData_v4',
+		type: 'SafeTx',
+		message: {
+			types: {
+				SafeTx: [
+					{ name: 'to', type: 'address' },
+					{ name: 'value', type: 'uint256' },
+					{ name: 'data', type: 'bytes' },
+					{ name: 'operation', type: 'uint8' },
+					{ name: 'safeTxGas', type: 'uint256' },
+					{ name: 'baseGas', type: 'uint256' },
+					{ name: 'gasPrice', type: 'uint256' },
+					{ name: 'gasToken', type: 'address' },
+					{ name: 'refundReceiver', type: 'address' },
+					{ name: 'nonce', type: 'uint256' },
+				],
+				EIP712Domain: [
+					{ name: 'chainId', type: 'uint256' },
+					{ name: 'verifyingContract', type: 'address' },
+				],
+			},
+			primaryType: 'SafeTx',
+			domain: {
+				chainId: 1n,
+				verifyingContract: gnosisSignerAddress.address,
+			},
+			message: {
+				to: 0x3n,
+				value: 0n,
+				data: new Uint8Array(),
+				operation: 0n,
+				safeTxGas: 0n,
+				baseGas: 0n,
+				gasPrice: 0n,
+				gasToken: zeroAddressEntry.address,
+				refundReceiver: zeroAddressEntry.address,
+				nonce: 1n,
+			},
+		},
+		parsedMessageDataAddressBookEntries: [],
+		parsedMessageData: { type: 'NonParsed', input: new Uint8Array() },
+		gasToken: zeroAddressEntry,
+		to: {
+			type: 'contact',
+			name: 'Recipient',
+			address: 0x3n,
+			entrySource: 'User',
+			chainId: 1n,
+		},
+		refundReceiver: zeroAddressEntry,
+		verifyingContract: {
+			type: 'contract',
+			name: 'Safe',
+			address: gnosisSignerAddress.address,
+			entrySource: 'User',
+			abi: '[]',
+			chainId: 1n,
+		},
+		messageHash: '0x1',
+		domainHash: '0x2',
+		safeTxHash: '0x3',
+	}
+}
+
+describe('popup async action UI', () => {
+	test('shows ABI lookup progress and a missing-reply error in AddNewAddress', async () => {
+		const modules = await modulesPromise
+		const dom = installDomMock()
+		const deferredReply = createDeferred<unknown>()
+		let requestCount = 0
+		runtimeSendMessage = async () => {
+			requestCount += 1
+			return requestCount === 1 ? deferredReply.promise : undefined
+		}
+
+		const modifyAddressWindowState = signal({
+			windowStateId: 'window-1',
+			errorState: undefined,
+			incompleteAddressBookEntry: {
+				addingAddress: false,
+				type: 'contract' as const,
+				address: '0x0000000000000000000000000000000000000001',
+				askForAddressAccess: true,
+				name: 'Governance Contract',
+				symbol: undefined,
+				decimals: undefined,
+				logoUri: undefined,
+				entrySource: 'User' as const,
+				abi: undefined,
+				useAsActiveAddress: undefined,
+				declarativeNetRequestBlockMode: undefined,
+				chainId: 1n,
+			},
+		})
+
+		const rpcEntries = signal([{
+			name: 'Ethereum Mainnet',
+			chainId: 1n,
+			httpsRpc: 'https://rpc.example',
+			currencyName: 'Ether',
+			currencyTicker: 'ETH',
+			primary: true,
+			minimized: false,
+			blockExplorer: { apiUrl: 'https://explorer.example/api', apiKey: '' },
+		}])
+
+		await act(() => {
+			render(h(modules.AddNewAddress, {
+				close: () => undefined,
+				setActiveAddressAndInformAboutIt: undefined,
+				modifyAddressWindowState,
+				activeAddress: undefined,
+				rpcEntries,
+			}), dom.document.body)
+		})
+
+		const buttons = collectElements(dom.document.body, 'button')
+		const fetchButton = buttons.find((button) => button.textContent?.includes('Fetch from Block Explorer'))
+		const modifyButton = buttons.find((button) => button.textContent?.includes('Modify'))
+		const cancelButton = buttons.find((button) => button.textContent?.includes('Cancel'))
+		if (fetchButton === undefined || modifyButton === undefined || cancelButton === undefined) throw new Error('Expected address modal buttons to render')
+
+		await act(async () => {
+			await clickElement(fetchButton)
+		})
+
+		assert.match(fetchButton.textContent ?? '', /Fetching\.\.\./)
+		assert.equal(isDisabled(fetchButton), true)
+		assert.equal(isDisabled(modifyButton), true)
+		assert.equal(isDisabled(cancelButton), true)
+
+		await act(async () => {
+			deferredReply.resolve(undefined)
+			await deferredReply.promise
+			await settleAsyncUpdates()
+		})
+
+		assert.equal(dom.document.body.textContent?.includes(modules.BLOCK_EXPLORER_REPLY_MISSING_ERROR), true)
+		assert.equal(dom.document.body.textContent?.includes('Fetch from Block Explorer'), true)
+		dom.restore()
+	})
+
+	test('ignores stale ABI lookup failures after the address changes', async () => {
+		const modules = await modulesPromise
+		const dom = installDomMock()
+		const staleReply = createAbiLookupFailureReply('stale block explorer failure')
+		const deferredReply = createDeferred<typeof staleReply>()
+		runtimeSendMessage = async () => deferredReply.promise
+
+		const modifyAddressWindowState = signal({
+			windowStateId: 'window-1',
+			errorState: undefined,
+			incompleteAddressBookEntry: {
+				addingAddress: false,
+				type: 'contract' as const,
+				address: '0x0000000000000000000000000000000000000001',
+				askForAddressAccess: true,
+				name: 'Governance Contract',
+				symbol: undefined,
+				decimals: undefined,
+				logoUri: undefined,
+				entrySource: 'User' as const,
+				abi: undefined,
+				useAsActiveAddress: undefined,
+				declarativeNetRequestBlockMode: undefined,
+				chainId: 1n,
+			},
+		})
+
+		const rpcEntries = signal([{
+			name: 'Ethereum Mainnet',
+			chainId: 1n,
+			httpsRpc: 'https://rpc.example',
+			currencyName: 'Ether',
+			currencyTicker: 'ETH',
+			primary: true,
+			minimized: false,
+			blockExplorer: { apiUrl: 'https://explorer.example/api', apiKey: '' },
+		}])
+
+		await act(() => {
+			render(h(modules.AddNewAddress, {
+				close: () => undefined,
+				setActiveAddressAndInformAboutIt: undefined,
+				modifyAddressWindowState,
+				activeAddress: undefined,
+				rpcEntries,
+			}), dom.document.body)
+		})
+
+		const fetchButton = collectElements(dom.document.body, 'button').find((button) => button.textContent?.includes('Fetch from Block Explorer'))
+		if (fetchButton === undefined) throw new Error('Expected block explorer fetch button to render')
+
+		await act(async () => {
+			await clickElement(fetchButton)
+		})
+
+		await act(async () => {
+			modifyAddressWindowState.value = {
+				...modifyAddressWindowState.value,
+				incompleteAddressBookEntry: {
+					...modifyAddressWindowState.value.incompleteAddressBookEntry,
+					address: '0x0000000000000000000000000000000000000002',
+				},
+			}
+			await settleAsyncUpdates()
+		})
+
+		assert.equal(dom.document.body.textContent?.includes('Fetching...'), false)
+
+		await act(async () => {
+			deferredReply.resolve(staleReply)
+			await deferredReply.promise
+			await settleAsyncUpdates()
+		})
+
+		assert.equal(dom.document.body.textContent?.includes('stale block explorer failure'), false)
+		assert.equal(dom.document.body.textContent?.includes('Fetch from Block Explorer'), true)
+		dom.restore()
+	})
+
+	test('shows governance simulation progress and a missing-reply error', async () => {
+		const modules = await modulesPromise
+		const dom = installDomMock()
+		const deferredReply = createDeferred<unknown>()
+		runtimeSendMessage = async () => deferredReply.promise
+
+		await act(() => {
+			render(h(modules.GovernanceVoteVisualizer, {
+				simTx: createGovernanceTransactionFixture(5n),
+				activeAddress: signal(0x2n),
+				renameAddressCallBack: () => undefined,
+				editEnsNamedHashCallBack: () => undefined,
+				governanceVoteInputParameters: createGovernanceVoteInputParameters(42n),
+			}), dom.document.body)
+		})
+
+		const buttons = collectElements(dom.document.body, 'button')
+		const simulateButton = buttons.find((button) => button.textContent?.includes('Simulate execution on a passing vote'))
+		if (simulateButton === undefined) throw new Error('Expected governance simulation button to render')
+
+		await act(async () => {
+			await clickElement(simulateButton)
+		})
+
+		assert.match(simulateButton.textContent ?? '', /Simulating\.\.\./)
+		assert.equal(isDisabled(simulateButton), true)
+
+		await act(async () => {
+			deferredReply.resolve(undefined)
+			await deferredReply.promise
+			await settleAsyncUpdates()
+		})
+
+		assert.equal(dom.document.body.textContent?.includes('Simulating governance execution failed because the background page did not return a reply.'), true)
+		assert.equal(dom.document.body.textContent?.includes('Simulate execution on a passing vote'), true)
+		dom.restore()
+	})
+
+	test('matching governance broadcasts clear later missing direct-reply errors', async () => {
+		const modules = await modulesPromise
+		const dom = installDomMock()
+		const deferredReply = createDeferred<unknown>()
+		runtimeSendMessage = async (message) => {
+			if (getRuntimeMethod(message) === 'popup_simulateGovernanceContractExecution') return deferredReply.promise
+			return undefined
+		}
+
+		await act(() => {
+			render(h(modules.GovernanceVoteVisualizer, {
+				simTx: createGovernanceTransactionFixture(5n),
+				activeAddress: signal(0x2n),
+				renameAddressCallBack: () => undefined,
+				editEnsNamedHashCallBack: () => undefined,
+				governanceVoteInputParameters: createGovernanceVoteInputParameters(42n),
+			}), dom.document.body)
+		})
+
+		const simulateButton = collectElements(dom.document.body, 'button').find((button) => button.textContent?.includes('Simulate execution on a passing vote'))
+		if (simulateButton === undefined) throw new Error('Expected governance simulation button to render')
+
+		await act(async () => {
+			await clickElement(simulateButton)
+		})
+
+		await act(async () => {
+			await emitRuntimeMessage(createSimulationFailureBroadcast(5n, 'governance broadcast reply'))
+			await settleAsyncUpdates()
+		})
+
+		assert.equal(dom.document.body.textContent?.includes('governance broadcast reply'), true)
+
+		await act(async () => {
+			deferredReply.resolve(undefined)
+			await deferredReply.promise
+			await settleAsyncUpdates()
+		})
+
+		assert.equal(dom.document.body.textContent?.includes('governance broadcast reply'), true)
+		assert.equal(dom.document.body.textContent?.includes('Simulating governance execution failed because the background page did not return a reply.'), false)
+		dom.restore()
+	})
+
+	test('ignores stale governance simulation replies after the visualizer switches to another transaction', async () => {
+		const modules = await modulesPromise
+		const dom = installDomMock()
+		const staleRequestReply = createSimulationFailureReply(5n, 'stale governance request reply')
+		const deferredReply = createDeferred<typeof staleRequestReply>()
+		runtimeSendMessage = async (message) => {
+			if (getRuntimeMethod(message) === 'popup_simulateGovernanceContractExecution') return deferredReply.promise
+			return undefined
+		}
+
+		await act(() => {
+			render(h(modules.GovernanceVoteVisualizer, {
+				simTx: createGovernanceTransactionFixture(5n),
+				activeAddress: signal(0x2n),
+				renameAddressCallBack: () => undefined,
+				editEnsNamedHashCallBack: () => undefined,
+				governanceVoteInputParameters: createGovernanceVoteInputParameters(42n),
+			}), dom.document.body)
+		})
+
+		const originalSimulateButton = collectElements(dom.document.body, 'button').find((button) => button.textContent?.includes('Simulate execution on a passing vote'))
+		if (originalSimulateButton === undefined) throw new Error('Expected governance simulation button to render')
+
+		await act(async () => {
+			await clickElement(originalSimulateButton)
+		})
+
+		await act(() => {
+			render(h(modules.GovernanceVoteVisualizer, {
+				simTx: createGovernanceTransactionFixture(6n),
+				activeAddress: signal(0x2n),
+				renameAddressCallBack: () => undefined,
+				editEnsNamedHashCallBack: () => undefined,
+				governanceVoteInputParameters: createGovernanceVoteInputParameters(43n),
+			}), dom.document.body)
+		})
+
+		await act(async () => {
+			await emitRuntimeMessage(createSimulationFailureBroadcast(5n, 'stale governance broadcast reply'))
+			await settleAsyncUpdates()
+		})
+
+		assert.equal(dom.document.body.textContent?.includes('stale governance broadcast reply'), false)
+		assert.equal(dom.document.body.textContent?.includes('Refresh'), false)
+
+		await act(async () => {
+			deferredReply.resolve(staleRequestReply)
+			await deferredReply.promise
+			await settleAsyncUpdates()
+		})
+
+		assert.equal(dom.document.body.textContent?.includes('stale governance request reply'), false)
+		assert.equal(dom.document.body.textContent?.includes('Refresh'), false)
+
+		await act(async () => {
+			await emitRuntimeMessage(createSimulationFailureBroadcast(6n, 'current governance broadcast reply'))
+			await settleAsyncUpdates()
+		})
+
+		assert.equal(dom.document.body.textContent?.includes('current governance broadcast reply'), true)
+		dom.restore()
+	})
+
+	test('shows Gnosis Safe simulation progress and a missing-reply error', async () => {
+		const modules = await modulesPromise
+		const dom = installDomMock()
+		const deferredReply = createDeferred<unknown>()
+		runtimeSendMessage = async () => deferredReply.promise
+
+		await act(() => {
+			render(h(modules.GnosisSafeVisualizer, {
+				gnosisSafeMessage: createGnosisSafeMessageFixture(7n),
+				activeAddress: gnosisSignerAddress.address,
+				renameAddressCallBack: () => undefined,
+				editEnsNamedHashCallBack: () => undefined,
+			}), dom.document.body)
+		})
+
+		const buttons = collectElements(dom.document.body, 'button')
+		const simulateButton = buttons.find((button) => button.textContent?.includes('Simulate execution'))
+		if (simulateButton === undefined) throw new Error('Expected Gnosis simulation button to render')
+
+		await act(async () => {
+			await clickElement(simulateButton)
+		})
+
+		assert.match(simulateButton.textContent ?? '', /Simulating\.\.\./)
+		assert.equal(isDisabled(simulateButton), true)
+
+		await act(async () => {
+			deferredReply.resolve(undefined)
+			await deferredReply.promise
+			await settleAsyncUpdates()
+		})
+
+		assert.equal(dom.document.body.textContent?.includes('Simulating Gnosis Safe execution failed because the background page did not return a reply.'), true)
+		dom.restore()
+	})
+
+	test('matching Gnosis broadcasts clear later closed-channel direct-reply errors', async () => {
+		const modules = await modulesPromise
+		const dom = installDomMock()
+		const deferredReply = createDeferred<unknown>()
+		runtimeSendMessage = async (message) => {
+			if (getRuntimeMethod(message) === 'popup_simulateGnosisSafeTransaction') return deferredReply.promise
+			return undefined
+		}
+
+		await act(() => {
+			render(h(modules.GnosisSafeVisualizer, {
+				gnosisSafeMessage: createGnosisSafeMessageFixture(7n),
+				activeAddress: gnosisSignerAddress.address,
+				renameAddressCallBack: () => undefined,
+				editEnsNamedHashCallBack: () => undefined,
+			}), dom.document.body)
+		})
+
+		const simulateButton = collectElements(dom.document.body, 'button').find((button) => button.textContent?.includes('Simulate execution'))
+		if (simulateButton === undefined) throw new Error('Expected Gnosis simulation button to render')
+
+		await act(async () => {
+			await clickElement(simulateButton)
+		})
+
+		await act(async () => {
+			await emitRuntimeMessage(createSimulationFailureBroadcast(7n, 'Gnosis broadcast reply'))
+			await settleAsyncUpdates()
+		})
+
+		assert.equal(dom.document.body.textContent?.includes('Gnosis broadcast reply'), true)
+
+		await act(async () => {
+			deferredReply.reject(new Error(ASYNC_CHANNEL_CLOSED_ERROR))
+			await deferredReply.promise.catch(() => undefined)
+			await settleAsyncUpdates()
+		})
+
+		assert.equal(dom.document.body.textContent?.includes('Gnosis broadcast reply'), true)
+		assert.equal(dom.document.body.textContent?.includes('Simulating Gnosis Safe execution failed because the background page did not return a reply.'), false)
+		dom.restore()
+	})
+
+	test('ignores stale Gnosis Safe simulation replies after the visualizer switches to another message', async () => {
+		const modules = await modulesPromise
+		const dom = installDomMock()
+		const staleRequestReply = createSimulationFailureReply(7n, 'stale Gnosis request reply')
+		const deferredReply = createDeferred<typeof staleRequestReply>()
+		runtimeSendMessage = async (message) => {
+			if (getRuntimeMethod(message) === 'popup_simulateGnosisSafeTransaction') return deferredReply.promise
+			return undefined
+		}
+
+		await act(() => {
+			render(h(modules.GnosisSafeVisualizer, {
+				gnosisSafeMessage: createGnosisSafeMessageFixture(7n),
+				activeAddress: gnosisSignerAddress.address,
+				renameAddressCallBack: () => undefined,
+				editEnsNamedHashCallBack: () => undefined,
+			}), dom.document.body)
+		})
+
+		const originalSimulateButton = collectElements(dom.document.body, 'button').find((button) => button.textContent?.includes('Simulate execution'))
+		if (originalSimulateButton === undefined) throw new Error('Expected Gnosis simulation button to render')
+
+		await act(async () => {
+			await clickElement(originalSimulateButton)
+		})
+
+		await act(() => {
+			render(h(modules.GnosisSafeVisualizer, {
+				gnosisSafeMessage: createGnosisSafeMessageFixture(8n),
+				activeAddress: gnosisSignerAddress.address,
+				renameAddressCallBack: () => undefined,
+				editEnsNamedHashCallBack: () => undefined,
+			}), dom.document.body)
+		})
+
+		await act(async () => {
+			await emitRuntimeMessage(createSimulationFailureBroadcast(7n, 'stale Gnosis broadcast reply'))
+			await settleAsyncUpdates()
+		})
+
+		assert.equal(dom.document.body.textContent?.includes('stale Gnosis broadcast reply'), false)
+		assert.equal(dom.document.body.textContent?.includes('Refresh simulation'), false)
+
+		await act(async () => {
+			deferredReply.resolve(staleRequestReply)
+			await deferredReply.promise
+			await settleAsyncUpdates()
+		})
+
+		assert.equal(dom.document.body.textContent?.includes('stale Gnosis request reply'), false)
+		assert.equal(dom.document.body.textContent?.includes('Refresh simulation'), false)
+
+		await act(async () => {
+			await emitRuntimeMessage(createSimulationFailureBroadcast(8n, 'current Gnosis broadcast reply'))
+			await settleAsyncUpdates()
+		})
+
+		assert.equal(dom.document.body.textContent?.includes('current Gnosis broadcast reply'), true)
+		dom.restore()
+	})
+})

--- a/test/tests/popupAsyncActionUi.test.tsx
+++ b/test/tests/popupAsyncActionUi.test.tsx
@@ -76,6 +76,7 @@ afterEach(() => {
 async function loadModules() {
 	return {
 		...await import('../../app/ts/components/pages/AddNewAddress.js'),
+		...await import('../../app/ts/components/pages/ChangeChain.js'),
 		...await import('../../app/ts/components/simulationExplaining/customExplainers/GovernanceVoteVisualizer.js'),
 		...await import('../../app/ts/components/simulationExplaining/customExplainers/GnosisSafeVisualizer.js'),
 	}
@@ -298,7 +299,84 @@ function createGnosisSafeMessageFixture(messageIdentifier: bigint): VisualizedPe
 	}
 }
 
+function createChangeChainMessage() {
+	return {
+		role: 'all' as const,
+		method: 'popup_ChangeChainRequest' as const,
+		data: {
+			website: { websiteOrigin: 'https://chain.example', icon: undefined, title: undefined },
+			popupOrTabId: { type: 'tab' as const, id: 1 },
+			request: {
+				method: 'wallet_switchEthereumChain',
+				interceptorRequest: true,
+				usingInterceptorWithoutSigner: false,
+				uniqueRequestIdentifier: {
+					requestId: 99,
+					requestSocket: {
+						tabId: 1,
+						connectionName: '0x1',
+					},
+				},
+			},
+			rpcNetwork: {
+				name: 'Ethereum Mainnet',
+				chainId: '0x1',
+				httpsRpc: 'https://rpc.example',
+				currencyName: 'Ether',
+				currencyTicker: 'ETH',
+				primary: true,
+				minimized: false,
+			},
+			simulationMode: false,
+		},
+	}
+}
+
 describe('popup async action UI', () => {
+	test('sends the change-chain request and resolves once a background reply arrives', async () => {
+		const modules = await modulesPromise
+		const dom = installDomMock()
+		const deferredReply = createDeferred<unknown>()
+		let chainDialogRequest: unknown = undefined
+		runtimeSendMessage = async (message) => {
+			if (getRuntimeMethod(message) === 'popup_changeChainDialog') {
+				chainDialogRequest = message
+				return deferredReply.promise
+			}
+			return undefined
+		}
+
+		await act(() => {
+			render(h(modules.ChangeChain, {}), dom.document.body)
+		})
+
+		await act(async () => {
+			await emitRuntimeMessage(createChangeChainMessage())
+		})
+
+		const changeChainButton = collectElements(dom.document.body, 'button').find((button) => button.textContent?.includes('Change chain'))
+		if (changeChainButton === undefined) throw new Error('Expected chain change confirm button to render')
+
+			await act(async () => {
+				await clickElement(changeChainButton)
+				await settleAsyncUpdates()
+			})
+
+			assert.equal(chainDialogRequest === undefined, false)
+			assert.equal(isDisabled(changeChainButton), true)
+
+			await act(async () => {
+				deferredReply.resolve(undefined)
+				await deferredReply.promise
+				await settleAsyncUpdates()
+			})
+
+			assert.equal(isDisabled(changeChainButton), false)
+			assert.equal(changeChainButton.textContent?.includes('Change chain'), true)
+			assert.equal(chainDialogRequest === undefined, false)
+			dom.restore()
+		})
+
 	test('shows ABI lookup progress and a missing-reply error in AddNewAddress', async () => {
 		const modules = await modulesPromise
 		const dom = installDomMock()

--- a/test/tests/popupOrTabFocus.test.ts
+++ b/test/tests/popupOrTabFocus.test.ts
@@ -1,0 +1,47 @@
+import * as assert from 'assert'
+import { describe, test } from 'bun:test'
+
+function installBrowserMock() {
+	const windowUpdates: Array<{ windowId: number, updateInfo: browser.windows._UpdateUpdateInfo }> = []
+	const tabUpdates: Array<{ tabId: number, updateInfo: browser.tabs._UpdateUpdateProperties }> = []
+
+	Object.defineProperty(globalThis, 'browser', {
+		configurable: true,
+		writable: true,
+		value: {
+			runtime: {
+				lastError: null,
+			},
+			tabs: {
+				async get() {
+					throw new Error('No tab with id: 7.')
+				},
+				async update(tabId: number, updateInfo: browser.tabs._UpdateUpdateProperties) {
+					tabUpdates.push({ tabId, updateInfo })
+					return { id: tabId }
+				},
+			},
+			windows: {
+				async update(windowId: number, updateInfo: browser.windows._UpdateUpdateInfo) {
+					windowUpdates.push({ windowId, updateInfo })
+					return { id: windowId }
+				},
+			},
+		},
+	})
+
+	return { windowUpdates, tabUpdates }
+}
+
+describe('popup/tab focusing', () => {
+	test('ignores missing originating tabs so reject flows can continue', async () => {
+		const { windowUpdates, tabUpdates } = installBrowserMock()
+		const { tryFocusingTabOrWindow } = await import('../../app/ts/utils/popupOrTab.js')
+
+		const result = await tryFocusingTabOrWindow({ type: 'tab', id: 7 })
+
+		assert.equal(result, undefined)
+		assert.deepEqual(windowUpdates, [])
+		assert.deepEqual(tabUpdates, [])
+	})
+})

--- a/test/tests/simulateExecutionRequestCodecs.test.ts
+++ b/test/tests/simulateExecutionRequestCodecs.test.ts
@@ -1,0 +1,46 @@
+import * as assert from 'assert'
+import { describe, test } from 'bun:test'
+import { MessageToPopup, PopupMessage } from '../../app/ts/types/interceptor-messages.js'
+import { PopupMessageReplyRequests, PopupRequestsReplies } from '../../app/ts/types/interceptor-reply-messages.js'
+import { SimulateGovernanceContractExecution } from '../../app/ts/types/simulateExecutionRequests.js'
+import { SimulateExecutionReply, serializeSimulateExecutionReply } from '../../app/ts/types/simulateExecutionReply.js'
+
+describe('simulate execution request codecs', () => {
+	test('shared governance request codec round-trips through popup request and popup message parsing', () => {
+		const request = {
+			method: 'popup_simulateGovernanceContractExecution' as const,
+			data: {
+				transactionIdentifier: 5n,
+			},
+		}
+
+		const serializedRequest = SimulateGovernanceContractExecution.serialize(request)
+		const parsedPopupRequest = PopupMessageReplyRequests.parse(serializedRequest)
+		const parsedPopupMessage = PopupMessage.parse(serializedRequest)
+
+		assert.deepEqual(parsedPopupRequest, request)
+		assert.deepEqual(parsedPopupMessage, request)
+	})
+
+	test('shared simulate execution reply serializer produces a popup-broadcast-safe wire payload', () => {
+		const reply = {
+			method: 'popup_simulateExecutionReply' as const,
+			data: {
+				success: false as const,
+				errorType: 'Other' as const,
+				transactionOrMessageIdentifier: 5n,
+				errorMessage: 'boom',
+			},
+		}
+
+		const serializedReply = serializeSimulateExecutionReply(reply)
+		const parsedBroadcastMessage = MessageToPopup.parse({ role: 'all' as const, ...serializedReply })
+		const parsedReply = SimulateExecutionReply.parse(serializedReply)
+		const parsedPopupReply = PopupRequestsReplies.popup_simulateGovernanceContractExecution.parse(serializedReply)
+
+		assert.equal(serializedReply.data.transactionOrMessageIdentifier, '0x5')
+		assert.equal(parsedBroadcastMessage.method, 'popup_simulateExecutionReply')
+		assert.deepEqual(parsedReply, reply)
+		assert.deepEqual(parsedPopupReply, reply)
+	})
+})


### PR DESCRIPTION
## Summary
- add a reusable AsyncAction pattern for popup queries and apply it across ABI lookup, governance execution, Gnosis Safe execution, import flow, and RPC probing UI
- harden popup/background async reply handling for stale replies, missing replies, and popup broadcast serialization so loading/error states stay consistent
- merge origin/main, resolve the safe tab/window target helper integration, and add focused regression coverage for shared async query behavior

Closes #719

## Validation
- bun test
- bun run setup-chrome
- bun run typecheck
- bun run lint