### PR TITLE
Handle empty multicall decode results safely

### DIFF
--- a/.codex/agents/reviewer.toml
+++ b/.codex/agents/reviewer.toml
@@ -20,7 +20,8 @@ Prioritize:
 5. Validation gaps that create concrete regression risk, especially when required checks were skipped or Chrome bundle/browser-communication behavior was changed.
 6. Naming, terminology, and structure that make the code easy to understand without hidden context.
 7. Code and text duplication that repeats existing behavior or guidance instead of reusing, consolidating, or linking to the canonical source.
-8. Maintainability problems that can cause future mistakes, especially unclear ownership boundaries, brittle special cases, hidden coupling, unnecessary divergence between similar code paths, or edits to generated output instead of TypeScript sources.
+8. Error handling that silently converts broad or unknown failures into fallback values. Broad `catch` blocks are only acceptable when they rethrow unexpected errors or prove the caught error is an expected, targeted condition.
+9. Maintainability problems that can cause future mistakes, especially unclear ownership boundaries, brittle special cases, hidden coupling, unnecessary divergence between similar code paths, or edits to generated output instead of TypeScript sources.
 
 Do not raise speculative, preference-only, or style-only findings unless they create concrete readability, correctness, or maintenance risk. Do not rely on hidden conversation context. Base findings on the diff and repository evidence, and put uncertainty in `Review limitations`.
 
@@ -36,6 +37,7 @@ Review method:
 - Check changed documentation, instructions, UI copy, and comments for repeated statements of the same guidance; prefer one canonical explanation with links or concise references.
 - Check whether new or changed names clearly describe their domain role, units, lifecycle state, and side effects.
 - Check whether the control flow, data flow, module boundaries, and tests are simple enough for a future maintainer to understand, extend, and change safely without hidden conversation context.
+- Check changed `catch` blocks closely. Flag any new or modified catch that swallows all errors, returns a fallback, logs-only, or maps unknown errors to benign values unless it first narrows to the specific expected error type/code/name/message and rethrows everything else.
 - Check whether the implementation creates long-term maintenance risk through hard-coded exceptions, inconsistent patterns, duplicated policy, fragile ordering assumptions, or missing ownership of shared behavior.
 - Check whether source changes were made in TypeScript rather than generated JavaScript output, and whether setup/build scripts are used only when generated extension output is intentionally refreshed.
 - Check whether validation matches the repository rules in AGENTS.md. The default final suite for code, tests, configuration, tooling, and repo-instruction changes is `bun test`, `bun run setup-chrome`, `bun run typecheck`, and `bun run lint`, run separately after the full task is complete.

--- a/app/ts/utils/abiRuntime.ts
+++ b/app/ts/utils/abiRuntime.ts
@@ -252,6 +252,32 @@ export function decodeFunctionOutput(abi: Abi, functionName: string, data: Hex |
 	return decodeFunctionOutputUnchecked(abi, functionName, data)
 }
 
+const viemAbiDataDecodeErrorNames = new Set([
+	'AbiDecodingDataSizeInvalidError',
+	'AbiDecodingDataSizeTooSmallError',
+	'AbiDecodingZeroDataError',
+	'InvalidBytesBooleanError',
+	'PositionOutOfBoundsError',
+])
+
+const isViemAbiDataDecodeError = (error: unknown) => error instanceof Error && viemAbiDataDecodeErrorNames.has(error.name)
+
+export const decodeFunctionOutputSafely = <T>(
+	abi: Abi,
+	functionName: string,
+	data: Hex | Uint8Array,
+	isExpectedType: (value: unknown) => value is T,
+): T | undefined => {
+	let decoded: unknown
+	try {
+		decoded = decodeFunctionOutput(abi, functionName, data)
+	} catch (error) {
+		if (!isViemAbiDataDecodeError(error)) throw error
+		return undefined
+	}
+	return isExpectedType(decoded) ? decoded : undefined
+}
+
 export function decodeFunctionDataStrict<const TAbi extends Abi>(
 	abi: TAbi,
 	data: Hex | Uint8Array,

--- a/app/ts/utils/tokenIdentification.ts
+++ b/app/ts/utils/tokenIdentification.ts
@@ -4,7 +4,7 @@ import type { EthereumAddress } from '../types/wire-types.js'
 import type { IEthereumClientService } from '../simulation/services/EthereumClientService.js'
 import { checksummedAddress, stringToUint8Array } from './bigint.js'
 import type { Erc1155Entry, Erc20TokenEntry, Erc721Entry } from '../types/addressBookTypes.js'
-import { decodeFunctionOutput, encodeFunctionCall } from './abiRuntime.js'
+import { decodeFunctionOutputSafely, encodeFunctionCall } from './abiRuntime.js'
 import { isBigint, isBoolean, isNumberOrBigint, isString } from './typescript.js'
 
 type EOA = {
@@ -39,25 +39,9 @@ type MulticallResult = {
 	returnData: Uint8Array
 }
 
-const viemAbiDataDecodeErrorNames = new Set([
-	'AbiDecodingDataSizeInvalidError',
-	'AbiDecodingDataSizeTooSmallError',
-	'AbiDecodingZeroDataError',
-	'InvalidBytesBooleanError',
-	'PositionOutOfBoundsError',
-])
-
-const isViemAbiDataDecodeError = (error: unknown) => error instanceof Error && viemAbiDataDecodeErrorNames.has(error.name)
-
-const decodeFunctionOutputSafely = <T>(abi: Abi, functionName: string, result: MulticallResult, isExpectedType: (value: unknown) => value is T): T | undefined => {
+const decodeMulticallFunctionOutputSafely = <T>(abi: Abi, functionName: string, result: MulticallResult, isExpectedType: (value: unknown) => value is T): T | undefined => {
 	if (!result.success || result.returnData.length === 0) return undefined
-	try {
-		const decoded = decodeFunctionOutput(abi, functionName, result.returnData)
-		return isExpectedType(decoded) ? decoded : undefined
-	} catch (error) {
-		if (!isViemAbiDataDecodeError(error)) throw error
-		return undefined
-	}
+	return decodeFunctionOutputSafely(abi, functionName, result.returnData, isExpectedType)
 }
 
 export async function itentifyAddressViaOnChainInformation(ethereumClientService: IEthereumClientService, requestAbortController: AbortController | undefined, address: EthereumAddress): Promise<IdentifiedAddress> {
@@ -77,20 +61,20 @@ export async function itentifyAddressViaOnChainInformation(ethereumClientService
 
 	const [isErc721, hasMetadata, isErc1155, name, symbol, decimals, totalSupply] = await tryAggregateMulticall(ethereumClientService, requestAbortController, calls)
 	if (isErc721 === undefined || hasMetadata === undefined || isErc1155 === undefined || name === undefined || symbol === undefined || decimals === undefined || totalSupply === undefined) throw new Error('Multicall result is too short')
-	const supportsErc721 = decodeFunctionOutputSafely(Erc721ABI, 'supportsInterface', isErc721, isBoolean)
-	const supportsMetadata = decodeFunctionOutputSafely(Erc721ABI, 'supportsInterface', hasMetadata, isBoolean)
-	const supportsErc1155 = decodeFunctionOutputSafely(Erc721ABI, 'supportsInterface', isErc1155, isBoolean)
-	const tokenName = decodeFunctionOutputSafely(Erc20ABI, 'name', name, isString)
-	const tokenSymbol = decodeFunctionOutputSafely(Erc20ABI, 'symbol', symbol, isString)
-	const tokenDecimals = decodeFunctionOutputSafely(Erc20ABI, 'decimals', decimals, isNumberOrBigint)
-	const tokenSupply = decodeFunctionOutputSafely(Erc20ABI, 'totalSupply', totalSupply, isBigint)
+	const supportsErc721 = decodeMulticallFunctionOutputSafely(Erc721ABI, 'supportsInterface', isErc721, isBoolean)
+	const supportsMetadata = decodeMulticallFunctionOutputSafely(Erc721ABI, 'supportsInterface', hasMetadata, isBoolean)
+	const supportsErc1155 = decodeMulticallFunctionOutputSafely(Erc721ABI, 'supportsInterface', isErc1155, isBoolean)
+	const tokenName = decodeMulticallFunctionOutputSafely(Erc20ABI, 'name', name, isString)
+	const tokenSymbol = decodeMulticallFunctionOutputSafely(Erc20ABI, 'symbol', symbol, isString)
+	const tokenDecimals = decodeMulticallFunctionOutputSafely(Erc20ABI, 'decimals', decimals, isNumberOrBigint)
+	const tokenSupply = decodeMulticallFunctionOutputSafely(Erc20ABI, 'totalSupply', totalSupply, isBigint)
 
 	if (supportsErc721 === true) {
 		return {
 			type: 'ERC721',
 			address,
-			name: supportsMetadata === true ? decodeFunctionOutputSafely(Erc721ABI, 'name', name, isString) ?? checksummedAddress(address) : checksummedAddress(address),
-			symbol: supportsMetadata === true ? decodeFunctionOutputSafely(Erc721ABI, 'symbol', symbol, isString) ?? '???' : '???',
+			name: supportsMetadata === true ? decodeMulticallFunctionOutputSafely(Erc721ABI, 'name', name, isString) ?? checksummedAddress(address) : checksummedAddress(address),
+			symbol: supportsMetadata === true ? decodeMulticallFunctionOutputSafely(Erc721ABI, 'symbol', symbol, isString) ?? '???' : '???',
 			entrySource: 'OnChain'
 		}
 	}

--- a/app/ts/utils/tokenIdentification.ts
+++ b/app/ts/utils/tokenIdentification.ts
@@ -5,7 +5,7 @@ import type { IEthereumClientService } from '../simulation/services/EthereumClie
 import { checksummedAddress, stringToUint8Array } from './bigint.js'
 import type { Erc1155Entry, Erc20TokenEntry, Erc721Entry } from '../types/addressBookTypes.js'
 import { decodeFunctionOutput, encodeFunctionCall } from './abiRuntime.js'
-import { isBigint, isBoolean, isNumber, isString } from './typescript.js'
+import { isBigint, isBoolean, isNumberOrBigint, isString } from './typescript.js'
 
 type EOA = {
 	type: 'EOA'
@@ -82,7 +82,7 @@ export async function itentifyAddressViaOnChainInformation(ethereumClientService
 	const supportsErc1155 = decodeFunctionOutputSafely(Erc721ABI, 'supportsInterface', isErc1155, isBoolean)
 	const tokenName = decodeFunctionOutputSafely(Erc20ABI, 'name', name, isString)
 	const tokenSymbol = decodeFunctionOutputSafely(Erc20ABI, 'symbol', symbol, isString)
-	const tokenDecimals = decodeFunctionOutputSafely(Erc20ABI, 'decimals', decimals, isNumber)
+	const tokenDecimals = decodeFunctionOutputSafely(Erc20ABI, 'decimals', decimals, isNumberOrBigint)
 	const tokenSupply = decodeFunctionOutputSafely(Erc20ABI, 'totalSupply', totalSupply, isBigint)
 
 	if (supportsErc721 === true) {

--- a/app/ts/utils/tokenIdentification.ts
+++ b/app/ts/utils/tokenIdentification.ts
@@ -5,6 +5,7 @@ import type { IEthereumClientService } from '../simulation/services/EthereumClie
 import { checksummedAddress, stringToUint8Array } from './bigint.js'
 import type { Erc1155Entry, Erc20TokenEntry, Erc721Entry } from '../types/addressBookTypes.js'
 import { decodeFunctionOutput, encodeFunctionCall } from './abiRuntime.js'
+import { isBigint, isBoolean, isNumber, isString } from './typescript.js'
 
 type EOA = {
 	type: 'EOA'
@@ -38,17 +39,23 @@ type MulticallResult = {
 	returnData: Uint8Array
 }
 
-const isBoolean = (value: unknown): value is boolean => typeof value === 'boolean'
-const isString = (value: unknown): value is string => typeof value === 'string'
-const isNumber = (value: unknown): value is number => typeof value === 'number'
-const isBigint = (value: unknown): value is bigint => typeof value === 'bigint'
+const viemAbiDataDecodeErrorNames = new Set([
+	'AbiDecodingDataSizeInvalidError',
+	'AbiDecodingDataSizeTooSmallError',
+	'AbiDecodingZeroDataError',
+	'InvalidBytesBooleanError',
+	'PositionOutOfBoundsError',
+])
+
+const isViemAbiDataDecodeError = (error: unknown) => error instanceof Error && viemAbiDataDecodeErrorNames.has(error.name)
 
 const decodeFunctionOutputSafely = <T>(abi: Abi, functionName: string, result: MulticallResult, isExpectedType: (value: unknown) => value is T): T | undefined => {
 	if (!result.success || result.returnData.length === 0) return undefined
 	try {
 		const decoded = decodeFunctionOutput(abi, functionName, result.returnData)
 		return isExpectedType(decoded) ? decoded : undefined
-	} catch {
+	} catch (error) {
+		if (!isViemAbiDataDecodeError(error)) throw error
 		return undefined
 	}
 }
@@ -68,50 +75,44 @@ export async function itentifyAddressViaOnChainInformation(ethereumClientService
 		{ targetAddress, callData: stringToUint8Array(encodeFunctionCall(Erc20ABI, 'totalSupply', [])) }
 	]
 
-	try {
-		const [isErc721, hasMetadata, isErc1155, name, symbol, decimals, totalSupply] = await tryAggregateMulticall(ethereumClientService, requestAbortController, calls)
-		if (isErc721 === undefined || hasMetadata === undefined || isErc1155 === undefined || name === undefined || symbol === undefined || decimals === undefined || totalSupply === undefined) throw new Error('Multicall result is too short')
-		const supportsErc721 = decodeFunctionOutputSafely(Erc721ABI, 'supportsInterface', isErc721, isBoolean)
-		const supportsMetadata = decodeFunctionOutputSafely(Erc721ABI, 'supportsInterface', hasMetadata, isBoolean)
-		const supportsErc1155 = decodeFunctionOutputSafely(Erc721ABI, 'supportsInterface', isErc1155, isBoolean)
-		const tokenName = decodeFunctionOutputSafely(Erc20ABI, 'name', name, isString)
-		const tokenSymbol = decodeFunctionOutputSafely(Erc20ABI, 'symbol', symbol, isString)
-		const tokenDecimals = decodeFunctionOutputSafely(Erc20ABI, 'decimals', decimals, isNumber)
-		const tokenSupply = decodeFunctionOutputSafely(Erc20ABI, 'totalSupply', totalSupply, isBigint)
+	const [isErc721, hasMetadata, isErc1155, name, symbol, decimals, totalSupply] = await tryAggregateMulticall(ethereumClientService, requestAbortController, calls)
+	if (isErc721 === undefined || hasMetadata === undefined || isErc1155 === undefined || name === undefined || symbol === undefined || decimals === undefined || totalSupply === undefined) throw new Error('Multicall result is too short')
+	const supportsErc721 = decodeFunctionOutputSafely(Erc721ABI, 'supportsInterface', isErc721, isBoolean)
+	const supportsMetadata = decodeFunctionOutputSafely(Erc721ABI, 'supportsInterface', hasMetadata, isBoolean)
+	const supportsErc1155 = decodeFunctionOutputSafely(Erc721ABI, 'supportsInterface', isErc1155, isBoolean)
+	const tokenName = decodeFunctionOutputSafely(Erc20ABI, 'name', name, isString)
+	const tokenSymbol = decodeFunctionOutputSafely(Erc20ABI, 'symbol', symbol, isString)
+	const tokenDecimals = decodeFunctionOutputSafely(Erc20ABI, 'decimals', decimals, isNumber)
+	const tokenSupply = decodeFunctionOutputSafely(Erc20ABI, 'totalSupply', totalSupply, isBigint)
 
-		if (supportsErc721 === true) {
-			return {
-				type: 'ERC721',
-				address,
-				name: supportsMetadata === true ? decodeFunctionOutputSafely(Erc721ABI, 'name', name, isString) ?? checksummedAddress(address) : checksummedAddress(address),
-				symbol: supportsMetadata === true ? decodeFunctionOutputSafely(Erc721ABI, 'symbol', symbol, isString) ?? '???' : '???',
-				entrySource: 'OnChain'
-			}
+	if (supportsErc721 === true) {
+		return {
+			type: 'ERC721',
+			address,
+			name: supportsMetadata === true ? decodeFunctionOutputSafely(Erc721ABI, 'name', name, isString) ?? checksummedAddress(address) : checksummedAddress(address),
+			symbol: supportsMetadata === true ? decodeFunctionOutputSafely(Erc721ABI, 'symbol', symbol, isString) ?? '???' : '???',
+			entrySource: 'OnChain'
 		}
-		if (supportsErc1155 === true) {
-			return {
-				type: 'ERC1155',
-				address,
-				entrySource: 'OnChain',
-				name: checksummedAddress(address),
-				symbol: '???',
-				decimals: undefined
-			}
+	}
+	if (supportsErc1155 === true) {
+		return {
+			type: 'ERC1155',
+			address,
+			entrySource: 'OnChain',
+			name: checksummedAddress(address),
+			symbol: '???',
+			decimals: undefined
 		}
-		if (tokenName !== undefined && tokenSymbol !== undefined && tokenDecimals !== undefined && tokenSupply !== undefined) {
-			return {
-				type: 'ERC20',
-				address,
-				name: tokenName,
-				symbol: tokenSymbol,
-				decimals: BigInt(tokenDecimals),
-				entrySource: 'OnChain'
-			}
+	}
+	if (tokenName !== undefined && tokenSymbol !== undefined && tokenDecimals !== undefined && tokenSupply !== undefined) {
+		return {
+			type: 'ERC20',
+			address,
+			name: tokenName,
+			symbol: tokenSymbol,
+			decimals: BigInt(tokenDecimals),
+			entrySource: 'OnChain'
 		}
-	} catch (error) {
-		// For any reason decoding txing fails catch and return as unknown contract
-		console.warn(error)
-		return { type: 'contract', address }
 	}
 
 	// If doesn't pass checks being an ERC20, ERC721 or ERC1155, then we only know its a contract

--- a/app/ts/utils/tokenIdentification.ts
+++ b/app/ts/utils/tokenIdentification.ts
@@ -1,3 +1,4 @@
+import type { Abi } from 'viem'
 import { Erc20ABI, Erc721ABI } from './abi.js'
 import type { EthereumAddress } from '../types/wire-types.js'
 import type { IEthereumClientService } from '../simulation/services/EthereumClientService.js'
@@ -32,6 +33,26 @@ async function tryAggregateMulticall(ethereumClientService: IEthereumClientServi
 	}))
 }
 
+type MulticallResult = {
+	success: boolean
+	returnData: Uint8Array
+}
+
+const isBoolean = (value: unknown): value is boolean => typeof value === 'boolean'
+const isString = (value: unknown): value is string => typeof value === 'string'
+const isNumber = (value: unknown): value is number => typeof value === 'number'
+const isBigint = (value: unknown): value is bigint => typeof value === 'bigint'
+
+const decodeFunctionOutputSafely = <T>(abi: Abi, functionName: string, result: MulticallResult, isExpectedType: (value: unknown) => value is T): T | undefined => {
+	if (!result.success || result.returnData.length === 0) return undefined
+	try {
+		const decoded = decodeFunctionOutput(abi, functionName, result.returnData)
+		return isExpectedType(decoded) ? decoded : undefined
+	} catch {
+		return undefined
+	}
+}
+
 export async function itentifyAddressViaOnChainInformation(ethereumClientService: IEthereumClientService, requestAbortController: AbortController | undefined, address: EthereumAddress): Promise<IdentifiedAddress> {
 	const contractCode = await ethereumClientService.getCode(address, 'latest', requestAbortController)
 	if (contractCode.length === 0) return { type: 'EOA', address }
@@ -50,17 +71,24 @@ export async function itentifyAddressViaOnChainInformation(ethereumClientService
 	try {
 		const [isErc721, hasMetadata, isErc1155, name, symbol, decimals, totalSupply] = await tryAggregateMulticall(ethereumClientService, requestAbortController, calls)
 		if (isErc721 === undefined || hasMetadata === undefined || isErc1155 === undefined || name === undefined || symbol === undefined || decimals === undefined || totalSupply === undefined) throw new Error('Multicall result is too short')
-		if (isErc721.success && decodeFunctionOutput(Erc721ABI, 'supportsInterface', isErc721.returnData) === true) {
-			const supportsMetadata = hasMetadata.success && decodeFunctionOutput(Erc721ABI, 'supportsInterface', hasMetadata.returnData)
+		const supportsErc721 = decodeFunctionOutputSafely(Erc721ABI, 'supportsInterface', isErc721, isBoolean)
+		const supportsMetadata = decodeFunctionOutputSafely(Erc721ABI, 'supportsInterface', hasMetadata, isBoolean)
+		const supportsErc1155 = decodeFunctionOutputSafely(Erc721ABI, 'supportsInterface', isErc1155, isBoolean)
+		const tokenName = decodeFunctionOutputSafely(Erc20ABI, 'name', name, isString)
+		const tokenSymbol = decodeFunctionOutputSafely(Erc20ABI, 'symbol', symbol, isString)
+		const tokenDecimals = decodeFunctionOutputSafely(Erc20ABI, 'decimals', decimals, isNumber)
+		const tokenSupply = decodeFunctionOutputSafely(Erc20ABI, 'totalSupply', totalSupply, isBigint)
+
+		if (supportsErc721 === true) {
 			return {
 				type: 'ERC721',
 				address,
-				name: supportsMetadata ? decodeFunctionOutput(Erc721ABI, 'name', name.returnData) : checksummedAddress(address),
-				symbol: supportsMetadata ? decodeFunctionOutput(Erc721ABI, 'symbol', symbol.returnData) : '???',
+				name: supportsMetadata === true ? decodeFunctionOutputSafely(Erc721ABI, 'name', name, isString) ?? checksummedAddress(address) : checksummedAddress(address),
+				symbol: supportsMetadata === true ? decodeFunctionOutputSafely(Erc721ABI, 'symbol', symbol, isString) ?? '???' : '???',
 				entrySource: 'OnChain'
 			}
 		}
-		if (isErc1155.success && decodeFunctionOutput(Erc721ABI, 'supportsInterface', isErc1155.returnData) === true) {
+		if (supportsErc1155 === true) {
 			return {
 				type: 'ERC1155',
 				address,
@@ -70,13 +98,13 @@ export async function itentifyAddressViaOnChainInformation(ethereumClientService
 				decimals: undefined
 			}
 		}
-		if (name.success && decimals.success && symbol.success && totalSupply.success) {
+		if (tokenName !== undefined && tokenSymbol !== undefined && tokenDecimals !== undefined && tokenSupply !== undefined) {
 			return {
 				type: 'ERC20',
 				address,
-				name: decodeFunctionOutput(Erc20ABI, 'name', name.returnData),
-				symbol: decodeFunctionOutput(Erc20ABI, 'symbol', symbol.returnData),
-				decimals: BigInt(decodeFunctionOutput(Erc20ABI, 'decimals', decimals.returnData)),
+				name: tokenName,
+				symbol: tokenSymbol,
+				decimals: BigInt(tokenDecimals),
 				entrySource: 'OnChain'
 			}
 		}

--- a/app/ts/utils/typescript.ts
+++ b/app/ts/utils/typescript.ts
@@ -12,6 +12,11 @@ export function assertUnreachable(value: never): never {
 	throw new Error(`Unreachable! (${ value })`)
 }
 
+export const isBoolean = (value: unknown): value is boolean => typeof value === 'boolean'
+export const isString = (value: unknown): value is string => typeof value === 'string'
+export const isNumber = (value: unknown): value is number => typeof value === 'number'
+export const isBigint = (value: unknown): value is bigint => typeof value === 'bigint'
+
 function isObject(maybe: unknown): maybe is Object {
 	return typeof maybe === 'object' && maybe !== null && !Array.isArray(maybe)
 }

--- a/app/ts/utils/typescript.ts
+++ b/app/ts/utils/typescript.ts
@@ -16,6 +16,7 @@ export const isBoolean = (value: unknown): value is boolean => typeof value === 
 export const isString = (value: unknown): value is string => typeof value === 'string'
 export const isNumber = (value: unknown): value is number => typeof value === 'number'
 export const isBigint = (value: unknown): value is bigint => typeof value === 'bigint'
+export const isNumberOrBigint = (value: unknown): value is number | bigint => isNumber(value) || isBigint(value)
 
 function isObject(maybe: unknown): maybe is Object {
 	return typeof maybe === 'object' && maybe !== null && !Array.isArray(maybe)

--- a/test/tests/abiRuntime.test.ts
+++ b/test/tests/abiRuntime.test.ts
@@ -1,0 +1,16 @@
+import { describe, expect, test } from 'bun:test'
+import { Erc721ABI } from '../../app/ts/utils/abi.js'
+import { decodeFunctionOutputSafely, encodeFunctionReturn } from '../../app/ts/utils/abiRuntime.js'
+
+describe('ABI runtime', () => {
+	test('decodeFunctionOutputSafely propagates type guard errors that look like viem decode errors', () => {
+		const encodedBooleanReturn = encodeFunctionReturn(Erc721ABI, 'supportsInterface', [true])
+		const throwingGuard = (_value: unknown): _value is boolean => {
+			const error = new Error('guard failed')
+			error.name = 'AbiDecodingZeroDataError'
+			throw error
+		}
+
+		expect(() => decodeFunctionOutputSafely(Erc721ABI, 'supportsInterface', encodedBooleanReturn, throwingGuard)).toThrow('guard failed')
+	})
+})

--- a/test/tests/tokenIdentification.test.ts
+++ b/test/tests/tokenIdentification.test.ts
@@ -1,0 +1,109 @@
+import { describe, test } from 'bun:test'
+import * as assert from 'assert'
+import { JsonRpcResponse, type EthereumJsonRpcRequest } from '../../app/ts/types/JsonRpc-types.js'
+import { Erc20ABI } from '../../app/ts/utils/abi.js'
+import { itentifyAddressViaOnChainInformation } from '../../app/ts/utils/tokenIdentification.js'
+import { EthereumClientService } from '../../app/ts/simulation/services/EthereumClientService.js'
+import { addressString } from '../../app/ts/utils/bigint.js'
+import { encodeFunctionReturn } from '../../app/ts/utils/abiRuntime.js'
+import { eth_getBlockByNumber_goerli_8443561_true } from '../RPCResponses.js'
+
+const tokenAddress = 0x1234567890123456789012345678901234567890n
+
+const rpcEntry = {
+	name: 'Goerli',
+	chainId: 5n,
+	httpsRpc: 'https://rpc-goerli.dark.florist/flipcardtrustone',
+	currencyName: 'Goerli Testnet ETH',
+	currencyTicker: 'GOETH',
+	primary: true,
+	minimized: true,
+}
+
+function parseRpcResult(data: string) {
+	const response = JsonRpcResponse.parse(JSON.parse(data))
+	if ('error' in response) throw Error(`Ethereum Client Error: ${ response.error.message }`)
+	return response.result
+}
+
+class TokenIdentificationRequestHandler {
+	public rpcUrl = rpcEntry.httpsRpc
+
+	public constructor(private readonly ethSimulateV1Result: unknown) {}
+
+	public readonly jsonRpcRequest = async (rpcEntry: EthereumJsonRpcRequest) => {
+		if (rpcEntry.method === 'eth_getCode') return '0x01'
+		if (rpcEntry.method === 'eth_getBlockByNumber') return parseRpcResult(eth_getBlockByNumber_goerli_8443561_true)
+		if (rpcEntry.method === 'eth_simulateV1') return this.ethSimulateV1Result
+		throw new Error(`Unexpected RPC method ${ rpcEntry.method }`)
+	}
+
+	public readonly clearCache = () => undefined
+
+	public readonly getChainId = async () => 5n
+}
+
+const createEthereum = (ethSimulateV1Result: unknown) => new EthereumClientService(
+	new TokenIdentificationRequestHandler(ethSimulateV1Result),
+	async () => undefined,
+	async () => undefined,
+	rpcEntry,
+)
+
+const createEthSimulateV1Result = (returnData: readonly `0x${ string }`[]) => [{
+	number: '0x1',
+	hash: `0x${ '1'.repeat(64) }`,
+	timestamp: '0x1',
+	gasLimit: '0x1c9c380',
+	gasUsed: '0x0',
+	baseFeePerGas: '0x1',
+	calls: returnData.map((data) => ({
+		status: '0x1',
+		returnData: data,
+		gasUsed: '0x0',
+		logs: [],
+	})),
+}]
+
+describe('token identification', () => {
+	test('identifies valid ERC20 metadata and keeps decimals as bigint', async () => {
+		const ethereum = createEthereum(createEthSimulateV1Result([
+			'0x',
+			'0x',
+			'0x',
+			encodeFunctionReturn(Erc20ABI, 'name', ['Example Token']),
+			encodeFunctionReturn(Erc20ABI, 'symbol', ['EXT']),
+			encodeFunctionReturn(Erc20ABI, 'decimals', [6n]),
+			encodeFunctionReturn(Erc20ABI, 'totalSupply', [1000000n]),
+		]))
+
+		const identifiedAddress = await itentifyAddressViaOnChainInformation(ethereum, undefined, tokenAddress)
+
+		assert.equal(identifiedAddress.type, 'ERC20')
+		assert.equal(identifiedAddress.address, tokenAddress)
+		if (identifiedAddress.type !== 'ERC20') throw new Error('Expected ERC20 token identification')
+		assert.equal(identifiedAddress.name, 'Example Token')
+		assert.equal(identifiedAddress.symbol, 'EXT')
+		assert.equal(identifiedAddress.decimals, 6n)
+	})
+
+	test('treats empty successful probe return data as an unknown contract', async () => {
+		const ethereum = createEthereum(createEthSimulateV1Result([
+			'0x',
+			'0x',
+			'0x',
+			'0x',
+			'0x',
+			'0x',
+			'0x',
+		]))
+
+		const identifiedAddress = await itentifyAddressViaOnChainInformation(ethereum, undefined, tokenAddress)
+
+		assert.deepEqual(identifiedAddress, {
+			type: 'contract',
+			address: tokenAddress,
+		})
+		assert.equal(addressString(identifiedAddress.address), '0x1234567890123456789012345678901234567890')
+	})
+})

--- a/test/tests/tokenIdentification.test.ts
+++ b/test/tests/tokenIdentification.test.ts
@@ -9,6 +9,8 @@ import { encodeFunctionReturn } from '../../app/ts/utils/abiRuntime.js'
 import { eth_getBlockByNumber_goerli_8443561_true } from '../RPCResponses.js'
 
 const tokenAddress = 0x1234567890123456789012345678901234567890n
+const invalidBooleanReturnData = `0x${ '0'.repeat(63) }2` as const
+const missingDynamicStringPayloadReturnData = `0x${ '0'.repeat(62) }20` as const
 
 const rpcEntry = {
 	name: 'Goerli',
@@ -105,5 +107,71 @@ describe('token identification', () => {
 			address: tokenAddress,
 		})
 		assert.equal(addressString(identifiedAddress.address), '0x1234567890123456789012345678901234567890')
+	})
+
+	test('treats malformed successful probe return data as an unknown contract', async () => {
+		const ethereum = createEthereum(createEthSimulateV1Result([
+			'0x01',
+			'0x01',
+			'0x01',
+			'0x01',
+			'0x01',
+			'0x01',
+			'0x01',
+		]))
+
+		const identifiedAddress = await itentifyAddressViaOnChainInformation(ethereum, undefined, tokenAddress)
+
+		assert.deepEqual(identifiedAddress, {
+			type: 'contract',
+			address: tokenAddress,
+		})
+	})
+
+	test('treats malformed boolean probe return data as an unknown contract', async () => {
+		const ethereum = createEthereum(createEthSimulateV1Result([
+			invalidBooleanReturnData,
+			invalidBooleanReturnData,
+			invalidBooleanReturnData,
+			'0x',
+			'0x',
+			'0x',
+			'0x',
+		]))
+
+		const identifiedAddress = await itentifyAddressViaOnChainInformation(ethereum, undefined, tokenAddress)
+
+		assert.deepEqual(identifiedAddress, {
+			type: 'contract',
+			address: tokenAddress,
+		})
+	})
+
+	test('treats malformed dynamic string probe return data as an unknown contract', async () => {
+		const ethereum = createEthereum(createEthSimulateV1Result([
+			'0x',
+			'0x',
+			'0x',
+			missingDynamicStringPayloadReturnData,
+			encodeFunctionReturn(Erc20ABI, 'symbol', ['EXT']),
+			encodeFunctionReturn(Erc20ABI, 'decimals', [6n]),
+			encodeFunctionReturn(Erc20ABI, 'totalSupply', [1000000n]),
+		]))
+
+		const identifiedAddress = await itentifyAddressViaOnChainInformation(ethereum, undefined, tokenAddress)
+
+		assert.deepEqual(identifiedAddress, {
+			type: 'contract',
+			address: tokenAddress,
+		})
+	})
+
+	test('propagates unexpected multicall result shape errors', async () => {
+		const ethereum = createEthereum(createEthSimulateV1Result(['0x']))
+
+		await assert.rejects(
+			async () => await itentifyAddressViaOnChainInformation(ethereum, undefined, tokenAddress),
+			/call length mismatch/,
+		)
 	})
 })

--- a/test/tests/typescriptUtils.test.ts
+++ b/test/tests/typescriptUtils.test.ts
@@ -1,0 +1,11 @@
+import { describe, test } from 'bun:test'
+import * as assert from 'assert'
+import { isNumberOrBigint } from '../../app/ts/utils/typescript.js'
+
+describe('typescript utils', () => {
+	test('isNumberOrBigint accepts numeric primitive values', () => {
+		assert.equal(isNumberOrBigint(6), true)
+		assert.equal(isNumberOrBigint(6n), true)
+		assert.equal(isNumberOrBigint('6'), false)
+	})
+})


### PR DESCRIPTION
## Summary
- Added safe decoding for multicall probe results so empty or malformed `returnData` no longer throws during token identification.
- Kept ERC-20, ERC-721, and ERC-1155 detection logic intact while falling back to unknown contract classification when probe results cannot be decoded.
- Added tests covering a valid ERC-20 identification path and the empty-return-data regression case.

## Testing
- `bun test`
- `bun run setup-chrome`
- `bun run typecheck`
- `bun run lint`