### PR TITLE
Fix Brave console noise from extension pages and recovery logs

### DIFF
--- a/app/ts/background/popupMessageHandlers.ts
+++ b/app/ts/background/popupMessageHandlers.ts
@@ -89,17 +89,17 @@ export async function getLastKnownCurrentTabId() {
 	const tabId = await tabIdPromise
 	// skip restricted or insufficient permission tabs
 	if (tabs[0]?.id === undefined || tabs[0]?.url === undefined) return tabId
-	if (isExtensionOwnedPageUrl(tabs[0].url)) return tabId
+	if (isExtensionPageUrl(tabs[0].url)) return tabId
 	if (tabId !== tabs[0].id) await saveCurrentTabId(tabs[0].id)
 	return tabs[0].id
 }
 
-function isExtensionOwnedPageUrl(urlString: string) {
+function isExtensionPageUrl(urlString: string) {
 	if (urlString.startsWith('/html/') || urlString.startsWith('/html3/')) return true
 	try {
 		const url = new URL(urlString)
 		const ownUrl = new URL(browser.runtime.getURL('/'))
-		return url.protocol === ownUrl.protocol && url.host === ownUrl.host
+		return url.protocol === ownUrl.protocol
 	} catch {
 		return false
 	}

--- a/app/ts/utils/errors.ts
+++ b/app/ts/utils/errors.ts
@@ -172,6 +172,19 @@ function createErrorReport(error: unknown, metadata: ErrorReportMetadata, policy
 	}
 }
 
+function formatLocalRecoveryConsoleMessage(report: InterceptorErrorReport) {
+	const parts = [
+		`code=${ report.code }`,
+		`message=${ JSON.stringify(report.message) }`,
+		`debugId=${ report.debugId }`,
+		`source=${ report.source }`,
+		`category=${ report.category }`,
+		`severity=${ report.severity }`,
+	]
+	if (report.cause !== undefined) parts.push(`cause=${ JSON.stringify(report.cause) }`)
+	return `Local Interceptor recovery: ${ parts.join(' ') }`
+}
+
 async function appendErrorDiagnostic(report: InterceptorErrorReport) {
 	try {
 		await appendInterceptorErrorDiagnostic(report)
@@ -223,16 +236,8 @@ function logLocalRecovery(error: unknown, metadata: LocalRecoveryMetadata) {
 		userVisible: ERROR_REPORTING_POLICY.localRecovery.userVisible,
 		details: metadata.details,
 	}, ERROR_REPORTING_POLICY.localRecovery, metadata.code, metadata.message ?? getErrorMessage(error) ?? 'Recovered from an Interceptor error.')
-	console.warn('Local Interceptor recovery', {
-		debugId: report.debugId,
-		source: report.source,
-		code: report.code,
-		category: report.category,
-		severity: report.severity,
-		message: report.message,
-		...(report.cause === undefined ? {} : { cause: report.cause }),
-	})
-	if (report.details !== undefined) console.warn(report.details)
+	console.warn(formatLocalRecoveryConsoleMessage(report))
+	if (report.details !== undefined) console.warn(`Local Interceptor recovery details: ${ report.details }`)
 	printError(error)
 	return report
 }

--- a/test/tests/openSimulationStackTab.test.ts
+++ b/test/tests/openSimulationStackTab.test.ts
@@ -202,14 +202,14 @@ describe('open simulation stack tab', () => {
 		assert.equal(storageState.currentTabId, 12)
 	})
 
-	test('does not keep the stored website tab when the active tab is another extension page', async () => {
+	test('keeps the stored website tab when the active tab is another extension page', async () => {
 		const { storageState } = installBrowserMock([{ id: 77, url: 'chrome-extension://other-extension/page.html' }], emptyOpenedTabs(), false, 12)
 		const getLastKnownCurrentTabId = await loadGetLastKnownCurrentTabId()
 
 		const tabId = await getLastKnownCurrentTabId()
 
-		assert.equal(tabId, 77)
-		assert.equal(storageState.currentTabId, 77)
+		assert.equal(tabId, 12)
+		assert.equal(storageState.currentTabId, 12)
 	})
 
 	test('clears a stale simulation stack hash when focusing the existing stack tab without a target', async () => {

--- a/test/tests/unexpectedErrorDiagnostics.test.ts
+++ b/test/tests/unexpectedErrorDiagnostics.test.ts
@@ -16,23 +16,30 @@ type RuntimeMessage = {
 async function captureConsoleCalls<T>(run: () => Promise<T>) {
 	const originalConsoleError = console.error
 	const originalConsoleTrace = console.trace
+	const originalConsoleWarn = console.warn
 	const consoleErrors: unknown[][] = []
 	const consoleTraces: unknown[][] = []
+	const consoleWarns: unknown[][] = []
 	console.error = (...args: unknown[]) => {
 		consoleErrors.push(args)
 	}
 	console.trace = (...args: unknown[]) => {
 		consoleTraces.push(args)
 	}
+	console.warn = (...args: unknown[]) => {
+		consoleWarns.push(args)
+	}
 	try {
 		return {
 			result: await run(),
 			consoleErrors,
 			consoleTraces,
+			consoleWarns,
 		}
 	} finally {
 		console.error = originalConsoleError
 		console.trace = originalConsoleTrace
+		console.warn = originalConsoleWarn
 	}
 }
 
@@ -395,6 +402,24 @@ describe('unexpected error diagnostics', () => {
 		assert.equal(diagnostic?.userVisible, false)
 		assert.equal(diagnostic?.code, 'test_local_recovery')
 		assert.equal(diagnostic?.details, '{"tokenId":"1"}')
+	})
+
+	test('logs local recovery diagnostics as readable console strings', async () => {
+		browserMock.reset()
+		const { reportLocalRecovery } = await modulesPromise
+
+		const { consoleWarns } = await captureConsoleCalls(async () => await reportLocalRecovery(new Error('decode failed'), {
+			code: 'test_local_recovery_log',
+			message: 'Continuing after a recovered test failure.',
+			details: { tokenId: 1n },
+		}))
+
+		assert.equal(consoleWarns.length, 2)
+		assert.equal(consoleWarns[0]?.length, 1)
+		assert.equal(typeof consoleWarns[0]?.[0], 'string')
+		assert.equal(String(consoleWarns[0]?.[0]).startsWith('Local Interceptor recovery: code=test_local_recovery_log'), true)
+		assert.equal(String(consoleWarns[0]?.[0]).includes('[object Object]'), false)
+		assert.equal(consoleWarns[1]?.[0], 'Local Interceptor recovery details: {"tokenId":"1"}')
 	})
 
 	test('best-effort local recovery does not block on diagnostic persistence', async () => {


### PR DESCRIPTION
## Summary
- Stop treating another extension's `chrome-extension://...` page as the current website tab.
- Format local recovery diagnostics as readable console strings instead of passing raw objects that Brave may show as `[object Object]`.
- Add regression coverage for both the cross-extension tab tracking case and the readable recovery warning format.

## Why
Brave can throw `Cannot access a chrome-extension:// URL of different extension` when extension code later operates on a tab that belongs to another extension. The current-tab bookkeeping only skipped this extension's own pages, so another extension page could be saved as the active website tab.

The `Local Interceptor recovery [object Object]` message came from logging a structured object as the second `console.warn` argument. The diagnostic is still persisted structurally, but the console line is now useful on browsers that stringify object arguments poorly.

## Testing
- `bun test test/tests/openSimulationStackTab.test.ts`
- `bun test test/tests/unexpectedErrorDiagnostics.test.ts test/tests/contentScriptsUpdating.test.ts`
- `bun test`
- `bun run setup-chrome`
- `bun run typecheck`
- `bun run lint`

Skipped `bun run test:chrome-communication` because this only changes current-tab bookkeeping and diagnostic console formatting, not MV3 registration, popup approval, injected provider communication, or page-to-extension messaging.