### PR TITLE
Stop logging user-facing unexpected errors to console

### DIFF
--- a/app/ts/utils/errors.ts
+++ b/app/ts/utils/errors.ts
@@ -185,15 +185,6 @@ export async function reportUnexpectedError(error: unknown, metadata: ErrorRepor
 	if ((metadata.suppressExpectedInfrastructure ?? true) && isExpectedInfrastructureError(error)) return
 	const defaultCode = isWrappedNewBlockAbort(error) ? 'wrapped_new_block_abort' : 'unexpected_error'
 	const report = createErrorReport(error, metadata, ERROR_REPORTING_POLICY.unexpected, defaultCode, metadata.displayMessage ?? normalizeUnexpectedError(error).message)
-	console.error('Unexpected Interceptor error', {
-		debugId: report.debugId,
-		source: report.source,
-		code: report.code,
-		category: report.category,
-		severity: report.severity,
-	})
-	printError(error)
-	console.trace()
 	await appendErrorDiagnostic(report)
 	const errorMessage = createUnexpectedErrorPopupMessage(report)
 	let messageToBroadcast = errorMessage

--- a/test/tests/unexpectedErrorDiagnostics.test.ts
+++ b/test/tests/unexpectedErrorDiagnostics.test.ts
@@ -13,6 +13,29 @@ type RuntimeMessage = {
 	data?: unknown
 }
 
+async function captureConsoleCalls<T>(run: () => Promise<T>) {
+	const originalConsoleError = console.error
+	const originalConsoleTrace = console.trace
+	const consoleErrors: unknown[][] = []
+	const consoleTraces: unknown[][] = []
+	console.error = (...args: unknown[]) => {
+		consoleErrors.push(args)
+	}
+	console.trace = (...args: unknown[]) => {
+		consoleTraces.push(args)
+	}
+	try {
+		return {
+			result: await run(),
+			consoleErrors,
+			consoleTraces,
+		}
+	} finally {
+		console.error = originalConsoleError
+		console.trace = originalConsoleTrace
+	}
+}
+
 function createBrowserMock() {
 	const storageState: Record<string, unknown> = {}
 	const sentMessages: RuntimeMessage[] = []
@@ -262,6 +285,39 @@ describe('unexpected error diagnostics', () => {
 		assert.equal(diagnostic?.source, 'internal')
 		assert.equal(diagnostic?.code, 'unexpected_error')
 		assert.equal(typeof diagnostic?.debugId, 'string')
+	})
+
+	test('does not log user-facing unexpected errors to the extension console', async () => {
+		browserMock.reset()
+		const { reportUnexpectedError } = await modulesPromise
+
+		const { consoleErrors, consoleTraces } = await captureConsoleCalls(async () => await reportUnexpectedError(new Error('plain error')))
+
+		assert.equal(consoleErrors.length, 0)
+		assert.equal(consoleTraces.length, 0)
+	})
+
+	test('still logs reporting pipeline failures to the extension console', async () => {
+		browserMock.reset()
+		browserMock.setStorageSet(async () => { throw new Error('storage failed') })
+		const { reportUnexpectedError } = await modulesPromise
+
+		const { consoleErrors, consoleTraces } = await captureConsoleCalls(async () => await reportUnexpectedError(new Error('plain error')))
+
+		assert.equal(consoleTraces.length, 0)
+		assert.equal(consoleErrors.some((args) => args.includes('Failed to persist interceptor error diagnostic.')), true)
+		assert.equal(consoleErrors.some((args) => args.includes('Failed to persist unexpected error.')), true)
+	})
+
+	test('still logs popup broadcast failures to the extension console', async () => {
+		browserMock.reset()
+		browserMock.setSendMessage(async () => { throw new Error('broadcast failed') })
+		const { reportUnexpectedError } = await modulesPromise
+
+		const { consoleErrors, consoleTraces } = await captureConsoleCalls(async () => await reportUnexpectedError(new Error('plain error')))
+
+		assert.equal(consoleTraces.length, 0)
+		assert.equal(consoleErrors.some((args) => args.includes('Failed to broadcast unexpected error to open popup windows.')), true)
 	})
 
 	test('uses metadata message without dropping the original error cause', async () => {


### PR DESCRIPTION
## Summary
- Removed the `console.error` and `console.trace` calls from `reportUnexpectedError`, so user-facing unexpected errors are no longer echoed to the extension console.
- Kept console logging for failure paths in the reporting pipeline and popup broadcast flow.
- Added regression tests covering the no-console-log case and the remaining failure logging behavior.

## Testing
- `bun test`
- `bun run setup-chrome`
- `bun run typecheck`
- `bun run lint`