### PR TITLE
Add simulation stack tab and responsive popup fixes

### DIFF
--- a/app/css/bulma.css
+++ b/app/css/bulma.css
@@ -314,7 +314,6 @@ html {
   font-size: 16px;
   -moz-osx-font-smoothing: grayscale;
   -webkit-font-smoothing: antialiased;
-  min-width: 300px;
   overflow-x: hidden;
   overflow-y: scroll;
   text-rendering: optimizeLegibility;

--- a/app/css/interceptor.css
+++ b/app/css/interceptor.css
@@ -115,10 +115,20 @@ svg[role="img"] {
 
 .form-control {
 	display: grid;
-	grid-template-columns: 1em auto;
+	grid-template-columns: 1em minmax(0, 1fr);
 	gap: 0.5em;
 	color: var(--text-color);
 	font-size: 0.8em;
+	max-width: 100%;
+	min-width: 0;
+}
+
+.form-control > * {
+	min-width: 0;
+}
+
+.form-control .checkbox-text {
+	overflow-wrap: anywhere;
 }
 
 input[type=checkbox]:not([role=switch]) {
@@ -230,6 +240,141 @@ html, body {
 	margin-bottom: unset;
 }
 
+.card-header-title {
+	min-width: 0;
+	overflow: hidden;
+	text-overflow: ellipsis;
+}
+
+.card-header-title > .paragraph {
+	min-width: 0;
+	overflow: hidden;
+	text-overflow: ellipsis;
+}
+
+.card-header-title > .card-header-title-text {
+	display: block;
+	min-width: 0;
+	overflow: hidden;
+	text-overflow: ellipsis;
+	white-space: inherit;
+}
+
+.card-header-website {
+	flex: 0 1 16rem;
+	min-width: 0;
+	max-width: 100%;
+	margin-left: auto;
+	margin-right: 0;
+	padding: 0.75rem 1rem;
+}
+
+.card-header-website--flush {
+	flex: 0 1 auto;
+	max-width: none;
+	padding: 0;
+}
+
+.stack-card-header > .card-header-icon {
+	flex: 0 0 auto;
+	padding: 0.55rem 0.35rem 0.55rem 0.55rem;
+}
+
+.stack-card-header > .card-header-title {
+	flex: 1 1 auto;
+	min-width: 0;
+	padding-left: 0.35rem;
+	padding-right: 0.5rem;
+	overflow: hidden;
+	text-overflow: ellipsis;
+	white-space: nowrap;
+}
+
+.stack-card-header > .card-header-website {
+	flex: 0 1 min(11rem, 42%);
+	padding: 0.55rem 0.5rem;
+}
+
+.stack-card-header > .card-header-website--flush {
+	padding: 0;
+}
+
+.stack-card-header > .card-header-website.card-header-website--flush {
+	flex: 0 1 auto;
+	max-width: none;
+	padding: 0;
+}
+
+.website-origin-text {
+	display: flex;
+	align-items: center;
+	min-width: 0;
+	max-width: 100%;
+}
+
+.website-origin-text-icon {
+	width: 24px;
+	height: 24px;
+	min-width: 24px;
+	flex: 0 0 24px;
+}
+
+.website-origin-text-body {
+	display: block;
+	min-width: 0;
+	overflow-x: clip;
+	overflow-y: hidden;
+	padding-left: 10px;
+}
+
+.website-origin-text-origin,
+.website-origin-text-title {
+	overflow: hidden;
+	text-overflow: ellipsis;
+	white-space: nowrap;
+}
+
+.stack-row-link-header {
+	position: relative;
+	cursor: pointer;
+	transition: transform 140ms ease, box-shadow 140ms ease, background-color 140ms ease;
+}
+
+.stack-row-link-header:hover,
+.stack-row-link-header:focus-visible {
+	background-color: var(--white-alpha-10);
+	box-shadow: inset 3px 0 0 var(--primary-color);
+	transform: translateY(-1px);
+}
+
+.stack-row-link-header:active {
+	transform: translateY(0) scale(0.995);
+}
+
+.simulation-stack-row {
+	border-radius: 10px;
+	scroll-margin-block: 2rem;
+}
+
+.simulation-stack-row--highlighted {
+	animation: simulation-stack-row-target-pulse 1800ms ease-out;
+}
+
+@keyframes simulation-stack-row-target-pulse {
+	0% {
+		background-color: color-mix(in srgb, var(--primary-color) 26%, transparent);
+		box-shadow: 0 0 0 0 color-mix(in srgb, var(--primary-color) 70%, transparent);
+	}
+	45% {
+		background-color: color-mix(in srgb, var(--primary-color) 14%, transparent);
+		box-shadow: 0 0 0 6px color-mix(in srgb, var(--primary-color) 20%, transparent);
+	}
+	100% {
+		background-color: transparent;
+		box-shadow: 0 0 0 14px transparent;
+	}
+}
+
 .hoverable:hover {
 	background-color: var(--highlighted-primary-color)
 }
@@ -306,6 +451,144 @@ html, body {
 	box-shadow: 0 0 0 1px var(--negative-color);
 }
 
+.address-book-page {
+	min-width: 0;
+	overflow-x: hidden;
+}
+
+.address-book-layout {
+	display: grid;
+	grid-template-columns: max-content minmax(0, 34rem);
+	column-gap: 0;
+	width: min(100%, 48rem);
+	min-width: 0;
+	margin: 0 auto;
+	padding: 0 1rem;
+}
+
+.address-book-sidebar {
+	min-width: 0;
+	padding: 1rem 0;
+}
+
+.address-book-chain-selector {
+	min-width: 0;
+	padding: 10px;
+}
+
+.address-book-chain-selector .dropdown,
+.address-book-chain-selector .dropdown-trigger {
+	width: 100%;
+	min-width: 0;
+}
+
+.address-book-sidebar .menu-list a {
+	overflow-wrap: anywhere;
+}
+
+.address-book-content {
+	display: grid;
+	grid-template-rows: min-content minmax(0, 1fr);
+	row-gap: 1rem;
+	height: 100vh;
+	min-width: 0;
+	padding-top: 1rem;
+}
+
+.address-book-toolbar {
+	display: grid;
+	grid-template-columns: minmax(0, 1fr) max-content;
+	column-gap: 1rem;
+	align-items: center;
+	min-width: 0;
+	padding: 0 1rem;
+}
+
+.address-book-toolbar > .input {
+	width: 100%;
+	min-width: 0;
+}
+
+.address-book-toolbar > .button {
+	max-width: 100%;
+}
+
+.address-book-list {
+	min-width: 0;
+	min-height: 0;
+	overflow: hidden;
+}
+
+.address-book-empty-state {
+	width: min(500px, 100%);
+	min-width: 0;
+	margin: 0 1rem;
+	padding: 0 1rem;
+	overflow-wrap: anywhere;
+}
+
+.address-book-entry-card {
+	min-width: 0;
+	max-width: 100%;
+	margin: 0 1rem 1rem;
+}
+
+.address-book-entry-content {
+	width: min(500px, 100%);
+	min-width: 0;
+	max-width: 100%;
+}
+
+.address-book-entry-media {
+	align-items: stretch;
+	min-width: 0;
+}
+
+.address-book-entry-main {
+	display: flex;
+	flex-direction: column;
+	min-width: 0;
+	overflow-x: hidden;
+	overflow-y: visible;
+}
+
+.address-book-entry-heading {
+	min-width: 0;
+	min-height: 40px;
+	padding-bottom: 10px;
+}
+
+.address-book-entry-meta {
+	display: inline-block;
+	font-size: 13px;
+	vertical-align: top;
+}
+
+.address-book-entry-abi {
+	display: block;
+	max-width: 100%;
+	min-width: 0;
+	overflow: hidden;
+	text-overflow: ellipsis;
+	white-space: nowrap;
+}
+
+.address-book-entry-source {
+	color: var(--subtitle-text-color);
+}
+
+.address-book-entry-actions {
+	display: flex;
+	flex-direction: column;
+	justify-content: space-between;
+	color: var(--text-color);
+}
+
+.address-book-entry-remove {
+	margin-left: auto;
+	padding: 0;
+}
+
 .input:not([type='checkbox']):disabled, input:not([type='checkbox'])[disabled] {
 	border-bottom: unset
 }
@@ -341,6 +624,10 @@ li {
 .card {
 	background-color: var(--card-bg-color);
 	box-shadow: 0 1px 4px 1px rgba(0, 0, 0, 0.5);
+}
+
+.simulation-summary-card {
+	margin: 10px;
 }
 
 .card-content {
@@ -983,6 +1270,73 @@ svg.spinner > circle {
 	overflow-wrap: anywhere;
 }
 
+@media screen and (max-width: 520px) {
+	.address-book-layout {
+		grid-template-columns: minmax(0, 1fr);
+		width: 100%;
+		padding: 0 0.5rem;
+	}
+
+	.address-book-sidebar {
+		padding: 0.75rem 0 0;
+	}
+
+	.address-book-sidebar .menu {
+		display: grid;
+		grid-template-columns: repeat(auto-fit, minmax(min(8rem, 100%), 1fr));
+		column-gap: 1rem;
+	}
+
+	.address-book-content {
+		height: auto;
+		min-height: 0;
+		padding-top: 0.5rem;
+	}
+
+	.address-book-toolbar {
+		grid-template-columns: minmax(0, 1fr);
+		row-gap: 0.75rem;
+		padding: 0;
+	}
+
+	.address-book-toolbar > .button {
+		justify-self: start;
+		height: auto;
+		min-height: 2.5em;
+		white-space: normal;
+	}
+
+	.address-book-list {
+		height: 60vh;
+		min-height: 14rem;
+	}
+
+	.address-book-entry-card,
+	.address-book-empty-state {
+		margin-right: 0;
+		margin-left: 0;
+	}
+}
+
+@media screen and (max-width: 220px) {
+	.address-book-entry-media {
+		flex-direction: column;
+		gap: 0.5rem;
+	}
+
+	.address-book-entry-actions {
+		flex-direction: row;
+		justify-content: flex-end;
+		align-items: center;
+		gap: 0.5rem;
+		margin-top: 0.25rem;
+	}
+
+	.address-book-entry-remove {
+		margin-left: 0;
+	}
+}
+
 .swap-box {
 	background-color: var(--alpha-005);
 	box-shadow: unset;
@@ -1060,6 +1414,24 @@ svg.spinner > circle {
 	padding-bottom: 10px;
 	padding-top: 10px;
 	border-radius: 10px 10px 0 0;
+}
+
+.settings-import-export-actions {
+	display: flex;
+	flex-direction: row;
+	flex-wrap: wrap;
+	gap: 0.5rem;
+}
+
+.settings-import-export-button {
+	position: relative;
+	flex: 1 1 10rem;
+	min-width: 0;
+	height: auto;
+	min-height: 2.5em;
+	overflow: hidden;
+	overflow-wrap: anywhere;
+	white-space: normal;
 }
 
 .popup-contents {
@@ -1185,9 +1557,12 @@ strong { color: inherit }
 	background-color: var(--s-bg);
 	color: var(--s-fg, var(--text-color));
 	font-size: var(--s-size, inherit);
+	line-height: 1.2;
 	filter: saturate(var(--s-saturation)) brightness(var(--s-brightness));
 	justify-content: var(--s-justify);
-	height: 2.25em;
+	box-sizing: border-box;
+	height: auto;
+	min-height: 2.25em;
 	padding: 0 0.75em;
 	border: var(--s-outline);
 	border-radius: 4px;
@@ -1297,6 +1672,8 @@ summary:where(details[open] > *) {
 	display: grid;
 	row-gap: var(--gap-y);
 	grid-template-columns: var(--grid-cols);
+	max-width: 100%;
+	min-width: 0;
 }
 
 :where(.flex) { display: flex }
@@ -1304,16 +1681,19 @@ summary:where(details[open] > *) {
 :where(.grid > *) {
 	--area: auto;
 	grid-area: var(--area);
+	min-width: 0;
 }
 
 .brief {
-	--grid-cols: 1fr max-content;
+	--grid-cols: minmax(0, 1fr) minmax(0, max-content);
 	--gap-x: 1rem;
 	--hl-color: white;
 	background-color: color(srgb .3 .3 .3);
 	color: color(srgb .6 .6 .6);
+	box-sizing: border-box;
 	font-size: var(--text-size, inherit);
 	font-weight: var(--font-weight, normal);
+	max-width: 100%;
 	padding: 0.5rem 1em;
 	border-radius: 4px;
 	margin: 0;
@@ -1322,6 +1702,35 @@ summary:where(details[open] > *) {
 .brief strong { color: var(--hl-color) }
 
 .brief .actions > .btn { --s-size: 0.8rem; }
+
+.rpc-summary-details {
+	--grid-cols: minmax(0, 1fr);
+	--gap-y: 0.125rem;
+	--text-color: gray;
+	min-width: 0;
+}
+
+.rpc-summary-details > .truncate {
+	min-width: 0;
+}
+
+.rpc-summary-details strong {
+	display: block;
+	min-width: 0;
+	overflow: hidden;
+	text-overflow: ellipsis;
+	white-space: nowrap;
+}
+
+.rpc-add-button {
+	justify-self: start;
+	max-width: 100%;
+	height: auto;
+	min-height: 2.25em;
+	border-style: dashed;
+	white-space: normal;
+	text-align: center;
+}
 
 .dialog {
 	background: var(--bg-color);
@@ -1548,13 +1957,14 @@ fieldset label:has([type=radio]:checked):before {
 :has(> .layout:first-child):not(dialog:not([open])) {
 	background: var(--bg-color);
 	display: grid;
-	grid-template-columns: var(--grid-columns, minmax(1rem,auto) minmax(min-content,800px) minmax(1rem,auto));
+	grid-template-columns: var(--grid-columns, minmax(0, 1fr) minmax(0, min(800px, 100%)) minmax(0, 1fr));
 
 	.layout {
 		--grid-col: var(--grid-column, 2);
 		--line-color: var(--layout-line-color);
 		display: grid;
 		grid-column: var(--grid-col);
+		min-width: 0;
 		min-height: 100vh;
 		grid-template-rows: min-content 1fr;
 
@@ -1577,17 +1987,22 @@ fieldset label:has([type=radio]:checked):before {
 }
 
 /* Search Component */
-form[role='search'] { flex: 1 0 auto }
+form[role='search'] {
+	flex: 1 1 12rem;
+	min-width: 0;
+	max-width: 100%;
+}
 
 form[role='search'] fieldset {
 	color: var(--text-color);
 	display: grid;
-	grid-template-columns: min-content auto min-content;
+	grid-template-columns: min-content minmax(0, 1fr) min-content;
 	column-gap: 0.25rem;
 	align-items: center;
 	border: 1px solid var(--line-color);
 	padding: 0.25rem;
 	border-radius: 2px;
+	min-width: 0;
 }
 
 form[role='search'] fieldset:focus-within {
@@ -1607,6 +2022,8 @@ form[role='search'] input[type='search'] {
 	outline: none;
 	border: 0 none;
 	color: var(--text-color);
+	min-width: 0;
+	width: 100%;
 }
 
 form[role='search'] input[type='search']::-webkit-search-cancel-button { appearance: none }
@@ -1708,14 +2125,96 @@ header:has(form[role='search']) {
 	row-gap: 0.25rem;
 	justify-content: space-between;
 	flex-wrap: wrap;
-	place-content: center;
+	align-items: center;
 	padding: 1rem 0;
 }
 
 header:has(form[role='search']) h1 {
 	color: var(--text-color);
 	font-size: 1.5rem;
-	flex: 1 0 auto;
+	flex: 1 1 12rem;
+	min-width: 0;
+}
+
+.simulation-stack-page {
+	--grid-column: 1 / -1;
+	box-sizing: border-box;
+	width: 100%;
+	justify-self: center;
+	padding-inline: 0;
+}
+
+.simulation-stack-page-header {
+	display: flex;
+	column-gap: 1rem;
+	row-gap: 0.75rem;
+	justify-content: space-between;
+	align-items: center;
+	flex-wrap: wrap;
+	padding: 1rem clamp(0.75rem, 2vw, 1.5rem);
+}
+
+.simulation-stack-page > .simulation-stack-page-header {
+	background-color: var(--bg-color);
+	position: sticky;
+	top: 0;
+	z-index: 10;
+}
+
+.simulation-stack-page-body {
+	min-width: 0;
+	min-height: 0;
+}
+
+.simulation-stack-page-title {
+	min-width: 0;
+	flex: 1 1 16rem;
+}
+
+.simulation-stack-page-title h1 {
+	color: var(--text-color);
+	font-size: 1.5rem;
+	line-height: 1.15;
+}
+
+.simulation-stack-page-title p {
+	color: var(--disabled-text-color);
+	font-size: 0.875rem;
+	line-height: 1.25;
+	margin-top: 0.25rem;
+}
+
+.simulation-stack-page-actions {
+	display: flex;
+	gap: 0.5rem;
+	align-items: center;
+	justify-content: flex-end;
+	flex-wrap: wrap;
+	min-width: 0;
+}
+
+.simulation-stack-page-content {
+	min-width: 0;
+	padding: 1rem clamp(0.75rem, 2vw, 1.5rem) 2rem;
+}
+
+.simulation-stack-page-content .simulation-stack-list {
+	margin: 0;
+	min-width: 0;
+	padding: 0;
+	width: 100%;
+}
+
+.simulation-stack-page-content .simulation-stack-list > li {
+	margin: 0;
+}
+
+.simulation-stack-page-content .simulation-stack-list > li > .simulation-stack-row {
+	margin: 10px 0;
+}
+
+.simulation-stack-page-content .simulation-summary-card {
+	margin: 10px 0;
 }
 
 [role=option]:has([type=radio]) {
@@ -2126,8 +2625,26 @@ header:has(form[role='search']) h1 {
 }
 
 .chainSelector {
+	max-width: 100%;
+	min-width: 0;
+	overflow: hidden;
 	padding-left: 0.5em;
 	padding-right: 0.5em;
+}
+
+.dropdown,
+.dropdown-trigger {
+	max-width: 100%;
+	min-width: 0;
+}
+
+.dropdown button {
+	min-width: 0;
+}
+
+.dropdown button > .truncate {
+	min-width: 0;
+	max-width: 100%;
 }
 
 .sub-importance-box {
@@ -2151,6 +2668,7 @@ header:has(form[role='search']) h1 {
 
 .btn.is-small {
 	font-size: 0.75rem;
+	line-height: 1.2;
 }
 
 .btn.is-danger {

--- a/app/html/addressBook.html
+++ b/app/html/addressBook.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html style = 'background-color: var(--bg-color); overflow: hidden;'>
+<html style = 'background-color: var(--bg-color); overflow-x: hidden; overflow-y: auto;'>
 	<head>
 		<title>Address Book - The Interceptor</title>
 		<meta charset = 'utf-8'>

--- a/app/html/simulationStack.html
+++ b/app/html/simulationStack.html
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
-<html style = 'background-color: var(--bg-color); overflow-x: hidden; overflow-y: auto;'>
+<html style = 'background-color: var(--bg-color); overflow-y: inherit;'>
 	<head>
-		<title>Address Book - The Interceptor</title>
+		<title>Simulation Stack - The Interceptor</title>
 		<meta charset = 'utf-8'>
 		<link rel = 'icon' type = 'image/x-icon' href = 'favicon.ico'>
 	</head>
@@ -9,11 +9,11 @@
 		<meta name = 'viewport' content = 'width = device-width, initial-scale = 1' />
 		<link rel = 'stylesheet' type = 'text/css' href = '../css/bulma.css' />
 		<link rel = 'stylesheet' type = 'text/css' href = '../css/bulma-divider.css' />
+		<link rel = 'stylesheet' type = 'text/css' href = '../css/bulma-badge.css' />
 		<link rel = 'stylesheet' type = 'text/css' href = '../css/interceptor.css' />
-
-		<main>Loading...</main>
-
 		<script src = '../vendor/webextension-polyfill/dist/browser-polyfill.js'></script>
-		<script type = 'module' src = '../js/addressBookRender.js'></script>
+		<div id = 'simulation-stack-root'>Loading...</div>
+
+		<script type = 'module' src = '../js/simulationStack.js'></script>
 	</body>
 </html>

--- a/app/html3/simulationStackV3.html
+++ b/app/html3/simulationStackV3.html
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
-<html style = 'background-color: var(--bg-color); overflow-x: hidden; overflow-y: auto;'>
+<html style = 'background-color: var(--bg-color); overflow-y: inherit;'>
 	<head>
-		<title>Address Book - The Interceptor</title>
+		<title>Simulation Stack - The Interceptor</title>
 		<meta charset = 'utf-8'>
 		<link rel = 'icon' type = 'image/x-icon' href = 'favicon.ico'>
 	</head>
@@ -9,11 +9,12 @@
 		<meta name = 'viewport' content = 'width = device-width, initial-scale = 1' />
 		<link rel = 'stylesheet' type = 'text/css' href = '../css/bulma.css' />
 		<link rel = 'stylesheet' type = 'text/css' href = '../css/bulma-divider.css' />
+		<link rel = 'stylesheet' type = 'text/css' href = '../css/bulma-badge.css' />
 		<link rel = 'stylesheet' type = 'text/css' href = '../css/interceptor.css' />
 
-		<main>Loading...</main>
+		<div id = 'simulation-stack-root'>Loading...</div>
 
 		<script src = '../vendor/webextension-polyfill/dist/browser-polyfill.js'></script>
-		<script type = 'module' src = '../js/addressBookRender.js'></script>
+		<script type = 'module' src = '../js/simulationStack.js'></script>
 	</body>
 </html>

--- a/app/ts/AddressBook.tsx
+++ b/app/ts/AddressBook.tsx
@@ -103,11 +103,11 @@ function AddressBookEntryCard({ removeEntry, renameAddressCallBack, ...entry }: 
 	}
 
 	return (
-		<div class = 'card' style = { { marginLeft: '1rem', marginRight: '1rem', marginBottom: '1rem' } }>
-			<div class = 'card-content' style = 'width: 500px;'>
-				<div class = 'media' style = { { alignItems: 'stretch' } }>
-					<div class = 'media-content' style = {{ overflowY: 'visible', overflowX: 'unset', display: 'flex', flexDirection: 'column', minWidth: 0 }}>
-						<div style = 'padding-bottom: 10px; height: 40px'>
+		<div class = 'card address-book-entry-card'>
+			<div class = 'card-content address-book-entry-content'>
+				<div class = 'media address-book-entry-media'>
+					<div class = 'media-content address-book-entry-main'>
+						<div class = 'address-book-entry-heading'>
 							{ entry.type === 'empty'
 								? <></>
 								: <BigAddress
@@ -120,14 +120,14 @@ function AddressBookEntryCard({ removeEntry, renameAddressCallBack, ...entry }: 
 
 						{ entry.category === 'ERC20 Tokens'
 							? <div>
-								<p class = 'paragraph' style = 'display: inline-block; font-size: 13px; vertical-align: top;'>{ `Decimals: ${ 'decimals' in entry && entry.decimals !== undefined ? entry.decimals.toString() : 'MISSING' }` }</p>
+								<p class = 'paragraph address-book-entry-meta'>{ `Decimals: ${ 'decimals' in entry && entry.decimals !== undefined ? entry.decimals.toString() : 'MISSING' }` }</p>
 							</div>
 							: <></>
 						}
 
 						{ entry.category === 'Non Fungible Tokens' || entry.category === 'Other Contracts'
 							? <div>
-								<p class = 'paragraph' style = 'display: inline-block; font-size: 13px; vertical-align: top;'>
+								<p class = 'paragraph address-book-entry-meta'>
 									{ `Protocol: ${ 'protocol' in entry ? entry.protocol : '' } ` }
 								</p>
 							</div>
@@ -141,20 +141,20 @@ function AddressBookEntryCard({ removeEntry, renameAddressCallBack, ...entry }: 
 							</label>
 							:
 							<div>
-								<p class = 'paragraph' style = 'display: inline-block; font-size: 13px; vertical-align: top; width: 420px; text-overflow: ellipsis; overflow: hidden; white-space: nowrap;'>
+								<p class = 'paragraph address-book-entry-meta address-book-entry-abi'>
 									{ `ABI: ${ 'abi' in entry && entry.abi !== undefined ? entry.abi : 'No ABI available' } ` }
 								</p>
 							</div>
 						}
 						<div>
-							<p class = 'paragraph' style = 'display: inline-block; font-size: 13px; color: var(--subtitle-text-color);'>
+							<p class = 'paragraph address-book-entry-meta address-book-entry-source'>
 								{ `Source: ${ 'entrySource' in entry ? entry.entrySource : '' }` }
 							</p>
 						</div>
 					</div>
 
-					<div class = 'content' style = 'color: var(--text-color); display: flex; flex-direction: column; justify-content: space-between;'>
-						<button class = 'card-header-icon' style = 'padding: 0px; margin-left: auto;' aria-label = 'delete' disabled = { entry.type === 'empty' || (entry.entrySource !== 'User' && entry.entrySource !== 'OnChain') } onClick = { conditionallyRemoveEntry }>
+					<div class = 'content address-book-entry-actions'>
+						<button class = 'card-header-icon address-book-entry-remove' aria-label = 'delete' disabled = { entry.type === 'empty' || (entry.entrySource !== 'User' && entry.entrySource !== 'OnChain') } onClick = { conditionallyRemoveEntry }>
 							<XMarkIcon />
 						</button>
 						<button class = 'button is-primary is-small' onClick = { conditionallyEditEntry }>Edit</button>
@@ -258,7 +258,7 @@ export function AddressBook() {
 		const errorMessage = (viewFilter.value.searchString && viewFilter.value.searchString.trim().length > 0 )
 			? `No entries found for "${ viewFilter.value.searchString }" in ${ viewFilter.value.activeFilter } on ${ viewFilter.value.chain?.name }`
 			: `No cute dinosaurs in ${ viewFilter.value.activeFilter } on ${ viewFilter.value.chain?.name }`
-		return <div style = { { width: 500, padding: '0 1rem', margin: '0 1rem' } }>{ errorMessage }</div>
+		return <div class = 'address-book-empty-state'>{ errorMessage }</div>
 	}
 
 	function openNewAddress(filter: FilterKey) {
@@ -311,11 +311,11 @@ export function AddressBook() {
 		})
 	}
 	return (
-		<main>
+		<main class = 'address-book-page'>
 			<Hint>
-				<div class = 'columns' style = { { width: 'fit-content', margin: 'auto', padding: '0 1rem' } }>
-					<div style = { { padding: '1rem 0'} }>
-						<div style = 'padding: 10px;'>
+				<div class = 'address-book-layout'>
+					<div class = 'address-book-sidebar'>
+						<div class = 'address-book-chain-selector'>
 							<ChainSelector rpcEntries = { rpcEntries } chainId = { activeChainId } changeChain = { changeActiveChain } buttonClassses = 'button is-primary chainSelector'/>
 						</div>
 						<aside class = 'menu'>
@@ -337,14 +337,14 @@ export function AddressBook() {
 							</ul>
 						</aside>
 					</div>
-					<div style = { { display: 'grid', gridTemplateRows: 'min-content 1fr', rowGap: '1rem', height: '100vh', paddingTop: '1rem' } }>
-						<div style = { { display: 'grid', gridTemplateColumns: '1fr max-content', columnGap: '1rem', padding: '0 1rem', alignItems: 'center' } }>
+					<div class = 'address-book-content'>
+						<div class = 'address-book-toolbar'>
 							<input class = 'input' type = 'text' placeholder = 'Search In Category' value = { viewFilter.value.searchString } onInput = { e => search(e.currentTarget.value) } />
 							<button class = 'button is-primary' onClick = { () => openNewAddress(viewFilter.value.activeFilter) }>
 								{ `Add New ${ filterDefs[viewFilter.value.activeFilter] }` }
 							</button>
 						</div>
-						<div style = { { minHeight: 0 } }>
+						<div class = 'address-book-list'>
 							{ addressBookEntriesWithFilter.value.addressBookEntries.length
 								? <DynamicScroller
 									items = { addressBookEntries }

--- a/app/ts/background/background.ts
+++ b/app/ts/background/background.ts
@@ -17,6 +17,7 @@ import { appendTransactionsToInput, mockSignTransaction } from '../simulation/se
 import { Semaphore } from '../utils/semaphore.js'
 import { JsonRpcResponseError, reportUnexpectedError, isExpectedInfrastructureError, isFailedToFetchError, isNewBlockAbort } from '../utils/errors.js'
 import { InterceptedRequest, type UniqueRequestIdentifier, type WebsiteSocket } from '../utils/requests.js'
+import { getSimulationStackTargetHash } from '../utils/simulationStackTargets.js'
 import { replyToInterceptedRequest } from './messageSending.js'
 import { bumpPopupRefreshGeneration } from './popupRefreshGeneration.js'
 import { type EthGetStorageAtParams, EthereumJsonRpcRequest, type SendRawTransactionParams, type SendTransactionParams, SupportedEthereumJsonRpcRequestMethods, type WalletAddEthereumChain } from '../types/JsonRpc-types.js'
@@ -574,6 +575,7 @@ export async function popupMessageHandler(
 				case 'popup_clearUnexpectedError': return await setLatestUnexpectedError(undefined)
 				case 'popup_setEnsNameForHash': return await setEnsNameForHash(parsedRequest)
 				case 'popup_openWebsiteAccess': return await openNewTab('websiteAccess')
+				case 'popup_openSimulationStack': return await openNewTab('simulationStack', 'data' in parsedRequest ? getSimulationStackTargetHash(parsedRequest.data) : undefined)
 				case 'popup_retrieveWebsiteAccess': return await retrieveWebsiteAccess(parsedRequest)
 				case 'popup_blockOrAllowExternalRequests': return await blockOrAllowExternalRequests(ethereum, tokenPriceService, resetSimulationServices, websiteTabConnections, parsedRequest)
 				case 'popup_allowOrPreventAddressAccessForWebsite': return await allowOrPreventAddressAccessForWebsite(websiteTabConnections, parsedRequest)
@@ -595,6 +597,7 @@ export async function popupMessageHandler(
 				case 'popup_requestSimulationMetadata': return await requestSimulationMetadata(ethereum)
 				case 'popup_requestIdentifyAddress': return await requestIdentifyAddress(ethereum, parsedRequest)
 				case 'popup_isMainPopupWindowOpen': return
+				case 'popup_isSimulationVisualizerOpen': return
 				default: assertUnreachable(parsedRequest)
 			}
 		}

--- a/app/ts/background/backgroundUtils.ts
+++ b/app/ts/background/backgroundUtils.ts
@@ -151,6 +151,11 @@ export async function requestIsMainPopupWindowOpen() {
 	return reply?.method === 'popup_isMainPopupWindowOpen' ? reply : undefined
 }
 
+export async function requestIsSimulationDataConsumerOpen() {
+	const reply = await sendPopupMessageWithReply({ method: 'popup_isSimulationVisualizerOpen' })
+	return reply?.method === 'popup_isSimulationVisualizerOpen' ? reply : undefined
+}
+
 export async function sendPopupReadyAndListening(page: PopupReadyAndListeningPage): Promise<PopupOrTabId | undefined> {
 	const reply = await sendPopupMessageWithReply({ method: 'popup_readyAndListening', data: { page } })
 	return reply?.method === 'popup_readyAndListening' ? reply.data.popupOrTabId : undefined
@@ -169,7 +174,7 @@ export function createInternalMessageListener(handler: (message: WindowMessage) 
 	}
 }
 
-type HTMLFile = 'popup' | 'addressBook' | 'changeChain' | 'confirmTransaction' | 'interceptorAccess' | 'personalSign' | 'settingsView' | 'websiteAccess' | 'fetchSimulationStack'
+type HTMLFile = 'popup' | 'addressBook' | 'changeChain' | 'confirmTransaction' | 'interceptorAccess' | 'personalSign' | 'settingsView' | 'websiteAccess' | 'fetchSimulationStack' | 'simulationStack'
 export function getHtmlFile(file: HTMLFile) {
 	const manifest = browser.runtime.getManifest()
 	if (manifest.manifest_version === 2) return `/html/${ file }.html`

--- a/app/ts/background/popupMessageHandlers.ts
+++ b/app/ts/background/popupMessageHandlers.ts
@@ -25,7 +25,7 @@ import { updateContentScriptInjectionStrategyManifestV2, updateContentScriptInje
 import type { Website } from '../types/websiteAccessTypes.js'
 import { makeSureInterceptorIsNotSleeping } from './sleeping.js'
 import { craftPersonalSignPopupMessage } from './windows/personalSign.js'
-import { checkAndThrowRuntimeLastError, silenceChromeUnCaughtPromise, updateTabIfExists } from '../utils/requests.js'
+import { checkAndThrowRuntimeLastError, silenceChromeUnCaughtPromise, updateTabIfExists, updateWindowIfExists } from '../utils/requests.js'
 import { assertNever, modifyObject } from '../utils/typescript.js'
 import type { VisualizedPersonalSignRequestSafeTx } from '../types/personal-message-definitions.js'
 import type { TokenPriceService } from '../simulation/services/priceEstimator.js'
@@ -88,8 +88,20 @@ export async function getLastKnownCurrentTabId() {
 	const tabId = await tabIdPromise
 	// skip restricted or insufficient permission tabs
 	if (tabs[0]?.id === undefined || tabs[0]?.url === undefined) return tabId
-	if (tabId !== tabs[0].id) saveCurrentTabId(tabs[0].id)
+	if (isExtensionOwnedPageUrl(tabs[0].url)) return tabId
+	if (tabId !== tabs[0].id) await saveCurrentTabId(tabs[0].id)
 	return tabs[0].id
+}
+
+function isExtensionOwnedPageUrl(urlString: string) {
+	if (urlString.startsWith('/html/') || urlString.startsWith('/html3/')) return true
+	try {
+		const url = new URL(urlString)
+		const ownUrl = new URL(browser.runtime.getURL('/'))
+		return url.protocol === ownUrl.protocol && url.host === ownUrl.host
+	} catch {
+		return false
+	}
 }
 
 export async function popupReadyAndListening(ethereum: EthereumClientService, page: PopupReadyAndListeningPage) {
@@ -470,9 +482,41 @@ export async function getAddressBookData(parsed: GetAddressBookData) {
 	})
 }
 
-export const openNewTab = async (tabName: 'settingsView' | 'addressBook' | 'websiteAccess') => {
+type ExtensionTabName = 'settingsView' | 'addressBook' | 'websiteAccess' | 'simulationStack'
+
+type ExistingTabUpdate = {
+	active: true
+	highlighted: true
+	url?: string
+}
+
+function getExistingTabUpdate(tabName: ExtensionTabName, targetUrl: string, resolvedTargetUrl: URL, currentTabUrl: string | undefined, targetHash: string): ExistingTabUpdate {
+	const url = getExistingTabUrlUpdate(tabName, targetUrl, resolvedTargetUrl, currentTabUrl, targetHash)
+	if (url === undefined) return { active: true, highlighted: true }
+	return { active: true, highlighted: true, url }
+}
+
+function getExistingTabUrlUpdate(tabName: ExtensionTabName, targetUrl: string, resolvedTargetUrl: URL, currentTabUrl: string | undefined, targetHash: string) {
+	if (targetHash.length !== 0) return targetUrl
+	if (tabName !== 'simulationStack') return undefined
+	if (currentTabUrl === undefined) return undefined
+	return shouldClearSimulationStackHash(currentTabUrl, targetUrl, resolvedTargetUrl) ? targetUrl : undefined
+}
+
+function shouldClearSimulationStackHash(currentTabUrl: string, targetUrl: string, resolvedTargetUrl: URL) {
+	try {
+		const currentUrl = new URL(currentTabUrl, browser.runtime.getURL('/'))
+		return currentUrl.pathname !== resolvedTargetUrl.pathname || currentUrl.hash !== ''
+	} catch {
+		return currentTabUrl !== targetUrl
+	}
+}
+
+export const openNewTab = async (tabName: ExtensionTabName, targetHash = '') => {
+	const targetUrl = `${ getHtmlFile(tabName) }${ targetHash }`
+	const resolvedTargetUrl = new URL(targetUrl, browser.runtime.getURL('/'))
 	const openInNewTab = async () => {
-		const tab = await browser.tabs.create({ url: getHtmlFile(tabName) })
+		const tab = await browser.tabs.create({ url: targetUrl })
 		if (tab.id !== undefined) await setIdsOfOpenedTabs({ [tabName]: tab.id })
 	}
 
@@ -482,8 +526,9 @@ export const openNewTab = async (tabName: 'settingsView' | 'addressBook' | 'webs
 	const addressBookTab = allTabs.find((tab) => tab.id === tabId)
 
 	if (addressBookTab?.id === undefined) return await openInNewTab()
-	const tab = await updateTabIfExists(addressBookTab.id, { active: true, highlighted: true })
-	if (tab === undefined) await openInNewTab()
+	const tab = await updateTabIfExists(addressBookTab.id, getExistingTabUpdate(tabName, targetUrl, resolvedTargetUrl, addressBookTab.url, targetHash))
+	if (tab === undefined) return await openInNewTab()
+	if (tab?.windowId !== undefined) await updateWindowIfExists(tab.windowId, { focused: true })
 }
 
 export async function requestNewHomeData(

--- a/app/ts/background/popupVisualisationUpdater.ts
+++ b/app/ts/background/popupVisualisationUpdater.ts
@@ -9,7 +9,7 @@ import { silenceChromeUnCaughtPromise } from '../utils/requests.js'
 import { Semaphore } from '../utils/semaphore.js'
 import { modifyObject } from '../utils/typescript.js'
 import { getUpdatedSimulationState } from './background.js'
-import { requestIsMainPopupWindowOpen, sendPopupMessageToOpenWindows } from './backgroundUtils.js'
+import { requestIsSimulationDataConsumerOpen, sendPopupMessageToOpenWindows } from './backgroundUtils.js'
 import { getPopupVisualisationFingerprint } from './popupSimulationFingerprint.js'
 import { getAddressesbeingMadeRich, getCurrentSimulationInput, visualizeSimulatorState } from './simulationUpdating.js'
 import { getPopupVisualisationState, setPopupVisualisationState } from './storageVariables.js'
@@ -62,8 +62,8 @@ export const updatePopupVisualisationIfNeeded = async (ethereum: EthereumClientS
 			const ageSeconds = (Date.now()- popupVisualisation.simulationState.value.simulationConductedTimestamp.getTime()) / 1000
 			if (ageSeconds < TIME_BETWEEN_BLOCKS) return popupVisualisation
 		}
-		const isMainPopupWindowOpenReply = await requestIsMainPopupWindowOpen()
-		if (!(isMainPopupWindowOpenReply?.data.isOpen === true)) return popupVisualisation
+		const isSimulationDataConsumerOpenReply = await requestIsSimulationDataConsumerOpen()
+		if (!(isSimulationDataConsumerOpenReply?.data.isOpen === true)) return popupVisualisation
 		if (skipIfUnchanged && popupVisualisation.simulationState.kind === 'simulated') {
 			const currentSimulationInput = await getCurrentSimulationStateInput(ethereum)
 			const currentFingerprint = getPopupVisualisationFingerprint(currentSimulationInput.simulationStateInput, currentSimulationInput.rpcNetwork, currentSimulationInput.blockNumber)

--- a/app/ts/background/storageVariables.ts
+++ b/app/ts/background/storageVariables.ts
@@ -18,7 +18,7 @@ import type { UnexpectedErrorOccured } from '../types/interceptor-reply-messages
 import { getLargeStateValue, setLargeStateValue } from '../utils/largeStateStore.js'
 import type { InterceptorErrorDiagnostic } from '../types/errorDiagnostics.js'
 
-export const getIdsOfOpenedTabs = async () => (await browserStorageLocalGet('idsOfOpenedTabs'))?.idsOfOpenedTabs ?? { settingsView: undefined, addressBook: undefined, websiteAccess: undefined }
+export const getIdsOfOpenedTabs = async () => (await browserStorageLocalGet('idsOfOpenedTabs'))?.idsOfOpenedTabs ?? { settingsView: undefined, addressBook: undefined, websiteAccess: undefined, simulationStack: undefined }
 export const setIdsOfOpenedTabs = async (ids: PartialIdsOfOpenedTabs) => await browserStorageLocalSet({ idsOfOpenedTabs: { ...await getIdsOfOpenedTabs(), ...ids } })
 
 const pendingTransactionsSemaphore = new Semaphore(1)

--- a/app/ts/components/App.tsx
+++ b/app/ts/components/App.tsx
@@ -1,34 +1,30 @@
 import { useEffect } from 'preact/hooks'
 import type { JSX } from 'preact'
-import { defaultActiveAddresses } from '../background/settings.js'
-import { PASSTHROUGH_STATE, type ResolvedSimulationResults, type ResolvedSimulationState, type TokenPriceEstimate, type SimulationUpdatingState, type SimulationResultState, type NamedTokenId, type ModifyAddressWindowState, type EditEnsNamedHashWindowState, type VisualizedSimulationState, type BlockTimeManipulation, type CompleteVisualizedSimulation, toResolvedSimulationResults } from '../types/visualizer-types.js'
+import type { ModifyAddressWindowState, EditEnsNamedHashWindowState } from '../types/visualizer-types.js'
 import { Home } from './pages/Home.js'
-import type { RpcConnectionStatus, TabIconDetails, TabState } from '../types/user-interface-types.js'
+import type { TabState } from '../types/user-interface-types.js'
 import Hint from './subcomponents/Hint.js'
 import { getAddress, isAddress } from '../utils/viem.js'
 import { PasteCatcher } from './subcomponents/PasteCatcher.js'
 import { truncateAddr } from '../utils/ethereum.js'
-import { DEFAULT_TAB_CONNECTION, METAMASK_ERROR_ALREADY_PENDING, METAMASK_ERROR_USER_REJECTED_REQUEST } from '../utils/constants.js'
-import { UpdateHomePage, type Settings, MessageToPopup } from '../types/interceptor-messages.js'
+import { METAMASK_ERROR_ALREADY_PENDING, METAMASK_ERROR_USER_REJECTED_REQUEST } from '../utils/constants.js'
+import type { Settings } from '../types/interceptor-messages.js'
 import { version, gitCommitSha } from '../version.js'
 import { sendPopupMessageToBackgroundPage } from '../background/backgroundUtils.js'
-import type { EthereumAddress, EthereumBytes32 } from '../types/wire-types.js'
+import type { EthereumBytes32 } from '../types/wire-types.js'
 import { checksummedAddress } from '../utils/bigint.js'
-import type { AddressBookEntry, AddressBookEntries } from '../types/addressBookTypes.js'
-import type { WebsiteAccessArray } from '../types/websiteAccessTypes.js'
-import type { RpcEntries, RpcEntry, RpcNetwork } from '../types/rpc.js'
+import type { AddressBookEntry } from '../types/addressBookTypes.js'
+import type { RpcEntry } from '../types/rpc.js'
 import { ErrorBoundary, ErrorComponent, UnexpectedError } from './subcomponents/Error.js'
 import { SignersLogoName } from './subcomponents/signers.js'
-import { SomeTimeAgo } from './subcomponents/SomeTimeAgo.js'
-import { addressEditEntry, humanReadableDate } from './ui-utils.js'
+import { addressEditEntry } from './ui-utils.js'
 import { Signal, useComputed, useSignal } from '@preact/signals'
-import type { EnrichedRichListElement, UnexpectedErrorOccured } from '../types/interceptor-reply-messages.js'
-import { PopupMessageReplyRequests } from '../types/interceptor-reply-messages.js'
 import { CenterToPageTextSpinner } from './subcomponents/Spinner.js'
-import { POPUP_PERFORMANCE_MARKS, markPerformance, markPerformanceOnce } from '../utils/popupPerformance.js'
-import { getRpcWarningState, shouldShowRpcWarningCountdown } from '../utils/rpcConnectionUi.js'
+import { POPUP_PERFORMANCE_MARKS, markPerformanceOnce } from '../utils/popupPerformance.js'
 import type { AddAddressParam, ChangeActiveAddressParam, InterceptorAccessListParams } from '../types/user-interface-types.js'
 import { createUnexpectedErrorPopupMessage } from '../utils/unexpectedErrorPopupMessage.js'
+import { useLiveSimulationHomeData } from './hooks/useLiveSimulationHomeData.js'
+import { NetworkErrors } from './subcomponents/NetworkErrors.js'
 
 type ProviderErrorsParam = {
 	tabState: Signal<TabState | undefined>
@@ -39,39 +35,6 @@ function ProviderErrors({ tabState } : ProviderErrorsParam) {
 	if (tabState.value.signerAccountError.code === METAMASK_ERROR_USER_REJECTED_REQUEST) return <ErrorComponent warning = { true } text = { <>Could not get an account from <SignersLogoName signerName = { tabState.value.signerName } /> as user denied the request.</> }/>
 	if (tabState.value.signerAccountError.code === METAMASK_ERROR_ALREADY_PENDING.error.code) return <ErrorComponent warning = { true } text = { <>There's a connection request pending on <SignersLogoName signerName = { tabState.value.signerName } />. Please review the request.</> }/>
 	return <ErrorComponent warning = { true } text = { <><SignersLogoName signerName = { tabState.value.signerName } /> returned error: "{ tabState.value.signerAccountError.message }".</> }/>
-}
-
-type NetworkErrorParams = {
-	rpcConnectionStatus: Signal<RpcConnectionStatus>
-}
-
-export function NetworkErrors({ rpcConnectionStatus } : NetworkErrorParams) {
-	const status = rpcConnectionStatus.value
-	if (status === undefined) return <></>
-	const warningState = getRpcWarningState(status)
-	if (warningState.kind === 'none') return <></>
-	const showCountdown = shouldShowRpcWarningCountdown(warningState)
-
-	if (warningState.kind === 'disconnected') {
-		if (warningState.retryState === 'paused') {
-			return <ErrorComponent warning = { true } text = { <>Unable to connect to { status.rpcNetwork.name }. Retrying resumes when the extension becomes active.</> }/>
-		}
-		if (showCountdown && warningState.nextRetryAt !== undefined) {
-			return <ErrorComponent warning = { true } text = { <>Unable to connect to { status.rpcNetwork.name }. Retrying in <SomeTimeAgo priorTimestamp = { warningState.nextRetryAt } countBackwards = { true }/>.</> }/>
-		}
-		return <ErrorComponent warning = { true } text = { <>Unable to connect to { status.rpcNetwork.name }. Retrying now.</> }/>
-	}
-
-	const latestBlock = status.latestBlock
-	if (latestBlock === undefined || latestBlock === null) return <></>
-	if (showCountdown && warningState.nextRetryAt !== undefined) {
-		return <ErrorComponent warning = { true } text = {
-			<>The connected RPC ({ status.rpcNetwork.name }) seems to be stuck at block { latestBlock.number } (occurred on: { humanReadableDate(latestBlock.timestamp) }). Retrying in <SomeTimeAgo priorTimestamp = { warningState.nextRetryAt } countBackwards = { true }/>.</>
-		}/>
-	}
-	return <ErrorComponent warning = { true } text = {
-		<>The connected RPC ({ status.rpcNetwork.name }) seems to be stuck at block { latestBlock.number } (occurred on: { humanReadableDate(latestBlock.timestamp) }). Retrying now.</>
-	}/>
 }
 
 type Page = { page: 'Home' | 'ChangeActiveAddress' | 'AccessList' | 'Settings' | 'Unknown' }
@@ -134,35 +97,45 @@ const LazyImportSimulationStack = createLazyPage<{ close: () => void, simulation
 
 export function App() {
 	const appPage = useSignal<Page>({ page: 'Unknown' })
-	const activeAddresses = useSignal<AddressBookEntries>(defaultActiveAddresses)
-	const activeSimulationAddress = useSignal<bigint | undefined>(undefined)
-	const activeSigningAddress = useSignal<bigint | undefined>(undefined)
-	const useSignersAddressAsActiveAddress = useSignal<boolean>(false)
-	const simVisResults = useSignal<ResolvedSimulationResults>(PASSTHROUGH_STATE)
-	const websiteAccess = useSignal<WebsiteAccessArray | undefined>(undefined)
-	const websiteAccessAddressMetadata = useSignal<AddressBookEntries>([])
-	const rpcNetwork = useSignal<RpcNetwork | undefined>(undefined)
-	const tabIconDetails = useSignal<TabIconDetails>(DEFAULT_TAB_CONNECTION)
-	const isSettingsLoaded = useSignal<boolean>(false)
-	const currentBlockNumber = useSignal<bigint | undefined>(undefined)
-	const tabState = useSignal<TabState | undefined>(undefined)
-	const rpcConnectionStatus = useSignal<RpcConnectionStatus>(undefined)
-	const currentTabId = useSignal<number | undefined>(undefined)
-	const rpcEntries = useSignal<RpcEntries>([])
-	const simulationUpdatingState = useSignal<SimulationUpdatingState | undefined>(undefined)
-	const simulationResultState = useSignal<SimulationResultState | undefined>(undefined)
-	const interceptorDisabled = useSignal<boolean>(false)
-	const unexpectedError = useSignal<UnexpectedErrorOccured | undefined>(undefined)
+	const {
+		activeAddresses,
+		activeSimulationAddress,
+		activeSigningAddress,
+		useSignersAddressAsActiveAddress,
+		simVisResults,
+		websiteAccess,
+		websiteAccessAddressMetadata,
+		rpcNetwork,
+		tabIconDetails,
+		isSettingsLoaded,
+		currentBlockNumber,
+		tabState,
+		rpcConnectionStatus,
+		rpcEntries,
+		simulationUpdatingState,
+		simulationResultState,
+		interceptorDisabled,
+		unexpectedError,
+		preSimulationBlockTimeManipulation,
+		popupRefreshAppliedGeneration,
+		fixedAddressRichList,
+		makeCurrentAddressRich,
+		simulationMode,
+		numberOfAddressesMadeRich,
+	} = useLiveSimulationHomeData({
+		answerMainPopupOpen: true,
+		answerSimulationDataConsumerOpen: true,
+		requestFreshHomeDataOnMount: true,
+		onInitialSettings(settings: Settings) {
+			if (appPage.value.page !== 'Unknown') return
+			if (settings.openedPage.page === 'AddNewAddress' || settings.openedPage.page === 'ModifyAddress') {
+				appPage.value = { ...settings.openedPage, state: new Signal(settings.openedPage.state) }
+				return
+			}
+			appPage.value = settings.openedPage
+		},
+	})
 	const boundaryResetKey = useSignal(0)
-	const preSimulationBlockTimeManipulation = useSignal<BlockTimeManipulation | undefined>(undefined)
-	const popupRefreshAppliedGeneration = useSignal(0)
-	const popupRefreshGeneration = useSignal(0)
-	const pendingPopupRefreshGeneration = useSignal(0)
-	const popupIconRefreshGeneration = useSignal(0)
-
-	const fixedAddressRichList = useSignal<readonly EnrichedRichListElement[]>([])
-	const makeCurrentAddressRich = useSignal<boolean>(false)
-	const simulationMode = useSignal<boolean>(false)
 
 	async function setActiveAddressAndInformAboutIt(address: bigint | 'signer') {
 		useSignersAddressAsActiveAddress.value = address === 'signer'
@@ -197,10 +170,6 @@ export function App() {
 			rpcNetwork.value = entry
 		}
 	}
-	const requestCachedHomeData = async () => {
-		await sendPopupMessageToBackgroundPage({ method: 'popup_requestNewHomeData' })
-	}
-
 	useEffect(() => {
 		if (popupRefreshAppliedGeneration.value === 0) return
 		if (popupRefreshAppliedGeneration.value === 1) {
@@ -208,179 +177,6 @@ export function App() {
 		}
 		markPerformanceOnce(POPUP_PERFORMANCE_MARKS.refreshRendered)
 	}, [popupRefreshAppliedGeneration.value])
-
-	useEffect(() => {
-		const setSimulationState = (
-			simState: ResolvedSimulationState,
-			addressBookEntries: AddressBookEntries,
-			tokenPriceEstimates: readonly TokenPriceEstimate[],
-			visualizedSimulationState: VisualizedSimulationState,
-			activeSimulationAddress: EthereumAddress | undefined,
-			namedTokenIds: readonly NamedTokenId[],
-		): void => {
-			if (activeSimulationAddress === undefined || simState.kind === 'passthrough') {
-				simVisResults.value = PASSTHROUGH_STATE
-				return
-			}
-			simVisResults.value = toResolvedSimulationResults({
-				blockNumber: simState.value.blockNumber,
-				blockTimestamp: simState.value.blockTimestamp,
-				simulationConductedTimestamp: simState.value.simulationConductedTimestamp,
-				simulationStateInput: simState.value.simulationStateInput,
-				visualizedSimulationState,
-				rpcNetwork: simState.value.rpcNetwork,
-				tokenPriceEstimates,
-				addressBookEntries: addressBookEntries,
-				namedTokenIds,
-			})
-		}
-
-		const updateVisualizedState = (state: CompleteVisualizedSimulation) => {
-			setSimulationState(
-				state.simulationState,
-				state.addressBookEntries,
-				state.tokenPriceEstimates,
-				state.visualizedSimulationState,
-				activeSimulationAddress.value,
-				state.namedTokenIds,
-			)
-			simulationUpdatingState.value = state.simulationUpdatingState
-			simulationResultState.value = state.simulationResultState
-		}
-
-		const shouldIgnoreOutdatedPopupRefreshMessage = (refreshGeneration: number, minimumGeneration = popupRefreshGeneration.value) => refreshGeneration < minimumGeneration
-		const updateHomePage = ({ data, popupRefreshGeneration: updateGeneration }: UpdateHomePage) => {
-			if (data.tabId !== currentTabId.value && currentTabId.value !== undefined) return
-			const minimumValidGeneration = Math.max(popupRefreshGeneration.value, pendingPopupRefreshGeneration.value)
-			if (shouldIgnoreOutdatedPopupRefreshMessage(updateGeneration, minimumValidGeneration)) return
-			popupRefreshGeneration.value = updateGeneration
-			if (pendingPopupRefreshGeneration.value <= updateGeneration) {
-				pendingPopupRefreshGeneration.value = 0
-			}
-			const wasLoaded = isSettingsLoaded.value
-			isSettingsLoaded.value = true
-			rpcEntries.value = data.rpcEntries
-			currentTabId.value = data.tabId
-			activeSigningAddress.value = data.activeSigningAddressInThisTab
-			activeAddresses.value = data.activeAddresses
-			interceptorDisabled.value = data.interceptorDisabled
-			makeCurrentAddressRich.value = data.makeCurrentAddressRich
-			fixedAddressRichList.value = data.richList
-			unexpectedError.value = data.latestUnexpectedError
-			updateHomePageSettings(data.settings, !wasLoaded)
-			if (popupIconRefreshGeneration.value <= updateGeneration) {
-				tabIconDetails.value = data.tabState.tabIconDetails
-				popupIconRefreshGeneration.value = updateGeneration
-			}
-			updateVisualizedState(data.visualizedSimulatorState)
-			tabState.value = data.tabState
-			currentBlockNumber.value = data.currentBlockNumber
-			websiteAccessAddressMetadata.value = data.websiteAccessAddressMetadata
-			rpcConnectionStatus.value = data.rpcConnectionStatus
-			preSimulationBlockTimeManipulation.value = data.preSimulationBlockTimeManipulation
-			markPerformance(POPUP_PERFORMANCE_MARKS.refreshComplete)
-			popupRefreshAppliedGeneration.value += 1
-		}
-		const updateHomePageSettings = (settings: Settings, updateQuery: boolean) => {
-			if (updateQuery && appPage.value.page === 'Unknown') {
-				if (settings.openedPage.page === 'AddNewAddress' || settings.openedPage.page === 'ModifyAddress') {
-					appPage.value = { ...settings.openedPage, state: new Signal(settings.openedPage.state) }
-				} else {
-					appPage.value = settings.openedPage
-				}
-			}
-			rpcNetwork.value = settings.activeRpcNetwork
-			activeSimulationAddress.value = settings.activeSimulationAddress
-			useSignersAddressAsActiveAddress.value = settings.useSignersAddressAsActiveAddress
-			websiteAccess.value = settings.websiteAccess
-			simulationMode.value = settings.simulationMode
-		}
-
-		const replyPopupMessageListener = (msg: unknown, _sender: unknown, sendResponse: (response?: unknown) => void) => {
-			const maybeRequest = PopupMessageReplyRequests.safeParse(msg)
-			if (maybeRequest.success && maybeRequest.value.method === 'popup_isMainPopupWindowOpen') {
-				sendResponse({ method: 'popup_isMainPopupWindowOpen', data: { isOpen: true } })
-				return true
-			}
-
-			const maybeParsed = MessageToPopup.safeParse(msg)
-			if (!maybeParsed.success) return undefined // not a message we are interested in
-			const parsed = maybeParsed.value
-			if (parsed.role === 'confirmTransaction') return undefined
-			switch(parsed.method) {
-				case 'popup_UnexpectedErrorOccured': {
-						unexpectedError.value = parsed
-						return undefined
-					}
-					case 'popup_settingsUpdated':
-						if (shouldIgnoreOutdatedPopupRefreshMessage(parsed.popupRefreshGeneration)) return undefined
-						pendingPopupRefreshGeneration.value = Math.max(pendingPopupRefreshGeneration.value, parsed.popupRefreshGeneration)
-						requestCachedHomeData()
-						return undefined
-					case 'popup_accounts_update':
-					case 'popup_chain_update':
-					case 'popup_signer_name_changed':
-					case 'popup_addressBookEntriesChanged':
-					case 'popup_interceptor_access_changed':
-					case 'popup_websiteAccess_changed':
-					case 'popup_setDisableInterceptorReply':
-					case 'popup_update_rpc_list':
-						requestCachedHomeData()
-						return undefined
-					case 'popup_activeSigningAddressChanged': {
-						if (parsed.data.tabId !== currentTabId.value) return undefined
-						activeSigningAddress.value = parsed.data.activeSigningAddress
-						return undefined
-					}
-					case 'popup_websiteIconChanged': {
-						if (currentTabId.value === undefined || parsed.tabId !== currentTabId.value) return undefined
-						if (shouldIgnoreOutdatedPopupRefreshMessage(parsed.popupRefreshGeneration)) return undefined
-						if (parsed.popupRefreshGeneration < popupIconRefreshGeneration.value) return undefined
-						popupIconRefreshGeneration.value = parsed.popupRefreshGeneration
-						tabIconDetails.value = parsed.data
-						return undefined
-					}
-					case 'popup_new_block_arrived': {
-						rpcConnectionStatus.value = parsed.data.rpcConnectionStatus
-						currentBlockNumber.value = parsed.data.rpcConnectionStatus?.latestBlock?.number
-						return undefined
-					}
-					case 'popup_failed_to_get_block': {
-						rpcConnectionStatus.value = parsed.data.rpcConnectionStatus
-						currentBlockNumber.value = parsed.data.rpcConnectionStatus?.latestBlock?.number
-						return undefined
-					}
-					case 'popup_simulation_state_changed': {
-						updateVisualizedState(parsed.data.visualizedSimulatorState)
-						return undefined
-					}
-				}
-				if (parsed.method !== 'popup_UpdateHomePage') {
-					return undefined
-				}
-				if (typeof msg !== 'object' || msg === null) {
-					return undefined
-				}
-				const { role: _role, ...popupUpdateHomePage } = msg as Record<string, unknown>
-				const parsedUpdateHomePage = UpdateHomePage.safeParse(popupUpdateHomePage)
-				if (!parsedUpdateHomePage.success) {
-					return undefined
-				}
-				return updateHomePage(parsedUpdateHomePage.value)
-			}
-
-		browser.runtime.onMessage.addListener(replyPopupMessageListener)
-		return () => {
-			browser.runtime.onMessage.removeListener(replyPopupMessageListener)
-		}
-	}, [])
-
-	useEffect(() => {
-		void (async () => {
-			await requestCachedHomeData()
-			void sendPopupMessageToBackgroundPage({ method: 'popup_refreshHomeData' })
-		})()
-	}, [])
 
 	function goHome() {
 		const newPage = { page: 'Home' } as const
@@ -544,7 +340,7 @@ export function App() {
 							interceptorDisabled = { interceptorDisabled }
 							preSimulationBlockTimeManipulation = { preSimulationBlockTimeManipulation }
 							fixedAddressRichList = { fixedAddressRichList }
-							openImportSimulation = { () => { appPage.value = { page: 'ImportSimulation', state: new Signal('') } } }
+							numberOfAddressesMadeRich = { numberOfAddressesMadeRich }
 						/>
 
 					</> }

--- a/app/ts/components/App.tsx
+++ b/app/ts/components/App.tsx
@@ -25,6 +25,7 @@ import type { AddAddressParam, ChangeActiveAddressParam, InterceptorAccessListPa
 import { createUnexpectedErrorPopupMessage } from '../utils/unexpectedErrorPopupMessage.js'
 import { useLiveSimulationHomeData } from './hooks/useLiveSimulationHomeData.js'
 import { NetworkErrors } from './subcomponents/NetworkErrors.js'
+export { NetworkErrors } from './subcomponents/NetworkErrors.js'
 
 type ProviderErrorsParam = {
 	tabState: Signal<TabState | undefined>

--- a/app/ts/components/hooks/useLiveSimulationHomeData.ts
+++ b/app/ts/components/hooks/useLiveSimulationHomeData.ts
@@ -1,0 +1,249 @@
+import { useEffect } from 'preact/hooks'
+import { defaultActiveAddresses } from '../../background/settings.js'
+import { MessageToPopup, type UpdateHomePage, type Settings } from '../../types/interceptor-messages.js'
+import type { RpcConnectionStatus, TabIconDetails, TabState } from '../../types/user-interface-types.js'
+import { PASSTHROUGH_STATE, type BlockTimeManipulation, type CompleteVisualizedSimulation, type NamedTokenId, type ResolvedSimulationResults, type ResolvedSimulationState, type SimulationResultState, type SimulationUpdatingState, type TokenPriceEstimate, type VisualizedSimulationState, toResolvedSimulationResults } from '../../types/visualizer-types.js'
+import type { AddressBookEntries } from '../../types/addressBookTypes.js'
+import type { RpcEntries, RpcNetwork } from '../../types/rpc.js'
+import type { WebsiteAccessArray } from '../../types/websiteAccessTypes.js'
+import type { EnrichedRichListElement, UnexpectedErrorOccured } from '../../types/interceptor-reply-messages.js'
+import { PopupMessageReplyRequests } from '../../types/interceptor-reply-messages.js'
+import { sendPopupMessageToBackgroundPage } from '../../background/backgroundUtils.js'
+import { DEFAULT_TAB_CONNECTION } from '../../utils/constants.js'
+import { useSignal } from '@preact/signals'
+import { POPUP_PERFORMANCE_MARKS, markPerformance } from '../../utils/popupPerformance.js'
+
+type LiveSimulationHomeDataOptions = {
+	answerMainPopupOpen: boolean
+	answerSimulationDataConsumerOpen: boolean
+	requestFreshHomeDataOnMount: boolean
+	filterByTabId?: boolean
+	requireActiveSimulationAddress?: boolean
+	requestHomeDataOnSimulationStateChange?: boolean
+	onInitialSettings?: (settings: Settings) => void
+}
+
+export function useLiveSimulationHomeData(options: LiveSimulationHomeDataOptions) {
+	const activeAddresses = useSignal<AddressBookEntries>(defaultActiveAddresses)
+	const activeSimulationAddress = useSignal<bigint | undefined>(undefined)
+	const activeSigningAddress = useSignal<bigint | undefined>(undefined)
+	const useSignersAddressAsActiveAddress = useSignal<boolean>(false)
+	const simVisResults = useSignal<ResolvedSimulationResults>(PASSTHROUGH_STATE)
+	const websiteAccess = useSignal<WebsiteAccessArray | undefined>(undefined)
+	const websiteAccessAddressMetadata = useSignal<AddressBookEntries>([])
+	const rpcNetwork = useSignal<RpcNetwork | undefined>(undefined)
+	const tabIconDetails = useSignal<TabIconDetails>(DEFAULT_TAB_CONNECTION)
+	const isSettingsLoaded = useSignal<boolean>(false)
+	const currentBlockNumber = useSignal<bigint | undefined>(undefined)
+	const tabState = useSignal<TabState | undefined>(undefined)
+	const rpcConnectionStatus = useSignal<RpcConnectionStatus>(undefined)
+	const currentTabId = useSignal<number | undefined>(undefined)
+	const rpcEntries = useSignal<RpcEntries>([])
+	const simulationUpdatingState = useSignal<SimulationUpdatingState | undefined>(undefined)
+	const simulationResultState = useSignal<SimulationResultState | undefined>(undefined)
+	const interceptorDisabled = useSignal<boolean>(false)
+	const unexpectedError = useSignal<UnexpectedErrorOccured | undefined>(undefined)
+	const preSimulationBlockTimeManipulation = useSignal<BlockTimeManipulation | undefined>(undefined)
+	const popupRefreshAppliedGeneration = useSignal(0)
+	const popupRefreshGeneration = useSignal(0)
+	const pendingPopupRefreshGeneration = useSignal(0)
+	const popupIconRefreshGeneration = useSignal(0)
+	const fixedAddressRichList = useSignal<readonly EnrichedRichListElement[]>([])
+	const makeCurrentAddressRich = useSignal<boolean>(false)
+	const simulationMode = useSignal<boolean>(false)
+	const numberOfAddressesMadeRich = useSignal(0)
+
+	const requestCachedHomeData = async () => {
+		await sendPopupMessageToBackgroundPage({ method: 'popup_requestNewHomeData' })
+	}
+
+	useEffect(() => {
+		const setSimulationState = (
+			simState: ResolvedSimulationState,
+			addressBookEntries: AddressBookEntries,
+			tokenPriceEstimates: readonly TokenPriceEstimate[],
+			visualizedSimulationState: VisualizedSimulationState,
+			activeSimulationAddress: bigint | undefined,
+			namedTokenIds: readonly NamedTokenId[],
+		): void => {
+			if ((options.requireActiveSimulationAddress !== false && activeSimulationAddress === undefined) || simState.kind === 'passthrough') {
+				simVisResults.value = PASSTHROUGH_STATE
+				return
+			}
+			simVisResults.value = toResolvedSimulationResults({
+				blockNumber: simState.value.blockNumber,
+				blockTimestamp: simState.value.blockTimestamp,
+				simulationConductedTimestamp: simState.value.simulationConductedTimestamp,
+				simulationStateInput: simState.value.simulationStateInput,
+				visualizedSimulationState,
+				rpcNetwork: simState.value.rpcNetwork,
+				tokenPriceEstimates,
+				addressBookEntries,
+				namedTokenIds,
+			})
+		}
+
+		const updateVisualizedState = (state: CompleteVisualizedSimulation) => {
+			setSimulationState(
+				state.simulationState,
+				state.addressBookEntries,
+				state.tokenPriceEstimates,
+				state.visualizedSimulationState,
+				activeSimulationAddress.value,
+				state.namedTokenIds,
+			)
+			simulationUpdatingState.value = state.simulationUpdatingState
+			simulationResultState.value = state.simulationResultState
+			numberOfAddressesMadeRich.value = state.numberOfAddressesMadeRich
+		}
+
+		const shouldIgnoreOutdatedPopupRefreshMessage = (refreshGeneration: number, minimumGeneration = popupRefreshGeneration.value) => refreshGeneration < minimumGeneration
+		const updateHomePageSettings = (settings: Settings) => {
+			rpcNetwork.value = settings.activeRpcNetwork
+			activeSimulationAddress.value = settings.activeSimulationAddress
+			useSignersAddressAsActiveAddress.value = settings.useSignersAddressAsActiveAddress
+			websiteAccess.value = settings.websiteAccess
+			simulationMode.value = settings.simulationMode
+		}
+		const updateHomePage = ({ data, popupRefreshGeneration: updateGeneration }: UpdateHomePage) => {
+			if (options.filterByTabId !== false && data.tabId !== currentTabId.value && currentTabId.value !== undefined) return
+			const minimumValidGeneration = Math.max(popupRefreshGeneration.value, pendingPopupRefreshGeneration.value)
+			if (shouldIgnoreOutdatedPopupRefreshMessage(updateGeneration, minimumValidGeneration)) return
+			popupRefreshGeneration.value = updateGeneration
+			if (pendingPopupRefreshGeneration.value <= updateGeneration) {
+				pendingPopupRefreshGeneration.value = 0
+			}
+			const wasLoaded = isSettingsLoaded.value
+			isSettingsLoaded.value = true
+			rpcEntries.value = data.rpcEntries
+			currentTabId.value = data.tabId
+			activeSigningAddress.value = data.activeSigningAddressInThisTab
+			activeAddresses.value = data.activeAddresses
+			interceptorDisabled.value = data.interceptorDisabled
+			makeCurrentAddressRich.value = data.makeCurrentAddressRich
+			fixedAddressRichList.value = data.richList
+			unexpectedError.value = data.latestUnexpectedError
+			if (!wasLoaded) options.onInitialSettings?.(data.settings)
+			updateHomePageSettings(data.settings)
+			if (popupIconRefreshGeneration.value <= updateGeneration) {
+				tabIconDetails.value = data.tabState.tabIconDetails
+				popupIconRefreshGeneration.value = updateGeneration
+			}
+			updateVisualizedState(data.visualizedSimulatorState)
+			tabState.value = data.tabState
+			currentBlockNumber.value = data.currentBlockNumber
+			websiteAccessAddressMetadata.value = data.websiteAccessAddressMetadata
+			rpcConnectionStatus.value = data.rpcConnectionStatus
+			preSimulationBlockTimeManipulation.value = data.preSimulationBlockTimeManipulation
+			markPerformance(POPUP_PERFORMANCE_MARKS.refreshComplete)
+			popupRefreshAppliedGeneration.value += 1
+		}
+
+		const replyPopupMessageListener = (msg: unknown, _sender: unknown, sendResponse: (response?: unknown) => void) => {
+			const maybeRequest = PopupMessageReplyRequests.safeParse(msg)
+			if (maybeRequest.success) {
+				if (maybeRequest.value.method === 'popup_isMainPopupWindowOpen' && options.answerMainPopupOpen) {
+					sendResponse({ method: 'popup_isMainPopupWindowOpen', data: { isOpen: true } })
+					return true
+				}
+				// Historical wire name: both the popup and the full stack tab consume live simulation data.
+				if (maybeRequest.value.method === 'popup_isSimulationVisualizerOpen' && options.answerSimulationDataConsumerOpen) {
+					sendResponse({ method: 'popup_isSimulationVisualizerOpen', data: { isOpen: true } })
+					return true
+				}
+			}
+
+			const maybeParsed = MessageToPopup.safeParse(msg)
+			if (!maybeParsed.success) return undefined
+			const parsed = maybeParsed.value
+			if (parsed.role === 'confirmTransaction') return undefined
+			switch(parsed.method) {
+				case 'popup_UnexpectedErrorOccured':
+					unexpectedError.value = parsed
+					return undefined
+				case 'popup_settingsUpdated':
+					if (shouldIgnoreOutdatedPopupRefreshMessage(parsed.popupRefreshGeneration)) return undefined
+					pendingPopupRefreshGeneration.value = Math.max(pendingPopupRefreshGeneration.value, parsed.popupRefreshGeneration)
+					requestCachedHomeData()
+					return undefined
+				case 'popup_accounts_update':
+				case 'popup_chain_update':
+				case 'popup_signer_name_changed':
+				case 'popup_addressBookEntriesChanged':
+				case 'popup_interceptor_access_changed':
+				case 'popup_websiteAccess_changed':
+				case 'popup_setDisableInterceptorReply':
+				case 'popup_update_rpc_list':
+					requestCachedHomeData()
+					return undefined
+				case 'popup_activeSigningAddressChanged': {
+					if (parsed.data.tabId !== currentTabId.value) return undefined
+					activeSigningAddress.value = parsed.data.activeSigningAddress
+					return undefined
+				}
+				case 'popup_websiteIconChanged': {
+					if (currentTabId.value === undefined || parsed.tabId !== currentTabId.value) return undefined
+					if (shouldIgnoreOutdatedPopupRefreshMessage(parsed.popupRefreshGeneration)) return undefined
+					if (parsed.popupRefreshGeneration < popupIconRefreshGeneration.value) return undefined
+					popupIconRefreshGeneration.value = parsed.popupRefreshGeneration
+					tabIconDetails.value = parsed.data
+					return undefined
+				}
+				case 'popup_new_block_arrived':
+				case 'popup_failed_to_get_block':
+					rpcConnectionStatus.value = parsed.data.rpcConnectionStatus
+					currentBlockNumber.value = parsed.data.rpcConnectionStatus?.latestBlock?.number
+					return undefined
+				case 'popup_simulation_state_changed':
+					updateVisualizedState(parsed.data.visualizedSimulatorState)
+					if (options.requestHomeDataOnSimulationStateChange === true) void requestCachedHomeData()
+					return undefined
+			}
+			if (parsed.method !== 'popup_UpdateHomePage') return undefined
+			updateHomePage(parsed)
+			return undefined
+		}
+
+		browser.runtime.onMessage.addListener(replyPopupMessageListener)
+		return () => {
+			browser.runtime.onMessage.removeListener(replyPopupMessageListener)
+		}
+	}, [])
+
+	useEffect(() => {
+		void (async () => {
+			await requestCachedHomeData()
+			if (options.requestFreshHomeDataOnMount) {
+				void sendPopupMessageToBackgroundPage({ method: 'popup_refreshHomeData' })
+			}
+		})()
+	}, [])
+
+	return {
+		activeAddresses,
+		activeSimulationAddress,
+		activeSigningAddress,
+		useSignersAddressAsActiveAddress,
+		simVisResults,
+		websiteAccess,
+		websiteAccessAddressMetadata,
+		rpcNetwork,
+		tabIconDetails,
+		isSettingsLoaded,
+		currentBlockNumber,
+		tabState,
+		rpcConnectionStatus,
+		currentTabId,
+		rpcEntries,
+		simulationUpdatingState,
+		simulationResultState,
+		interceptorDisabled,
+		unexpectedError,
+		preSimulationBlockTimeManipulation,
+		popupRefreshAppliedGeneration,
+		fixedAddressRichList,
+		makeCurrentAddressRich,
+		simulationMode,
+		numberOfAddressesMadeRich,
+	}
+}

--- a/app/ts/components/hooks/useResetSimulation.ts
+++ b/app/ts/components/hooks/useResetSimulation.ts
@@ -1,0 +1,35 @@
+import { useSignal } from '@preact/signals'
+import { useEffect, useRef } from 'preact/hooks'
+import { sendPopupMessageToBackgroundPage } from '../../background/backgroundUtils.js'
+
+const RESET_BUTTON_RECOVERY_DELAY_MS = 4000
+
+export function useResetSimulation(resetButtonRecoveryDelayMs = RESET_BUTTON_RECOVERY_DELAY_MS) {
+	const disableReset = useSignal<boolean>(false)
+	const resetRecoveryTimeoutId = useRef<ReturnType<typeof globalThis.setTimeout> | undefined>(undefined)
+
+	function clearResetRecoveryTimeout() {
+		if (resetRecoveryTimeoutId.current === undefined) return
+		globalThis.clearTimeout(resetRecoveryTimeoutId.current)
+		resetRecoveryTimeoutId.current = undefined
+	}
+
+	function markSimulationDataReceived() {
+		clearResetRecoveryTimeout()
+		disableReset.value = false
+	}
+
+	useEffect(() => () => clearResetRecoveryTimeout(), [])
+
+	function resetSimulation() {
+		disableReset.value = true
+		clearResetRecoveryTimeout()
+		resetRecoveryTimeoutId.current = globalThis.setTimeout(() => {
+			resetRecoveryTimeoutId.current = undefined
+			disableReset.value = false
+		}, resetButtonRecoveryDelayMs)
+		void sendPopupMessageToBackgroundPage({ method: 'popup_resetSimulation' })
+	}
+
+	return { disableReset, resetSimulation, markSimulationDataReceived }
+}

--- a/app/ts/components/pages/ConfirmTransaction.tsx
+++ b/app/ts/components/pages/ConfirmTransaction.tsx
@@ -24,8 +24,9 @@ import { getWebsiteWarningMessage } from '../../utils/websiteData.js'
 import { ErrorComponent } from '../subcomponents/Error.js'
 import { checkAndThrowRuntimeLastError } from '../../utils/requests.js'
 import { Link } from '../subcomponents/link.js'
-import { NetworkErrors } from '../App.js'
-import { InvalidMessage, SignatureCard, SignatureHeader, identifySignature, isPossibleToSignMessage } from './PersonalSign.js'
+import { NetworkErrors } from '../subcomponents/NetworkErrors.js'
+import { identifySignature } from '../simulationExplaining/identifySignature.js'
+import { InvalidMessage, SignatureCard, SignatureHeader, isPossibleToSignMessage } from './PersonalSign.js'
 import type { EditEnsNamedHashCallBack } from '../subcomponents/ens.js'
 import { EditEnsLabelHash } from './EditEnsLabelHash.js'
 import { type ReadonlySignal, Signal, useComputed, useSignal } from '@preact/signals'
@@ -147,9 +148,7 @@ function UnderTransactions(param: UnderTransactionsParams) {
 					<p class = 'card-header-title' style = 'white-space: nowrap;'>
 						{ pendingTransaction.transactionOrMessageCreationStatus === 'FailedToSimulate' ? pendingTransaction.transactionToSimulate.error.message : 'Simulating...' }
 					</p>
-					<p class = 'card-header-icon unsetcursor' style = { 'margin-left: auto; margin-right: 0; overflow: hidden;' }>
-						<WebsiteOriginText website = { pendingTransaction.website } />
-					</p>
+					<WebsiteOriginText website = { pendingTransaction.website } class = 'card-header-website' />
 				</header>
 				<div style = { absoluteStyle }></div>
 			</div>
@@ -270,9 +269,7 @@ function FailedTransactionPreviewDetails({
 			<p class = 'card-header-title' style = 'white-space: nowrap;'>
 				{ isGasEstimationError ? 'Gas estimation error' : 'Execution error' }
 			</p>
-			<p class = 'card-header-icon unsetcursor' style = { 'margin-left: auto; margin-right: 0; overflow: hidden;' }>
-				<WebsiteOriginText website = { website } />
-			</p>
+			<WebsiteOriginText website = { website } class = 'card-header-website' />
 		</header>
 		<div class = 'card-content' style = 'padding-bottom: 5px;'>
 			<div class = 'container'>

--- a/app/ts/components/pages/Home.tsx
+++ b/app/ts/components/pages/Home.tsx
@@ -2,17 +2,17 @@ import type { HomeParams, FirstCardParams, SimulationStateParam, RenameAddressCa
 import { type SimulationAndVisualisationResults, isEmptySimulationAndVisualisationResults } from '../../types/visualizer-types.js'
 import { ActiveAddressComponent, SmallAddress, WebsiteOriginText, getActiveAddressEntry } from '../subcomponents/address.js'
 import { SimulationSummary } from '../simulationExplaining/SimulationSummary.js'
+import { TransactionsAndSignedMessages } from '../simulationExplaining/Transactions.js'
 import { ICON_ACTIVE, ICON_INTERCEPTOR_DISABLED, ICON_NOT_ACTIVE, ICON_NOT_ACTIVE_WITH_SHIELD } from '../../utils/constants.js'
 import { getPrettySignerName, SignerLogoText, SignersLogoName } from '../subcomponents/signers.js'
 import { ErrorComponent } from '../subcomponents/Error.js'
 import { ToolTip } from '../subcomponents/CopyToClipboard.js'
 import { sendPopupMessageToBackgroundPage } from '../../background/backgroundUtils.js'
-import { TransactionsAndSignedMessages } from '../simulationExplaining/Transactions.js'
 import { DinoSays } from '../subcomponents/DinoSays.js'
 import type { Website } from '../../types/websiteAccessTypes.js'
 import type { TransactionOrMessageIdentifier } from '../../types/interceptor-messages.js'
 import type { AddressBookEntry } from '../../types/addressBookTypes.js'
-import { BroomIcon, ChevronIcon, ImportIcon } from '../subcomponents/icons.js'
+import { BroomIcon, ChevronIcon, OpenInNewIcon } from '../subcomponents/icons.js'
 import { RpcSelector } from '../subcomponents/ChainSelector.js'
 import { type Signal, type ReadonlySignal, useComputed, useSignal, useSignalEffect } from '@preact/signals'
 import { useEffect } from 'preact/hooks'
@@ -22,6 +22,7 @@ import { bigintSecondsToDate } from '../../utils/bigint.js'
 import { DEFAULT_BLOCK_MANIPULATION } from '../../simulation/services/SimulationModeEthereumClientService.js'
 import type { EnrichedRichListElement } from '../../types/interceptor-reply-messages.js'
 import { Spinner } from '../subcomponents/Spinner.js'
+import { useResetSimulation } from '../hooks/useResetSimulation.js'
 
 function scheduleAfterPaint(callback: () => void) {
 	if (typeof globalThis.requestAnimationFrame === 'function' && typeof globalThis.cancelAnimationFrame === 'function') {
@@ -284,25 +285,27 @@ export const isEmptySimulation = (simulationAndVisualisationResults: SimulationA
 }
 
 type SimulationResultsHeaderParams = {
-	openImportSimulation: () => void
+	openSimulationStack?: () => void
 	disableReset?: ReadonlySignal<boolean>
 	resetSimulation?: () => void
 }
 
 function SimulationResultsHeader(param: SimulationResultsHeaderParams) {
-	return <div style = 'display: grid; grid-template-columns: auto auto; padding-left: 10px; padding-right: 10px' >
-		<div class = 'log-cell' style = 'justify-content: left;'>
-			<p class = 'h1'> Simulation Results </p>
+	return <div style = 'display: grid; grid-template-columns: minmax(0, 1fr) auto; gap: 8px; align-items: start; padding-left: 10px; padding-right: 10px' >
+		<div class = 'log-cell' style = 'justify-content: left; align-items: center; gap: 8px; flex-wrap: wrap; min-width: 0;'>
+			<p class = 'h1' style = 'margin: 0;'> Simulation Results </p>
 		</div>
-		<div class = 'log-cell' style = 'justify-content: right; gap: 10px;'>
-			<button class = 'btn btn--outline is-small' onClick = { param.openImportSimulation }>
-				<span style = { { marginRight: '0.25rem', fontSize: '1rem', width: '1em', height: '1em' } }>
-					<ImportIcon/>
-				</span>
-				<span>Import Simulation Stack</span>
-			</button>
+		<div class = 'log-cell' style = 'justify-content: right; align-items: center; gap: 6px; flex-wrap: wrap; max-width: 300px;'>
+			{ param.openSimulationStack === undefined ? <></> :
+				<button class = 'btn btn--outline is-small' onClick = { () => param.openSimulationStack?.() } title = 'Open simulation stack details in a new tab' aria-label = 'Open simulation stack details in a new tab'>
+					<span style = { { marginRight: '0.25rem', fontSize: '1rem', width: '1em', height: '1em' } }>
+						<OpenInNewIcon/>
+					</span>
+					<span>View stack details</span>
+				</button>
+			}
 			{ param.disableReset === undefined || param.resetSimulation === undefined ? <></> :
-				<button class = 'btn is-small is-danger' disabled = { param.disableReset.value } onClick = { param.resetSimulation } >
+				<button class = 'btn is-small is-danger' disabled = { param.disableReset.value } onClick = { param.resetSimulation } title = 'Clear simulation stack' aria-label = 'Clear simulation stack'>
 					<span style = { { marginRight: '0.25rem', fontSize: '1rem', width: '1em', height: '1em' } }>
 						<BroomIcon />
 					</span>
@@ -313,8 +316,39 @@ function SimulationResultsHeader(param: SimulationResultsHeaderParams) {
 	</div>
 }
 
+function RichAddressesTitleCard({ numberOfAddressesMadeRich, openSimulationStack }: { numberOfAddressesMadeRich: number, openSimulationStack?: () => void }) {
+	if (numberOfAddressesMadeRich === 0) return <></>
+	const actionLabel = 'Open rich address state in the full simulation stack'
+	return <section class = 'card' style = 'margin: 10px;'>
+		<header
+			class = { `card-header stack-card-header${ openSimulationStack === undefined ? '' : ' stack-row-link-header' }` }
+			onClick = { openSimulationStack }
+			onKeyDown = { (event) => {
+				if (openSimulationStack === undefined || (event.key !== 'Enter' && event.key !== ' ')) return
+				if (event.target !== event.currentTarget) return
+				event.preventDefault()
+				openSimulationStack()
+			} }
+			role = { openSimulationStack === undefined ? undefined : 'button' }
+			tabIndex = { openSimulationStack === undefined ? undefined : 0 }
+			title = { openSimulationStack === undefined ? undefined : actionLabel }
+			aria-label = { openSimulationStack === undefined ? undefined : actionLabel }
+		>
+			<div class = 'card-header-icon unset-cursor'>
+				<span class = 'icon'>
+					<img src = '../img/success-icon.svg' width = '24' height = '24' />
+				</span>
+			</div>
+			<p class = 'card-header-title' style = 'white-space: nowrap;'>
+				Simply making { numberOfAddressesMadeRich } { numberOfAddressesMadeRich === 1 ? 'address' : 'addresses' } rich
+			</p>
+		</header>
+	</section>
+}
+
 function PopupVisualisation(param: SimulationStateParam) {
 	const isEmpty = useComputed(() => {
+		if (param.numberOfAddressesMadeRich.value > 0) return false
 		if (param.simulationAndVisualisationResults.value.kind === 'passthrough') return true
 		return isEmptySimulation(param.simulationAndVisualisationResults.value.value)
 	})
@@ -330,39 +364,47 @@ function PopupVisualisation(param: SimulationStateParam) {
 
 	if (currentResults.kind === 'passthrough') {
 		return <div>
-			<SimulationResultsHeader openImportSimulation = { param.openImportSimulation } />
-			<div style = 'padding: 10px'><DinoSays text = { 'Give me some transactions to munch on!' } /></div>
+			<SimulationResultsHeader openSimulationStack = { param.openSimulationStack } />
+			{ isEmpty.value ?
+				<div style = 'padding: 10px'><DinoSays text = { 'Give me some transactions to munch on!' } /></div>
+			: <RichAddressesTitleCard numberOfAddressesMadeRich = { param.numberOfAddressesMadeRich.value } openSimulationStack = { () => param.openSimulationStack() } /> }
 		</div>
 	}
 
 	const resolvedResults = currentResults.value
 
 	return <div>
-		<SimulationResultsHeader openImportSimulation = { param.openImportSimulation } disableReset = { param.disableReset } resetSimulation = { param.resetSimulation } />
+		<SimulationResultsHeader openSimulationStack = { param.openSimulationStack } disableReset = { param.disableReset } resetSimulation = { param.resetSimulation } />
 
 		{ resolvedResults.visualizedSimulationState.success === false ? <>
 			<ErrorComponent text = { `Failed to simulate the stack due to error: "${ resolvedResults.visualizedSimulationState.jsonRpcError.error.message }". Please modify the stack to make it simutable.` }/>
-				<TransactionsAndSignedMessages
-					simulationAndVisualisationResults = { param.simulationAndVisualisationResults }
-					removeTransactionOrSignedMessage = { param.removeTransactionOrSignedMessage }
-					activeAddress = { param.activeSimulationAddress }
-					renameAddressCallBack = { param.renameAddressCallBack }
-					editEnsNamedHashCallBack = { param.editEnsNamedHashCallBack }
-					addressMetaData = { computedAddressBookEntries }
-				/>
+			<RichAddressesTitleCard numberOfAddressesMadeRich = { param.numberOfAddressesMadeRich.value } openSimulationStack = { () => param.openSimulationStack() } />
+			<TransactionsAndSignedMessages
+				simulationAndVisualisationResults = { param.simulationAndVisualisationResults }
+				removeTransactionOrSignedMessage = { param.removeTransactionOrSignedMessage }
+				activeAddress = { param.activeSimulationAddress }
+				renameAddressCallBack = { param.renameAddressCallBack }
+				editEnsNamedHashCallBack = { param.editEnsNamedHashCallBack }
+				addressMetaData = { computedAddressBookEntries }
+				displayMode = 'titleOnly'
+				openSimulationStackAt = { param.openSimulationStack }
+			/>
 		</> : <>
 			{ isEmpty.value ?
 				<div style = 'padding: 10px'><DinoSays text = { 'Give me some transactions to munch on!' } /></div>
 			: <>
 				<div class = { param.simulationResultState.value === 'invalid' || param.simulationUpdatingState.value === 'failed' ? 'blur' : '' }>
-						<TransactionsAndSignedMessages
-							simulationAndVisualisationResults = { param.simulationAndVisualisationResults }
-							removeTransactionOrSignedMessage = { param.removeTransactionOrSignedMessage }
-							activeAddress = { param.activeSimulationAddress }
-							renameAddressCallBack = { param.renameAddressCallBack }
-							editEnsNamedHashCallBack = { param.editEnsNamedHashCallBack }
-							addressMetaData = { computedAddressBookEntries }
-						/>
+					<RichAddressesTitleCard numberOfAddressesMadeRich = { param.numberOfAddressesMadeRich.value } openSimulationStack = { () => param.openSimulationStack() } />
+					<TransactionsAndSignedMessages
+						simulationAndVisualisationResults = { param.simulationAndVisualisationResults }
+						removeTransactionOrSignedMessage = { param.removeTransactionOrSignedMessage }
+						activeAddress = { param.activeSimulationAddress }
+						renameAddressCallBack = { param.renameAddressCallBack }
+						editEnsNamedHashCallBack = { param.editEnsNamedHashCallBack }
+						addressMetaData = { computedAddressBookEntries }
+						displayMode = 'titleOnly'
+						openSimulationStackAt = { param.openSimulationStack }
+					/>
 					{ param.removedTransactionOrSignedMessages.length > 0
 						? <></>
 						: <SimulationSummary
@@ -381,7 +423,7 @@ function PopupVisualisation(param: SimulationStateParam) {
 }
 
 export function Home(param: HomeParams) {
-	const disableReset = useSignal<boolean>(false)
+	const { disableReset, resetSimulation, markSimulationDataReceived } = useResetSimulation()
 	const removedTransactionOrSignedMessages = useSignal<readonly TransactionOrMessageIdentifier[]>([])
 	const showPopupVisualisation = useSignal<boolean>(false)
 	const tabWebsite = useComputed(() => param.tabState.value?.website)
@@ -407,14 +449,9 @@ export function Home(param: HomeParams) {
 
 	useSignalEffect(() => {
 		param.simVisResults.value
-		disableReset.value = false
+		markSimulationDataReceived()
 		removedTransactionOrSignedMessages.value = []
 	})
-
-	function resetSimulation() {
-		disableReset.value = true
-		sendPopupMessageToBackgroundPage({ method: 'popup_resetSimulation' })
-	}
 
 	async function removeTransactionOrSignedMessage(transactionOrMessageIdentifier: TransactionOrMessageIdentifier) {
 		removedTransactionOrSignedMessages.value = [...removedTransactionOrSignedMessages.value, transactionOrMessageIdentifier]
@@ -425,6 +462,14 @@ export function Home(param: HomeParams) {
 		if (param.tabState.value?.website === undefined) return
 		const newValue = !param.interceptorDisabled.value
 		sendPopupMessageToBackgroundPage({ method: 'popup_setDisableInterceptor', data: { interceptorDisabled: newValue, website: param.tabState.value.website } })
+	}
+
+	async function openSimulationStack(target?: TransactionOrMessageIdentifier) {
+		await sendPopupMessageToBackgroundPage(target === undefined
+			? { method: 'popup_openSimulationStack' }
+			: { method: 'popup_openSimulationStack', data: target }
+		)
+		globalThis.close()
 	}
 
 	if (param.rpcNetwork.value === undefined) return <></>
@@ -466,7 +511,8 @@ export function Home(param: HomeParams) {
 					rpcConnectionStatus = { param.rpcConnectionStatus }
 					simulationUpdatingState = { param.simulationUpdatingState }
 					simulationResultState = { param.simulationResultState }
-					openImportSimulation = { param.openImportSimulation }
+					openSimulationStack = { openSimulationStack }
+					numberOfAddressesMadeRich = { param.numberOfAddressesMadeRich }
 				/>
 				: <section class = 'card' style = 'margin: 10px; min-height: 250px; display: grid; place-items: center;'>
 					<Spinner height = '3em'/>

--- a/app/ts/components/pages/PersonalSign.tsx
+++ b/app/ts/components/pages/PersonalSign.tsx
@@ -24,6 +24,7 @@ import { TransactionInput } from '../subcomponents/ParsedInputData.js'
 import { ErrorComponent } from '../subcomponents/Error.js'
 import type { ReadonlySignal } from '@preact/signals'
 import type { PopupPendingTransactionOrSignableMessage as PendingTransactionOrSignableMessage } from '../../types/accessRequest.js'
+import { identifySignature } from '../simulationExplaining/identifySignature.js'
 
 type SignatureCardParams = {
 	visualizedPersonalSignRequest: VisualizedPersonalSignRequest
@@ -31,83 +32,52 @@ type SignatureCardParams = {
 	removeTransactionOrSignedMessage: ((transactionOrMessageIdentifier: TransactionOrMessageIdentifier) => void) | undefined
 	numberOfUnderTransactions: number
 	editEnsNamedHashCallBack: EditEnsNamedHashCallBack
+	collapsed?: boolean
+	toggleCollapsed?: () => void
 }
 
 type SignatureHeaderParams = {
 	visualizedPersonalSignRequest: VisualizedPersonalSignRequest
 	removeTransactionOrSignedMessage?: (transactionOrMessageIdentifier: TransactionOrMessageIdentifier) => void
-}
-
-export function identifySignature(data: VisualizedPersonalSignRequest) {
-	switch (data.type) {
-		case 'OrderComponents': return {
-			title: 'Opensea order',
-			rejectAction: 'Reject Opensea order',
-			simulationAction: 'Simulate Opensea order',
-			signingAction: 'Sign Opensea order',
-		}
-		case 'SafeTx': return {
-			title: 'Gnosis Safe message',
-			rejectAction: 'Reject Gnosis Safe message',
-			simulationAction: 'Simulate Gnosis Safe message',
-			signingAction: 'Sign Gnosis Safe message',
-		}
-		case 'EIP712': {
-			const { name: domainName } = data.message.domain
-			const name = domainName?.type === 'string' ? `${ domainName.value } - ${ data.message.primaryType }` : 'Arbitrary EIP712 message'
-			return {
-				title: `${ name } signing request`,
-				rejectAction: `Reject ${ name }`,
-				simulationAction: `Simulate ${ name }`,
-				signingAction: `Sign ${ name }`,
-			}
-		}
-		case 'NotParsed': return {
-			title: 'Arbitrary Ethereum message',
-			rejectAction: 'Reject arbitrary message',
-			simulationAction: 'Simulate arbitrary message',
-			signingAction: 'Sign arbitrary message',
-		}
-		case 'Permit': {
-			const symbol = data.verifyingContract
-			return {
-				title: `${ symbol } Permit`,
-				signingAction: `Sign ${ symbol } Permit`,
-				simulationAction: `Simulate ${ symbol } Permit`,
-				rejectAction: `Reject ${ symbol } Permit`,
-				to: data.spender
-			}
-		}
-		case 'Permit2': {
-			const symbol = 'symbol' in data.token ? data.token.symbol : '???'
-			return {
-				title: `${ symbol } Permit`,
-				signingAction: `Sign ${ symbol } Permit`,
-				simulationAction: `Simulate ${ symbol } Permit`,
-				rejectAction: `Reject ${ symbol } Permit`,
-				to: data.spender
-			}
-		}
-		default: assertNever(data)
-	}
+	onHeaderClick?: () => void
+	headerActionLabel?: string
+	ariaExpanded?: boolean
 }
 
 export function SignatureHeader(params: SignatureHeaderParams) {
 	const removeSignedMessage = params.removeTransactionOrSignedMessage
-	return <header class = 'card-header'>
+	return <header
+		class = { `card-header stack-card-header${ params.onHeaderClick === undefined ? '' : ' stack-row-link-header' }` }
+		onClick = { params.onHeaderClick }
+		onKeyDown = { (event) => {
+			if (params.onHeaderClick === undefined || (event.key !== 'Enter' && event.key !== ' ')) return
+			if (event.target !== event.currentTarget) return
+			event.preventDefault()
+			params.onHeaderClick()
+		} }
+		role = { params.onHeaderClick === undefined ? undefined : 'button' }
+		tabIndex = { params.onHeaderClick === undefined ? undefined : 0 }
+		title = { params.onHeaderClick === undefined ? undefined : params.headerActionLabel ?? 'Open this signature in the full simulation stack' }
+		aria-label = { params.onHeaderClick === undefined ? undefined : params.headerActionLabel ?? 'Open this signature in the full simulation stack' }
+		aria-expanded = { params.onHeaderClick === undefined ? undefined : params.ariaExpanded }
+	>
 		<div class = 'card-header-icon unset-cursor'>
 			<span class = 'icon'>
 				<img src = { params.visualizedPersonalSignRequest.simulationMode ? '../img/head-simulating.png' : '../img/head-signing.png' } width = '24' height = '24' />
 			</span>
 		</div>
 		<p class = 'card-header-title' style = 'white-space: nowrap;'>
-			{ identifySignature(params.visualizedPersonalSignRequest).title }
+			<span class = 'card-header-title-text'>{ identifySignature(params.visualizedPersonalSignRequest).title }</span>
 		</p>
-		<p class = 'card-header-icon unsetcursor' style = { `margin-left: auto; margin-right: 0; overflow: hidden; ${ params.removeTransactionOrSignedMessage !== undefined ? 'padding: 0' : ''}` }>
-			<WebsiteOriginText website = { params.visualizedPersonalSignRequest.website } />
-		</p>
+		<WebsiteOriginText
+			website = { params.visualizedPersonalSignRequest.website }
+			class = { `card-header-website${ params.removeTransactionOrSignedMessage !== undefined ? ' card-header-website--flush' : ''}` }
+		/>
 		{ removeSignedMessage !== undefined
-			? <button class = 'card-header-icon' aria-label = 'remove' onClick = { () => removeSignedMessage({ type: 'Message', messageIdentifier: params.visualizedPersonalSignRequest.messageIdentifier }) }>
+			? <button class = 'card-header-icon' aria-label = 'remove' onClick = { (event) => {
+				event.stopPropagation()
+				removeSignedMessage({ type: 'Message', messageIdentifier: params.visualizedPersonalSignRequest.messageIdentifier })
+			} }>
 				<XMarkIcon />
 			</button>
 			: <></>
@@ -455,9 +425,10 @@ function Signer({ signer, renameAddressCallBack }: { signer: AddressBookEntry, r
 const HALF_HEADER_HEIGHT = 48 / 2
 
 export function SignatureCard(params: SignatureCardParams) {
+	const headerActionLabel = params.collapsed === undefined ? undefined : params.collapsed ? 'Expand signature details' : 'Collapse signature details'
 	return <div class = 'card' style = { `top: ${ params.numberOfUnderTransactions * -HALF_HEADER_HEIGHT }px` }>
-		<SignatureHeader { ...params }/>
-		<div class = 'card-content' style = 'padding-bottom: 5px;'>
+		<SignatureHeader { ...params } onHeaderClick = { params.toggleCollapsed } headerActionLabel = { headerActionLabel } ariaExpanded = { params.collapsed === undefined ? undefined : !params.collapsed }/>
+		{ params.collapsed === true ? <></> : <div class = 'card-content' style = 'padding-bottom: 5px;'>
 			<div class = 'container'>
 				<SignRequest { ...params }/>
 			</div>
@@ -474,7 +445,7 @@ export function SignatureCard(params: SignatureCardParams) {
 				<div class = 'log-cell'> <TransactionCreated created = { params.visualizedPersonalSignRequest.created } /> </div>
 				<div class = 'log-cell' style = 'justify-content: right;'></div>
 			</span>
-		</div>
+		</div> }
 	</div>
 }
 

--- a/app/ts/components/pages/SettingsView.tsx
+++ b/app/ts/components/pages/SettingsView.tsx
@@ -101,12 +101,12 @@ function ImportExport() {
 			/>
 			: <></> }
 		<div class = 'popup-button-row'>
-			<div style = 'display: flex; flex-direction: row;'>
-				<label class = 'button is-primary is-danger' style = 'flex-grow: 1; margin-left: 5px; margin-right: 5px;'>
+			<div class = 'settings-import-export-actions'>
+				<label class = 'button is-primary is-danger settings-import-export-button'>
 					Import settings
 					<input type = 'file' accept = '.json' onInput = { importSettings } style = 'position: absolute; width: 100%; height: 100%; opacity: 0;' />
 				</label>
-				<button class = 'button is-primary' style = 'flex-grow: 1; margin-left: 5px; margin-right: 5px;' onClick = { exportSettings }>
+				<button class = 'button is-primary settings-import-export-button' onClick = { exportSettings }>
 					Export settings
 				</button>
 			</div>
@@ -235,10 +235,10 @@ const RpcSummary = ({ info }: { info: SignalOrValue<RpcEntry | undefined> }) => 
 
 	return (
 		<li class = 'grid brief'>
-			<div class = 'grid' style = '--grid-cols: 1fr max-content; --text-color: gray'>
-				<div style = '--area: 1 / 1'><strong>{ currentInfo.name }</strong></div>
-				<div style = '--area: span 2 / 2'>{ networkName }</div>
-				<div>{ currentInfo.httpsRpc }</div>
+			<div class = 'grid rpc-summary-details'>
+				<div class = 'truncate' title = { currentInfo.name }><strong>{ currentInfo.name }</strong></div>
+				<div class = 'truncate' title = { networkName }>{ networkName }</div>
+				<div class = 'truncate' title = { currentInfo.httpsRpc }>{ currentInfo.httpsRpc }</div>
 			</div>
 			<div class = 'actions'>
 				<ConfigureRpcConnection key = { infoKey } rpcInfo = { currentInfo } />

--- a/app/ts/components/pages/SimulationStackPage.tsx
+++ b/app/ts/components/pages/SimulationStackPage.tsx
@@ -1,0 +1,397 @@
+import { Signal, useComputed, useSignal, useSignalEffect } from '@preact/signals'
+import { requestPopupInterceptorSimulationInput, sendPopupMessageToBackgroundPage } from '../../background/backgroundUtils.js'
+import type { TransactionOrMessageIdentifier } from '../../types/interceptor-messages.js'
+import type { AddressBookEntries, AddressBookEntry } from '../../types/addressBookTypes.js'
+import type { EditEnsNamedHashWindowState, ModifyAddressWindowState, SimulationAndVisualisationResults } from '../../types/visualizer-types.js'
+import { addressEditEntry } from '../ui-utils.js'
+import { ErrorBoundary, ErrorComponent, UnexpectedError } from '../subcomponents/Error.js'
+import { CenterToPageTextSpinner } from '../subcomponents/Spinner.js'
+import { BroomIcon, ChevronIcon, ExportIcon, ImportIcon } from '../subcomponents/icons.js'
+import { clipboardCopy } from '../subcomponents/clipboardcopy.js'
+import { DinoSays } from '../subcomponents/DinoSays.js'
+import { TransactionsAndSignedMessages } from '../simulationExplaining/Transactions.js'
+import { SimulationSummary } from '../simulationExplaining/SimulationSummary.js'
+import { AddNewAddress } from './AddNewAddress.js'
+import { EditEnsLabelHash } from './EditEnsLabelHash.js'
+import { ImportSimulationStack } from './ImportSimulationStack.js'
+import { NetworkErrors } from '../subcomponents/NetworkErrors.js'
+import { useLiveSimulationHomeData } from '../hooks/useLiveSimulationHomeData.js'
+import { useResetSimulation } from '../hooks/useResetSimulation.js'
+import { useEffect } from 'preact/hooks'
+import { getSimulationStackTargetElementIdFromHash } from '../../utils/simulationStackTargets.js'
+import { SmallAddress, getActiveAddressEntry } from '../subcomponents/address.js'
+import type { EnrichedRichListElement } from '../../types/interceptor-reply-messages.js'
+import { createUnexpectedErrorPopupMessage } from '../../utils/unexpectedErrorPopupMessage.js'
+
+type ModalState =
+	{ page: 'modifyAddress', state: Signal<ModifyAddressWindowState> } |
+	{ page: 'editEnsNamedHash', state: EditEnsNamedHashWindowState } |
+	{ page: 'importSimulation', state: Signal<string> } |
+	{ page: 'noModal' }
+
+function isEmptySimulation(simulationAndVisualisationResults: SimulationAndVisualisationResults) {
+	return !simulationAndVisualisationResults.simulationStateInput.some((block) => block.transactions.length > 0 || block.signedMessages.length > 0)
+}
+
+function getMadeRichAddressBookEntries(
+	richList: readonly EnrichedRichListElement[],
+	makeCurrentAddressRich: boolean,
+	activeSimulationAddress: bigint | undefined,
+	activeAddresses: AddressBookEntries,
+) {
+	const entries = richList.filter((element) => element.makingRich).map((element) => element.addressBookEntry)
+	if (!makeCurrentAddressRich || activeSimulationAddress === undefined || entries.some((entry) => entry.address === activeSimulationAddress)) return entries
+	return [...entries, getActiveAddressEntry(activeSimulationAddress, activeAddresses)]
+}
+
+function SimulationStackToolbar({ openImportSimulation, resetSimulation, disableReset }: {
+	openImportSimulation: () => void
+	resetSimulation: () => void
+	disableReset: Signal<boolean>
+}) {
+	const exportSimulationStack = async () => {
+		const reply = await requestPopupInterceptorSimulationInput()
+		if (reply === undefined) return
+		await clipboardCopy(reply.ethSimulateV1InputString)
+	}
+	return <header class = 'simulation-stack-page-header'>
+		<div class = 'simulation-stack-page-title'>
+			<h1>Simulation Stack</h1>
+			<p>Import, export, and adjust the simulation stack.</p>
+		</div>
+		<div class = 'simulation-stack-page-actions'>
+			<button class = 'btn btn--outline' type = 'button' onClick = { openImportSimulation } title = 'Import simulation stack' aria-label = 'Import simulation stack'>
+				<span style = { { marginRight: '0.25rem', fontSize: '1rem', width: '1em', height: '1em' } }>
+					<ImportIcon/>
+				</span>
+				<span>Import</span>
+			</button>
+			<button
+				class = 'btn btn--outline'
+				type = 'button'
+				onClick = { exportSimulationStack }
+				title = 'Export simulation stack'
+				aria-label = 'Export simulation stack'
+				data-hint-clickable-hide-timer-ms = { 1500 }
+				data-hint = 'Interceptor Simulation input copied!'
+			>
+				<span style = { { marginRight: '0.25rem', fontSize: '1rem', width: '1em', height: '1em' } }>
+					<ExportIcon/>
+				</span>
+				<span>Export</span>
+			</button>
+			<button class = 'btn btn--destructive' type = 'button' disabled = { disableReset.value } onClick = { resetSimulation } title = 'Clear simulation stack' aria-label = 'Clear simulation stack'>
+				<span style = { { marginRight: '0.25rem', fontSize: '1rem', width: '1em', height: '1em' } }>
+					<BroomIcon />
+				</span>
+				<span>Clear</span>
+			</button>
+		</div>
+	</header>
+}
+
+function RichAddressesTitleCard({ numberOfAddressesMadeRich, madeRichAddressBookEntries, renameAddressCallBack }: {
+	numberOfAddressesMadeRich: number
+	madeRichAddressBookEntries: readonly AddressBookEntry[]
+	renameAddressCallBack: (entry: AddressBookEntry) => void
+}) {
+	const collapsed = useSignal(false)
+	if (numberOfAddressesMadeRich === 0) return <></>
+	const headerActionLabel = collapsed.value ? 'Expand rich address details' : 'Collapse rich address details'
+	const richAddressesSentence = getRichAddressesSentence(madeRichAddressBookEntries)
+	const richAddressesIntro = getRichAddressesIntro(madeRichAddressBookEntries.length)
+	return <section class = 'card' style = 'margin: 10px 0;'>
+		<header
+			class = 'card-header stack-card-header stack-row-link-header'
+			onClick = { () => { collapsed.value = !collapsed.value } }
+			onKeyDown = { (event) => {
+				if (event.key !== 'Enter' && event.key !== ' ') return
+				if (event.target !== event.currentTarget) return
+				event.preventDefault()
+				collapsed.value = !collapsed.value
+			} }
+			role = 'button'
+			tabIndex = { 0 }
+			title = { headerActionLabel }
+			aria-label = { headerActionLabel }
+			aria-expanded = { !collapsed.value }
+		>
+			<div class = 'card-header-icon unset-cursor'>
+				<span class = 'icon'>
+					<img src = '../img/success-icon.svg' width = '24' height = '24' />
+				</span>
+			</div>
+			<p class = 'card-header-title' style = 'white-space: nowrap;'>
+				Simply making { numberOfAddressesMadeRich } { numberOfAddressesMadeRich === 1 ? 'address' : 'addresses' } rich
+			</p>
+			<div class = 'card-header-icon noselect'>
+				<span class = 'icon'><ChevronIcon /></span>
+			</div>
+		</header>
+		{ collapsed.value ? <></> : <div class = 'card-content' style = 'padding-bottom: 5px;'>
+			<div class = 'container'>
+				<p class = 'paragraph checkbox-text' style = { { marginBottom: 0 } } aria-label = { richAddressesSentence }>
+					<span>{ richAddressesIntro } </span>
+					{ madeRichAddressBookEntries.map((entry, index) =>
+						<span key = { entry.address.toString() } class = 'rich-address-sentence-group' style = 'white-space: nowrap;'>
+							<RichAddressPrefix index = { index } total = { madeRichAddressBookEntries.length } />
+							<SmallAddress addressBookEntry = { entry } renameAddressCallBack = { renameAddressCallBack } />
+							<RichAddressSuffix index = { index } total = { madeRichAddressBookEntries.length } />
+						</span>
+					) }
+					<span>.</span>
+				</p>
+			</div>
+		</div> }
+	</section>
+}
+
+function getRichAddressesIntro(numberOfAddresses: number) {
+	return numberOfAddresses === 1 ? 'Address being made rich is' : 'Addresses being made rich are'
+}
+
+function getRichAddressesSentence(madeRichAddressBookEntries: readonly AddressBookEntry[]) {
+	const names = madeRichAddressBookEntries.map((entry) => entry.name)
+	if (names.length === 0) return 'Addresses being made rich are.'
+	if (names.length === 1) return `Address being made rich is ${ names[0] }.`
+	const finalName = names[names.length - 1]
+	const previousNames = names.slice(0, -1)
+	return `Addresses being made rich are ${ previousNames.join(', ') } and ${ finalName }.`
+}
+
+function RichAddressPrefix({ index, total }: { index: number, total: number }) {
+	if (index === 0) return <></>
+	if (index === total - 1) return <span> and </span>
+	return <span> </span>
+}
+
+function RichAddressSuffix({ index, total }: { index: number, total: number }) {
+	if (index < total - 2) return <span>,</span>
+	return <></>
+}
+
+function scheduleStackTargetFrame(callback: () => void) {
+	if (typeof globalThis.requestAnimationFrame === 'function') {
+		globalThis.requestAnimationFrame(callback)
+		return
+	}
+	if (typeof globalThis.setTimeout === 'function') {
+		globalThis.setTimeout(callback, 0)
+		return
+	}
+	callback()
+}
+
+function scheduleStackTargetTimeout(callback: () => void, delayMs: number) {
+	if (typeof globalThis.setTimeout === 'function') {
+		globalThis.setTimeout(callback, delayMs)
+		return
+	}
+	callback()
+}
+
+export function SimulationStackPage() {
+	const {
+		activeSimulationAddress,
+		activeAddresses,
+		simVisResults,
+		rpcNetwork,
+		isSettingsLoaded,
+		currentBlockNumber,
+		rpcConnectionStatus,
+		rpcEntries,
+		simulationUpdatingState,
+		simulationResultState,
+		unexpectedError,
+		fixedAddressRichList,
+		makeCurrentAddressRich,
+		numberOfAddressesMadeRich,
+	} = useLiveSimulationHomeData({
+		answerMainPopupOpen: false,
+		answerSimulationDataConsumerOpen: true,
+		requestFreshHomeDataOnMount: true,
+		filterByTabId: false,
+		requireActiveSimulationAddress: false,
+		requestHomeDataOnSimulationStateChange: true,
+	})
+	const { disableReset, resetSimulation, markSimulationDataReceived } = useResetSimulation()
+	const modalState = useSignal<ModalState>({ page: 'noModal' })
+	const boundaryResetKey = useSignal(0)
+	const highlightedStackTargetId = useSignal<string | undefined>(undefined)
+	const handledStackTargetHash = useSignal<string | undefined>(undefined)
+	const addressMetaData = useComputed(() => simVisResults.value.kind === 'simulated' ? simVisResults.value.value.addressBookEntries : [])
+	const madeRichAddressBookEntries = useComputed(() => getMadeRichAddressBookEntries(
+		fixedAddressRichList.value,
+		makeCurrentAddressRich.value,
+		activeSimulationAddress.value,
+		activeAddresses.value,
+	))
+	const isEmpty = useComputed(() => {
+		if (numberOfAddressesMadeRich.value > 0) return false
+		if (simVisResults.value.kind === 'passthrough') return true
+		return isEmptySimulation(simVisResults.value.value)
+	})
+
+	useSignalEffect(() => {
+		simVisResults.value
+		markSimulationDataReceived()
+	})
+
+	const scrollToRequestedStackRow = () => {
+		const browserWindow = globalThis.window
+		const browserDocument = globalThis.document
+		if (browserWindow === undefined || browserDocument === undefined) return
+		const targetHash = browserWindow.location?.hash
+		if (targetHash === undefined) return
+		if (handledStackTargetHash.value === targetHash) return
+		const targetElementId = getSimulationStackTargetElementIdFromHash(targetHash)
+		if (targetElementId === undefined) return
+		if (typeof browserDocument.getElementById !== 'function') return
+		const targetElement = browserDocument.getElementById(targetElementId)
+		if (targetElement === null) return
+		if (typeof targetElement.scrollIntoView !== 'function') return
+		targetElement.scrollIntoView({ behavior: 'smooth', block: 'center' })
+		handledStackTargetHash.value = targetHash
+		highlightedStackTargetId.value = targetElementId
+		scheduleStackTargetTimeout(() => {
+			if (highlightedStackTargetId.value === targetElementId) highlightedStackTargetId.value = undefined
+		}, 1800)
+	}
+
+	useEffect(() => {
+		const scrollOnHashChange = () => {
+			handledStackTargetHash.value = undefined
+			scrollToRequestedStackRow()
+		}
+		const browserWindow = globalThis.window
+		if (browserWindow === undefined || typeof browserWindow.addEventListener !== 'function' || typeof browserWindow.removeEventListener !== 'function') {
+			scheduleStackTargetFrame(scrollOnHashChange)
+			return undefined
+		}
+		browserWindow.addEventListener('hashchange', scrollOnHashChange)
+		scheduleStackTargetFrame(scrollOnHashChange)
+		return () => browserWindow.removeEventListener('hashchange', scrollOnHashChange)
+	}, [])
+
+	useSignalEffect(() => {
+		simVisResults.value
+		scheduleStackTargetFrame(scrollToRequestedStackRow)
+	})
+
+	function renameAddressCallBack(entry: AddressBookEntry) {
+		modalState.value = { page: 'modifyAddress', state: new Signal(addressEditEntry(entry)) }
+	}
+
+	function editEnsNamedHashCallBack(type: 'nameHash' | 'labelHash', nameHash: bigint, name: string | undefined) {
+		modalState.value = { page: 'editEnsNamedHash', state: { type, nameHash, name } }
+	}
+
+	async function removeTransactionOrSignedMessage(transactionOrMessageIdentifier: TransactionOrMessageIdentifier) {
+		await sendPopupMessageToBackgroundPage({ method: 'popup_removeTransactionOrSignedMessage', data: transactionOrMessageIdentifier })
+	}
+
+	function onRenderError(error: Error) {
+		unexpectedError.value = createUnexpectedErrorPopupMessage({
+			timestamp: new Date(),
+			message: error.message,
+			source: 'simulationStack',
+			code: 'render_error',
+			debugId: undefined,
+		})
+	}
+
+	async function clearUnexpectedError() {
+		unexpectedError.value = undefined
+		boundaryResetKey.value += 1
+		await sendPopupMessageToBackgroundPage({ method: 'popup_clearUnexpectedError' })
+	}
+
+	const currentResults = simVisResults.value
+	const shouldBlurSimulationContent = simulationResultState.value === 'invalid' || simulationUpdatingState.value === 'failed'
+	const simulationErrorText = currentResults.kind === 'simulated' && currentResults.value.visualizedSimulationState.success === false
+		? `Failed to simulate the stack due to error: "${ currentResults.value.visualizedSimulationState.jsonRpcError.error.message }". Please modify the stack to make it simutable.`
+		: undefined
+
+	return <main>
+		<div class = 'layout simulation-stack-page'>
+			{ !isSettingsLoaded.value ? <>
+				<UnexpectedError close = { clearUnexpectedError } error = { unexpectedError.value === undefined ? undefined : unexpectedError.value.data }/>
+				<NetworkErrors rpcConnectionStatus = { rpcConnectionStatus }/>
+				{ rpcNetwork.value?.httpsRpc === undefined && rpcNetwork.value !== undefined ?
+					<ErrorComponent text = { `${ rpcNetwork.value.name } is not a supported network. The Interceptor is disabled while you are using ${ rpcNetwork.value.name }.` }/>
+				: <></> }
+				<CenterToPageTextSpinner/>
+			</> : <>
+				<SimulationStackToolbar
+					openImportSimulation = { () => { modalState.value = { page: 'importSimulation', state: new Signal('') } } }
+					resetSimulation = { resetSimulation }
+					disableReset = { disableReset }
+				/>
+				<div class = 'simulation-stack-page-body'>
+					<UnexpectedError close = { clearUnexpectedError } error = { unexpectedError.value === undefined ? undefined : unexpectedError.value.data }/>
+					<NetworkErrors rpcConnectionStatus = { rpcConnectionStatus }/>
+					{ rpcNetwork.value?.httpsRpc === undefined && rpcNetwork.value !== undefined ?
+						<ErrorComponent text = { `${ rpcNetwork.value.name } is not a supported network. The Interceptor is disabled while you are using ${ rpcNetwork.value.name }.` }/>
+					: <></> }
+					<ErrorBoundary key = { boundaryResetKey.value } onError = { onRenderError }>
+					{ isEmpty.value ?
+						<article class = 'simulation-stack-page-content'><DinoSays text = { 'Give me some transactions to munch on!' } /></article>
+					: currentResults.kind === 'passthrough' ?
+						<article class = 'simulation-stack-page-content'><RichAddressesTitleCard numberOfAddressesMadeRich = { numberOfAddressesMadeRich.value } madeRichAddressBookEntries = { madeRichAddressBookEntries.value } renameAddressCallBack = { renameAddressCallBack } /></article>
+					: <article class = 'simulation-stack-page-content'>
+						{ simulationErrorText === undefined ? <></> : <ErrorComponent text = { simulationErrorText }/> }
+						<div class = { shouldBlurSimulationContent ? 'blur' : undefined }>
+							<RichAddressesTitleCard numberOfAddressesMadeRich = { numberOfAddressesMadeRich.value } madeRichAddressBookEntries = { madeRichAddressBookEntries.value } renameAddressCallBack = { renameAddressCallBack } />
+							<TransactionsAndSignedMessages
+								simulationAndVisualisationResults = { simVisResults }
+								removeTransactionOrSignedMessage = { removeTransactionOrSignedMessage }
+								activeAddress = { activeSimulationAddress }
+								renameAddressCallBack = { renameAddressCallBack }
+								editEnsNamedHashCallBack = { editEnsNamedHashCallBack }
+								addressMetaData = { addressMetaData }
+								highlightedStackTargetId = { highlightedStackTargetId }
+							/>
+							<SimulationSummary
+								simulationAndVisualisationResults = { simVisResults }
+								currentBlockNumber = { currentBlockNumber }
+								activeAddress = { activeSimulationAddress }
+								renameAddressCallBack = { renameAddressCallBack }
+								rpcConnectionStatus = { rpcConnectionStatus }
+							/>
+						</div>
+					</article> }
+					</ErrorBoundary>
+				</div>
+			</> }
+		</div>
+		<div class = { `modal ${ modalState.value.page !== 'noModal' ? 'is-active' : ''}` }>
+			{ modalState.value.page === 'modifyAddress' ?
+				<ErrorBoundary key = { boundaryResetKey.value } onError = { onRenderError }>
+					<AddNewAddress
+						setActiveAddressAndInformAboutIt = { undefined }
+						modifyAddressWindowState = { modalState.value.state }
+						close = { () => { modalState.value = { page: 'noModal' } } }
+						activeAddress = { activeSimulationAddress.value }
+						rpcEntries = { rpcEntries }
+					/>
+				</ErrorBoundary>
+			: <></> }
+			{ modalState.value.page === 'editEnsNamedHash' ?
+				<ErrorBoundary key = { boundaryResetKey.value } onError = { onRenderError }>
+					<EditEnsLabelHash
+						close = { () => { modalState.value = { page: 'noModal' } } }
+						editEnsNamedHashWindowState = { modalState.value.state }
+					/>
+				</ErrorBoundary>
+			: <></> }
+			{ modalState.value.page === 'importSimulation' ?
+				<ErrorBoundary key = { boundaryResetKey.value } onError = { onRenderError }>
+					<ImportSimulationStack
+						close = { () => { modalState.value = { page: 'noModal' } } }
+						simulationInput = { modalState.value.state }
+					/>
+				</ErrorBoundary>
+			: <></> }
+		</div>
+	</main>
+}

--- a/app/ts/components/simulationExplaining/SimulationSummary.tsx
+++ b/app/ts/components/simulationExplaining/SimulationSummary.tsx
@@ -17,9 +17,9 @@ import type { Website } from '../../types/websiteAccessTypes.js'
 import { extractTokenEvents } from '../../background/metadataUtils.js'
 import type { EditEnsNamedHashCallBack } from '../subcomponents/ens.js'
 import type { EnrichedEthereumInputData } from '../../types/EnrichedEthereumData.js'
-import { ChevronIcon, ExportIcon, XMarkIcon } from '../subcomponents/icons.js'
+import { ChevronIcon, XMarkIcon } from '../subcomponents/icons.js'
 import { TransactionInput } from '../subcomponents/ParsedInputData.js'
-import { requestPopupInterceptorSimulationInput, sendPopupMessageToBackgroundPage } from '../../background/backgroundUtils.js'
+import { sendPopupMessageToBackgroundPage } from '../../background/backgroundUtils.js'
 import { IntegerInput } from '../subcomponents/AutosizingInput.js'
 import { useOptionalSignal } from '../../utils/OptionalSignal.js'
 import { type ReadonlySignal, type Signal, useComputed, useSignal } from '@preact/signals'
@@ -583,47 +583,82 @@ export function GasFee({ tx, rpcNetwork }: { tx: TransactionGasses, rpcNetwork: 
 type TransactionHeaderParams = {
 	simTx: MaybeSimulatedTransaction
 	removeTransactionOrSignedMessage?: () => void
+	onHeaderClick?: () => void
+	headerActionLabel?: string
+	ariaExpanded?: boolean
 }
 
-export function TransactionHeader({ simTx, removeTransactionOrSignedMessage } : TransactionHeaderParams) {
+export function TransactionHeader({ simTx, removeTransactionOrSignedMessage, onHeaderClick, headerActionLabel, ariaExpanded } : TransactionHeaderParams) {
 	const icon = useComputed(() => {
 		if (simTx.transactionStatus === 'Failed To Simulate' || simTx.transactionStatus === 'Transaction Failed') return '../img/error-icon.svg'
 		if (simTx.quarantine) return '../img/warning-sign.svg'
 		return '../img/success-icon.svg'
 	})
-	return <header class = 'card-header'>
+	const actionLabel = headerActionLabel ?? 'Open this transaction in the full simulation stack'
+	return <header
+		class = { `card-header stack-card-header${ onHeaderClick === undefined ? '' : ' stack-row-link-header' }` }
+		onClick = { onHeaderClick }
+		onKeyDown = { (event) => {
+			if (onHeaderClick === undefined || (event.key !== 'Enter' && event.key !== ' ')) return
+			if (event.target !== event.currentTarget) return
+			event.preventDefault()
+			onHeaderClick()
+		} }
+		role = { onHeaderClick === undefined ? undefined : 'button' }
+		tabIndex = { onHeaderClick === undefined ? undefined : 0 }
+		title = { onHeaderClick === undefined ? undefined : actionLabel }
+		aria-label = { onHeaderClick === undefined ? undefined : actionLabel }
+		aria-expanded = { onHeaderClick === undefined ? undefined : ariaExpanded }
+	>
 		<div class = 'card-header-icon unset-cursor'>
 			<span class = 'icon'>
 				<img src = { icon.value } width = '24' height = '24' />
 			</span>
 		</div>
 		<p class = 'card-header-title' style = 'white-space: nowrap;'>
-			{ identifyTransaction(simTx).title }
+			<span class = 'card-header-title-text'>{ identifyTransaction(simTx).title }</span>
 		</p>
 		{ simTx.transaction.to === undefined
 			? <></>
-			: <p class = 'card-header-icon unsetcursor' style = { `margin-left: auto; margin-right: 0; overflow: hidden; ${ removeTransactionOrSignedMessage !== undefined ? 'padding: 0' : ''}` }>
-				<WebsiteOriginText website = { simTx.website } />
-			</p>
+			: <WebsiteOriginText
+				website = { simTx.website }
+				class = { `card-header-website${ removeTransactionOrSignedMessage !== undefined ? ' card-header-website--flush' : ''}` }
+			/>
 		}
 		{ removeTransactionOrSignedMessage !== undefined
-			? <button class = 'card-header-icon' aria-label = 'remove' onClick = { removeTransactionOrSignedMessage }><XMarkIcon /></button>
+			? <button class = 'card-header-icon' aria-label = 'remove' onClick = { (event) => {
+				event.stopPropagation()
+				removeTransactionOrSignedMessage()
+			} }><XMarkIcon /></button>
 			: <></>
 		}
 	</header>
 }
 
-export function TransactionHeaderForFailedToSimulate({ website } : { website: Website }) {
-	return <header class = 'card-header'>
+export function TransactionHeaderForFailedToSimulate({ website, onHeaderClick, headerActionLabel, ariaExpanded } : { website: Website, onHeaderClick?: () => void, headerActionLabel?: string, ariaExpanded?: boolean }) {
+	const actionLabel = headerActionLabel ?? 'Open this transaction in the full simulation stack'
+	return <header
+		class = { `card-header stack-card-header${ onHeaderClick === undefined ? '' : ' stack-row-link-header' }` }
+		onClick = { onHeaderClick }
+		onKeyDown = { (event) => {
+			if (onHeaderClick === undefined || (event.key !== 'Enter' && event.key !== ' ')) return
+			if (event.target !== event.currentTarget) return
+			event.preventDefault()
+			onHeaderClick()
+		} }
+		role = { onHeaderClick === undefined ? undefined : 'button' }
+		tabIndex = { onHeaderClick === undefined ? undefined : 0 }
+		title = { onHeaderClick === undefined ? undefined : actionLabel }
+		aria-label = { onHeaderClick === undefined ? undefined : actionLabel }
+		aria-expanded = { onHeaderClick === undefined ? undefined : ariaExpanded }
+	>
 		<div class = 'card-header-icon unset-cursor'>
 			<span class = 'icon'>
 				<img src = { '../img/error-icon.svg' } width = '24' height = '24' />
 			</span>
 		</div>
 		<p class = 'card-header-title' style = 'white-space: nowrap;'> Not simulated </p>
-		<p class = 'card-header-icon unsetcursor' style = 'margin-left: auto; margin-right: 0; overflow: hidden;'>
-			<WebsiteOriginText website = { website } />
-		</p>
+		<WebsiteOriginText website = { website } class = 'card-header-website' />
 	</header>
 }
 
@@ -703,14 +738,8 @@ export function SimulationSummary(param: SimulationSummaryParams) {
 			? '../img/warning-sign.svg'
 			: '../img/success-icon.svg'
 
-	const exportEthSimulateInput = async () => {
-		const reply = await requestPopupInterceptorSimulationInput()
-		if (reply === undefined) return
-		return reply.ethSimulateV1InputString
-	}
-
 	return (
-		<div class = 'card' style = 'background-color: var(--card-bg-color); margin: 10px;'>
+		<div class = 'card simulation-summary-card' style = 'background-color: var(--card-bg-color);'>
 			<header class = 'card-header'>
 				<div class = 'card-header-icon unset-cursor'>
 					<span class = 'icon'>
@@ -764,23 +793,7 @@ export function SimulationSummary(param: SimulationSummaryParams) {
 					}
 				</div>
 
-				<span class = 'log-table' style = 'margin-top: 10px; grid-template-columns: max-content auto auto; grid-column-gap: 5px;'>
-					<div class = 'log-cell'>
-						<CopyToClipboard
-							copyFunction = { exportEthSimulateInput }
-							copyMessage = 'Interceptor Simulation input copied!'
-							classNames = { 'btn btn--outline is-small' }
-						>
-							<p class = 'paragraph noselect nopointer' style = 'text-overflow: ellipsis; overflow: hidden; white-space: nowrap; display: block;'>
-								<span style = { { marginRight: '0.25rem', fontSize: '1rem', width: '1em', height: '1em' } }>
-									<ExportIcon/>
-								</span>
-								<span>Export Simulation Stack</span>
-							</p>
-						</CopyToClipboard>
-					</div>
-
-					<div class = 'log-cell' style = 'justify-content: center;'> </div>
+				<span class = 'log-table' style = 'margin-top: 10px; grid-template-columns: auto;'>
 					<div class = 'log-cell' style = 'justify-content: right;'>
 						<SimulatedInBlockNumber
 							simulationBlockNumber = { getSimulationDisplayBlockNumber(simulationAndVisualisationResults.blockNumber, simulationAndVisualisationResults.visualizedSimulationState.visualizedBlocks.length) }

--- a/app/ts/components/simulationExplaining/Transactions.tsx
+++ b/app/ts/components/simulationExplaining/Transactions.tsx
@@ -6,7 +6,7 @@ import { TokenSymbol, TokenAmount, AllApproval } from '../subcomponents/coins.js
 import type { LogAnalysisParams, NonLogAnalysisParams, RenameAddressCallBack } from '../../types/user-interface-types.js'
 import { ErrorComponent } from '../subcomponents/Error.js'
 import { identifyRoutes, identifySwap, SwapVisualization } from './SwapTransactions.js'
-import { RawTransactionDetailsCard, GasFee, TokenLogAnalysisCard, TransactionCreated, TransactionHeader, NonTokenLogAnalysisCard, TransactionsAccountChangesCard } from './SimulationSummary.js'
+import { RawTransactionDetailsCard, GasFee, TokenLogAnalysisCard, TransactionCreated, TransactionHeader, TransactionHeaderForFailedToSimulate, NonTokenLogAnalysisCard, TransactionsAccountChangesCard } from './SimulationSummary.js'
 import { identifyTransaction } from './identifyTransaction.js'
 import { ApproveIcon, ArrowIcon } from '../subcomponents/icons.js'
 import { SimpleTokenTransferVisualisation } from './customExplainers/SimpleSendVisualisations.js'
@@ -14,7 +14,7 @@ import { SimpleTokenApprovalVisualisation } from './customExplainers/SimpleToken
 import { assertNever } from '../../utils/typescript.js'
 import { CatchAllVisualizer, tokenEventToTokenSymbolParams } from './customExplainers/CatchAllVisualizer.js'
 import type { AddressBookEntry } from '../../types/addressBookTypes.js'
-import { SignatureCard } from '../pages/PersonalSign.js'
+import { SignatureCard, SignatureHeader } from '../pages/PersonalSign.js'
 import { bigintSecondsToDate, bytes32String, dataStringWith0xStart } from '../../utils/bigint.js'
 import { GovernanceVoteVisualizer } from './customExplainers/GovernanceVoteVisualizer.js'
 import { EnrichedSolidityTypeComponentWithAddressBook, StringElement } from '../subcomponents/solidityType.js'
@@ -40,6 +40,7 @@ import type { OriginalSendRequestParameters } from '../../types/JsonRpc-types.js
 import type { Website } from '../../types/websiteAccessTypes.js'
 import type { EthereumSendableSignedTransaction } from '../../types/wire-types.js'
 import { Blockie } from '../subcomponents/SVGBlockie.js'
+import { getSimulationStackElementId } from '../../utils/simulationStackTargets.js'
 
 function isPositiveEvent(visResult: TokenVisualizerResultWithMetadata, ourAddressInReferenceFrame: bigint) {
 	if (visResult.type === 'ERC20') {
@@ -234,19 +235,31 @@ export function SenderReceiver({ from, to, renameAddressCallBack }: { from: Addr
 	</span>
 }
 
-export function Transaction(param: TransactionVisualizationParameters) {
+type CollapsibleStackCardParams = {
+	collapsed?: boolean
+	toggleCollapsed?: () => void
+}
+
+export function Transaction(param: TransactionVisualizationParameters & CollapsibleStackCardParams) {
 	const removeTransactionOrSignedMessage = param.removeTransactionOrSignedMessage
 	const remove = removeTransactionOrSignedMessage === undefined ? undefined : () => {
 		return removeTransactionOrSignedMessage({ type: 'Transaction', transactionIdentifier: param.simTx.transactionIdentifier })
 	}
+	const headerActionLabel = param.collapsed === undefined ? undefined : param.collapsed ? 'Expand transaction details' : 'Collapse transaction details'
 	const rpcNetwork = useSignal(param.simulationAndVisualisationResults.rpcNetwork)
 	useEffect(() => {
 		rpcNetwork.value = param.simulationAndVisualisationResults.rpcNetwork
 	}, [param.simulationAndVisualisationResults.rpcNetwork])
 	return (
 		<div class = 'card'>
-			<TransactionHeader simTx = { param.simTx } removeTransactionOrSignedMessage = { remove } />
-			<div class = 'card-content' style = 'padding-bottom: 5px;'>
+			<TransactionHeader
+				simTx = { param.simTx }
+				removeTransactionOrSignedMessage = { remove }
+				onHeaderClick = { param.toggleCollapsed }
+				headerActionLabel = { headerActionLabel }
+				ariaExpanded = { param.collapsed === undefined ? undefined : !param.collapsed }
+			/>
+			{ param.collapsed === true ? <></> : <div class = 'card-content' style = 'padding-bottom: 5px;'>
 				<div class = 'container'>
 					<TransactionImportanceBlock { ...param } rpcNetwork = { rpcNetwork } addressMetadata = { param.addressMetaData }/>
 				</div>
@@ -275,25 +288,42 @@ export function Transaction(param: TransactionVisualizationParameters) {
 						</> }
 					</div>
 				</span>
-			</div>
+			</div> }
 		</div>
 	)
 }
 
-function PendingStackHeader({ title, website, statusIcon } : { title: string, website: SignalOrValue<Website | undefined>, statusIcon: string }) {
-	return <header class = 'card-header'>
+export function PendingStackHeader({ title, website, statusIcon, onHeaderClick, openLabel, ariaExpanded } : { title: string, website: SignalOrValue<Website | undefined>, statusIcon: string, onHeaderClick?: () => void, openLabel?: string, ariaExpanded?: boolean }) {
+	return <header
+		class = { `card-header stack-card-header${ onHeaderClick === undefined ? '' : ' stack-row-link-header' }` }
+		onClick = { onHeaderClick }
+		onKeyDown = { (event) => {
+			if (onHeaderClick === undefined || (event.key !== 'Enter' && event.key !== ' ')) return
+			if (event.target !== event.currentTarget) return
+			event.preventDefault()
+			onHeaderClick()
+		} }
+		role = { onHeaderClick === undefined ? undefined : 'button' }
+		tabIndex = { onHeaderClick === undefined ? undefined : 0 }
+		title = { onHeaderClick === undefined ? undefined : openLabel }
+		aria-label = { onHeaderClick === undefined ? undefined : openLabel }
+		aria-expanded = { onHeaderClick === undefined ? undefined : ariaExpanded }
+	>
 		<div class = 'card-header-icon unset-cursor'>
 			<span class = 'icon'>
 				<img src = { statusIcon } width = '24' height = '24' />
 			</span>
 		</div>
 		<p class = 'card-header-title' style = 'white-space: nowrap;'>
-			{ title }
+			<span class = 'card-header-title-text'>{ title }</span>
 		</p>
-		<p class = 'card-header-icon unsetcursor' style = 'margin-left: auto; margin-right: 0; overflow: hidden;'>
-			<WebsiteOriginText website = { website } />
-		</p>
+		<WebsiteOriginText website = { website } class = 'card-header-website' />
 	</header>
+}
+
+function getStackRowIdentifier(stackRow: SimulationStackTransactionRow | SimulationStackMessageRow): TransactionOrMessageIdentifier {
+	if (stackRow.type === 'Message') return { type: 'Message', messageIdentifier: stackRow.signedMessageTransaction.messageIdentifier }
+	return { type: 'Transaction', transactionIdentifier: stackRow.preSimulationTransaction.transactionIdentifier }
 }
 
 function TransactionPreviewDetails({
@@ -306,6 +336,8 @@ function TransactionPreviewDetails({
 	renameAddressCallBack,
 	errorMessage,
 	title,
+	collapsed,
+	toggleCollapsed,
 }: {
 	website: SignalOrValue<Website | undefined>,
 	created: Date,
@@ -316,16 +348,20 @@ function TransactionPreviewDetails({
 	renameAddressCallBack: RenameAddressCallBack,
 	errorMessage: string | undefined,
 	title: string,
-}) {
+} & CollapsibleStackCardParams) {
 	const from = getAddressBookEntryOrAFiller(addressMetaData.value, signedTransaction.from)
 	const to = signedTransaction.to === null || signedTransaction.to === undefined ? undefined : getAddressBookEntryOrAFiller(addressMetaData.value, signedTransaction.to)
+	const headerActionLabel = collapsed === undefined ? undefined : collapsed ? 'Expand transaction details' : 'Collapse transaction details'
 	return <div class = 'card'>
 		<PendingStackHeader
 			title = { title }
 			website = { website }
 			statusIcon = { errorMessage === undefined ? '../img/question-mark-sign.svg' : '../img/error-icon.svg' }
+			onHeaderClick = { toggleCollapsed }
+			openLabel = { headerActionLabel }
+			ariaExpanded = { collapsed === undefined ? undefined : !collapsed }
 		/>
-		<div class = 'card-content' style = 'padding-bottom: 5px;'>
+		{ collapsed === true ? <></> : <div class = 'card-content' style = 'padding-bottom: 5px;'>
 			{ errorMessage === undefined ? <></> : <ErrorComponent text = { errorMessage } containerStyle = { { margin: '0px', marginBottom: '10px' } } /> }
 			<div class = 'container'>
 				<dl class = 'grid key-value-pair'>
@@ -360,7 +396,7 @@ function TransactionPreviewDetails({
 				</div>
 				<div class = 'log-cell' style = { { display: 'inline-flex', justifyContent: 'right' } } />
 			</span>
-		</div>
+		</div> }
 	</div>
 }
 
@@ -370,20 +406,26 @@ function MessagePreviewDetails({
 	signedMessageTransaction,
 	visualizedPersonalSignRequest,
 	errorMessage,
+	collapsed,
+	toggleCollapsed,
 }: {
 	website: SignalOrValue<Website | undefined>,
 	created: Date,
 	signedMessageTransaction: SignedMessageTransaction,
 	visualizedPersonalSignRequest: VisualizedPersonalSignRequest | undefined,
 	errorMessage: string | undefined,
-}) {
+} & CollapsibleStackCardParams) {
+	const headerActionLabel = collapsed === undefined ? undefined : collapsed ? 'Expand signature details' : 'Collapse signature details'
 	return <div class = 'card'>
 		<PendingStackHeader
 			title = { errorMessage === undefined ? 'Pending signature' : 'Signature failed' }
 			website = { website }
 			statusIcon = { errorMessage === undefined ? '../img/question-mark-sign.svg' : '../img/error-icon.svg' }
+			onHeaderClick = { toggleCollapsed }
+			openLabel = { headerActionLabel }
+			ariaExpanded = { collapsed === undefined ? undefined : !collapsed }
 		/>
-		<div class = 'card-content' style = 'padding-bottom: 5px;'>
+		{ collapsed === true ? <></> : <div class = 'card-content' style = 'padding-bottom: 5px;'>
 			{ errorMessage === undefined ? <></> : <ErrorComponent text = { errorMessage } containerStyle = { { margin: '0px', marginBottom: '10px' } } /> }
 			<div class = 'textbox'>
 				<p class = 'paragraph' style = 'color: var(--subtitle-text-color)'>Signature request</p>
@@ -408,7 +450,7 @@ function MessagePreviewDetails({
 				</div>
 				<div class = 'log-cell' style = { { display: 'inline-flex', justifyContent: 'right' } } />
 			</span>
-		</div>
+		</div> }
 	</div>
 }
 
@@ -422,14 +464,88 @@ type TransactionOrMessageWithBlockTimeManipulatorParams = {
 	addressMetaData: ReadonlySignal<readonly AddressBookEntry[]>
 	blockTimeManipulation: BlockTimeManipulationWithNoDelay
 	showTimePicker?: boolean
+	displayMode?: 'full' | 'titleOnly'
+	openSimulationStackAt?: (transactionOrMessageIdentifier: TransactionOrMessageIdentifier) => void
+	stackRowElementId?: string
+	highlightStackRow?: boolean
 }
 
-const TransactionOrMessageWithBlockTimeManipulator = ({ stackRow, renameAddressCallBack, editEnsNamedHashCallBack, removeTransactionOrSignedMessage, simulationAndVisualisationResults, activeAddress, addressMetaData, blockTimeManipulation, showTimePicker = true }: TransactionOrMessageWithBlockTimeManipulatorParams) => {
+function getPendingTransactionTitle(stackRow: SimulationStackTransactionRow) {
+	if (stackRow.preSimulationTransaction.originalRequestParameters.method === 'eth_sendRawTransaction') return 'Pending raw transaction'
+	return 'Pending transaction'
+}
+
+function TransactionOrMessageTitleOnlyCard({
+	stackRow,
+	removeTransactionOrSignedMessage,
+	openSimulationStackAt,
+}: {
+	stackRow: SimulationStackTransactionRow | SimulationStackMessageRow
+	removeTransactionOrSignedMessage?: (transactionOrMessageIdentifier: TransactionOrMessageIdentifier) => void
+	openSimulationStackAt?: (transactionOrMessageIdentifier: TransactionOrMessageIdentifier) => void
+}) {
+	const stackRowIdentifier = getStackRowIdentifier(stackRow)
+	const openHeader = openSimulationStackAt === undefined ? undefined : () => openSimulationStackAt(stackRowIdentifier)
+	if (stackRow.type === 'Message') {
+		if (stackRow.status === 'simulated' && stackRow.visualizedPersonalSignRequest !== undefined) {
+			return <div class = 'card'>
+				<SignatureHeader
+					visualizedPersonalSignRequest = { stackRow.visualizedPersonalSignRequest }
+					removeTransactionOrSignedMessage = { removeTransactionOrSignedMessage }
+					onHeaderClick = { openHeader }
+				/>
+			</div>
+		}
+		return <div class = 'card'>
+			<PendingStackHeader
+				title = 'Pending signature'
+				website = { stackRow.signedMessageTransaction.website }
+				statusIcon = '../img/question-mark-sign.svg'
+				onHeaderClick = { openHeader }
+				openLabel = 'Open this signature in the full simulation stack'
+			/>
+		</div>
+	}
+	if (stackRow.status === 'simulated' && stackRow.simulatedTransaction !== undefined) {
+		const simulatedTransaction = stackRow.simulatedTransaction
+		const remove = removeTransactionOrSignedMessage === undefined ? undefined : () => {
+			return removeTransactionOrSignedMessage({ type: 'Transaction', transactionIdentifier: simulatedTransaction.transactionIdentifier })
+		}
+		return <div class = 'card'>
+			<TransactionHeader simTx = { simulatedTransaction } removeTransactionOrSignedMessage = { remove } onHeaderClick = { openHeader } />
+		</div>
+	}
+	if (stackRow.status === 'failed') {
+		return <div class = 'card'>
+			<TransactionHeaderForFailedToSimulate website = { stackRow.preSimulationTransaction.website } onHeaderClick = { openHeader } />
+		</div>
+	}
+	return <div class = 'card'>
+		<PendingStackHeader
+			title = { getPendingTransactionTitle(stackRow) }
+			website = { stackRow.preSimulationTransaction.website }
+			statusIcon = '../img/question-mark-sign.svg'
+			onHeaderClick = { openHeader }
+			openLabel = 'Open this transaction in the full simulation stack'
+		/>
+	</div>
+}
+
+const TransactionOrMessageWithBlockTimeManipulator = ({ stackRow, renameAddressCallBack, editEnsNamedHashCallBack, removeTransactionOrSignedMessage, simulationAndVisualisationResults, activeAddress, addressMetaData, blockTimeManipulation, showTimePicker = true, displayMode = 'full', openSimulationStackAt, stackRowElementId, highlightStackRow = false }: TransactionOrMessageWithBlockTimeManipulatorParams) => {
 	const timeSelectorMode = useSignal<TimePickerMode>('No Delay')
 	const timeSelectorAbsoluteTime = useSignal<Date | undefined>(undefined)
 	const timeSelectorDeltaValue = useSignal<bigint>(12n)
 	const timeSelectorDeltaUnit = useSignal<DeltaUnit>('Seconds')
+	const collapsed = useSignal(false)
 	const currentSimulationAndVisualisationResults = simulationAndVisualisationResults.value
+	const toggleCollapsed = () => {
+		collapsed.value = !collapsed.value
+	}
+
+	useEffect(() => {
+		if (displayMode !== 'full' || !highlightStackRow) return
+		collapsed.value = false
+	}, [displayMode, highlightStackRow])
 
 	useEffect(() => {
 		switch(blockTimeManipulation.type) {
@@ -461,51 +577,82 @@ const TransactionOrMessageWithBlockTimeManipulator = ({ stackRow, renameAddressC
 	const timeSelectorOnChange = (transactionOrMessage: SimulationStackTransactionRow | SimulationStackMessageRow) => {
 		const blockTimeManipulation = getTimeManipulatorFromSignals(timeSelectorMode.value, timeSelectorAbsoluteTime.value, timeSelectorDeltaValue.value, timeSelectorDeltaUnit.value)
 		if (blockTimeManipulation === undefined) return
-		const transactionOrMessageIdentifier = transactionOrMessage.type === 'Message' ?
-			{ type: 'Message', messageIdentifier: transactionOrMessage.signedMessageTransaction.messageIdentifier } as const :
-			{ type: 'Transaction', transactionIdentifier: transactionOrMessage.preSimulationTransaction.transactionIdentifier } as const
-		return sendPopupMessageToBackgroundPage({ method: 'popup_setTransactionOrMessageBlockTimeManipulator', data: { transactionOrMessageIdentifier, blockTimeManipulation } })
+		return sendPopupMessageToBackgroundPage({ method: 'popup_setTransactionOrMessageBlockTimeManipulator', data: { transactionOrMessageIdentifier: getStackRowIdentifier(transactionOrMessage), blockTimeManipulation } })
 	}
+	const stackRowWrapperProps = {
+		id: stackRowElementId,
+		class: `simulation-stack-row${ highlightStackRow ? ' simulation-stack-row--highlighted' : '' }`,
+	}
+	if (displayMode === 'titleOnly') return <>
+		<div { ...stackRowWrapperProps }>
+			<TransactionOrMessageTitleOnlyCard
+				stackRow = { stackRow }
+				removeTransactionOrSignedMessage = { removeTransactionOrSignedMessage }
+				openSimulationStackAt = { openSimulationStackAt }
+			/>
+		</div>
+		{ showTimePicker ? <div style = 'display: flex; justify-content: center; padding-top: 10px;'>
+			<TimePicker
+				startText = { 'Simulate delay' }
+				mode = { timeSelectorMode }
+				absoluteTime = { timeSelectorAbsoluteTime }
+				deltaValue = { timeSelectorDeltaValue }
+				deltaUnit = { timeSelectorDeltaUnit }
+				onChangedCallBack = { () => { timeSelectorOnChange(stackRow) } }
+				removeNoDelayOption = { false }
+			/>
+		</div> : <></> }
+	</>
 	return <>
-		{ stackRow.type === 'Message' ? <>
-			{ stackRow.status === 'simulated' && stackRow.visualizedPersonalSignRequest !== undefined ?
-				<SignatureCard
-					visualizedPersonalSignRequest = { stackRow.visualizedPersonalSignRequest }
-					renameAddressCallBack = { renameAddressCallBack }
-					removeTransactionOrSignedMessage = { removeTransactionOrSignedMessage }
-					editEnsNamedHashCallBack = { editEnsNamedHashCallBack }
-					numberOfUnderTransactions = { 0 }
-				/>
-			: <MessagePreviewDetails
-				website = { stackRow.signedMessageTransaction.website }
-				created = { stackRow.signedMessageTransaction.created }
-				signedMessageTransaction = { stackRow.signedMessageTransaction }
-				visualizedPersonalSignRequest = { stackRow.visualizedPersonalSignRequest }
-				errorMessage = { undefined }
-			/> }
-			</> : <>
-				{ stackRow.status === 'simulated' && stackRow.simulatedTransaction !== undefined && currentSimulationAndVisualisationResults !== undefined ?
-					<Transaction
-						simTx = { stackRow.simulatedTransaction }
-						simulationAndVisualisationResults = { currentSimulationAndVisualisationResults }
-						removeTransactionOrSignedMessage = { removeTransactionOrSignedMessage }
-						activeAddress = { activeAddress }
+		<div { ...stackRowWrapperProps }>
+			{ stackRow.type === 'Message' ? <>
+				{ stackRow.status === 'simulated' && stackRow.visualizedPersonalSignRequest !== undefined ?
+					<SignatureCard
+						visualizedPersonalSignRequest = { stackRow.visualizedPersonalSignRequest }
 						renameAddressCallBack = { renameAddressCallBack }
-						addressMetaData = { addressMetaData }
-					editEnsNamedHashCallBack = { editEnsNamedHashCallBack }
-				/>
-			: <TransactionPreviewDetails
-				website = { stackRow.preSimulationTransaction.website }
-				created = { stackRow.preSimulationTransaction.created }
-				originalRequestParameters = { stackRow.preSimulationTransaction.originalRequestParameters }
-				signedTransaction = { stackRow.preSimulationTransaction.signedTransaction }
-				parsedInputData = { stackRow.simulatedTransaction?.parsedInputData }
-				addressMetaData = { addressMetaData }
-				renameAddressCallBack = { renameAddressCallBack }
-				errorMessage = { stackRow.status === 'failed' ? (stackRow.simulatedTransaction as NonSimulatedAndVisualizedTransaction | undefined)?.error.decodedErrorMessage ?? 'Failed to simulate this transaction.' : undefined }
-				title = { stackRow.status === 'failed' ? 'Not simulated' : 'Pending transaction' }
-			/> }
-		</> }
+						removeTransactionOrSignedMessage = { removeTransactionOrSignedMessage }
+						editEnsNamedHashCallBack = { editEnsNamedHashCallBack }
+						numberOfUnderTransactions = { 0 }
+						collapsed = { collapsed.value }
+						toggleCollapsed = { toggleCollapsed }
+					/>
+				: <MessagePreviewDetails
+					website = { stackRow.signedMessageTransaction.website }
+					created = { stackRow.signedMessageTransaction.created }
+					signedMessageTransaction = { stackRow.signedMessageTransaction }
+					visualizedPersonalSignRequest = { stackRow.visualizedPersonalSignRequest }
+					errorMessage = { undefined }
+					collapsed = { collapsed.value }
+					toggleCollapsed = { toggleCollapsed }
+				/> }
+				</> : <>
+					{ stackRow.status === 'simulated' && stackRow.simulatedTransaction !== undefined && currentSimulationAndVisualisationResults !== undefined ?
+						<Transaction
+							simTx = { stackRow.simulatedTransaction }
+							simulationAndVisualisationResults = { currentSimulationAndVisualisationResults }
+							removeTransactionOrSignedMessage = { removeTransactionOrSignedMessage }
+							activeAddress = { activeAddress }
+							renameAddressCallBack = { renameAddressCallBack }
+							addressMetaData = { addressMetaData }
+							editEnsNamedHashCallBack = { editEnsNamedHashCallBack }
+							collapsed = { collapsed.value }
+							toggleCollapsed = { toggleCollapsed }
+						/>
+				: <TransactionPreviewDetails
+					website = { stackRow.preSimulationTransaction.website }
+					created = { stackRow.preSimulationTransaction.created }
+					originalRequestParameters = { stackRow.preSimulationTransaction.originalRequestParameters }
+					signedTransaction = { stackRow.preSimulationTransaction.signedTransaction }
+					parsedInputData = { stackRow.simulatedTransaction?.parsedInputData }
+					addressMetaData = { addressMetaData }
+					renameAddressCallBack = { renameAddressCallBack }
+					errorMessage = { stackRow.status === 'failed' ? (stackRow.simulatedTransaction as NonSimulatedAndVisualizedTransaction | undefined)?.error.decodedErrorMessage ?? 'Failed to simulate this transaction.' : undefined }
+					title = { stackRow.status === 'failed' ? 'Not simulated' : 'Pending transaction' }
+					collapsed = { collapsed.value }
+					toggleCollapsed = { toggleCollapsed }
+				/> }
+			</> }
+		</div>
 		{ showTimePicker ? <div style = 'display: flex; justify-content: center; padding-top: 10px;'>
 			<TimePicker
 				startText = { 'Simulate delay' }
@@ -528,6 +675,9 @@ type TransactionsAndSignedMessagesParams = {
 	editEnsNamedHashCallBack: EditEnsNamedHashCallBack
 	addressMetaData: ReadonlySignal<readonly AddressBookEntry[]>
 	showTimePicker?: boolean
+	displayMode?: 'full' | 'titleOnly'
+	openSimulationStackAt?: (transactionOrMessageIdentifier: TransactionOrMessageIdentifier) => void
+	highlightedStackTargetId?: ReadonlySignal<string | undefined>
 }
 
 export function TransactionsAndSignedMessages(param: TransactionsAndSignedMessagesParams) {
@@ -535,7 +685,7 @@ export function TransactionsAndSignedMessages(param: TransactionsAndSignedMessag
 		const currentResults = param.simulationAndVisualisationResults.value
 		return currentResults.kind === 'passthrough' ? undefined : currentResults.value
 	})
-	return <SimulationStackRows { ...param } simulationAndVisualisationResults = { simulationAndVisualisationResults } showTimePicker = { true } />
+	return <SimulationStackRows { ...param } simulationAndVisualisationResults = { simulationAndVisualisationResults } showTimePicker = { param.showTimePicker !== false } />
 }
 
 type SimulationStackRowsParams = Omit<TransactionsAndSignedMessagesParams, 'simulationAndVisualisationResults'> & {
@@ -551,22 +701,31 @@ export function SimulationStackRows(param: SimulationStackRowsParams) {
 			results.visualizedSimulationState,
 		)
 	})
-	return <ul> {
+	return <ul class = 'simulation-stack-list'> {
 		transactionsAndMessagesInBlock.value.flatMap((block, blockIndex) => {
 			const nextBlockManipulator = transactionsAndMessagesInBlock.value[blockIndex + 1]?.blockTimeManipulation || { type: 'No Delay' } as const
-			return block.rows.map((stackRow, transactionIndex) => <li key = { stackRow.type === 'Message' ? `message-${ stackRow.signedMessageTransaction.messageIdentifier.toString() }` : `transaction-${ stackRow.preSimulationTransaction.transactionIdentifier.toString() }` }>
-				<TransactionOrMessageWithBlockTimeManipulator
-					simulationAndVisualisationResults = { param.simulationAndVisualisationResults }
-					stackRow = { stackRow }
-					renameAddressCallBack = { param.renameAddressCallBack }
-					editEnsNamedHashCallBack = { param.editEnsNamedHashCallBack }
-					removeTransactionOrSignedMessage = { param.removeTransactionOrSignedMessage }
-					activeAddress = { param.activeAddress }
-					addressMetaData = { param.addressMetaData }
-					blockTimeManipulation = { transactionIndex === block.rows.length - 1 ? nextBlockManipulator : { type: 'No Delay' } as const }
-					showTimePicker = { param.showTimePicker !== false }
-				/>
-			</li> )
+			return block.rows.map((stackRow, transactionIndex) => {
+				const stackRowElementId = getSimulationStackElementId(getStackRowIdentifier(stackRow))
+				return <li
+					key = { stackRow.type === 'Message' ? `message-${ stackRow.signedMessageTransaction.messageIdentifier.toString() }` : `transaction-${ stackRow.preSimulationTransaction.transactionIdentifier.toString() }` }
+				>
+					<TransactionOrMessageWithBlockTimeManipulator
+						simulationAndVisualisationResults = { param.simulationAndVisualisationResults }
+						stackRow = { stackRow }
+						renameAddressCallBack = { param.renameAddressCallBack }
+						editEnsNamedHashCallBack = { param.editEnsNamedHashCallBack }
+						removeTransactionOrSignedMessage = { param.removeTransactionOrSignedMessage }
+						activeAddress = { param.activeAddress }
+						addressMetaData = { param.addressMetaData }
+						blockTimeManipulation = { transactionIndex === block.rows.length - 1 ? nextBlockManipulator : { type: 'No Delay' } as const }
+						showTimePicker = { param.showTimePicker !== false }
+						displayMode = { param.displayMode }
+						openSimulationStackAt = { param.openSimulationStackAt }
+						stackRowElementId = { stackRowElementId }
+						highlightStackRow = { param.highlightedStackTargetId?.value === stackRowElementId }
+					/>
+				</li>
+			})
 			})
 		} </ul>
 	}

--- a/app/ts/components/simulationExplaining/identifySignature.ts
+++ b/app/ts/components/simulationExplaining/identifySignature.ts
@@ -1,0 +1,66 @@
+import type { VisualizedPersonalSignRequest } from '../../types/personal-message-definitions.js'
+import type { AddressBookEntry } from '../../types/addressBookTypes.js'
+import { addressString } from '../../utils/bigint.js'
+import { assertNever } from '../../utils/typescript.js'
+
+function getPermitTokenLabel(entry: AddressBookEntry) {
+	const symbol = entry.type === 'ERC20' ? entry.symbol.trim() : ''
+	if (symbol !== '') return symbol
+	const name = entry.name.trim()
+	if (name !== '') return name
+	return addressString(entry.address)
+}
+
+export function identifySignature(data: VisualizedPersonalSignRequest) {
+	switch (data.type) {
+		case 'OrderComponents': return {
+			title: 'Opensea order',
+			rejectAction: 'Reject Opensea order',
+			simulationAction: 'Simulate Opensea order',
+			signingAction: 'Sign Opensea order',
+		}
+		case 'SafeTx': return {
+			title: 'Gnosis Safe message',
+			rejectAction: 'Reject Gnosis Safe message',
+			simulationAction: 'Simulate Gnosis Safe message',
+			signingAction: 'Sign Gnosis Safe message',
+		}
+		case 'EIP712': {
+			const { name: domainName } = data.message.domain
+			const name = domainName?.type === 'string' ? `${ domainName.value } - ${ data.message.primaryType }` : 'Arbitrary EIP712 message'
+			return {
+				title: `${ name } signing request`,
+				rejectAction: `Reject ${ name }`,
+				simulationAction: `Simulate ${ name }`,
+				signingAction: `Sign ${ name }`,
+			}
+		}
+		case 'NotParsed': return {
+			title: 'Arbitrary Ethereum message',
+			rejectAction: 'Reject arbitrary message',
+			simulationAction: 'Simulate arbitrary message',
+			signingAction: 'Sign arbitrary message',
+		}
+		case 'Permit': {
+			const tokenLabel = getPermitTokenLabel(data.verifyingContract)
+			return {
+				title: `${ tokenLabel } Permit`,
+				signingAction: `Sign ${ tokenLabel } Permit`,
+				simulationAction: `Simulate ${ tokenLabel } Permit`,
+				rejectAction: `Reject ${ tokenLabel } Permit`,
+				to: data.spender
+			}
+		}
+		case 'Permit2': {
+			const tokenLabel = getPermitTokenLabel(data.token)
+			return {
+				title: `${ tokenLabel } Permit`,
+				signingAction: `Sign ${ tokenLabel } Permit`,
+				simulationAction: `Simulate ${ tokenLabel } Permit`,
+				rejectAction: `Reject ${ tokenLabel } Permit`,
+				to: data.spender
+			}
+		}
+		default: assertNever(data)
+	}
+}

--- a/app/ts/components/subcomponents/ConfigureRpcConnection.tsx
+++ b/app/ts/components/subcomponents/ConfigureRpcConnection.tsx
@@ -149,7 +149,7 @@ export const ConfigureRpcConnection = ({ rpcInfo }: { rpcInfo?: RpcEntry }) => {
 		<RpcQueryProvider>
 			{ rpcInfo
 				? <button type = 'button' onClick = { showConfigurationModal } class = 'btn btn--outline'>Edit</button>
-				: <button type = 'button' onClick = { showConfigurationModal } class = 'btn btn--outline' style = 'border-style: dashed'>+ New RPC Connection</button>
+				: <button type = 'button' onClick = { showConfigurationModal } class = 'btn btn--outline rpc-add-button'>+ New RPC Connection</button>
 			}
 			<dialog class = 'dialog' ref = { modalRef }>
 				<ConfigureRpcForm defaultValues = { rpcInfo } onCancel = { cancelAndCloseModal } onSave = { saveRpcEntry } onRemove = { rpcEntries.value.length > 1 ? removeRpcEntryByUrl : undefined } />

--- a/app/ts/components/subcomponents/Hint.tsx
+++ b/app/ts/components/subcomponents/Hint.tsx
@@ -25,8 +25,15 @@ export default function Container(props: Props) {
 		const containerElement = containerElementRef.current
 		if (!containerElement) return
 
+		const getHintElement = (target: EventTarget | null, attribute: string) => {
+			if (!(target instanceof Element)) return undefined
+			const element = target.hasAttribute(attribute) ? target : target.closest(`[${ attribute }]`)
+			if (element === null || !containerElement.contains(element)) return undefined
+			return element
+		}
+
 		const hide = (event: Event) => {
-			if (!(event.target instanceof Element) || !event.target.hasAttribute(toolTipAttribute)) return
+			if (getHintElement(event.target, toolTipAttribute) === undefined) return
 
 			clearTimeout(toolTipTimeoutIdRef.current ?? undefined)
 
@@ -37,17 +44,18 @@ export default function Container(props: Props) {
 		}
 
 		const click = (event: MouseEvent) => {
-			if (!(event.target instanceof Element) || !event.target.hasAttribute(copyAttribute) || !event.target.hasAttribute(timerAttribute)) return
+			const targetElement = getHintElement(event.target, copyAttribute)
+			if (targetElement === undefined || !targetElement.hasAttribute(timerAttribute)) return
 
 			clearTimeout(toolTipTimeoutIdRef.current ?? undefined)
 
-			const delayValue = event.target.getAttribute(timerAttribute)
+			const delayValue = targetElement.getAttribute(timerAttribute)
 			if (delayValue === null) return
 
 			clearTimeout(copyMessageTimeoutIdRef.current ?? undefined)
 			copyMessageTimeoutIdRef.current = null
 
-			content.value = event.target.getAttribute(copyAttribute) || ''
+			content.value = targetElement.getAttribute(copyAttribute) || ''
 			clickPosition.value = { x: event.clientX, y: event.clientY }
 
 			copyMessageTimeoutIdRef.current = setTimeout(() => {
@@ -58,9 +66,10 @@ export default function Container(props: Props) {
 		}
 
 		const mouseover = (event: MouseEvent) => {
-			if (!(event.target instanceof Element) || (!event.target.hasAttribute(toolTipAttribute) && !event.target.hasAttribute(timerAttribute))) return
+			const targetElement = getHintElement(event.target, toolTipAttribute) ?? getHintElement(event.target, timerAttribute)
+			if (targetElement === undefined) return
 			clearTimeout(toolTipTimeoutIdRef.current ?? undefined)
-			const tooltipContent = event.target.getAttribute(toolTipAttribute) || ''
+			const tooltipContent = targetElement.getAttribute(toolTipAttribute) || ''
 			toolTipTimeoutIdRef.current = setTimeout(() => {
 				content.value = tooltipContent
 				clickPosition.value = { x: event.clientX, y: event.clientY }

--- a/app/ts/components/subcomponents/NetworkErrors.tsx
+++ b/app/ts/components/subcomponents/NetworkErrors.tsx
@@ -26,6 +26,10 @@ export function NetworkErrors({ rpcConnectionStatus } : NetworkErrorParams) {
 		return <ErrorComponent warning = { true } text = { <>Unable to connect to { status.rpcNetwork.name }. Retrying now.</> }/>
 	}
 
+	if (warningState.kind === 'slowRequest') {
+		return <ErrorComponent warning = { true } text = { <>The connected RPC ({ status.rpcNetwork.name }) is taking longer than expected to answer { warningState.slowRequest.method }. It has been waiting for <SomeTimeAgo priorTimestamp = { warningState.slowRequest.startedAt }/>.</> }/>
+	}
+
 	const latestBlock = status.latestBlock
 	if (latestBlock === undefined || latestBlock === null) return <></>
 	if (showCountdown && warningState.nextRetryAt !== undefined) {

--- a/app/ts/components/subcomponents/NetworkErrors.tsx
+++ b/app/ts/components/subcomponents/NetworkErrors.tsx
@@ -1,0 +1,39 @@
+import type { Signal } from '@preact/signals'
+import type { RpcConnectionStatus } from '../../types/user-interface-types.js'
+import { getRpcWarningState, shouldShowRpcWarningCountdown } from '../../utils/rpcConnectionUi.js'
+import { humanReadableDate } from '../ui-utils.js'
+import { ErrorComponent } from './Error.js'
+import { SomeTimeAgo } from './SomeTimeAgo.js'
+
+type NetworkErrorParams = {
+	rpcConnectionStatus: Signal<RpcConnectionStatus>
+}
+
+export function NetworkErrors({ rpcConnectionStatus } : NetworkErrorParams) {
+	const status = rpcConnectionStatus.value
+	if (status === undefined) return <></>
+	const warningState = getRpcWarningState(status)
+	if (warningState.kind === 'none') return <></>
+	const showCountdown = shouldShowRpcWarningCountdown(warningState)
+
+	if (warningState.kind === 'disconnected') {
+		if (warningState.retryState === 'paused') {
+			return <ErrorComponent warning = { true } text = { <>Unable to connect to { status.rpcNetwork.name }. Retrying resumes when the extension becomes active.</> }/>
+		}
+		if (showCountdown && warningState.nextRetryAt !== undefined) {
+			return <ErrorComponent warning = { true } text = { <>Unable to connect to { status.rpcNetwork.name }. Retrying in <SomeTimeAgo priorTimestamp = { warningState.nextRetryAt } countBackwards = { true }/>.</> }/>
+		}
+		return <ErrorComponent warning = { true } text = { <>Unable to connect to { status.rpcNetwork.name }. Retrying now.</> }/>
+	}
+
+	const latestBlock = status.latestBlock
+	if (latestBlock === undefined || latestBlock === null) return <></>
+	if (showCountdown && warningState.nextRetryAt !== undefined) {
+		return <ErrorComponent warning = { true } text = {
+			<>The connected RPC ({ status.rpcNetwork.name }) seems to be stuck at block { latestBlock.number } (occurred on: { humanReadableDate(latestBlock.timestamp) }). Retrying in <SomeTimeAgo priorTimestamp = { warningState.nextRetryAt } countBackwards = { true }/>.</>
+		}/>
+	}
+	return <ErrorComponent warning = { true } text = {
+		<>The connected RPC ({ status.rpcNetwork.name }) seems to be stuck at block { latestBlock.number } (occurred on: { humanReadableDate(latestBlock.timestamp) }). Retrying now.</>
+	}/>
+}

--- a/app/ts/components/subcomponents/address.tsx
+++ b/app/ts/components/subcomponents/address.tsx
@@ -141,19 +141,23 @@ export function SmallAddress({ addressBookEntry, renameAddressCallBack, style }:
 	return <InlineCard label = { currentAddressBookEntry.name } copyValue = { addressString } icon = { generateIcon } onEditClicked = { () => renameAddressCallBack(currentAddressBookEntry) } style = { style } />
 }
 
-export function WebsiteOriginText({ website }: { website: SignalOrValue<Website | undefined> }) {
+export function WebsiteOriginText({ website, class: cssClass, style }: {
+	website: SignalOrValue<Website | undefined>
+	class?: string
+	style?: JSX.CSSProperties | string
+}) {
 	const currentWebsite = resolveSignal(website)
 	if (currentWebsite === undefined) return <></>
 	const icon = sanitizeStoredWebsiteIcon(currentWebsite.icon)
 	const { websiteOrigin, title } = currentWebsite
-	return <div class = 'card-header-icon unsetcursor' style = 'width: 100%; padding: 0'>
-		<span style = 'width: 24px; height: 24px; min-width: 24px'>
+	return <div class = { `website-origin-text${ cssClass === undefined ? '' : ` ${ cssClass }` }` } style = { style }>
+		<span class = 'website-origin-text-icon'>
 			{ icon === undefined ? <></> : <img src = { icon } width = '24' height = '24' style = 'width: 24px; height: 24px;' /> }
 		</span>
 
-		<div class = 'media-content' style = 'overflow-y: hidden; overflow-x: clip; display: block; padding-left: 10px;'>
-			<p class = 'title is-5 is-spaced address-text' style = 'overflow: hidden;'>{ websiteOrigin }</p>
-			<p class = 'subtitle is-7' style = 'text-overflow: ellipsis; white-space: nowrap; overflow: hidden;'> { title } </p>
+		<div class = 'media-content website-origin-text-body'>
+			<p class = 'title is-5 is-spaced address-text website-origin-text-origin'>{ websiteOrigin }</p>
+			<p class = 'subtitle is-7 website-origin-text-title'> { title } </p>
 		</div>
 	</div>
 }

--- a/app/ts/components/subcomponents/icons.tsx
+++ b/app/ts/components/subcomponents/icons.tsx
@@ -66,3 +66,9 @@ export const ExportIcon = () =>
 		<path d = 'M4 20h16v-4h2v5a1 1 0 0 1-1 1H3a1 1 0 0 1-1-1v-5h2z' fill = 'currentColor' />
 		<path fill-rule = 'evenodd' clip-rule = 'evenodd' d = 'M12 3l-5 5h3v6h4V8h3z' fill = 'currentColor' />
 	</svg>
+
+export const OpenInNewIcon = () =>
+	<svg width = '1em' height = '1em' viewBox = '0 0 24 24' fill = 'none' xmlns = 'http://www.w3.org/2000/svg'>
+		<path fill-rule = 'evenodd' clip-rule = 'evenodd' d = 'M14 3a1 1 0 0 1 1-1h6a1 1 0 0 1 1 1v6h-2V5.414l-8.293 8.293-1.414-1.414L18.586 4H14z' fill = 'currentColor' />
+		<path fill-rule = 'evenodd' clip-rule = 'evenodd' d = 'M5 7a1 1 0 0 0-1 1v11a1 1 0 0 0 1 1h11a1 1 0 0 0 1-1v-5h2v6a2 2 0 0 1-2 2H4a2 2 0 0 1-2-2V7a2 2 0 0 1 2-2h6v2z' fill = 'currentColor' />
+	</svg>

--- a/app/ts/simulationStack.ts
+++ b/app/ts/simulationStack.ts
@@ -1,0 +1,13 @@
+import * as preact from 'preact'
+import { SimulationStackPage } from './components/pages/SimulationStackPage.js'
+import { ErrorBoundary } from './components/subcomponents/Error.js'
+import Hint from './components/subcomponents/Hint.js'
+
+function rerender() {
+	const root = document.getElementById('simulation-stack-root')
+	if (root === null) throw new Error('Missing simulation stack root element')
+	root.textContent = ''
+	preact.render(preact.createElement(ErrorBoundary, {}, preact.createElement(Hint, { children: preact.createElement(SimulationStackPage, {}) })), root)
+}
+
+rerender()

--- a/app/ts/types/interceptor-messages.ts
+++ b/app/ts/types/interceptor-messages.ts
@@ -314,6 +314,12 @@ export const RemoveTransaction = funtypes.ReadonlyObject({
 	data: TransactionOrMessageIdentifier
 }).asReadonly()
 
+export type OpenSimulationStack = funtypes.Static<typeof OpenSimulationStack>
+export const OpenSimulationStack = funtypes.Union(
+	funtypes.ReadonlyObject({ method: funtypes.Literal('popup_openSimulationStack'), data: TransactionOrMessageIdentifier }),
+	funtypes.ReadonlyObject({ method: funtypes.Literal('popup_openSimulationStack') }),
+)
+
 type ResetSimulation = funtypes.Static<typeof ResetSimulation>
 const ResetSimulation = funtypes.ReadonlyObject({
 	method: funtypes.Literal('popup_resetSimulation')
@@ -989,6 +995,7 @@ const PopupMessageRuntype = funtypes.Union(
 	DisableInterceptor,
 	SetEnsNameForHash,
 	funtypes.ReadonlyObject({ method: funtypes.Literal('popup_openWebsiteAccess') }),
+	OpenSimulationStack,
 	RetrieveWebsiteAccess,
 	BlockOrAllowExternalRequests,
 	AllowOrPreventAddressAccessForWebsite,

--- a/app/ts/types/interceptor-reply-messages.ts
+++ b/app/ts/types/interceptor-reply-messages.ts
@@ -138,6 +138,14 @@ const RequestIsMainWindowOpen = funtypes.ReadonlyObject({
 	})
 }).asReadonly()
 
+type RequestIsSimulationVisualizerOpen = funtypes.Static<typeof RequestIsSimulationVisualizerOpen>
+const RequestIsSimulationVisualizerOpen = funtypes.ReadonlyObject({
+	method: funtypes.Literal('popup_isSimulationVisualizerOpen'),
+	data: funtypes.ReadonlyObject({
+		isOpen: funtypes.Boolean,
+	})
+}).asReadonly()
+
 type ConfirmTransactionBootstrapReply = funtypes.Static<typeof ConfirmTransactionBootstrapReply>
 const ConfirmTransactionBootstrapReply = funtypes.ReadonlyObject({
 	pendingTransactionAndSignableMessages: funtypes.ReadonlyArray(PopupPendingTransactionOrSignableMessage),
@@ -167,6 +175,7 @@ type PopupRequestsRepliesMap = {
 	popup_requestAbiAndNameFromBlockExplorer: typeof RequestAbiAndNameFromBlockExplorerReply
 	popup_requestIdentifyAddress: typeof RequestIdentifyAddressReply
 	popup_isMainPopupWindowOpen: typeof RequestIsMainWindowOpen
+	popup_isSimulationVisualizerOpen: typeof RequestIsSimulationVisualizerOpen
 	popup_readyAndListening: typeof PopupReadyAndListeningReply
 }
 
@@ -182,6 +191,7 @@ export const PopupRequestsReplies: PopupRequestsRepliesMap = {
 	popup_requestAbiAndNameFromBlockExplorer: RequestAbiAndNameFromBlockExplorerReply,
 	popup_requestIdentifyAddress: RequestIdentifyAddressReply,
 	popup_isMainPopupWindowOpen: RequestIsMainWindowOpen,
+	popup_isSimulationVisualizerOpen: RequestIsSimulationVisualizerOpen,
 	popup_readyAndListening: PopupReadyAndListeningReply,
 }
 
@@ -207,6 +217,7 @@ export const PopupMessageReplyRequests = funtypes.Union(
 	funtypes.ReadonlyObject({ method: funtypes.Literal('popup_requestCompleteVisualizedSimulation') }),
 	funtypes.ReadonlyObject({ method: funtypes.Literal('popup_requestSimulationMetadata') }),
 	funtypes.ReadonlyObject({ method: funtypes.Literal('popup_isMainPopupWindowOpen') }),
+	funtypes.ReadonlyObject({ method: funtypes.Literal('popup_isSimulationVisualizerOpen') }),
 	funtypes.ReadonlyObject({
 		method: funtypes.Literal('popup_readyAndListening'),
 		data: funtypes.ReadonlyObject({
@@ -235,6 +246,7 @@ export type PopupReplyOption =
 	| RequestAbiAndNameFromBlockExplorerReply
 	| RequestIdentifyAddressReply
 	| RequestIsMainWindowOpen
+	| RequestIsSimulationVisualizerOpen
 	| PopupReadyAndListeningReply
 	| undefined
 
@@ -250,6 +262,7 @@ export const PopupReplyOption: funtypes.Codec<PopupReplyOption> = funtypes.Union
 	RequestAbiAndNameFromBlockExplorerReply,
 	RequestIdentifyAddressReply,
 	RequestIsMainWindowOpen,
+	RequestIsSimulationVisualizerOpen,
 	PopupReadyAndListeningReply,
 	funtypes.Undefined,
 )

--- a/app/ts/types/user-interface-types.ts
+++ b/app/ts/types/user-interface-types.ts
@@ -54,7 +54,7 @@ export type HomeParams = {
 	interceptorDisabled: Signal<boolean>
 	preSimulationBlockTimeManipulation: Signal<BlockTimeManipulation | undefined>
 	fixedAddressRichList: Signal<readonly EnrichedRichListElement[]>
-	openImportSimulation: () => void
+	numberOfAddressesMadeRich: Signal<number>
 }
 
 export type ChangeActiveAddressParam = {
@@ -97,7 +97,8 @@ export type SimulationStateParam = {
 	rpcConnectionStatus: Signal<RpcConnectionStatus>
 	simulationUpdatingState: Signal<SimulationUpdatingState | undefined>
 	simulationResultState: Signal<SimulationResultState | undefined>
-	openImportSimulation: () => void
+	openSimulationStack: (target?: TransactionOrMessageIdentifier) => void
+	numberOfAddressesMadeRich: Signal<number>
 }
 
 export type LogAnalysisParams = {

--- a/app/ts/utils/simulationStackTargets.ts
+++ b/app/ts/utils/simulationStackTargets.ts
@@ -1,0 +1,28 @@
+import type { TransactionOrMessageIdentifier } from '../types/interceptor-messages.js'
+
+const SIMULATION_STACK_TARGET_HASH_KEY = 'simulation-stack-target'
+const SIMULATION_STACK_TARGET_FOCUS_KEY = 'focus'
+
+const bigintToQuantityString = (value: bigint) => `0x${ value.toString(16) }`
+
+export function getSimulationStackElementId(identifier: TransactionOrMessageIdentifier) {
+	switch(identifier.type) {
+		case 'Transaction': return `simulation-stack-transaction-${ bigintToQuantityString(identifier.transactionIdentifier) }`
+		case 'Message': return `simulation-stack-message-${ bigintToQuantityString(identifier.messageIdentifier) }`
+	}
+}
+
+export function getSimulationStackTargetHash(identifier: TransactionOrMessageIdentifier, focusToken = Date.now().toString(36)) {
+	const hashParameters = new URLSearchParams()
+	hashParameters.set(SIMULATION_STACK_TARGET_HASH_KEY, getSimulationStackElementId(identifier))
+	hashParameters.set(SIMULATION_STACK_TARGET_FOCUS_KEY, focusToken)
+	return `#${ hashParameters.toString() }`
+}
+
+export function getSimulationStackTargetElementIdFromHash(hash: string) {
+	const hashParameters = new URLSearchParams(hash.startsWith('#') ? hash.slice(1) : hash)
+	const targetElementId = hashParameters.get(SIMULATION_STACK_TARGET_HASH_KEY)
+	if (targetElementId === null) return undefined
+	if (!/^simulation-stack-(transaction|message)-0x[a-f0-9]+$/.test(targetElementId)) return undefined
+	return targetElementId
+}

--- a/app/ts/utils/storageUtils.ts
+++ b/app/ts/utils/storageUtils.ts
@@ -13,16 +13,23 @@ import { UnexpectedErrorOccured } from '../types/interceptor-reply-messages.js'
 import { InterceptorErrorDiagnostic } from '../types/errorDiagnostics.js'
 
 type IdsOfOpenedTabs = funtypes.Static<typeof IdsOfOpenedTabs>
-const IdsOfOpenedTabs = funtypes.ReadonlyObject({
-	addressBook: funtypes.Union(funtypes.Undefined, funtypes.Number),
-	settingsView: funtypes.Union(funtypes.Undefined, funtypes.Number),
-	websiteAccess: funtypes.Union(funtypes.Undefined, funtypes.Number),
-})
+const IdsOfOpenedTabs = funtypes.Intersect(
+	funtypes.ReadonlyObject({
+		addressBook: funtypes.Union(funtypes.Undefined, funtypes.Number),
+		settingsView: funtypes.Union(funtypes.Undefined, funtypes.Number),
+		websiteAccess: funtypes.Union(funtypes.Undefined, funtypes.Number),
+	}),
+	funtypes.ReadonlyPartial({
+		simulationStack: funtypes.Union(funtypes.Undefined, funtypes.Number),
+	}),
+)
 
 export type PartialIdsOfOpenedTabs = funtypes.Static<typeof PartialIdsOfOpenedTabs>
 export const PartialIdsOfOpenedTabs = funtypes.ReadonlyPartial({
 	addressBook: funtypes.Union(funtypes.Undefined, funtypes.Number),
 	settingsView: funtypes.Union(funtypes.Undefined, funtypes.Number),
+	websiteAccess: funtypes.Union(funtypes.Undefined, funtypes.Number),
+	simulationStack: funtypes.Union(funtypes.Undefined, funtypes.Number),
 })
 
 export type OldActiveAddressEntry = funtypes.Static<typeof OldActiveAddressEntry>

--- a/build/bundler.mts
+++ b/build/bundler.mts
@@ -376,6 +376,7 @@ const runtimeEntrypointPaths = [
 	path.join(appDirectory, 'js', 'interceptorAccess.js'),
 	path.join(appDirectory, 'js', 'popup.js'),
 	path.join(appDirectory, 'js', 'settingsView.js'),
+	path.join(appDirectory, 'js', 'simulationStack.js'),
 	path.join(appDirectory, 'js', 'websiteAccess.js'),
 	path.join(appDirectory, 'inpage', 'js', 'document_start.js'),
 	path.join(appDirectory, 'inpage', 'js', 'inpage.js'),

--- a/test/tests/domMock.test.ts
+++ b/test/tests/domMock.test.ts
@@ -1,0 +1,41 @@
+import * as assert from 'assert'
+import { test } from 'bun:test'
+import { installDomMock } from './domMock.js'
+
+test('installDomMock restore keeps newer interleaved mock globals active', () => {
+	const first = installDomMock()
+	const firstSetInterval = globalThis.setInterval
+	const firstClearInterval = globalThis.clearInterval
+	const firstRequestAnimationFrame = globalThis.requestAnimationFrame
+	const firstCancelAnimationFrame = globalThis.cancelAnimationFrame
+
+	const second = installDomMock()
+	const secondSetInterval = globalThis.setInterval
+	const secondClearInterval = globalThis.clearInterval
+	const secondRequestAnimationFrame = globalThis.requestAnimationFrame
+	const secondCancelAnimationFrame = globalThis.cancelAnimationFrame
+
+	first.restore()
+
+	assert.equal(globalThis.document, second.document)
+	assert.equal(globalThis.window?.document, second.document)
+	assert.equal(globalThis.setInterval, secondSetInterval)
+	assert.equal(globalThis.clearInterval, secondClearInterval)
+	assert.equal(globalThis.requestAnimationFrame, secondRequestAnimationFrame)
+	assert.equal(globalThis.cancelAnimationFrame, secondCancelAnimationFrame)
+
+	second.restore()
+
+	assert.notEqual(globalThis.document, first.document)
+	assert.notEqual(globalThis.document, second.document)
+	assert.notEqual(globalThis.window?.document, first.document)
+	assert.notEqual(globalThis.window?.document, second.document)
+	assert.notEqual(globalThis.setInterval, firstSetInterval)
+	assert.notEqual(globalThis.setInterval, secondSetInterval)
+	assert.notEqual(globalThis.clearInterval, firstClearInterval)
+	assert.notEqual(globalThis.clearInterval, secondClearInterval)
+	assert.notEqual(globalThis.requestAnimationFrame, firstRequestAnimationFrame)
+	assert.notEqual(globalThis.requestAnimationFrame, secondRequestAnimationFrame)
+	assert.notEqual(globalThis.cancelAnimationFrame, firstCancelAnimationFrame)
+	assert.notEqual(globalThis.cancelAnimationFrame, secondCancelAnimationFrame)
+})

--- a/test/tests/domMock.ts
+++ b/test/tests/domMock.ts
@@ -168,34 +168,95 @@ class TestDocument {
 	}
 }
 
+type TestWindow = {
+	document: TestDocument
+	addEventListener(): undefined
+	removeEventListener(): undefined
+}
+
+type DomMockState = {
+	restored: boolean
+	previousDocument: unknown
+	previousWindow: unknown
+	previousSetInterval: unknown
+	previousClearInterval: unknown
+	previousRequestAnimationFrame: unknown
+	previousCancelAnimationFrame: unknown
+}
+
+const fallbackDocument = new TestDocument()
+const fallbackWindow: TestWindow = {
+	document: fallbackDocument,
+	addEventListener() { return undefined },
+	removeEventListener() { return undefined },
+}
+const domMockOwners = new Map<unknown, DomMockState>()
+
+function resolveRestorablePreviousValue(previousValue: unknown, fallbackValue: unknown, getPreviousValue: (state: DomMockState) => unknown): unknown {
+	const owner = domMockOwners.get(previousValue)
+	if (owner?.restored === true) return resolveRestorablePreviousValue(getPreviousValue(owner), fallbackValue, getPreviousValue)
+	return previousValue ?? fallbackValue
+}
+
+function defineGlobalValue(name: string, value: unknown) {
+	Object.defineProperty(globalThis, name, { value, configurable: true, writable: true })
+}
+
+function restoreOwnedGlobal(name: string, isOwnedByThisMock: boolean, previousValue: unknown, fallbackValue: unknown, getPreviousValue: (state: DomMockState) => unknown) {
+	if (!isOwnedByThisMock) return
+	defineGlobalValue(name, resolveRestorablePreviousValue(previousValue, fallbackValue, getPreviousValue))
+}
+
 export function installDomMock() {
 	const document = new TestDocument()
+	const window: TestWindow = {
+		document,
+		addEventListener() { return undefined },
+		removeEventListener() { return undefined },
+	}
+	const setIntervalMock: typeof globalThis.setInterval = () => 1
+	const clearIntervalMock: typeof globalThis.clearInterval = () => undefined
+	const requestAnimationFrameMock: typeof globalThis.requestAnimationFrame = (callback) => {
+		callback(0)
+		return 1
+	}
+	const cancelAnimationFrameMock: typeof globalThis.cancelAnimationFrame = () => undefined
 	const previousDocument = globalThis.document
 	const previousWindow = globalThis.window
 	const previousSetInterval = globalThis.setInterval
 	const previousClearInterval = globalThis.clearInterval
 	const previousRequestAnimationFrame = globalThis.requestAnimationFrame
 	const previousCancelAnimationFrame = globalThis.cancelAnimationFrame
+	const state: DomMockState = {
+		restored: false,
+		previousDocument,
+		previousWindow,
+		previousSetInterval,
+		previousClearInterval,
+		previousRequestAnimationFrame,
+		previousCancelAnimationFrame,
+	}
+	for (const ownedValue of [document, window, setIntervalMock, clearIntervalMock, requestAnimationFrameMock, cancelAnimationFrameMock]) domMockOwners.set(ownedValue, state)
 
-	Object.defineProperty(globalThis, 'document', { value: document, configurable: true, writable: true })
-	Object.defineProperty(globalThis, 'window', { value: { document }, configurable: true, writable: true })
-	Object.defineProperty(globalThis, 'setInterval', { value: () => 1, configurable: true, writable: true })
-	globalThis.clearInterval = () => undefined
-	globalThis.requestAnimationFrame = ((callback: FrameRequestCallback) => {
-		callback(0)
-		return 1
-	})
-	globalThis.cancelAnimationFrame = () => undefined
+	defineGlobalValue('document', document)
+	defineGlobalValue('window', window)
+	defineGlobalValue('setInterval', setIntervalMock)
+	defineGlobalValue('clearInterval', clearIntervalMock)
+	defineGlobalValue('requestAnimationFrame', requestAnimationFrameMock)
+	defineGlobalValue('cancelAnimationFrame', cancelAnimationFrameMock)
 
 	return {
 		document,
 		restore() {
-			globalThis.document = previousDocument
-			globalThis.window = previousWindow
-			globalThis.setInterval = previousSetInterval
-			globalThis.clearInterval = previousClearInterval
-			globalThis.requestAnimationFrame = previousRequestAnimationFrame
-			globalThis.cancelAnimationFrame = previousCancelAnimationFrame
+			// Bun runs test files concurrently. Do not remove another test's active DOM
+			// or leave Preact cleanup with an undefined global document.
+			state.restored = true
+			restoreOwnedGlobal('document', globalThis.document === document, previousDocument, fallbackDocument, (owner) => owner.previousDocument)
+			restoreOwnedGlobal('window', globalThis.window === window || globalThis.window?.document === document, previousWindow, fallbackWindow, (owner) => owner.previousWindow)
+			restoreOwnedGlobal('setInterval', globalThis.setInterval === setIntervalMock, previousSetInterval, undefined, (owner) => owner.previousSetInterval)
+			restoreOwnedGlobal('clearInterval', globalThis.clearInterval === clearIntervalMock, previousClearInterval, undefined, (owner) => owner.previousClearInterval)
+			restoreOwnedGlobal('requestAnimationFrame', globalThis.requestAnimationFrame === requestAnimationFrameMock, previousRequestAnimationFrame, undefined, (owner) => owner.previousRequestAnimationFrame)
+			restoreOwnedGlobal('cancelAnimationFrame', globalThis.cancelAnimationFrame === cancelAnimationFrameMock, previousCancelAnimationFrame, undefined, (owner) => owner.previousCancelAnimationFrame)
 		},
 	}
 }

--- a/test/tests/homeClearEmptyState.test.ts
+++ b/test/tests/homeClearEmptyState.test.ts
@@ -6,12 +6,13 @@ import { act } from 'preact/test-utils'
 import { Home } from '../../app/ts/components/pages/Home.js'
 import { installDomMock } from './domMock.js'
 import { ICON_SIMULATING } from '../../app/ts/utils/constants.js'
+import { mockSignTransaction } from '../../app/ts/simulation/services/SimulationModeEthereumClientService.js'
 import type { EnrichedRichListElement } from '../../app/ts/types/interceptor-reply-messages.js'
 import type { ContactEntry } from '../../app/ts/types/addressBookTypes.js'
 import type { RpcEntry } from '../../app/ts/types/rpc.js'
-import type { RpcConnectionStatus, TabState } from '../../app/ts/types/user-interface-types.js'
+import type { HomeParams, RpcConnectionStatus, TabState } from '../../app/ts/types/user-interface-types.js'
 import { toResolvedSimulationResults } from '../../app/ts/types/visualizer-types.js'
-import type { BlockTimeManipulation, ResolvedSimulationResults, SimulationAndVisualisationResults, SimulatedAndVisualizedTransaction } from '../../app/ts/types/visualizer-types.js'
+import type { BlockTimeManipulation, PreSimulationTransaction, ResolvedSimulationResults, SignedMessageTransaction, SimulationAndVisualisationResults, SimulatedAndVisualizedTransaction } from '../../app/ts/types/visualizer-types.js'
 
 const ACTIVE_ADDRESS = 0x1000000000000000000000000000000000000001n
 const RECIPIENT_ADDRESS = 0x2000000000000000000000000000000000000002n
@@ -43,6 +44,35 @@ const rpcNetwork: RpcEntry = {
 }
 
 const ZERO_BLOCK_TIME_MANIPULATION: BlockTimeManipulation = { type: 'AddToTimestamp', deltaToAdd: 0n, deltaUnit: 'Seconds' }
+
+const makePreSimulationTransaction = (): PreSimulationTransaction => ({
+	signedTransaction: mockSignTransaction({
+		type: '1559',
+		from: ACTIVE_ADDRESS,
+		to: RECIPIENT_ADDRESS,
+		value: 0n,
+		input: new Uint8Array(),
+		nonce: 0n,
+		gas: 21_000n,
+		chainId: 1n,
+		maxFeePerGas: 1n,
+		maxPriorityFeePerGas: 1n,
+	}),
+	website: { websiteOrigin: 'https://example.com', icon: undefined, title: 'Example' },
+	created: new Date('2024-01-01T00:00:00.000Z'),
+	originalRequestParameters: { method: 'eth_sendTransaction', params: [{ from: ACTIVE_ADDRESS, to: RECIPIENT_ADDRESS, value: 0n, input: new Uint8Array() }] },
+	transactionIdentifier: 1n,
+})
+
+const makeSignedMessageTransaction = (): SignedMessageTransaction => ({
+	website: { websiteOrigin: 'https://example.com', icon: undefined, title: 'Example' },
+	created: new Date('2024-01-01T00:00:00.000Z'),
+	fakeSignedFor: ACTIVE_ADDRESS,
+	originalRequestParameters: { method: 'personal_sign', params: ['0x68656c6c6f', ACTIVE_ADDRESS] },
+	request: { method: 'personal_sign', params: ['0x68656c6c6f', ACTIVE_ADDRESS] },
+	simulationMode: true,
+	messageIdentifier: 77n,
+})
 
 const makeSimulatedTransaction = (): SimulatedAndVisualizedTransaction => ({
 	website: { websiteOrigin: 'https://example.com', icon: undefined, title: 'Example' },
@@ -78,6 +108,13 @@ const createSimulationResults = (): SimulationAndVisualisationResults => ({
 	blockNumber: 100n,
 	blockTimestamp: new Date('2024-01-01T00:00:00.000Z'),
 	simulationConductedTimestamp: new Date('2024-01-01T00:00:05.000Z'),
+	simulationStateInput: [{
+		stateOverrides: {},
+		transactions: [makePreSimulationTransaction()],
+		signedMessages: [],
+		blockTimeManipulation: ZERO_BLOCK_TIME_MANIPULATION,
+		simulateWithZeroBaseFee: false,
+	}],
 	addressBookEntries: [activeAddressEntry, recipientEntry],
 	visualizedSimulationState: {
 		success: true,
@@ -94,6 +131,15 @@ const createSimulationResults = (): SimulationAndVisualisationResults => ({
 
 const createEmptySimulationResults = (): SimulationAndVisualisationResults => ({
 	...createSimulationResults(),
+	simulationStateInput: [],
+	visualizedSimulationState: {
+		success: true,
+		visualizedBlocks: [],
+	},
+})
+
+const createPendingSimulationResults = (): SimulationAndVisualisationResults => ({
+	...createSimulationResults(),
 	visualizedSimulationState: {
 		success: true,
 		visualizedBlocks: [{
@@ -104,37 +150,175 @@ const createEmptySimulationResults = (): SimulationAndVisualisationResults => ({
 	},
 })
 
+const createPendingSignedMessageSimulationResults = (): SimulationAndVisualisationResults => ({
+	...createSimulationResults(),
+	simulationStateInput: [{
+		stateOverrides: {},
+		transactions: [],
+		signedMessages: [makeSignedMessageTransaction()],
+		blockTimeManipulation: ZERO_BLOCK_TIME_MANIPULATION,
+		simulateWithZeroBaseFee: false,
+	}],
+	visualizedSimulationState: {
+		success: true,
+		visualizedBlocks: [{
+			simulatedAndVisualizedTransactions: [],
+			visualizedPersonalSignRequests: [],
+			blockTimeManipulation: ZERO_BLOCK_TIME_MANIPULATION,
+		}],
+	},
+})
+
+function createHomeParams(overrides: Partial<HomeParams> = {}): HomeParams {
+	return {
+		changeActiveAddress: () => undefined,
+		makeCurrentAddressRich: new Signal(false),
+		activeAddresses: new Signal([activeAddressEntry]),
+		tabState: new Signal<TabState | undefined>(undefined),
+		activeSimulationAddress: new Signal<bigint | undefined>(ACTIVE_ADDRESS),
+		activeSigningAddress: new Signal<bigint | undefined>(undefined),
+		useSignersAddressAsActiveAddress: new Signal(false),
+		simVisResults: new Signal<ResolvedSimulationResults>(toResolvedSimulationResults(createSimulationResults())),
+		rpcNetwork: new Signal(rpcNetwork),
+		setActiveRpcAndInformAboutIt: () => undefined,
+		simulationMode: new Signal(true),
+		tabIconDetails: new Signal({ icon: ICON_SIMULATING, iconReason: 'Simulating transactions.' }),
+		currentBlockNumber: new Signal<bigint | undefined>(101n),
+		renameAddressCallBack: () => undefined,
+		editEnsNamedHashCallBack: () => undefined,
+		rpcConnectionStatus: new Signal<RpcConnectionStatus>(undefined),
+		rpcEntries: new Signal([rpcNetwork]),
+		simulationUpdatingState: new Signal<'done' | 'updating' | 'failed' | undefined>('done'),
+		simulationResultState: new Signal<'done' | 'invalid' | 'corrupted' | undefined>('done'),
+		interceptorDisabled: new Signal(false),
+		preSimulationBlockTimeManipulation: new Signal<BlockTimeManipulation | undefined>(undefined),
+		fixedAddressRichList: new Signal<readonly EnrichedRichListElement[]>([]),
+		numberOfAddressesMadeRich: new Signal(0),
+		...overrides,
+	}
+}
+
+type TestDomNode = {
+	readonly tagName?: string
+	readonly parentNode?: TestDomNode | null
+	readonly childNodes?: readonly TestDomNode[]
+	readonly textContent?: string | null
+	readonly l?: Record<string, (event: unknown) => unknown>
+	readonly getAttribute?: (name: string) => string | null
+}
+
+function collectElements(node: TestDomNode | null | undefined, tagName: string, results: TestDomNode[] = []) {
+	if (node?.tagName === tagName.toUpperCase()) results.push(node)
+	for (const child of node?.childNodes ?? []) collectElements(child, tagName, results)
+	return results
+}
+
+async function clickElement(element: { l?: Record<string, (event: unknown) => unknown> }) {
+	const clickHandler = element.l === undefined ? undefined : Object.entries(element.l).find(([key]) => key.startsWith('Click'))?.[1]
+	if (clickHandler === undefined) throw new Error('Expected click handler')
+	await clickHandler({ currentTarget: element, stopPropagation() { return undefined } })
+}
+
+async function keyDownElement(element: { l?: Record<string, (event: unknown) => unknown> }, event: unknown) {
+	const keyDownHandler = element.l === undefined ? undefined : Object.entries(element.l).find(([key]) => key.startsWith('KeyDown'))?.[1]
+	if (keyDownHandler === undefined) throw new Error('Expected keydown handler')
+	await keyDownHandler(event)
+}
+
+function getButtonByText(root: TestDomNode, text: string) {
+	const button = collectElements(root, 'button').find((button) => button.textContent?.replace(/\s+/g, ' ').trim() === text)
+	if (button === undefined) throw new Error(`Expected button with text "${ text }"`)
+	return button
+}
+
+function getButtonByAriaLabel(root: TestDomNode, ariaLabel: string) {
+	const button = collectElements(root, 'button').find((button) => button.getAttribute?.('aria-label') === ariaLabel)
+	if (button === undefined) throw new Error(`Expected button with aria-label "${ ariaLabel }"`)
+	return button
+}
+
+function getHeaderContainingText(root: TestDomNode, text: string) {
+	const header = collectElements(root, 'header').find((header) => header.textContent?.includes(text))
+	if (header === undefined) throw new Error(`Expected header containing text "${ text }"`)
+	return header
+}
+
+function getAncestor(node: TestDomNode, tagName: string) {
+	let currentNode = node.parentNode
+	while (currentNode !== undefined && currentNode !== null) {
+		if (currentNode.tagName === tagName.toUpperCase()) return currentNode
+		currentNode = currentNode.parentNode
+	}
+	throw new Error(`Expected ancestor ${ tagName }`)
+}
+
+function getButtonInTimePicker(root: TestDomNode, timePickerLabel: string, buttonText: string) {
+	const timePickerLabelElement = collectElements(root, 'p').find((element) => element.textContent?.replace(/\s+/g, ' ').trim() === timePickerLabel)
+	if (timePickerLabelElement?.parentNode === undefined || timePickerLabelElement.parentNode === null) throw new Error(`Expected time picker label "${ timePickerLabel }"`)
+	return getButtonByText(timePickerLabelElement.parentNode, buttonText)
+}
+
+function installBrowserMock() {
+	const previousBrowser = globalThis.browser
+	const sentMessages: unknown[] = []
+	Object.defineProperty(globalThis, 'browser', {
+		configurable: true,
+		writable: true,
+		value: {
+			runtime: {
+				lastError: null,
+				async sendMessage(message: unknown) {
+					sentMessages.push(message)
+					return undefined
+				},
+			},
+		},
+	})
+	return {
+		sentMessages,
+		restore() {
+			globalThis.browser = previousBrowser
+		},
+	}
+}
+
+function installCloseMock() {
+	const previousClose = globalThis.close
+	let closeCount = 0
+	Object.defineProperty(globalThis, 'close', {
+		configurable: true,
+		writable: true,
+		value: () => {
+			closeCount += 1
+		},
+	})
+	return {
+		get closeCount() {
+			return closeCount
+		},
+		restore() {
+			globalThis.close = previousClose
+		},
+	}
+}
+
+function hasMethod(message: unknown, method: string) {
+	return typeof message === 'object' && message !== null && 'method' in message && message.method === method
+}
+
+function getMessageWithMethod(messages: readonly unknown[], method: string) {
+	const message = messages.find((message) => hasMethod(message, method))
+	if (message === undefined) throw new Error(`Expected message with method "${ method }"`)
+	return message
+}
+
 describe('Home popup clear empty state', () => {
 	test('rerenders to the empty-state dino when simulation results are cleared', async () => {
 		const dom = installDomMock()
 		const simVisResults = new Signal<ResolvedSimulationResults>(toResolvedSimulationResults(createSimulationResults()))
 		try {
 			await act(() => {
-				render(h(Home, {
-					changeActiveAddress: () => undefined,
-					makeCurrentAddressRich: new Signal(false),
-					activeAddresses: new Signal([activeAddressEntry]),
-					tabState: new Signal<TabState | undefined>(undefined),
-					activeSimulationAddress: new Signal<bigint | undefined>(ACTIVE_ADDRESS),
-					activeSigningAddress: new Signal<bigint | undefined>(undefined),
-					useSignersAddressAsActiveAddress: new Signal(false),
-					simVisResults,
-					rpcNetwork: new Signal(rpcNetwork),
-					setActiveRpcAndInformAboutIt: () => undefined,
-					simulationMode: new Signal(true),
-					tabIconDetails: new Signal({ icon: ICON_SIMULATING, iconReason: 'Simulating transactions.' }),
-					currentBlockNumber: new Signal<bigint | undefined>(101n),
-					renameAddressCallBack: () => undefined,
-					editEnsNamedHashCallBack: () => undefined,
-					rpcConnectionStatus: new Signal<RpcConnectionStatus>(undefined),
-					rpcEntries: new Signal([rpcNetwork]),
-					simulationUpdatingState: new Signal<'done' | 'updating' | 'failed' | undefined>('done'),
-					simulationResultState: new Signal<'done' | 'invalid' | 'corrupted' | undefined>('done'),
-					interceptorDisabled: new Signal(false),
-					preSimulationBlockTimeManipulation: new Signal<BlockTimeManipulation | undefined>(undefined),
-					fixedAddressRichList: new Signal<readonly EnrichedRichListElement[]>([]),
-					openImportSimulation: () => undefined,
-				}), dom.document.body)
+				render(h(Home, createHomeParams({ simVisResults })), dom.document.body)
 			})
 
 			assert.equal(dom.document.body.textContent?.includes('Simulation Outcome'), true)
@@ -152,15 +336,289 @@ describe('Home popup clear empty state', () => {
 		}
 	})
 
+	test('shows rich-only simulation state instead of the empty-state dino', async () => {
+		const dom = installDomMock()
+		const simVisResults = new Signal<ResolvedSimulationResults>(toResolvedSimulationResults(createEmptySimulationResults()))
+		try {
+			await act(() => {
+				render(h(Home, createHomeParams({
+					simVisResults,
+					numberOfAddressesMadeRich: new Signal(2),
+				})), dom.document.body)
+			})
+
+			assert.equal(dom.document.body.textContent?.includes('Simply making 2 addresses rich'), true)
+			assert.equal(dom.document.body.textContent?.includes('Give me some transactions to munch on!'), false)
+		} finally {
+			dom.restore()
+		}
+	})
+
+	test('opens the simulation stack from the rich-only state card', async () => {
+		const dom = installDomMock()
+		const browserMock = installBrowserMock()
+		const closeMock = installCloseMock()
+		const simVisResults = new Signal<ResolvedSimulationResults>(toResolvedSimulationResults(createEmptySimulationResults()))
+		try {
+			await act(() => {
+				render(h(Home, createHomeParams({
+					simVisResults,
+					numberOfAddressesMadeRich: new Signal(2),
+				})), dom.document.body)
+			})
+
+			const richHeader = getHeaderContainingText(dom.document.body, 'Simply making 2 addresses rich')
+			assert.equal(richHeader.getAttribute?.('role'), 'button')
+			assert.equal(richHeader.getAttribute?.('aria-label'), 'Open rich address state in the full simulation stack')
+
+			await act(async () => {
+				await clickElement(richHeader)
+			})
+
+			assert.deepStrictEqual(getMessageWithMethod(browserMock.sentMessages, 'popup_openSimulationStack'), { method: 'popup_openSimulationStack' })
+			assert.equal(closeMock.closeCount, 1)
+		} finally {
+			render(null, dom.document.body)
+			dom.restore()
+			browserMock.restore()
+			closeMock.restore()
+		}
+	})
+
+	test('shows title-only stack cards while keeping per-transaction delay controls', async () => {
+		const dom = installDomMock()
+		const simVisResults = new Signal<ResolvedSimulationResults>(toResolvedSimulationResults(createPendingSimulationResults()))
+		try {
+			await act(() => {
+				render(h(Home, createHomeParams({ simVisResults })), dom.document.body)
+			})
+
+			assert.equal(dom.document.body.textContent?.includes('Pending transaction'), true)
+			assert.equal(dom.document.body.textContent?.includes('Simulate delay'), true)
+			assert.equal(dom.document.body.textContent?.includes('Original request'), false)
+			assert.equal(dom.document.body.textContent?.includes('Transaction Input'), false)
+		} finally {
+			dom.restore()
+		}
+	})
+
+		test('opens the simulation stack at a title-only transaction header', async () => {
+			const dom = installDomMock()
+			const browserMock = installBrowserMock()
+			const closeMock = installCloseMock()
+		const simVisResults = new Signal<ResolvedSimulationResults>(toResolvedSimulationResults(createPendingSimulationResults()))
+		try {
+			await act(() => {
+				render(h(Home, createHomeParams({ simVisResults })), dom.document.body)
+			})
+
+			await act(async () => {
+				await clickElement(getHeaderContainingText(dom.document.body, 'Pending transaction'))
+			})
+
+			assert.deepStrictEqual(getMessageWithMethod(browserMock.sentMessages, 'popup_openSimulationStack'), {
+				method: 'popup_openSimulationStack',
+				data: { type: 'Transaction', transactionIdentifier: '0x1' },
+			})
+			assert.equal(closeMock.closeCount, 1)
+		} finally {
+			render(null, dom.document.body)
+			dom.restore()
+			browserMock.restore()
+			closeMock.restore()
+			}
+		})
+
+		test('opens the simulation stack from a title-only transaction header with Enter', async () => {
+			const dom = installDomMock()
+			const browserMock = installBrowserMock()
+			const closeMock = installCloseMock()
+			const simVisResults = new Signal<ResolvedSimulationResults>(toResolvedSimulationResults(createPendingSimulationResults()))
+			try {
+				await act(() => {
+					render(h(Home, createHomeParams({ simVisResults })), dom.document.body)
+				})
+
+				const header = getHeaderContainingText(dom.document.body, 'Pending transaction')
+				let preventDefaultCalled = false
+				await act(async () => {
+					await keyDownElement(header, {
+						key: 'Enter',
+						target: header,
+						currentTarget: header,
+						preventDefault() {
+							preventDefaultCalled = true
+						},
+					})
+				})
+
+				assert.equal(preventDefaultCalled, true)
+				assert.deepStrictEqual(getMessageWithMethod(browserMock.sentMessages, 'popup_openSimulationStack'), {
+					method: 'popup_openSimulationStack',
+					data: { type: 'Transaction', transactionIdentifier: '0x1' },
+				})
+				assert.equal(closeMock.closeCount, 1)
+			} finally {
+				render(null, dom.document.body)
+				dom.restore()
+				browserMock.restore()
+				closeMock.restore()
+			}
+		})
+
+		test('opens the simulation stack from a title-only signature header with Space', async () => {
+			const dom = installDomMock()
+			const browserMock = installBrowserMock()
+			const closeMock = installCloseMock()
+			const simVisResults = new Signal<ResolvedSimulationResults>(toResolvedSimulationResults(createPendingSignedMessageSimulationResults()))
+			try {
+				await act(() => {
+					render(h(Home, createHomeParams({ simVisResults })), dom.document.body)
+				})
+
+				const header = getHeaderContainingText(dom.document.body, 'Pending signature')
+				let preventDefaultCalled = false
+				await act(async () => {
+					await keyDownElement(header, {
+						key: ' ',
+						target: header,
+						currentTarget: header,
+						preventDefault() {
+							preventDefaultCalled = true
+						},
+					})
+				})
+
+				assert.equal(preventDefaultCalled, true)
+				assert.deepStrictEqual(getMessageWithMethod(browserMock.sentMessages, 'popup_openSimulationStack'), {
+					method: 'popup_openSimulationStack',
+					data: { type: 'Message', messageIdentifier: '0x4d' },
+				})
+				assert.equal(closeMock.closeCount, 1)
+			} finally {
+				render(null, dom.document.body)
+				dom.restore()
+				browserMock.restore()
+				closeMock.restore()
+			}
+		})
+
+		test('does not open the simulation stack from bubbled remove-button key events', async () => {
+			const dom = installDomMock()
+			const browserMock = installBrowserMock()
+		const closeMock = installCloseMock()
+		const simVisResults = new Signal<ResolvedSimulationResults>(toResolvedSimulationResults(createSimulationResults()))
+		try {
+			await act(() => {
+				render(h(Home, createHomeParams({ simVisResults })), dom.document.body)
+			})
+
+			const removeButton = getButtonByAriaLabel(dom.document.body, 'remove')
+			const header = getAncestor(removeButton, 'header')
+			let preventDefaultCalled = false
+
+			await act(async () => {
+				await keyDownElement(header, {
+					key: 'Enter',
+					target: removeButton,
+					currentTarget: header,
+					preventDefault() {
+						preventDefaultCalled = true
+					},
+				})
+			})
+
+			assert.equal(preventDefaultCalled, false)
+			assert.equal(browserMock.sentMessages.some((message) => hasMethod(message, 'popup_openSimulationStack')), false)
+
+			await act(async () => {
+				await clickElement(removeButton)
+			})
+
+			assert.deepStrictEqual(getMessageWithMethod(browserMock.sentMessages, 'popup_removeTransactionOrSignedMessage'), {
+				method: 'popup_removeTransactionOrSignedMessage',
+				data: { type: 'Transaction', transactionIdentifier: '0x1' },
+			})
+			assert.equal(browserMock.sentMessages.some((message) => hasMethod(message, 'popup_openSimulationStack')), false)
+			assert.equal(closeMock.closeCount, 0)
+		} finally {
+			render(null, dom.document.body)
+			dom.restore()
+			browserMock.restore()
+			closeMock.restore()
+		}
+	})
+
+	test('commits title-only signed-message delay controls with the message identifier', async () => {
+		const dom = installDomMock()
+		const browserMock = installBrowserMock()
+		const simVisResults = new Signal<ResolvedSimulationResults>(toResolvedSimulationResults(createPendingSignedMessageSimulationResults()))
+		try {
+			await act(() => {
+				render(h(Home, createHomeParams({ simVisResults })), dom.document.body)
+			})
+
+			assert.equal(dom.document.body.textContent?.includes('Pending signature'), true)
+			assert.equal(dom.document.body.textContent?.includes('Simulate delay'), true)
+			assert.equal(dom.document.body.textContent?.includes('Signature request'), false)
+			assert.equal(dom.document.body.textContent?.includes('Raw request'), false)
+
+			await act(async () => {
+				await clickElement(getButtonInTimePicker(dom.document.body, 'Simulate delay', 'For'))
+			})
+			await act(async () => {
+				await clickElement(getButtonInTimePicker(dom.document.body, 'Simulate delay', 'Commit'))
+			})
+
+			assert.deepStrictEqual(getMessageWithMethod(browserMock.sentMessages, 'popup_setTransactionOrMessageBlockTimeManipulator'), {
+				method: 'popup_setTransactionOrMessageBlockTimeManipulator',
+				data: {
+					transactionOrMessageIdentifier: { type: 'Message', messageIdentifier: '0x4d' },
+					blockTimeManipulation: { type: 'AddToTimestamp', deltaToAdd: '0xc', deltaUnit: 'Seconds' },
+				},
+			})
+		} finally {
+			render(null, dom.document.body)
+			dom.restore()
+			browserMock.restore()
+		}
+	})
+
+	test('opens the simulation stack view from the popup button', async () => {
+		const dom = installDomMock()
+		const browserMock = installBrowserMock()
+		const closeMock = installCloseMock()
+		const simVisResults = new Signal<ResolvedSimulationResults>(toResolvedSimulationResults(createSimulationResults()))
+		try {
+			await act(() => {
+				render(h(Home, createHomeParams({ simVisResults })), dom.document.body)
+			})
+
+			const viewStackButton = getButtonByText(dom.document.body, 'View stack details')
+			assert.equal(viewStackButton.getAttribute?.('aria-label'), 'Open simulation stack details in a new tab')
+			assert.equal(collectElements(dom.document.body, 'button').some((button) => button.textContent?.replace(/\s+/g, ' ').trim() === 'Import'), false)
+			assert.equal(dom.document.body.textContent?.includes('Export Simulation Stack'), false)
+
+			await act(async () => {
+				await clickElement(viewStackButton)
+			})
+
+			assert.deepStrictEqual(getMessageWithMethod(browserMock.sentMessages, 'popup_openSimulationStack'), { method: 'popup_openSimulationStack' })
+			assert.equal(closeMock.closeCount, 1)
+		} finally {
+			render(null, dom.document.body)
+			dom.restore()
+			browserMock.restore()
+			closeMock.restore()
+		}
+	})
+
 	test('treats a known signer account as connected even if the signerConnected flag is stale', async () => {
 		const dom = installDomMock()
 		const simVisResults = new Signal<ResolvedSimulationResults>(toResolvedSimulationResults(createEmptySimulationResults()))
 		try {
 			await act(() => {
-				render(h(Home, {
-					changeActiveAddress: () => undefined,
-					makeCurrentAddressRich: new Signal(false),
-					activeAddresses: new Signal([activeAddressEntry]),
+				render(h(Home, createHomeParams({
 					tabState: new Signal<TabState | undefined>({
 						tabId: 1,
 						website: { websiteOrigin: 'https://example.com', icon: undefined, title: 'Example' },
@@ -176,22 +634,9 @@ describe('Home popup clear empty state', () => {
 					activeSigningAddress: new Signal<bigint | undefined>(ACTIVE_ADDRESS),
 					useSignersAddressAsActiveAddress: new Signal(true),
 					simVisResults,
-					rpcNetwork: new Signal(rpcNetwork),
-					setActiveRpcAndInformAboutIt: () => undefined,
 					simulationMode: new Signal(false),
 					tabIconDetails: new Signal({ icon: ICON_SIMULATING, iconReason: 'Connected through MetaMask.' }),
-					currentBlockNumber: new Signal<bigint | undefined>(101n),
-					renameAddressCallBack: () => undefined,
-					editEnsNamedHashCallBack: () => undefined,
-					rpcConnectionStatus: new Signal<RpcConnectionStatus>(undefined),
-					rpcEntries: new Signal([rpcNetwork]),
-					simulationUpdatingState: new Signal<'done' | 'updating' | 'failed' | undefined>('done'),
-					simulationResultState: new Signal<'done' | 'invalid' | 'corrupted' | undefined>('done'),
-					interceptorDisabled: new Signal(false),
-					preSimulationBlockTimeManipulation: new Signal<BlockTimeManipulation | undefined>(undefined),
-					fixedAddressRichList: new Signal<readonly EnrichedRichListElement[]>([]),
-					openImportSimulation: () => undefined,
-				}), dom.document.body)
+				})), dom.document.body)
 			})
 
 			assert.equal(dom.document.body.textContent?.includes('CONNECTED'), true)

--- a/test/tests/narrowTextLayoutCss.test.ts
+++ b/test/tests/narrowTextLayoutCss.test.ts
@@ -1,0 +1,148 @@
+import * as assert from 'assert'
+import { describe, test } from 'bun:test'
+
+function expectRule(css: string, selector: string) {
+	const escapedSelector = selector.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')
+	const match = new RegExp(`${ escapedSelector }\\s*\\{([\\s\\S]*?)\\}`).exec(css)
+	if (match?.[1] === undefined) throw new Error(`Missing CSS rule for ${ selector }`)
+	return match[1]
+}
+
+describe('narrow text layout CSS', () => {
+	test('keeps checkbox labels and dropdown text constrained inside narrow containers', async () => {
+		const css = await Bun.file('app/css/interceptor.css').text()
+
+		const formControl = expectRule(css, '.form-control')
+		assert.match(formControl, /grid-template-columns\s*:\s*1em minmax\(0,\s*1fr\)\s*;/)
+		assert.match(formControl, /min-width\s*:\s*0\s*;/)
+		assert.match(formControl, /max-width\s*:\s*100%\s*;/)
+
+		const checkboxText = expectRule(css, '.form-control .checkbox-text')
+		assert.match(checkboxText, /overflow-wrap\s*:\s*anywhere\s*;/)
+
+		const dropdownText = expectRule(css, '.dropdown button > .truncate')
+		assert.match(dropdownText, /min-width\s*:\s*0\s*;/)
+		assert.match(dropdownText, /max-width\s*:\s*100%\s*;/)
+
+		const chainSelector = expectRule(css, '.chainSelector')
+		assert.match(chainSelector, /min-width\s*:\s*0\s*;/)
+		assert.match(chainSelector, /max-width\s*:\s*100%\s*;/)
+		assert.match(chainSelector, /overflow\s*:\s*hidden\s*;/)
+
+		const grid = expectRule(css, ':where(.grid)')
+		assert.match(grid, /min-width\s*:\s*0\s*;/)
+		assert.match(grid, /max-width\s*:\s*100%\s*;/)
+
+		assert.match(css, /\.card-header-title\s*\{[\s\S]*?min-width\s*:\s*0\s*;[\s\S]*?\}/)
+		assert.match(css, /\.card-header-title\s*\{[\s\S]*?overflow\s*:\s*hidden\s*;[\s\S]*?\}/)
+		assert.match(css, /\.card-header-title\s*\{[\s\S]*?text-overflow\s*:\s*ellipsis\s*;[\s\S]*?\}/)
+
+		const cardHeaderTitleText = expectRule(css, '.card-header-title > .card-header-title-text')
+		assert.match(cardHeaderTitleText, /display\s*:\s*block\s*;/)
+		assert.match(cardHeaderTitleText, /overflow\s*:\s*hidden\s*;/)
+		assert.match(cardHeaderTitleText, /text-overflow\s*:\s*ellipsis\s*;/)
+		assert.match(cardHeaderTitleText, /white-space\s*:\s*inherit\s*;/)
+
+		const cardHeaderWebsite = expectRule(css, '.card-header-website')
+		assert.match(cardHeaderWebsite, /flex\s*:\s*0 1 16rem\s*;/)
+		assert.match(cardHeaderWebsite, /min-width\s*:\s*0\s*;/)
+		assert.match(cardHeaderWebsite, /max-width\s*:\s*100%\s*;/)
+
+		const cardHeaderWebsiteFlush = expectRule(css, '.card-header-website--flush')
+		assert.match(cardHeaderWebsiteFlush, /flex\s*:\s*0 1 auto\s*;/)
+		assert.match(cardHeaderWebsiteFlush, /max-width\s*:\s*none\s*;/)
+		assert.match(cardHeaderWebsiteFlush, /padding\s*:\s*0\s*;/)
+
+		const stackCardHeaderIcon = expectRule(css, '.stack-card-header > .card-header-icon')
+		assert.match(stackCardHeaderIcon, /padding\s*:\s*0\.55rem 0\.35rem 0\.55rem 0\.55rem\s*;/)
+
+		const stackCardHeaderTitle = expectRule(css, '.stack-card-header > .card-header-title')
+		assert.match(stackCardHeaderTitle, /flex\s*:\s*1 1 auto\s*;/)
+		assert.match(stackCardHeaderTitle, /min-width\s*:\s*0\s*;/)
+		assert.match(stackCardHeaderTitle, /padding-left\s*:\s*0\.35rem\s*;/)
+		assert.match(stackCardHeaderTitle, /overflow\s*:\s*hidden\s*;/)
+		assert.match(stackCardHeaderTitle, /text-overflow\s*:\s*ellipsis\s*;/)
+		assert.match(stackCardHeaderTitle, /white-space\s*:\s*nowrap\s*;/)
+
+		const stackCardHeaderWebsite = expectRule(css, '.stack-card-header > .card-header-website')
+		assert.match(stackCardHeaderWebsite, /flex\s*:\s*0 1 min\(11rem,\s*42%\)\s*;/)
+		assert.match(stackCardHeaderWebsite, /padding\s*:\s*0\.55rem 0\.5rem\s*;/)
+
+		const stackCardHeaderWebsiteFlush = expectRule(css, '.stack-card-header > .card-header-website.card-header-website--flush')
+		assert.match(stackCardHeaderWebsiteFlush, /flex\s*:\s*0 1 auto\s*;/)
+		assert.match(stackCardHeaderWebsiteFlush, /max-width\s*:\s*none\s*;/)
+		assert.match(stackCardHeaderWebsiteFlush, /padding\s*:\s*0\s*;/)
+
+		const websiteOriginText = expectRule(css, '.website-origin-text')
+		assert.match(websiteOriginText, /display\s*:\s*flex\s*;/)
+		assert.match(websiteOriginText, /min-width\s*:\s*0\s*;/)
+		assert.match(websiteOriginText, /max-width\s*:\s*100%\s*;/)
+
+		const stackRowLinkHeader = expectRule(css, '.stack-row-link-header')
+		assert.match(stackRowLinkHeader, /cursor\s*:\s*pointer\s*;/)
+		assert.match(stackRowLinkHeader, /transition\s*:/)
+
+		const simulationStackRow = expectRule(css, '.simulation-stack-row')
+		assert.match(simulationStackRow, /scroll-margin-block\s*:\s*2rem\s*;/)
+
+		const highlightedSimulationStackRow = expectRule(css, '.simulation-stack-row--highlighted')
+		assert.match(highlightedSimulationStackRow, /animation\s*:\s*simulation-stack-row-target-pulse 1800ms ease-out\s*;/)
+		assert.match(css, /@keyframes simulation-stack-row-target-pulse/)
+	})
+
+	test('lets simulation stack rows use the available page width', async () => {
+		const css = await Bun.file('app/css/interceptor.css').text()
+
+		const simulationStackPage = expectRule(css, '.simulation-stack-page')
+		assert.match(simulationStackPage, /--grid-column\s*:\s*1 \/ -1\s*;/)
+		assert.match(simulationStackPage, /width\s*:\s*100%\s*;/)
+		assert.match(simulationStackPage, /padding-inline\s*:\s*0\s*;/)
+		assert.doesNotMatch(simulationStackPage, /1100px/)
+
+		const simulationStackHeader = expectRule(css, '.simulation-stack-page-header')
+		assert.match(simulationStackHeader, /padding\s*:\s*1rem clamp\(0\.75rem,\s*2vw,\s*1\.5rem\)\s*;/)
+
+		const simulationStackHeaderDirectChild = expectRule(css, '.simulation-stack-page > .simulation-stack-page-header')
+		assert.match(simulationStackHeaderDirectChild, /background-color\s*:\s*var\(--bg-color\)\s*;/)
+		assert.match(simulationStackHeaderDirectChild, /position\s*:\s*sticky\s*;/)
+		assert.match(simulationStackHeaderDirectChild, /top\s*:\s*0\s*;/)
+		assert.match(simulationStackHeaderDirectChild, /z-index\s*:\s*10\s*;/)
+
+		const simulationStackBody = expectRule(css, '.simulation-stack-page-body')
+		assert.match(simulationStackBody, /min-width\s*:\s*0\s*;/)
+		assert.match(simulationStackBody, /min-height\s*:\s*0\s*;/)
+
+		const simulationStackSummaryCard = expectRule(css, '.simulation-summary-card')
+		assert.match(simulationStackSummaryCard, /margin\s*:\s*10px\s*;/)
+
+		const simulationStackPageSummaryCard = expectRule(css, '.simulation-stack-page-content .simulation-summary-card')
+		assert.match(simulationStackPageSummaryCard, /margin\s*:\s*10px 0\s*;/)
+
+		const simulationStackContent = expectRule(css, '.simulation-stack-page-content')
+		assert.match(simulationStackContent, /padding\s*:\s*1rem clamp\(0\.75rem,\s*2vw,\s*1\.5rem\) 2rem\s*;/)
+
+		const simulationStackContentList = expectRule(css, '.simulation-stack-page-content .simulation-stack-list')
+		assert.match(simulationStackContentList, /margin\s*:\s*0\s*;/)
+		assert.match(simulationStackContentList, /padding\s*:\s*0\s*;/)
+		assert.match(simulationStackContentList, /width\s*:\s*100%\s*;/)
+
+		const simulationStackContentListItem = expectRule(css, '.simulation-stack-page-content .simulation-stack-list > li')
+		assert.match(simulationStackContentListItem, /margin\s*:\s*0\s*;/)
+
+		const simulationStackContentRow = expectRule(css, '.simulation-stack-page-content .simulation-stack-list > li > .simulation-stack-row')
+		assert.match(simulationStackContentRow, /margin\s*:\s*10px 0\s*;/)
+	})
+
+	test('uses flexible button height and stacks address book card actions at ultra-narrow widths', async () => {
+		const css = await Bun.file('app/css/interceptor.css').text()
+
+		const button = expectRule(css, ':where(.btn)')
+		assert.match(button, /box-sizing\s*:\s*border-box\s*;/)
+		assert.match(button, /height\s*:\s*auto\s*;/)
+		assert.match(button, /min-height\s*:\s*2\.25em\s*;/)
+		assert.match(button, /line-height\s*:\s*1\.2\s*;/)
+
+		assert.match(css, /@media screen and \(max-width:\s*220px\)\s*\{[\s\S]*?\.address-book-entry-media\s*\{[\s\S]*?flex-direction\s*:\s*column\s*;/)
+		assert.match(css, /@media screen and \(max-width:\s*220px\)\s*\{[\s\S]*?\.address-book-entry-actions\s*\{[\s\S]*?flex-direction\s*:\s*row\s*;/)
+	})
+})

--- a/test/tests/networkErrors.test.ts
+++ b/test/tests/networkErrors.test.ts
@@ -3,6 +3,7 @@ import { h, render } from 'preact'
 import { act } from 'preact/test-utils'
 import { Signal } from '@preact/signals'
 import { describe, test } from 'bun:test'
+import { NetworkErrors } from '../../app/ts/components/subcomponents/NetworkErrors.js'
 import { installDateMock, installDomMock } from './domMock.js'
 
 function installBrowserMock() {
@@ -73,7 +74,6 @@ describe('NetworkErrors', () => {
 	test('shows a paused disconnect immediately on first render', async () => {
 		installBrowserMock()
 		const dom = installDomMock()
-		const { NetworkErrors } = await import('../../app/ts/components/App.js')
 
 		await act(() => {
 			render(h(NetworkErrors, {
@@ -95,7 +95,6 @@ describe('NetworkErrors', () => {
 		installBrowserMock()
 		const dom = installDomMock()
 		const clock = installDateMock('2024-01-01T00:00:00.000Z')
-		const { NetworkErrors } = await import('../../app/ts/components/App.js')
 
 		await act(() => {
 			render(h(NetworkErrors, {

--- a/test/tests/openSimulationStackTab.test.ts
+++ b/test/tests/openSimulationStackTab.test.ts
@@ -1,0 +1,225 @@
+import * as assert from 'assert'
+import { describe, test } from 'bun:test'
+import { getSimulationStackTargetHash } from '../../app/ts/utils/simulationStackTargets.js'
+
+type TabRecord = {
+	readonly id: number
+	readonly url?: string
+	readonly windowId?: number
+}
+
+type TabCreateDetails = {
+	readonly url: string
+}
+
+type TabUpdateDetails = {
+	readonly tabId: number
+	readonly update: {
+		readonly active?: boolean
+		readonly highlighted?: boolean
+		readonly url?: string
+	}
+}
+
+type WindowUpdateDetails = {
+	readonly windowId: number
+	readonly update: {
+		readonly focused?: boolean
+	}
+}
+
+type OpenedTabIds = {
+	addressBook: number | undefined
+	settingsView: number | undefined
+	websiteAccess: number | undefined
+	simulationStack?: number | undefined
+}
+
+type StorageState = {
+	idsOfOpenedTabs?: OpenedTabIds
+	currentTabId?: number
+}
+
+function installBrowserMock(tabs: readonly TabRecord[], openedTabs: OpenedTabIds | undefined, updateShouldFail = false, currentTabId?: number) {
+	const createdTabs: TabCreateDetails[] = []
+	const updatedTabs: TabUpdateDetails[] = []
+	const updatedWindows: WindowUpdateDetails[] = []
+	const storageState: StorageState = { idsOfOpenedTabs: openedTabs, currentTabId }
+	const getStorageValue = (key: string) => key === 'idsOfOpenedTabs' ? storageState.idsOfOpenedTabs : key === 'currentTabId' ? storageState.currentTabId : undefined
+	Object.defineProperty(globalThis, 'browser', {
+		configurable: true,
+		writable: true,
+		value: {
+			runtime: {
+				lastError: null,
+				getManifest: () => ({ manifest_version: 3 }),
+				getURL: (path: string) => `chrome-extension://test-extension${ path }`,
+			},
+			storage: {
+				local: {
+					async get(keys?: string | string[]) {
+						const requestedKeys = Array.isArray(keys) ? keys : keys === undefined ? Object.keys(storageState) : [keys]
+						return Object.fromEntries(requestedKeys.map((key) => [key, getStorageValue(key)]))
+					},
+					async set(items: StorageState) {
+						Object.assign(storageState, items)
+					},
+				},
+			},
+			tabs: {
+				async query() {
+					return [...tabs]
+				},
+				async create(details: TabCreateDetails) {
+					createdTabs.push(details)
+					return { id: 99, ...details }
+				},
+				async update(tabId: number, update: TabUpdateDetails['update']) {
+					if (updateShouldFail) return undefined
+					updatedTabs.push({ tabId, update })
+					return tabs.find((tab) => tab.id === tabId)
+				},
+			},
+			windows: {
+				async update(windowId: number, update: WindowUpdateDetails['update']) {
+					updatedWindows.push({ windowId, update })
+					return { id: windowId }
+				},
+			},
+		},
+	})
+	Object.defineProperty(globalThis, 'chrome', {
+		configurable: true,
+		writable: true,
+		value: { runtime: { id: 'test-extension' } },
+	})
+	return { createdTabs, updatedTabs, updatedWindows, storageState }
+}
+
+async function loadOpenNewTab() {
+	return (await import('../../app/ts/background/popupMessageHandlers.js')).openNewTab
+}
+
+async function loadGetLastKnownCurrentTabId() {
+	return (await import('../../app/ts/background/popupMessageHandlers.js')).getLastKnownCurrentTabId
+}
+
+const emptyOpenedTabs = (): OpenedTabIds => ({
+	addressBook: undefined,
+	settingsView: undefined,
+	websiteAccess: undefined,
+	simulationStack: undefined,
+})
+
+describe('open simulation stack tab', () => {
+	test('focuses the existing simulation stack tab without opening a duplicate', async () => {
+		const { createdTabs, updatedTabs } = installBrowserMock([{ id: 42, url: 'chrome-extension://test-extension/html3/simulationStackV3.html' }], { ...emptyOpenedTabs(), simulationStack: 42 })
+		const openNewTab = await loadOpenNewTab()
+
+		await openNewTab('simulationStack')
+
+		assert.deepEqual(createdTabs, [])
+		assert.deepEqual(updatedTabs, [{ tabId: 42, update: { active: true, highlighted: true } }])
+	})
+
+	test('focuses the existing simulation stack tab window without opening a duplicate', async () => {
+		const { createdTabs, updatedTabs, updatedWindows } = installBrowserMock([{ id: 42, url: 'chrome-extension://test-extension/html3/simulationStackV3.html', windowId: 7 }], { ...emptyOpenedTabs(), simulationStack: 42 })
+		const openNewTab = await loadOpenNewTab()
+
+		await openNewTab('simulationStack')
+
+		assert.deepEqual(createdTabs, [])
+		assert.deepEqual(updatedTabs, [{ tabId: 42, update: { active: true, highlighted: true } }])
+		assert.deepEqual(updatedWindows, [{ windowId: 7, update: { focused: true } }])
+	})
+
+	test('focuses and targets an existing simulation stack tab', async () => {
+		const { createdTabs, updatedTabs } = installBrowserMock([{ id: 42, url: 'chrome-extension://test-extension/html3/simulationStackV3.html' }], { ...emptyOpenedTabs(), simulationStack: 42 })
+		const openNewTab = await loadOpenNewTab()
+		const targetHash = getSimulationStackTargetHash({ type: 'Transaction', transactionIdentifier: 1n }, 'test-focus')
+
+		await openNewTab('simulationStack', targetHash)
+
+		assert.deepEqual(createdTabs, [])
+		assert.deepEqual(updatedTabs, [{
+			tabId: 42,
+			update: { active: true, highlighted: true, url: `/html3/simulationStackV3.html${ targetHash }` },
+		}])
+	})
+
+	test('opens and stores a new simulation stack tab when none is tracked', async () => {
+		const { createdTabs, updatedTabs, storageState } = installBrowserMock([], emptyOpenedTabs())
+		const openNewTab = await loadOpenNewTab()
+
+		await openNewTab('simulationStack')
+
+		assert.deepEqual(updatedTabs, [])
+		assert.deepEqual(createdTabs, [{ url: '/html3/simulationStackV3.html' }])
+		assert.equal(storageState.idsOfOpenedTabs?.simulationStack, 99)
+	})
+
+	test('opens a new simulation stack tab with a target hash when none is tracked', async () => {
+		const { createdTabs, updatedTabs, storageState } = installBrowserMock([], emptyOpenedTabs())
+		const openNewTab = await loadOpenNewTab()
+		const targetHash = getSimulationStackTargetHash({ type: 'Message', messageIdentifier: 2n }, 'test-focus')
+
+		await openNewTab('simulationStack', targetHash)
+
+		assert.deepEqual(updatedTabs, [])
+		assert.deepEqual(createdTabs, [{ url: `/html3/simulationStackV3.html${ targetHash }` }])
+		assert.equal(storageState.idsOfOpenedTabs?.simulationStack, 99)
+	})
+
+	test('opens a replacement tab when the tracked simulation stack tab is gone', async () => {
+		const { createdTabs, updatedTabs, storageState } = installBrowserMock([], { ...emptyOpenedTabs(), simulationStack: 42 })
+		const openNewTab = await loadOpenNewTab()
+
+		await openNewTab('simulationStack')
+
+		assert.deepEqual(updatedTabs, [])
+		assert.deepEqual(createdTabs, [{ url: '/html3/simulationStackV3.html' }])
+		assert.equal(storageState.idsOfOpenedTabs?.simulationStack, 99)
+	})
+
+	test('opens a replacement tab when focusing the tracked simulation stack tab fails', async () => {
+		const { createdTabs, updatedTabs, storageState } = installBrowserMock([{ id: 42 }], { ...emptyOpenedTabs(), simulationStack: 42 }, true)
+		const openNewTab = await loadOpenNewTab()
+
+		await openNewTab('simulationStack')
+
+		assert.deepEqual(updatedTabs, [])
+		assert.deepEqual(createdTabs, [{ url: '/html3/simulationStackV3.html' }])
+		assert.equal(storageState.idsOfOpenedTabs?.simulationStack, 99)
+	})
+
+	test('keeps the stored website tab when the active tab is the extension simulation stack page', async () => {
+		const { storageState } = installBrowserMock([{ id: 77, url: '/html3/simulationStackV3.html' }], emptyOpenedTabs(), false, 12)
+		const getLastKnownCurrentTabId = await loadGetLastKnownCurrentTabId()
+
+		const tabId = await getLastKnownCurrentTabId()
+
+		assert.equal(tabId, 12)
+		assert.equal(storageState.currentTabId, 12)
+	})
+
+	test('does not keep the stored website tab when the active tab is another extension page', async () => {
+		const { storageState } = installBrowserMock([{ id: 77, url: 'chrome-extension://other-extension/page.html' }], emptyOpenedTabs(), false, 12)
+		const getLastKnownCurrentTabId = await loadGetLastKnownCurrentTabId()
+
+		const tabId = await getLastKnownCurrentTabId()
+
+		assert.equal(tabId, 77)
+		assert.equal(storageState.currentTabId, 77)
+	})
+
+	test('clears a stale simulation stack hash when focusing the existing stack tab without a target', async () => {
+		const targetHash = getSimulationStackTargetHash({ type: 'Transaction', transactionIdentifier: 1n }, 'test-focus')
+		const { createdTabs, updatedTabs } = installBrowserMock([{ id: 42, url: `chrome-extension://test-extension/html3/simulationStackV3.html${ targetHash }` }], { ...emptyOpenedTabs(), simulationStack: 42 })
+		const openNewTab = await loadOpenNewTab()
+
+		await openNewTab('simulationStack')
+
+		assert.deepEqual(createdTabs, [])
+		assert.deepEqual(updatedTabs, [{ tabId: 42, update: { active: true, highlighted: true, url: '/html3/simulationStackV3.html' } }])
+	})
+})

--- a/test/tests/popupClearReset.test.ts
+++ b/test/tests/popupClearReset.test.ts
@@ -92,6 +92,9 @@ function createBrowserMock(): BrowserMock {
 			lastError: null,
 			async sendMessage(message: RuntimeMessage) {
 				sentMessages.push(message)
+				if (message.method === 'popup_isSimulationVisualizerOpen') {
+					return { method: 'popup_isSimulationVisualizerOpen', data: { isOpen: popupIsOpen } }
+				}
 				if (message.method === 'popup_isMainPopupWindowOpen') {
 					return { method: 'popup_isMainPopupWindowOpen', data: { isOpen: popupIsOpen } }
 				}

--- a/test/tests/popupHeaderMarkup.test.tsx
+++ b/test/tests/popupHeaderMarkup.test.tsx
@@ -1,0 +1,174 @@
+import * as assert from 'assert'
+import { h, render } from 'preact'
+import { act } from 'preact/test-utils'
+import { describe, test } from 'bun:test'
+import { SignatureHeader } from '../../app/ts/components/pages/PersonalSign.js'
+import { TransactionHeader } from '../../app/ts/components/simulationExplaining/SimulationSummary.js'
+import { PendingStackHeader } from '../../app/ts/components/simulationExplaining/Transactions.js'
+import type { AddressBookEntry } from '../../app/ts/types/addressBookTypes.js'
+import type { VisualizedPersonalSignRequest } from '../../app/ts/types/personal-message-definitions.js'
+import type { RpcNetwork } from '../../app/ts/types/rpc.js'
+import type { Website } from '../../app/ts/types/websiteAccessTypes.js'
+import type { SimulatedAndVisualizedTransaction } from '../../app/ts/types/visualizer-types.js'
+import { installDomMock } from './domMock.js'
+
+type TestNode = {
+	nodeType?: number
+	textContent?: string | null
+	childNodes?: readonly TestNode[]
+	getAttribute?: (name: string) => string | null
+}
+
+const website: Website = {
+	websiteOrigin: 'https://example.com',
+	title: 'Example Website',
+	icon: undefined,
+}
+
+const rpcNetwork: RpcNetwork = {
+	name: 'Ethereum',
+	chainId: 1n,
+	httpsRpc: 'https://example.invalid',
+	currencyName: 'Ether',
+	currencyTicker: 'ETH',
+	primary: true,
+	minimized: false,
+}
+
+const fromEntry: AddressBookEntry = {
+	type: 'contact',
+	name: 'Sender',
+	address: 0x1000000000000000000000000000000000000001n,
+	entrySource: 'OnChain',
+}
+
+const toEntry: AddressBookEntry = {
+	type: 'contact',
+	name: 'Receiver',
+	address: 0x2000000000000000000000000000000000000002n,
+	entrySource: 'OnChain',
+}
+
+const fallbackMethodTransaction: SimulatedAndVisualizedTransaction = {
+	website,
+	created: new Date('2024-01-01T00:00:00.000Z'),
+	parsedInputData: { type: 'NonParsed', input: new Uint8Array() },
+	transactionIdentifier: 1n,
+	originalRequestParameters: { method: 'eth_sendTransaction', params: [{ from: fromEntry.address, to: toEntry.address, value: 0n, input: new Uint8Array() }] },
+	tokenBalancesAfter: [],
+	tokenPriceEstimates: [],
+	tokenPriceQuoteToken: undefined,
+	gasSpent: 0n,
+	realizedGasPrice: 1n,
+	quarantine: false,
+	quarantineReasons: [],
+	transactionStatus: 'Transaction Succeeded',
+	transaction: {
+		from: fromEntry,
+		to: toEntry,
+		rpcNetwork,
+		input: new Uint8Array(),
+		value: 0n,
+		gas: 21000n,
+		type: '1559',
+		maxFeePerGas: 1n,
+		maxPriorityFeePerGas: 1n,
+		nonce: 1n,
+		hash: 1n,
+	},
+	events: [],
+}
+
+const personalSignRequest: VisualizedPersonalSignRequest = {
+	method: 'personal_sign',
+	type: 'NotParsed',
+	message: 'hello',
+	messageHash: '0x1',
+	simulationMode: false,
+	signerName: 'NoSigner',
+	requestAccessToAddress: false,
+	activeAddress: fromEntry.address,
+	quarantineReasons: [],
+	quarantine: false,
+	account: fromEntry,
+	website,
+	created: new Date('2024-01-01T00:00:00.000Z'),
+	rawMessage: 'hello',
+	stringifiedMessage: 'hello',
+	messageIdentifier: 2n,
+}
+
+function hasClass(node: TestNode | undefined, className: string) {
+	const classes = node?.getAttribute?.('class')?.split(/\s+/).filter((value) => value !== '') ?? []
+	return classes.includes(className)
+}
+
+function findFirstByClass(node: TestNode | undefined, className: string): TestNode | undefined {
+	if (node === undefined) return undefined
+	if (hasClass(node, className)) return node
+	for (const child of node.childNodes ?? []) {
+		const match = findFirstByClass(child, className)
+		if (match !== undefined) return match
+	}
+	return undefined
+}
+
+function assertClasses(node: TestNode | undefined, expectedClasses: string[]) {
+	assert.notEqual(node, undefined)
+	for (const expectedClass of expectedClasses) {
+		assert.equal(hasClass(node, expectedClass), true, `expected class ${ expectedClass }`)
+	}
+}
+
+describe('popup header markup', () => {
+	test('TransactionHeader renders the fallback title inside the ellipsis target and composes the flush website class', async () => {
+		const dom = installDomMock()
+
+		await act(() => {
+			render(h(TransactionHeader, {
+				simTx: fallbackMethodTransaction,
+				removeTransactionOrSignedMessage: () => undefined,
+			}), dom.document.body)
+		})
+
+		const titleText = findFirstByClass(dom.document.body, 'card-header-title-text')
+		assert.equal(titleText?.textContent, 'Contract Fallback Method')
+		assertClasses(findFirstByClass(dom.document.body, 'card-header-website'), ['card-header-website', 'card-header-website--flush'])
+
+		dom.restore()
+	})
+
+	test('SignatureHeader renders the title inside the ellipsis target and composes the flush website class', async () => {
+		const dom = installDomMock()
+
+		await act(() => {
+			render(h(SignatureHeader, {
+				visualizedPersonalSignRequest: personalSignRequest,
+				removeTransactionOrSignedMessage: () => undefined,
+			}), dom.document.body)
+		})
+
+		const titleText = findFirstByClass(dom.document.body, 'card-header-title-text')
+		assert.notEqual(titleText?.textContent?.length, 0)
+		assertClasses(findFirstByClass(dom.document.body, 'card-header-website'), ['card-header-website', 'card-header-website--flush'])
+
+		dom.restore()
+	})
+
+	test('PendingStackHeader renders its title inside the ellipsis target', async () => {
+		const dom = installDomMock()
+
+		await act(() => {
+			render(h(PendingStackHeader, {
+				title: 'Pending stack row title',
+				website,
+				statusIcon: '../img/question-mark-sign.svg',
+			}), dom.document.body)
+		})
+
+		const titleText = findFirstByClass(dom.document.body, 'card-header-title-text')
+		assert.equal(titleText?.textContent, 'Pending stack row title')
+
+		dom.restore()
+	})
+})

--- a/test/tests/popupIconResync.test.ts
+++ b/test/tests/popupIconResync.test.ts
@@ -15,7 +15,7 @@ function installBrowserMock() {
 	const sentMessages: unknown[] = []
 	let messageListener: RuntimeMessageListener | undefined
 
-	Object.defineProperty(globalThis, 'browser', { value: {
+	Object.defineProperty(globalThis, 'browser', { configurable: true, value: {
 		runtime: {
 			lastError: null,
 			async sendMessage(message: unknown) {
@@ -74,7 +74,7 @@ function installBrowserMock() {
 		},
 	}, writable: true })
 
-	Object.defineProperty(globalThis, 'chrome', { value: { runtime: { id: 'test-extension' } }, writable: true })
+	Object.defineProperty(globalThis, 'chrome', { configurable: true, value: { runtime: { id: 'test-extension' } }, writable: true })
 
 	return { messageListener: () => messageListener, sentMessages }
 }
@@ -139,6 +139,41 @@ const defaultRpcEntries = [{ name: 'Ethereum', chainId: '0x1', httpsRpc: 'https:
 })
 
 describe('popup icon sync', () => {
+	test('does not request full home data after popup live simulation updates', async () => {
+		const dom = installDomMock()
+		const { messageListener, sentMessages } = installBrowserMock()
+		try {
+			Object.defineProperty(globalThis, 'window', {
+				value: {
+					document: dom.document,
+					addEventListener: () => undefined,
+					removeEventListener: () => undefined,
+				},
+				configurable: true,
+				writable: true,
+			})
+
+			await act(() => {
+				render(h(App, {}), dom.document.body)
+			})
+			const listener = messageListener()
+			assert.equal(typeof listener, 'function')
+			sentMessages.splice(0)
+
+			await act(() => {
+				listener?.({
+					role: 'all',
+					method: 'popup_simulation_state_changed',
+					data: { visualizedSimulatorState: createPassthroughCompleteVisualizedSimulation() },
+				}, undefined, () => undefined)
+			})
+
+			assert.equal(sentMessages.some((message) => typeof message === 'object' && message !== null && 'method' in message && message.method === 'popup_requestNewHomeData'), false)
+		} finally {
+			dom.restore()
+		}
+	})
+
 	test('ignores icon updates for a different tab id', async () => {
 		const dom = installDomMock()
 		const { messageListener, sentMessages } = installBrowserMock()

--- a/test/tests/rootMinWidthCss.test.ts
+++ b/test/tests/rootMinWidthCss.test.ts
@@ -1,0 +1,46 @@
+import * as assert from 'assert'
+import { describe, test } from 'bun:test'
+import { readdir } from 'fs/promises'
+
+async function readHtmlShells(directory: string) {
+	const filenames = await readdir(directory)
+	return await Promise.all(filenames
+		.filter((filename) => filename.endsWith('.html'))
+		.map(async (filename) => {
+			const path = `${ directory }/${ filename }`
+			return {
+				path,
+				text: await Bun.file(path).text(),
+			}
+		}))
+}
+
+describe('root page CSS', () => {
+	test('does not restore Bulma root min-width', async () => {
+		const css = await Bun.file('app/css/bulma.css').text()
+		assert.doesNotMatch(css, /html\s*\{[\s\S]*?min-width\s*:\s*300px\s*;/)
+	})
+
+	test('does not add narrow tab page minimum widths back to HTML shells', async () => {
+		const htmlShells = [
+			...await readHtmlShells('app/html'),
+			...await readHtmlShells('app/html3'),
+		]
+		for (const { path, text } of htmlShells) {
+			if (path.endsWith('/popup.html') || path.endsWith('/popupV3.html')) continue
+			assert.doesNotMatch(text, /min-width\s*:\s*(?:300|320)px\s*;/, path)
+		}
+	})
+
+	test('simulation stack shells mount the app into a div root placeholder', async () => {
+		const simulationStackShells = [
+			'app/html/simulationStack.html',
+			'app/html3/simulationStackV3.html',
+		]
+		for (const path of simulationStackShells) {
+			const text = await Bun.file(path).text()
+			assert.match(text, /<div id = 'simulation-stack-root'>Loading\.\.\.<\/div>/, path)
+			assert.doesNotMatch(text, /<main id = 'simulation-stack-root'>/, path)
+		}
+	})
+})

--- a/test/tests/simulationVisualizerOpen.test.tsx
+++ b/test/tests/simulationVisualizerOpen.test.tsx
@@ -1,0 +1,1046 @@
+import * as assert from 'assert'
+import { describe, test } from 'bun:test'
+import { h, render } from 'preact'
+import { act } from 'preact/test-utils'
+import { useLiveSimulationHomeData } from '../../app/ts/components/hooks/useLiveSimulationHomeData.js'
+import { SimulationStackPage } from '../../app/ts/components/pages/SimulationStackPage.js'
+import { mockSignTransaction } from '../../app/ts/simulation/services/SimulationModeEthereumClientService.js'
+import { createPassthroughCompleteVisualizedSimulation } from '../../app/ts/types/visualizer-types.js'
+import type { BlockTimeManipulation, CompleteVisualizedSimulation, PreSimulationTransaction } from '../../app/ts/types/visualizer-types.js'
+import { MessageToPopup, UpdateHomePage, type Settings } from '../../app/ts/types/interceptor-messages.js'
+import { serialize, type EthereumUnsignedTransaction } from '../../app/ts/types/wire-types.js'
+import { installDomMock } from './domMock.js'
+import { getSimulationStackTargetHash } from '../../app/ts/utils/simulationStackTargets.js'
+import type { AddressBookEntry } from '../../app/ts/types/addressBookTypes.js'
+import type { EnrichedRichListElement } from '../../app/ts/types/interceptor-reply-messages.js'
+
+type RuntimeMessageListener = (message: unknown, sender: unknown, sendResponse: (response?: unknown) => void) => boolean | undefined
+type TestDomNode = {
+	readonly tagName?: string
+	readonly childNodes?: readonly TestDomNode[]
+	readonly textContent?: string | null
+	readonly getAttribute?: (name: string) => string | null
+	readonly l?: Record<string, (event: unknown) => unknown>
+	scrollIntoView?: (options?: ScrollIntoViewOptions) => void
+}
+
+function installBrowserMock(sendMessageReply?: (message: unknown) => unknown | Promise<unknown>) {
+	const listeners: RuntimeMessageListener[] = []
+	const sentMessages: unknown[] = []
+	Object.defineProperty(globalThis, 'browser', {
+		configurable: true,
+		writable: true,
+		value: {
+			runtime: {
+				lastError: null,
+				async sendMessage(message: unknown) {
+					sentMessages.push(message)
+					return await sendMessageReply?.(message)
+				},
+				onMessage: {
+					addListener(listener: RuntimeMessageListener) {
+						listeners.push(listener)
+					},
+					removeListener(listener: RuntimeMessageListener) {
+						const index = listeners.indexOf(listener)
+						if (index >= 0) listeners.splice(index, 1)
+					},
+				},
+			},
+		},
+	})
+	Object.defineProperty(globalThis, 'chrome', {
+		configurable: true,
+		writable: true,
+		value: { runtime: { id: 'test-extension' } },
+	})
+	return { listeners, sentMessages }
+}
+
+function installClipboardMock() {
+	const previousNavigator = globalThis.navigator
+	const copiedText: string[] = []
+	Object.defineProperty(globalThis, 'navigator', {
+		configurable: true,
+		writable: true,
+		value: {
+			clipboard: {
+				async writeText(text: string) {
+					copiedText.push(text)
+				},
+			},
+		},
+	})
+	return {
+		copiedText,
+		restore() {
+			Object.defineProperty(globalThis, 'navigator', {
+				configurable: true,
+				writable: true,
+				value: previousNavigator,
+			})
+		},
+	}
+}
+
+function StackVisualizerHookProbe() {
+	useLiveSimulationHomeData({
+		answerMainPopupOpen: false,
+		answerSimulationDataConsumerOpen: true,
+		requestFreshHomeDataOnMount: false,
+	})
+	return <div>ready</div>
+}
+
+function CrossTabStackVisualizerHookProbe() {
+	const { tabState } = useLiveSimulationHomeData({
+		answerMainPopupOpen: false,
+		answerSimulationDataConsumerOpen: true,
+		requestFreshHomeDataOnMount: false,
+		filterByTabId: false,
+	})
+	return <div>{ tabState.value?.tabIconDetails.iconReason ?? 'empty' }</div>
+}
+
+function sendRuntimeMessage(listener: RuntimeMessageListener, message: unknown) {
+	let response: unknown
+	const returned = listener(message, {}, (nextResponse?: unknown) => {
+		response = nextResponse
+	})
+	return { returned, response }
+}
+
+function collectElements(node: TestDomNode | null | undefined, tagName: string, results: TestDomNode[] = []) {
+	if (node?.tagName === tagName.toUpperCase()) results.push(node)
+	for (const child of node?.childNodes ?? []) collectElements(child, tagName, results)
+	return results
+}
+
+async function clickElement(element: { l?: Record<string, (event: unknown) => unknown> }) {
+	const clickHandler = element.l === undefined ? undefined : Object.entries(element.l).find(([key]) => key.startsWith('Click'))?.[1]
+	if (clickHandler === undefined) throw new Error('Expected click handler')
+	await clickHandler({ currentTarget: element, stopPropagation() { return undefined } })
+}
+
+function getHeadersContainingText(root: TestDomNode, text: string) {
+	return collectElements(root, 'header').filter((header) => header.textContent?.includes(text) === true)
+}
+
+function countTextOccurrences(input: string, text: string) {
+	return input.split(text).length - 1
+}
+
+function findElementById(root: TestDomNode, id: string) {
+	const elements = [
+		...collectElements(root, 'li'),
+		...collectElements(root, 'div'),
+	]
+	return elements.find((element) => element.getAttribute?.('id') === id)
+}
+
+function hasCompactStackCard(root: TestDomNode) {
+	return collectElements(root, 'header').some((header) => header.textContent?.replace(/\s+/g, ' ').trim() === 'Stack')
+}
+
+function hasClass(node: TestDomNode, className: string) {
+	return node.getAttribute?.('class')?.split(/\s+/).includes(className) === true
+}
+
+function findElementByClass(root: TestDomNode, tagName: string, className: string) {
+	return collectElements(root, tagName).find((element) => hasClass(element, className))
+}
+
+function getFirstElementChild(node: TestDomNode) {
+	return (node.childNodes ?? []).find((child) => child.tagName !== undefined)
+}
+
+function getElementChildren(node: TestDomNode) {
+	return (node.childNodes ?? []).filter((child) => child.tagName !== undefined)
+}
+
+function hasAncestorWithClass(node: TestDomNode, className: string) {
+	let currentNode = node.parentNode
+	while (currentNode !== undefined && currentNode !== null) {
+		if (hasClass(currentNode, className)) return true
+		currentNode = currentNode.parentNode
+	}
+	return false
+}
+
+function hasButtonWithText(root: TestDomNode, text: string) {
+	return collectElements(root, 'button').some((button) => button.textContent?.replace(/\s+/g, ' ').trim() === text)
+}
+
+function getButtonByText(root: TestDomNode, text: string) {
+	const button = collectElements(root, 'button').find((button) => button.textContent?.replace(/\s+/g, ' ').trim() === text)
+	if (button === undefined) throw new Error(`Expected button with text "${ text }"`)
+	return button
+}
+
+function getParagraphByAriaLabel(root: TestDomNode, ariaLabel: string) {
+	const paragraph = collectElements(root, 'p').find((element) => element.getAttribute?.('aria-label') === ariaLabel)
+	if (paragraph === undefined) throw new Error(`Expected paragraph with aria-label "${ ariaLabel }"`)
+	return paragraph
+}
+
+function getRichAddressGroups(paragraph: TestDomNode) {
+	return (paragraph.childNodes ?? []).filter((child) => child.tagName === 'SPAN' && hasClass(child, 'rich-address-sentence-group'))
+}
+
+function installQueuedAnimationFrames() {
+	const animationFrames: FrameRequestCallback[] = []
+	globalThis.requestAnimationFrame = (callback: FrameRequestCallback) => {
+		animationFrames.push(callback)
+		return animationFrames.length
+	}
+	return () => {
+		const pendingFrames = animationFrames.splice(0)
+		for (const callback of pendingFrames) callback(0)
+	}
+}
+
+const settings: Settings = {
+	activeSimulationAddress: undefined,
+	activeRpcNetwork: {
+		name: 'Ethereum',
+		chainId: '0x1',
+		httpsRpc: 'https://example.invalid',
+		currencyName: 'Ether',
+		currencyTicker: 'ETH',
+		primary: true,
+		minimized: false,
+	},
+	openedPage: { page: 'Home' },
+	useSignersAddressAsActiveAddress: false,
+	websiteAccess: [],
+	simulationMode: false,
+}
+
+function createRichAddressEntry(address: bigint, name: string): AddressBookEntry {
+	return {
+		type: 'contact',
+		name,
+		address,
+		entrySource: 'User',
+		askForAddressAccess: true,
+		useAsActiveAddress: true,
+	}
+}
+
+function createRichListElement(address: bigint, name: string): EnrichedRichListElement {
+	return {
+		addressBookEntry: createRichAddressEntry(address, name),
+		makingRich: true,
+		type: 'UserAdded',
+	}
+}
+
+function createHomePageUpdate(tabId: number, popupRefreshGeneration: number, iconReason: string, numberOfAddressesMadeRich = 0, richList: readonly EnrichedRichListElement[] = []): UpdateHomePage {
+	return {
+		method: 'popup_UpdateHomePage',
+		popupRefreshGeneration,
+		data: {
+			visualizedSimulatorState: createPassthroughCompleteVisualizedSimulation(0, 'done', numberOfAddressesMadeRich),
+			activeAddresses: [],
+			richList,
+			makeCurrentAddressRich: false,
+			latestUnexpectedError: undefined,
+			websiteAccessAddressMetadata: [],
+			tabState: {
+				tabId,
+				website: { websiteOrigin: `https://tab-${ tabId }.example`, icon: undefined, title: `Tab ${ tabId }` },
+				signerConnected: false,
+				signerName: 'NoSigner',
+				signerAccounts: [],
+				signerAccountError: undefined,
+				signerChain: undefined,
+				tabIconDetails: { icon: '../img/head-not-active.png', iconReason },
+				activeSigningAddress: undefined,
+			},
+			currentBlockNumber: undefined,
+			settings,
+			rpcConnectionStatus: undefined,
+			activeSigningAddressInThisTab: undefined,
+			tabId,
+			rpcEntries: [settings.activeRpcNetwork],
+			interceptorDisabled: false,
+			preSimulationBlockTimeManipulation: { type: 'AddToTimestamp', deltaToAdd: '0x0', deltaUnit: 'Seconds' },
+		},
+	}
+}
+
+function createPreSimulationTransaction(transactionIdentifier: bigint): PreSimulationTransaction {
+	const sendTransactionParams = {
+		from: 0x1000000000000000000000000000000000000001n,
+		to: 0x2000000000000000000000000000000000000002n,
+		value: 0n,
+		input: new Uint8Array(),
+		gas: 21_000n,
+		maxFeePerGas: 1n,
+		maxPriorityFeePerGas: 1n,
+	}
+	const transaction: EthereumUnsignedTransaction = {
+		type: '1559',
+		...sendTransactionParams,
+		nonce: transactionIdentifier,
+		chainId: 1n,
+	}
+	const signedTransaction = mockSignTransaction(transaction)
+	return {
+		signedTransaction,
+		website: { websiteOrigin: 'https://example.com', icon: undefined, title: 'Example' },
+		created: new Date('2024-01-01T00:00:00.000Z'),
+		originalRequestParameters: {
+			method: 'eth_sendTransaction',
+			params: [sendTransactionParams],
+		},
+		transactionIdentifier,
+	}
+}
+
+function createSerializableSettings(): Settings {
+	return {
+		...settings,
+		activeSimulationAddress: undefined,
+		activeRpcNetwork: {
+			...settings.activeRpcNetwork,
+			chainId: 1n,
+		},
+	}
+}
+
+function createSimulatedCompleteVisualizedSimulation(serializableSettings: Settings, transactionIdentifiers: readonly bigint[] = [1n], numberOfAddressesMadeRich = 0): CompleteVisualizedSimulation {
+	const blockTimeManipulation: BlockTimeManipulation = { type: 'AddToTimestamp', deltaToAdd: 0n, deltaUnit: 'Seconds' }
+	const simulationStateInput = [{
+		stateOverrides: {},
+		transactions: transactionIdentifiers.map(createPreSimulationTransaction),
+		signedMessages: [],
+		blockTimeManipulation,
+		simulateWithZeroBaseFee: false,
+	}]
+	return {
+		addressBookEntries: [],
+		tokenPriceEstimates: [],
+		tokenPriceQuoteToken: undefined,
+		namedTokenIds: [],
+		simulationState: {
+			kind: 'simulated',
+			value: {
+				success: true,
+				simulationStateInput,
+				simulatedBlocks: [],
+				blockNumber: 100n,
+				blockTimestamp: new Date('2024-01-01T00:00:00.000Z'),
+				baseFeePerGas: 1n,
+				simulationConductedTimestamp: new Date('2024-01-01T00:00:05.000Z'),
+				rpcNetwork: serializableSettings.activeRpcNetwork,
+			},
+		},
+		simulationUpdatingState: 'done',
+		simulationResultState: 'done',
+		simulationId: 1,
+		visualizedSimulationState: {
+			success: true,
+			visualizedBlocks: [{
+				simulatedAndVisualizedTransactions: [],
+				visualizedPersonalSignRequests: [],
+				blockTimeManipulation,
+			}],
+		},
+		numberOfAddressesMadeRich,
+	}
+}
+
+function createStackHomePageUpdate(tabId: number, popupRefreshGeneration: number, iconReason: string, transactionIdentifiers: readonly bigint[] = [1n], numberOfAddressesMadeRich = 0, richList: readonly EnrichedRichListElement[] = []): UpdateHomePage {
+	const update = createHomePageUpdate(tabId, popupRefreshGeneration, iconReason, numberOfAddressesMadeRich, richList)
+	const serializableSettings = createSerializableSettings()
+	return {
+		...update,
+		data: {
+			...update.data,
+			visualizedSimulatorState: createSimulatedCompleteVisualizedSimulation(serializableSettings, transactionIdentifiers, numberOfAddressesMadeRich),
+			settings: serializableSettings,
+			rpcEntries: [serializableSettings.activeRpcNetwork],
+			preSimulationBlockTimeManipulation: { type: 'AddToTimestamp', deltaToAdd: 0n, deltaUnit: 'Seconds' },
+		},
+	}
+}
+
+function createSerializableRichHomePageUpdate(tabId: number, popupRefreshGeneration: number, iconReason: string, numberOfAddressesMadeRich: number, richList: readonly EnrichedRichListElement[]): UpdateHomePage {
+	const update = createHomePageUpdate(tabId, popupRefreshGeneration, iconReason, numberOfAddressesMadeRich, richList)
+	const serializableSettings = createSerializableSettings()
+	return {
+		...update,
+		data: {
+			...update.data,
+			settings: serializableSettings,
+			rpcEntries: [serializableSettings.activeRpcNetwork],
+			preSimulationBlockTimeManipulation: { type: 'AddToTimestamp', deltaToAdd: 0n, deltaUnit: 'Seconds' },
+		},
+	}
+}
+
+function createSimulationStateChangedMessage(visualizedSimulatorState: CompleteVisualizedSimulation): MessageToPopup {
+	return {
+		role: 'all',
+		method: 'popup_simulation_state_changed',
+		data: { visualizedSimulatorState },
+	}
+}
+
+function createFailedStackHomePageUpdate(tabId: number, popupRefreshGeneration: number, iconReason: string): UpdateHomePage {
+	const update = createHomePageUpdate(tabId, popupRefreshGeneration, iconReason)
+	const serializableSettings = createSerializableSettings()
+	const blockTimeManipulation: BlockTimeManipulation = { type: 'AddToTimestamp', deltaToAdd: 0n, deltaUnit: 'Seconds' }
+	return {
+		...update,
+		data: {
+			...update.data,
+			visualizedSimulatorState: {
+				addressBookEntries: [],
+				tokenPriceEstimates: [],
+				tokenPriceQuoteToken: undefined,
+				namedTokenIds: [],
+				simulationState: {
+					kind: 'simulated',
+					value: {
+						success: false,
+						simulationStateInput: [{
+							stateOverrides: {},
+							transactions: [createPreSimulationTransaction(1n)],
+							signedMessages: [],
+							blockTimeManipulation,
+							simulateWithZeroBaseFee: false,
+						}],
+						jsonRpcError: {
+							jsonrpc: '2.0',
+							id: 1,
+							error: { code: 3, message: 'execution reverted' },
+						},
+						blockNumber: 100n,
+						blockTimestamp: new Date('2024-01-01T00:00:00.000Z'),
+						baseFeePerGas: 1n,
+						simulationConductedTimestamp: new Date('2024-01-01T00:00:05.000Z'),
+						rpcNetwork: serializableSettings.activeRpcNetwork,
+					},
+				},
+				simulationUpdatingState: 'failed',
+				simulationResultState: 'invalid',
+				simulationId: 2,
+				visualizedSimulationState: {
+					success: false,
+					jsonRpcError: {
+						jsonrpc: '2.0',
+						id: 1,
+						error: { code: 3, message: 'execution reverted' },
+					},
+					visualizedBlocks: [{
+						simulatedAndVisualizedTransactions: [],
+						visualizedPersonalSignRequests: [],
+						blockTimeManipulation,
+					}],
+				},
+				numberOfAddressesMadeRich: 0,
+			},
+			settings: serializableSettings,
+			rpcEntries: [serializableSettings.activeRpcNetwork],
+			preSimulationBlockTimeManipulation: { type: 'AddToTimestamp', deltaToAdd: 0n, deltaUnit: 'Seconds' },
+		},
+	}
+}
+
+describe('simulation visualizer open replies', () => {
+	test('stack visualizer entrypoint wraps the page in Hint for toolbar feedback', async () => {
+		const source = await Bun.file('app/ts/simulationStack.ts').text()
+
+		assert.match(source, /import Hint from '\.\/components\/subcomponents\/Hint\.js'/)
+		assert.match(source, /preact\.createElement\(Hint,\s*\{\s*children:\s*preact\.createElement\(SimulationStackPage,\s*\{\}\)\s*\}\)/)
+	})
+
+	test('stack visualizer entrypoint clears the shell loading placeholder before rendering', async () => {
+		const dom = installDomMock()
+		installBrowserMock()
+		const root = dom.document.createElement('div')
+		root.setAttribute('id', 'simulation-stack-root')
+		root.textContent = 'Loading...'
+		dom.document.body.appendChild(root)
+		Object.defineProperty(dom.document, 'getElementById', {
+			configurable: true,
+			value: (id: string) => id === 'simulation-stack-root' ? root : null,
+		})
+		try {
+			await import(`../../app/ts/simulationStack.ts?entrypoint-test=${ crypto.randomUUID() }`)
+			assert.equal(root.textContent?.includes('Loading...'), false)
+		} finally {
+			dom.restore()
+		}
+	})
+
+	test('Hint resolves copied feedback from nested toolbar click targets', async () => {
+		const source = await Bun.file('app/ts/components/subcomponents/Hint.tsx').text()
+
+		assert.match(source, /target\.closest\(`\[\$\{ attribute \}\]`\)/)
+		assert.match(source, /getHintElement\(event\.target,\s*copyAttribute\)/)
+	})
+
+	test('stack visualizer hook answers the visualizer-open probe but not the main-popup probe', async () => {
+		const dom = installDomMock()
+		const { listeners } = installBrowserMock()
+		try {
+			await act(() => {
+				render(h(StackVisualizerHookProbe, {}), dom.document.body)
+			})
+			const listener = listeners[0]
+			if (listener === undefined) throw new Error('Expected hook to register a runtime listener')
+
+			const visualizerReply = sendRuntimeMessage(listener, { method: 'popup_isSimulationVisualizerOpen' })
+			assert.equal(visualizerReply.returned, true)
+			assert.deepEqual(visualizerReply.response, { method: 'popup_isSimulationVisualizerOpen', data: { isOpen: true } })
+
+			const mainPopupReply = sendRuntimeMessage(listener, { method: 'popup_isMainPopupWindowOpen' })
+			assert.equal(mainPopupReply.returned, undefined)
+			assert.equal(mainPopupReply.response, undefined)
+		} finally {
+			dom.restore()
+		}
+	})
+
+	test('stack visualizer hook accepts updates from a different tab id', async () => {
+		const dom = installDomMock()
+		const { listeners } = installBrowserMock()
+		try {
+			await act(() => {
+				render(h(CrossTabStackVisualizerHookProbe, {}), dom.document.body)
+			})
+			const listener = listeners[0]
+			if (listener === undefined) throw new Error('Expected hook to register a runtime listener')
+
+			await act(() => {
+				listener({ role: 'all', ...createHomePageUpdate(10, 1, 'First tab') }, {}, () => undefined)
+			})
+			assert.equal(dom.document.body.textContent?.includes('First tab'), true)
+
+			await act(() => {
+				listener({ role: 'all', ...createHomePageUpdate(11, 2, 'Second tab') }, {}, () => undefined)
+			})
+			assert.equal(dom.document.body.textContent?.includes('Second tab'), true)
+			assert.equal(dom.document.body.textContent?.includes('First tab'), false)
+		} finally {
+			dom.restore()
+		}
+	})
+
+	test('stack visualizer page shows rich-only state instead of the empty-state dino', async () => {
+		const dom = installDomMock()
+		const { listeners } = installBrowserMock()
+		const richList = [
+			createRichListElement(0x1000000000000000000000000000000000000001n, 'Treasury One'),
+			createRichListElement(0x2000000000000000000000000000000000000002n, 'Treasury Two'),
+			createRichListElement(0x3000000000000000000000000000000000000003n, 'Treasury, Cold'),
+		]
+		try {
+			await act(() => {
+				render(h(SimulationStackPage, {}), dom.document.body)
+			})
+			const listener = listeners[0]
+			if (listener === undefined) throw new Error('Expected page to register a runtime listener')
+
+			await act(() => {
+				listener({ role: 'all', ...serialize(UpdateHomePage, createSerializableRichHomePageUpdate(12, 1, 'Rich tab', 3, richList)) }, {}, () => undefined)
+			})
+
+			assert.equal(dom.document.body.textContent?.includes('Simply making 3 addresses rich'), true)
+			assert.equal(dom.document.body.textContent?.includes('Addresses being made rich are'), true)
+			assert.equal(dom.document.body.textContent?.includes('Treasury One'), true)
+			assert.equal(dom.document.body.textContent?.includes('Treasury Two'), true)
+			assert.equal(dom.document.body.textContent?.includes('Treasury, Cold'), true)
+			const richAddressParagraph = getParagraphByAriaLabel(dom.document.body, 'Addresses being made rich are Treasury One, Treasury Two and Treasury, Cold.')
+			const richAddressGroups = getRichAddressGroups(richAddressParagraph)
+			assert.equal(richAddressGroups.length, 3)
+			assert.equal(richAddressGroups[0]?.textContent?.endsWith(','), true)
+			assert.equal(richAddressGroups[2]?.textContent?.startsWith(' and '), true)
+			assert.equal(richAddressGroups[2]?.textContent?.includes('Treasury, Cold'), true)
+			assert.equal(hasCompactStackCard(dom.document.body), false)
+			assert.equal(dom.document.body.textContent?.includes('Give me some transactions to munch on!'), false)
+			assert.equal(collectElements(dom.document.body, 'nav').some((nav) => hasClass(nav, 'window-header')), false)
+			assert.ok(findElementByClass(dom.document.body, 'div', 'simulation-stack-page'))
+			const richHeader = collectElements(dom.document.body, 'header').find((header) => header.textContent?.includes('Simply making 3 addresses rich') === true)
+			assert.ok(richHeader)
+			assert.equal(String(richHeader.getAttribute?.('aria-expanded')), 'true')
+			assert.ok(findElementByClass(richHeader, 'div', 'card-header-icon'))
+			assert.ok(findElementByClass(richHeader, 'p', 'card-header-title'))
+			await act(async () => {
+				await clickElement(richHeader)
+			})
+			assert.equal(String(richHeader.getAttribute?.('aria-expanded')), 'false')
+			assert.equal(dom.document.body.textContent?.includes('Addresses being made rich are'), false)
+		} finally {
+			dom.restore()
+		}
+	})
+
+	test('stack visualizer rich address sentence handles one entry', async () => {
+		const dom = installDomMock()
+		const { listeners } = installBrowserMock()
+		const richList = [
+			createRichListElement(0x1000000000000000000000000000000000000001n, 'Treasury One'),
+		]
+		try {
+			await act(() => {
+				render(h(SimulationStackPage, {}), dom.document.body)
+			})
+			const listener = listeners[0]
+			if (listener === undefined) throw new Error('Expected page to register a runtime listener')
+
+			await act(() => {
+				listener({ role: 'all', ...serialize(UpdateHomePage, createSerializableRichHomePageUpdate(12, 1, 'Rich tab', 1, richList)) }, {}, () => undefined)
+			})
+
+			assert.equal(dom.document.body.textContent?.includes('Address being made rich is'), true)
+			assert.equal(collectElements(dom.document.body, 'p').some((paragraph) => paragraph.getAttribute?.('aria-label') === 'Address being made rich is Treasury One.'), true)
+		} finally {
+			dom.restore()
+		}
+	})
+
+	test('stack visualizer page shows stack operations without an active simulation address', async () => {
+		const dom = installDomMock()
+		const { listeners } = installBrowserMock()
+		try {
+			await act(() => {
+				render(h(SimulationStackPage, {}), dom.document.body)
+			})
+			const listener = listeners[0]
+			if (listener === undefined) throw new Error('Expected page to register a runtime listener')
+
+			await act(() => {
+				listener({ role: 'all', ...serialize(UpdateHomePage, createStackHomePageUpdate(13, 1, 'Stack tab')) }, {}, () => undefined)
+			})
+
+			assert.equal(dom.document.body.textContent?.includes('Pending transaction'), true)
+			assert.equal(dom.document.body.textContent?.includes('Import, export, and adjust the simulation stack.'), true)
+			assert.equal(dom.document.body.textContent?.includes('Loading...'), false)
+			assert.equal(hasButtonWithText(dom.document.body, 'Import'), true)
+			assert.equal(hasButtonWithText(dom.document.body, 'Export'), true)
+			assert.equal(hasButtonWithText(dom.document.body, 'Clear'), true)
+			assert.equal(getButtonByText(dom.document.body, 'Import').getAttribute?.('class')?.includes('is-small') ?? false, false)
+			assert.equal(getButtonByText(dom.document.body, 'Export').getAttribute?.('class')?.includes('is-small') ?? false, false)
+			assert.equal(getButtonByText(dom.document.body, 'Clear').getAttribute?.('class')?.includes('is-small') ?? false, false)
+			assert.equal(dom.document.body.textContent?.includes('Export Simulation Stack'), false)
+			assert.equal(hasCompactStackCard(dom.document.body), false)
+			const targetRow = findElementById(dom.document.body, 'simulation-stack-transaction-0x1')
+			assert.ok(targetRow)
+			assert.equal(targetRow.textContent?.includes('Pending transaction'), true)
+			assert.equal(targetRow.textContent?.includes('Simulate delay'), false)
+			assert.equal(dom.document.body.textContent?.includes('Give me some transactions to munch on!'), false)
+		} finally {
+			dom.restore()
+		}
+	})
+
+	test('stack visualizer keeps the page header first when an unexpected error is visible', async () => {
+		const dom = installDomMock()
+		const { listeners } = installBrowserMock()
+		const update = createStackHomePageUpdate(13, 1, 'Stack tab')
+		try {
+			await act(() => {
+				render(h(SimulationStackPage, {}), dom.document.body)
+			})
+			const listener = listeners[0]
+			if (listener === undefined) throw new Error('Expected page to register a runtime listener')
+
+			await act(() => {
+				listener({
+					role: 'all',
+					...serialize(UpdateHomePage, {
+						...update,
+						data: {
+							...update.data,
+							latestUnexpectedError: {
+								method: 'popup_UnexpectedErrorOccured',
+								data: {
+									message: 'render failed',
+									timestamp: new Date('2024-01-01T00:00:00.000Z'),
+									source: 'simulationStack',
+									code: 'render_error',
+									debugId: undefined,
+								},
+							},
+						},
+					}),
+				}, {}, () => undefined)
+			})
+
+			const layout = findElementByClass(dom.document.body, 'div', 'simulation-stack-page')
+			assert.ok(layout)
+			assert.equal(getFirstElementChild(layout)?.tagName, 'HEADER')
+			assert.equal(getFirstElementChild(layout)?.textContent?.includes('Simulation Stack'), true)
+			const layoutChildren = getElementChildren(layout)
+			assert.equal(layoutChildren[1]?.tagName, 'DIV')
+			assert.equal(hasClass(layoutChildren[1], 'simulation-stack-page-body'), true)
+			assert.equal(dom.document.body.textContent?.includes('An unexpected error occured!'), true)
+		} finally {
+			dom.restore()
+		}
+	})
+
+	test('stack visualizer page shows rich addresses in simulated stack state', async () => {
+		const dom = installDomMock()
+		const { listeners } = installBrowserMock()
+		const richList = [
+			createRichListElement(0x3000000000000000000000000000000000000003n, 'Treasury Three'),
+			createRichListElement(0x4000000000000000000000000000000000000004n, 'Treasury Four'),
+		]
+		try {
+			await act(() => {
+				render(h(SimulationStackPage, {}), dom.document.body)
+			})
+			const listener = listeners[0]
+			if (listener === undefined) throw new Error('Expected page to register a runtime listener')
+
+			await act(() => {
+				listener({ role: 'all', ...serialize(UpdateHomePage, createStackHomePageUpdate(13, 1, 'Stack tab', [1n], 2, richList)) }, {}, () => undefined)
+			})
+
+			assert.equal(dom.document.body.textContent?.includes('Pending transaction'), true)
+			assert.equal(dom.document.body.textContent?.includes('Simply making 2 addresses rich'), true)
+			assert.equal(dom.document.body.textContent?.includes('Addresses being made rich are'), true)
+			assert.equal(dom.document.body.textContent?.includes('Treasury Three'), true)
+			assert.equal(dom.document.body.textContent?.includes('Treasury Four'), true)
+			assert.equal(collectElements(dom.document.body, 'p').some((paragraph) => paragraph.getAttribute?.('aria-label') === 'Addresses being made rich are Treasury Three and Treasury Four.'), true)
+			const richHeader = collectElements(dom.document.body, 'header').find((header) => header.textContent?.includes('Simply making 2 addresses rich') === true)
+			assert.ok(richHeader)
+			assert.equal(String(richHeader.getAttribute?.('aria-expanded')), 'true')
+
+			await act(async () => {
+				await clickElement(richHeader)
+			})
+			assert.equal(String(richHeader.getAttribute?.('aria-expanded')), 'false')
+			assert.equal(dom.document.body.textContent?.includes('Addresses being made rich are'), false)
+			assert.equal(dom.document.body.textContent?.includes('Pending transaction'), true)
+		} finally {
+			dom.restore()
+		}
+	})
+
+	test('stack visualizer refreshes rich metadata after live simulation updates', async () => {
+		const dom = installDomMock()
+		const { listeners, sentMessages } = installBrowserMock()
+		const serializableSettings = createSerializableSettings()
+		try {
+			await act(() => {
+				render(h(SimulationStackPage, {}), dom.document.body)
+			})
+			const listener = listeners[0]
+			if (listener === undefined) throw new Error('Expected page to register a runtime listener')
+			sentMessages.splice(0)
+
+			await act(() => {
+				listener(serialize(MessageToPopup, createSimulationStateChangedMessage(createSimulatedCompleteVisualizedSimulation(serializableSettings, [1n], 1))), {}, () => undefined)
+			})
+
+			assert.equal(sentMessages.some((message) => typeof message === 'object' && message !== null && 'method' in message && message.method === 'popup_requestNewHomeData'), true)
+		} finally {
+			dom.restore()
+		}
+	})
+
+	test('stack visualizer failure banner stays readable outside blurred simulation content', async () => {
+		const dom = installDomMock()
+		const { listeners } = installBrowserMock()
+		try {
+			await act(() => {
+				render(h(SimulationStackPage, {}), dom.document.body)
+			})
+			const listener = listeners[0]
+			if (listener === undefined) throw new Error('Expected page to register a runtime listener')
+
+			await act(() => {
+				listener({ role: 'all', ...serialize(UpdateHomePage, createFailedStackHomePageUpdate(16, 1, 'Failed stack tab')) }, {}, () => undefined)
+			})
+
+			const errorMessage = 'Failed to simulate the stack due to error: "execution reverted". Please modify the stack to make it simutable.'
+			const errorBanner = collectElements(dom.document.body, 'p').find((element) => element.textContent?.includes(errorMessage) === true)
+			assert.ok(errorBanner)
+			assert.equal(hasAncestorWithClass(errorBanner, 'blur'), false)
+			const blurredContent = findElementByClass(dom.document.body, 'div', 'blur')
+			assert.ok(blurredContent)
+			assert.equal(blurredContent?.textContent?.includes('Pending transaction') ?? false, true)
+		} finally {
+			dom.restore()
+		}
+	})
+
+	test('stack visualizer export button copies the simulation stack export payload', async () => {
+		const dom = installDomMock()
+		const clipboardMock = installClipboardMock()
+		const exportPayload = '{ "name": "Interceptor Simulation Export" }'
+		const { listeners, sentMessages } = installBrowserMock((message) => {
+			if (typeof message === 'object' && message !== null && 'method' in message && message.method === 'popup_requestInterceptorSimulationInput') {
+				return { method: 'popup_requestInterceptorSimulationInput', ethSimulateV1InputString: exportPayload }
+			}
+			return undefined
+		})
+		try {
+			await act(() => {
+				render(h(SimulationStackPage, {}), dom.document.body)
+			})
+			const listener = listeners[0]
+			if (listener === undefined) throw new Error('Expected page to register a runtime listener')
+
+			await act(() => {
+				listener({ role: 'all', ...serialize(UpdateHomePage, createStackHomePageUpdate(19, 1, 'Stack tab')) }, {}, () => undefined)
+			})
+
+			await act(async () => {
+				await clickElement(getButtonByText(dom.document.body, 'Export'))
+			})
+
+			assert.equal(sentMessages.some((message) => typeof message === 'object' && message !== null && 'method' in message && message.method === 'popup_requestInterceptorSimulationInput'), true)
+			assert.deepStrictEqual(clipboardMock.copiedText, [exportPayload])
+		} finally {
+			clipboardMock.restore()
+			dom.restore()
+		}
+	})
+
+	test('stack visualizer transaction cards collapse and reopen independently', async () => {
+		const dom = installDomMock()
+		const { listeners } = installBrowserMock()
+		try {
+			await act(() => {
+				render(h(SimulationStackPage, {}), dom.document.body)
+			})
+			const listener = listeners[0]
+			if (listener === undefined) throw new Error('Expected page to register a runtime listener')
+
+			await act(() => {
+				listener({ role: 'all', ...serialize(UpdateHomePage, createStackHomePageUpdate(18, 1, 'Stack tab', [1n, 2n])) }, {}, () => undefined)
+			})
+
+			const transactionHeaders = getHeadersContainingText(dom.document.body, 'Pending transaction')
+			assert.equal(transactionHeaders.length, 2)
+			const firstHeader = transactionHeaders[0]
+			const secondHeader = transactionHeaders[1]
+			if (firstHeader === undefined || secondHeader === undefined) throw new Error('Expected two transaction headers')
+			assert.equal(String(firstHeader.getAttribute?.('aria-expanded')), 'true')
+			assert.equal(String(secondHeader.getAttribute?.('aria-expanded')), 'true')
+			assert.equal(countTextOccurrences(dom.document.body.textContent ?? '', 'Original request'), 2)
+
+			await act(async () => {
+				await clickElement(firstHeader)
+			})
+			assert.equal(String(firstHeader.getAttribute?.('aria-expanded')), 'false')
+			assert.equal(String(secondHeader.getAttribute?.('aria-expanded')), 'true')
+			assert.equal(countTextOccurrences(dom.document.body.textContent ?? '', 'Original request'), 1)
+			assert.equal(dom.document.body.textContent?.includes('Simulate delay'), true)
+
+			await act(async () => {
+				await clickElement(secondHeader)
+			})
+			assert.equal(String(firstHeader.getAttribute?.('aria-expanded')), 'false')
+			assert.equal(String(secondHeader.getAttribute?.('aria-expanded')), 'false')
+			assert.equal(countTextOccurrences(dom.document.body.textContent ?? '', 'Original request'), 0)
+			assert.equal(dom.document.body.textContent?.includes('Simulate delay'), true)
+
+			await act(async () => {
+				await clickElement(firstHeader)
+			})
+			assert.equal(String(firstHeader.getAttribute?.('aria-expanded')), 'true')
+			assert.equal(String(secondHeader.getAttribute?.('aria-expanded')), 'false')
+			assert.equal(countTextOccurrences(dom.document.body.textContent ?? '', 'Original request'), 1)
+
+			await act(async () => {
+				await clickElement(secondHeader)
+			})
+			assert.equal(String(firstHeader.getAttribute?.('aria-expanded')), 'true')
+			assert.equal(String(secondHeader.getAttribute?.('aria-expanded')), 'true')
+			assert.equal(countTextOccurrences(dom.document.body.textContent ?? '', 'Original request'), 2)
+		} finally {
+			dom.restore()
+		}
+	})
+
+	test('stack visualizer target hash no-ops when the target element cannot scroll', async () => {
+		const dom = installDomMock()
+		const flushAnimationFrames = installQueuedAnimationFrames()
+		const { listeners } = installBrowserMock()
+		Object.defineProperty(globalThis.window, 'location', {
+			configurable: true,
+			writable: true,
+			value: { hash: getSimulationStackTargetHash({ type: 'Transaction', transactionIdentifier: 1n }, 'no-scroll') },
+		})
+		Object.defineProperty(dom.document, 'getElementById', {
+			configurable: true,
+			value: (id: string) => findElementById(dom.document.body, id) ?? null,
+		})
+		try {
+			await act(() => {
+				render(h(SimulationStackPage, {}), dom.document.body)
+			})
+			const listener = listeners[0]
+			if (listener === undefined) throw new Error('Expected page to register a runtime listener')
+
+			await act(() => {
+				listener({ role: 'all', ...serialize(UpdateHomePage, createStackHomePageUpdate(14, 1, 'Stack tab')) }, {}, () => undefined)
+			})
+			await act(() => {
+				flushAnimationFrames()
+			})
+
+			const targetRow = findElementById(dom.document.body, 'simulation-stack-transaction-0x1')
+			assert.ok(targetRow)
+			assert.equal(targetRow.getAttribute?.('class')?.includes('simulation-stack-row--highlighted'), false)
+		} finally {
+			dom.restore()
+		}
+	})
+
+	test('stack visualizer target hash no-ops when target lookup is unavailable', async () => {
+		const dom = installDomMock()
+		const flushAnimationFrames = installQueuedAnimationFrames()
+		const { listeners } = installBrowserMock()
+		Object.defineProperty(globalThis.window, 'location', {
+			configurable: true,
+			writable: true,
+			value: { hash: getSimulationStackTargetHash({ type: 'Transaction', transactionIdentifier: 1n }, 'no-lookup') },
+		})
+		Object.defineProperty(dom.document, 'getElementById', {
+			configurable: true,
+			value: undefined,
+		})
+		try {
+			await act(() => {
+				render(h(SimulationStackPage, {}), dom.document.body)
+			})
+			const listener = listeners[0]
+			if (listener === undefined) throw new Error('Expected page to register a runtime listener')
+
+			await act(() => {
+				listener({ role: 'all', ...serialize(UpdateHomePage, createStackHomePageUpdate(16, 1, 'Stack tab')) }, {}, () => undefined)
+			})
+			await act(() => {
+				flushAnimationFrames()
+			})
+
+			const targetRow = findElementById(dom.document.body, 'simulation-stack-transaction-0x1')
+			assert.ok(targetRow)
+			assert.equal(targetRow.getAttribute?.('class')?.includes('simulation-stack-row--highlighted'), false)
+		} finally {
+			dom.restore()
+		}
+	})
+
+	test('stack visualizer target hash scrolls to and highlights the matching row', async () => {
+		const dom = installDomMock()
+		const flushAnimationFrames = installQueuedAnimationFrames()
+		const { listeners } = installBrowserMock()
+		const scrollCalls: ScrollIntoViewOptions[] = []
+		Object.defineProperty(globalThis.window, 'location', {
+			configurable: true,
+			writable: true,
+			value: { hash: getSimulationStackTargetHash({ type: 'Transaction', transactionIdentifier: 1n }, 'scroll') },
+		})
+		Object.defineProperty(dom.document, 'getElementById', {
+			configurable: true,
+			value: (id: string) => {
+				const element = findElementById(dom.document.body, id)
+				if (element === undefined) return null
+				element.scrollIntoView = (options?: ScrollIntoViewOptions) => {
+					if (options !== undefined) scrollCalls.push(options)
+				}
+				return element
+			},
+		})
+		try {
+			await act(() => {
+				render(h(SimulationStackPage, {}), dom.document.body)
+			})
+			const listener = listeners[0]
+			if (listener === undefined) throw new Error('Expected page to register a runtime listener')
+
+			await act(() => {
+				listener({ role: 'all', ...serialize(UpdateHomePage, createStackHomePageUpdate(15, 1, 'Stack tab')) }, {}, () => undefined)
+			})
+			const targetHeader = getHeadersContainingText(dom.document.body, 'Pending transaction')[0]
+			if (targetHeader === undefined) throw new Error('Expected target transaction header')
+			await act(async () => {
+				await clickElement(targetHeader)
+			})
+			assert.equal(String(targetHeader.getAttribute?.('aria-expanded')), 'false')
+			await act(() => {
+				flushAnimationFrames()
+			})
+
+			assert.deepStrictEqual(scrollCalls.at(-1), { behavior: 'smooth', block: 'center' })
+			const targetRow = findElementById(dom.document.body, 'simulation-stack-transaction-0x1')
+			assert.ok(targetRow)
+			assert.equal(targetRow.getAttribute?.('class')?.includes('simulation-stack-row--highlighted'), true)
+			assert.equal(String(targetHeader.getAttribute?.('aria-expanded')), 'true')
+		} finally {
+			dom.restore()
+		}
+	})
+
+	test('stack visualizer target hash does not replay after same-hash updates', async () => {
+		const dom = installDomMock()
+		const flushAnimationFrames = installQueuedAnimationFrames()
+		const { listeners } = installBrowserMock()
+		const scrollCalls: ScrollIntoViewOptions[] = []
+		Object.defineProperty(globalThis.window, 'location', {
+			configurable: true,
+			writable: true,
+			value: { hash: getSimulationStackTargetHash({ type: 'Transaction', transactionIdentifier: 1n }, 'retry') },
+		})
+		Object.defineProperty(dom.document, 'getElementById', {
+			configurable: true,
+			value: (id: string) => {
+				const element = findElementById(dom.document.body, id)
+				if (element === undefined) return null
+				element.scrollIntoView = (options?: ScrollIntoViewOptions) => {
+					if (options !== undefined) scrollCalls.push(options)
+				}
+				return element
+			},
+		})
+		try {
+			await act(() => {
+				render(h(SimulationStackPage, {}), dom.document.body)
+			})
+			const listener = listeners[0]
+			if (listener === undefined) throw new Error('Expected page to register a runtime listener')
+
+			await act(() => {
+				flushAnimationFrames()
+			})
+			assert.equal(scrollCalls.length, 0)
+
+			await act(() => {
+				listener({ role: 'all', ...serialize(UpdateHomePage, createStackHomePageUpdate(17, 1, 'Stack tab')) }, {}, () => undefined)
+			})
+			await act(() => {
+				flushAnimationFrames()
+			})
+			assert.equal(scrollCalls.length, 1)
+
+			await act(() => {
+				listener({ role: 'all', ...serialize(UpdateHomePage, createStackHomePageUpdate(17, 2, 'Stack tab refresh')) }, {}, () => undefined)
+			})
+			await act(() => {
+				flushAnimationFrames()
+			})
+			assert.equal(scrollCalls.length, 1)
+
+			globalThis.window.location.hash = getSimulationStackTargetHash({ type: 'Transaction', transactionIdentifier: 1n }, 'retry-again')
+			await act(() => {
+				listener({ role: 'all', ...serialize(UpdateHomePage, createStackHomePageUpdate(17, 3, 'Stack tab retarget')) }, {}, () => undefined)
+			})
+			await act(() => {
+				flushAnimationFrames()
+			})
+			assert.equal(scrollCalls.length, 2)
+		} finally {
+			dom.restore()
+		}
+	})
+	})

--- a/test/tests/useResetSimulation.test.tsx
+++ b/test/tests/useResetSimulation.test.tsx
@@ -1,0 +1,107 @@
+import * as assert from 'assert'
+import { describe, test } from 'bun:test'
+import { h, render } from 'preact'
+import { act } from 'preact/test-utils'
+import { useResetSimulation } from '../../app/ts/components/hooks/useResetSimulation.js'
+import { installDomMock } from './domMock.js'
+
+type ResetHookApi = ReturnType<typeof useResetSimulation>
+
+let hookApi: ResetHookApi | undefined
+
+function installBrowserMock() {
+	const previousBrowser = globalThis.browser
+	const sentMessages: unknown[] = []
+	Object.defineProperty(globalThis, 'browser', {
+		configurable: true,
+		writable: true,
+		value: {
+			runtime: {
+				lastError: null,
+				async sendMessage(message: unknown) {
+					sentMessages.push(message)
+					return undefined
+				},
+			},
+		},
+	})
+	return {
+		sentMessages,
+		restore() {
+			globalThis.browser = previousBrowser
+		},
+	}
+}
+
+function ResetHookProbe({ recoveryDelayMs }: { recoveryDelayMs: number }) {
+	hookApi = useResetSimulation(recoveryDelayMs)
+	return <button disabled = { hookApi.disableReset.value }>Clear</button>
+}
+
+function getHookApi() {
+	if (hookApi === undefined) throw new Error('Expected reset hook to be rendered')
+	return hookApi
+}
+
+async function wait(milliseconds: number) {
+	await new Promise((resolve) => globalThis.setTimeout(resolve, milliseconds))
+}
+
+describe('useResetSimulation', () => {
+	test('re-enables reset when no simulation update arrives', async () => {
+		const dom = installDomMock()
+		const browserMock = installBrowserMock()
+		hookApi = undefined
+		try {
+			await act(() => {
+				render(h(ResetHookProbe, { recoveryDelayMs: 1 }), dom.document.body)
+			})
+
+			const resetHook = getHookApi()
+			assert.equal(resetHook.disableReset.value, false)
+
+			await act(() => {
+				resetHook.resetSimulation()
+			})
+
+			assert.equal(resetHook.disableReset.value, true)
+			assert.equal(browserMock.sentMessages.length, 1)
+
+			await act(async () => {
+				await wait(5)
+			})
+
+			assert.equal(resetHook.disableReset.value, false)
+		} finally {
+			render(null, dom.document.body)
+			dom.restore()
+			browserMock.restore()
+			hookApi = undefined
+		}
+	})
+
+	test('re-enables reset immediately when simulation data arrives', async () => {
+		const dom = installDomMock()
+		const browserMock = installBrowserMock()
+		hookApi = undefined
+		try {
+			await act(() => {
+				render(h(ResetHookProbe, { recoveryDelayMs: 1000 }), dom.document.body)
+			})
+
+			const resetHook = getHookApi()
+			await act(() => {
+				resetHook.resetSimulation()
+				resetHook.markSimulationDataReceived()
+			})
+
+			assert.equal(resetHook.disableReset.value, false)
+			assert.equal(browserMock.sentMessages.length, 1)
+		} finally {
+			render(null, dom.document.body)
+			dom.restore()
+			browserMock.restore()
+			hookApi = undefined
+		}
+	})
+})


### PR DESCRIPTION
## Summary
- Add the dedicated simulation stack tab/page with live stack updates, deep-linked row navigation, auto-expanded target transactions, collapsible transaction/rich-address cards, stack export/import/reset actions, and loading-state cleanup.
- Tighten responsive popup and simulation-stack layout behavior, including header text ellipsizing, website/title truncation, full-width simulation outcome cards, normal-sized stack action buttons, and narrow-screen overflow fixes.
- Improve simulation-stack error and status handling so network/unexpected-error banners stay readable without distorting the page header or blurring failure messages.
- Refactor shared popup data flow around live simulation home data/reset handling and expand related DOM/CSS/component test coverage.

## Testing
- `bun test`
- `bun run setup-chrome`
- `bun run typecheck`
- `bun run lint`

## Review
- Final reviewer pass found no High, Medium, or Low issues.
- Reviewer score: 94/100.
