### PR TITLE
Preserve legacy large-state backups after IndexedDB migration

### DIFF
--- a/app/ts/utils/largeStateStore.ts
+++ b/app/ts/utils/largeStateStore.ts
@@ -7,6 +7,7 @@ export type LargeStateStorageKey = 'interceptorTransactionStack' | 'popupVisuali
 const LARGE_STATE_DB_NAME = 'interceptorLargeState'
 const LARGE_STATE_STORE_NAME = 'largeState'
 const LARGE_STATE_DELETE_MARKER_PREFIX = 'interceptorLargeStateDeleted:'
+const LARGE_STATE_MIGRATED_MARKER_PREFIX = 'interceptorLargeStateMigrated:'
 
 type IndexedDbLookup =
 	| { kind: 'available', found: false }
@@ -14,6 +15,7 @@ type IndexedDbLookup =
 	| { kind: 'unavailable' }
 
 type LegacyLocalLookup =
+	| { kind: 'backup', value: unknown }
 	| { kind: 'deleted' }
 	| { kind: 'found', value: unknown }
 	| { kind: 'missing' }
@@ -22,8 +24,12 @@ type LargeStateDeleteMarkerKey =
 	| 'interceptorLargeStateDeleted:interceptorTransactionStack'
 	| 'interceptorLargeStateDeleted:popupVisualisation'
 
-let indexedDbPromise: Promise<IDBDatabase | undefined> | undefined 
-let indexedDbSource: IDBFactory | undefined 
+type LargeStateMigratedMarkerKey =
+	| 'interceptorLargeStateMigrated:interceptorTransactionStack'
+	| 'interceptorLargeStateMigrated:popupVisualisation'
+
+let indexedDbPromise: Promise<IDBDatabase | undefined> | undefined
+let indexedDbSource: IDBFactory | undefined
 
 function canUseIndexedDb() {
 	return typeof indexedDB !== 'undefined'
@@ -125,9 +131,19 @@ function getLegacyDeleteMarkerKey(key: LargeStateStorageKey): LargeStateDeleteMa
 	}
 }
 
+function getLegacyMigratedMarkerKey(key: LargeStateStorageKey): LargeStateMigratedMarkerKey {
+	switch (key) {
+		case 'interceptorTransactionStack': return `${ LARGE_STATE_MIGRATED_MARKER_PREFIX }interceptorTransactionStack`
+		case 'popupVisualisation': return `${ LARGE_STATE_MIGRATED_MARKER_PREFIX }popupVisualisation`
+		default: return assertNever(key)
+	}
+}
+
 async function getLegacyLocalLookup(key: LargeStateStorageKey): Promise<LegacyLocalLookup> {
 	const deleteMarkerKey = getLegacyDeleteMarkerKey(key)
-	const localValue = await browser.storage.local.get([key, deleteMarkerKey])
+	const migratedMarkerKey = getLegacyMigratedMarkerKey(key)
+	const localValue = await browser.storage.local.get([key, deleteMarkerKey, migratedMarkerKey])
+	if (Object.prototype.hasOwnProperty.call(localValue, key) && localValue[migratedMarkerKey] === true && localValue[deleteMarkerKey] !== true) return { kind: 'backup', value: localValue[key] }
 	if (Object.prototype.hasOwnProperty.call(localValue, key)) return { kind: 'found', value: localValue[key] }
 	if (localValue[deleteMarkerKey] === true) return { kind: 'deleted' }
 	return { kind: 'missing' }
@@ -137,17 +153,26 @@ async function removeLegacyLocalValue(key: LargeStateStorageKey) {
 	await browser.storage.local.remove(key)
 }
 
-async function clearLegacyLocalState(key: LargeStateStorageKey) {
-	await browser.storage.local.remove([key, getLegacyDeleteMarkerKey(key)])
+async function setLegacyLocalDeleted(key: LargeStateStorageKey) {
+	await browser.storage.local.set({
+		[getLegacyDeleteMarkerKey(key)]: true,
+		[getLegacyMigratedMarkerKey(key)]: true,
+	})
 }
 
-async function setLegacyLocalDeleted(key: LargeStateStorageKey) {
-	await browser.storage.local.set({ [getLegacyDeleteMarkerKey(key)]: true })
+async function setLegacyLocalMigrated(key: LargeStateStorageKey) {
+	await browser.storage.local.set({
+		[getLegacyDeleteMarkerKey(key)]: false,
+		[getLegacyMigratedMarkerKey(key)]: true,
+	})
 }
 
 async function setLegacyLocalValue(key: LargeStateStorageKey, value: unknown) {
-	await browser.storage.local.set({ [key]: value })
-	await browser.storage.local.remove(getLegacyDeleteMarkerKey(key))
+	await browser.storage.local.set({
+		[key]: value,
+		[getLegacyDeleteMarkerKey(key)]: false,
+		[getLegacyMigratedMarkerKey(key)]: false,
+	})
 }
 
 function parseSerializedValue<T>(codec: funtypes.Codec<T>, value: unknown) {
@@ -161,14 +186,14 @@ export async function getLargeStateValue<T>(key: LargeStateStorageKey, codec: fu
 		const parsedLegacyValue = parseSerializedValue(codec, legacyLocalValue.value)
 		if (parsedLegacyValue !== undefined) {
 			const wasMigrated = await setIndexedDbValue(key, legacyLocalValue.value)
-			if (wasMigrated) await clearLegacyLocalState(key)
+			if (wasMigrated) await setLegacyLocalMigrated(key)
 			return parsedLegacyValue
 		}
 		await removeLegacyLocalValue(key)
 	}
 	if (legacyLocalValue.kind === 'deleted') {
 		const wasRemoved = await removeIndexedDbValue(key)
-		if (wasRemoved) await clearLegacyLocalState(key)
+		if (wasRemoved) await setLegacyLocalMigrated(key)
 		return undefined
 	}
 	const indexedDbValue = await getIndexedDbValue(key)
@@ -187,7 +212,7 @@ export async function setLargeStateValue<T>(key: LargeStateStorageKey, codec: fu
 	if (canUseIndexedDb()) {
 		const wasStoredInIndexedDb = await setIndexedDbValue(key, serializedValue)
 		if (wasStoredInIndexedDb) {
-			await clearLegacyLocalState(key)
+			await setLegacyLocalMigrated(key)
 			return
 		}
 	}
@@ -202,7 +227,7 @@ export async function removeLargeStateValue(key: LargeStateStorageKey) {
 	}
 	const wasRemovedFromIndexedDb = await removeIndexedDbValue(key)
 	if (wasRemovedFromIndexedDb) {
-		await clearLegacyLocalState(key)
+		await setLegacyLocalMigrated(key)
 		return
 	}
 	await removeLegacyLocalValue(key)

--- a/test/tests/largeStateStore.test.ts
+++ b/test/tests/largeStateStore.test.ts
@@ -18,6 +18,9 @@ const staleStack: InterceptorTransactionStack = {
 	}],
 }
 
+const transactionStackDeleteMarkerKey = 'interceptorLargeStateDeleted:interceptorTransactionStack'
+const transactionStackMigratedMarkerKey = 'interceptorLargeStateMigrated:interceptorTransactionStack'
+
 type StorageGetKeys = string | string[] | Record<string, unknown> | null | undefined
 
 type FakeIndexedDbOptions = {
@@ -210,6 +213,7 @@ describe('large state store helpers', () => {
 
 		await setLargeStateValue('interceptorTransactionStack', InterceptorTransactionStack, stack)
 		assert.equal('interceptorTransactionStack' in storageState, false)
+		assert.equal(storageState[transactionStackMigratedMarkerKey], true)
 		assert.deepEqual(indexedDbState.get('interceptorTransactionStack'), serializedStack())
 
 		assert.deepEqual(await getLargeStateValue('interceptorTransactionStack', InterceptorTransactionStack), stack)
@@ -233,7 +237,8 @@ describe('large state store helpers', () => {
 
 		assert.deepEqual(await getLargeStateValue('interceptorTransactionStack', InterceptorTransactionStack), stack)
 		assert.deepEqual(indexedDbState.get('interceptorTransactionStack'), serializedStack())
-		assert.equal('interceptorTransactionStack' in storageState, false)
+		assert.deepEqual(storageState.interceptorTransactionStack, serializedStack())
+		assert.equal(storageState[transactionStackMigratedMarkerKey], true)
 	})
 
 	test('reads storage.local fallback over stale IndexedDB after write failure', async () => {
@@ -245,6 +250,84 @@ describe('large state store helpers', () => {
 		assert.deepEqual(await getLargeStateValue('interceptorTransactionStack', InterceptorTransactionStack), stack)
 		assert.deepEqual(indexedDbState.get('interceptorTransactionStack'), serializedStack(staleStack))
 		assert.deepEqual(storageState.interceptorTransactionStack, serializedStack())
+	})
+
+	test('preserves legacy storage.local backup after a successful migration', async () => {
+		const { indexedDbState, storageState } = installLargeStateEnvironment()
+		storageState.interceptorTransactionStack = serializedStack()
+
+		assert.deepEqual(await getLargeStateValue('interceptorTransactionStack', InterceptorTransactionStack), stack)
+		assert.deepEqual(indexedDbState.get('interceptorTransactionStack'), serializedStack())
+		assert.deepEqual(storageState.interceptorTransactionStack, serializedStack())
+		assert.equal(storageState[transactionStackMigratedMarkerKey], true)
+	})
+
+	test('reads IndexedDB over a migrated storage.local backup after newer writes', async () => {
+		const { indexedDbState, storageState } = installLargeStateEnvironment()
+		storageState.interceptorTransactionStack = serializedStack(staleStack)
+
+		assert.deepEqual(await getLargeStateValue('interceptorTransactionStack', InterceptorTransactionStack), staleStack)
+
+		await setLargeStateValue('interceptorTransactionStack', InterceptorTransactionStack, stack)
+
+		assert.deepEqual(indexedDbState.get('interceptorTransactionStack'), serializedStack())
+		assert.deepEqual(storageState.interceptorTransactionStack, serializedStack(staleStack))
+		assert.equal(storageState[transactionStackMigratedMarkerKey], true)
+		assert.deepEqual(await getLargeStateValue('interceptorTransactionStack', InterceptorTransactionStack), stack)
+	})
+
+	test('clears the migration marker when writes fall back to storage.local', async () => {
+		const { fakeIndexedDb, indexedDbState, storageState } = installLargeStateEnvironment()
+		storageState.interceptorTransactionStack = serializedStack(staleStack)
+
+		assert.deepEqual(await getLargeStateValue('interceptorTransactionStack', InterceptorTransactionStack), staleStack)
+		assert.deepEqual(indexedDbState.get('interceptorTransactionStack'), serializedStack(staleStack))
+		assert.equal(storageState[transactionStackMigratedMarkerKey], true)
+
+		Object.defineProperty(globalThis, 'indexedDB', { value: undefined, configurable: true, writable: true })
+
+		await setLargeStateValue('interceptorTransactionStack', InterceptorTransactionStack, stack)
+
+		assert.deepEqual(storageState.interceptorTransactionStack, serializedStack())
+		assert.equal(storageState[transactionStackDeleteMarkerKey], false)
+		assert.equal(storageState[transactionStackMigratedMarkerKey], false)
+
+		Object.defineProperty(globalThis, 'indexedDB', { value: fakeIndexedDb, configurable: true, writable: true })
+
+		assert.deepEqual(await getLargeStateValue('interceptorTransactionStack', InterceptorTransactionStack), stack)
+		assert.deepEqual(indexedDbState.get('interceptorTransactionStack'), serializedStack())
+	})
+
+	test('fallback writes overwrite stale marker values in one storage.local write', async () => {
+		const { fakeIndexedDb, indexedDbState, storageState } = installLargeStateEnvironment()
+		indexedDbState.set('interceptorTransactionStack', serializedStack(staleStack))
+		storageState[transactionStackDeleteMarkerKey] = true
+		storageState[transactionStackMigratedMarkerKey] = true
+		Object.defineProperty(globalThis, 'indexedDB', { value: undefined, configurable: true, writable: true })
+
+		await setLargeStateValue('interceptorTransactionStack', InterceptorTransactionStack, stack)
+
+		assert.deepEqual(storageState.interceptorTransactionStack, serializedStack())
+		assert.equal(storageState[transactionStackDeleteMarkerKey], false)
+		assert.equal(storageState[transactionStackMigratedMarkerKey], false)
+
+		Object.defineProperty(globalThis, 'indexedDB', { value: fakeIndexedDb, configurable: true, writable: true })
+
+		assert.deepEqual(await getLargeStateValue('interceptorTransactionStack', InterceptorTransactionStack), stack)
+		assert.deepEqual(indexedDbState.get('interceptorTransactionStack'), serializedStack())
+	})
+
+	test('reads an authoritative local value over a stale delete marker from earlier fallback writes', async () => {
+		const { indexedDbState, storageState } = installLargeStateEnvironment()
+		indexedDbState.set('interceptorTransactionStack', serializedStack(staleStack))
+		storageState.interceptorTransactionStack = serializedStack()
+		storageState[transactionStackDeleteMarkerKey] = true
+		storageState[transactionStackMigratedMarkerKey] = false
+
+		assert.deepEqual(await getLargeStateValue('interceptorTransactionStack', InterceptorTransactionStack), stack)
+		assert.deepEqual(indexedDbState.get('interceptorTransactionStack'), serializedStack())
+		assert.equal(storageState[transactionStackDeleteMarkerKey], false)
+		assert.equal(storageState[transactionStackMigratedMarkerKey], true)
 	})
 
 	test('falls back to storage.local when IndexedDB write transaction aborts after request success', async () => {
@@ -295,7 +378,23 @@ describe('large state store helpers', () => {
 		await removeLargeStateValue('interceptorTransactionStack')
 
 		assert.equal('interceptorTransactionStack' in storageState, false)
-		assert.equal(storageState['interceptorLargeStateDeleted:interceptorTransactionStack'], true)
+		assert.equal(storageState[transactionStackDeleteMarkerKey], true)
+		assert.deepEqual(await getLargeStateValue('interceptorTransactionStack', InterceptorTransactionStack), undefined)
+		assert.equal(storageState[transactionStackDeleteMarkerKey], true)
+		assert.equal(storageState[transactionStackMigratedMarkerKey], true)
+	})
+
+	test('preserves the migrated storage.local backup after IndexedDB deletes succeed', async () => {
+		const { indexedDbState, storageState } = installLargeStateEnvironment()
+		storageState.interceptorTransactionStack = serializedStack()
+
+		assert.deepEqual(await getLargeStateValue('interceptorTransactionStack', InterceptorTransactionStack), stack)
+
+		await removeLargeStateValue('interceptorTransactionStack')
+
+		assert.equal(indexedDbState.has('interceptorTransactionStack'), false)
+		assert.deepEqual(storageState.interceptorTransactionStack, serializedStack())
+		assert.equal(storageState[transactionStackMigratedMarkerKey], true)
 		assert.deepEqual(await getLargeStateValue('interceptorTransactionStack', InterceptorTransactionStack), undefined)
 	})
 
@@ -308,13 +407,14 @@ describe('large state store helpers', () => {
 		await removeLargeStateValue('interceptorTransactionStack')
 
 		assert.equal('interceptorTransactionStack' in storageState, false)
-		assert.equal(storageState['interceptorLargeStateDeleted:interceptorTransactionStack'], true)
+		assert.equal(storageState[transactionStackDeleteMarkerKey], true)
 
 		Object.defineProperty(globalThis, 'indexedDB', { value: fakeIndexedDb, configurable: true, writable: true })
 
 		assert.deepEqual(await getLargeStateValue('interceptorTransactionStack', InterceptorTransactionStack), undefined)
 		assert.equal(indexedDbState.has('interceptorTransactionStack'), false)
-		assert.equal('interceptorLargeStateDeleted:interceptorTransactionStack' in storageState, false)
+		assert.equal(storageState[transactionStackDeleteMarkerKey], false)
+		assert.equal(storageState[transactionStackMigratedMarkerKey], true)
 	})
 
 	test('falls back to storage.local when IndexedDB transactions fail', async () => {


### PR DESCRIPTION
## Summary
- Preserve legacy `browser.storage.local` large-state values as backups after successful IndexedDB migration instead of deleting them.
- Add per-key migrated markers so retained local values are treated as backups while IndexedDB remains authoritative.
- Make fallback `storage.local` writes authoritative in one write by neutralizing stale migrated/delete markers, including compatibility for older stale tombstone states.
- Keep delete-marker behavior for IndexedDB outages and add regression coverage for backup preservation, stale markers, fallback writes, and delete flows.

