### PR TITLE
Add `wallet_revokePermissions` support

### DIFF
--- a/app/ts/background/background.ts
+++ b/app/ts/background/background.ts
@@ -1,7 +1,7 @@
 import { type InpageScriptRequest, PopupMessage, type RPCReply, type Settings } from '../types/interceptor-messages.js'
 import 'webextension-polyfill'
 import { getTabState, promoteRpcAsPrimary, setLatestUnexpectedError, updateInterceptorTransactionStack } from './storageVariables.js'
-import { changeSimulationMode, getFixedAddressRichList, getSettings, setFixedMakeMeRichList } from './settings.js'
+import { changeSimulationMode, getFixedAddressRichList, getSettings, setFixedMakeMeRichList, updateWebsiteAccess } from './settings.js'
 import { blockNumber, call, chainId, estimateGas, gasPrice, getAccounts, getBalance, getBlockByNumber, getCode, getLogs, getPermissions, getTransactionByHash, getTransactionCount, getTransactionReceipt, netVersion, personalSign, sendTransaction, subscribe, switchEthereumChain, unsubscribe, web3ClientVersion, getBlockByHash, feeHistory, installNewFilter, uninstallNewFilter, getFilterChanges, getFilterLogs, handleIterceptorError, requestInterceptorSimulatorStack, ethSimulateV1 } from './simulationModeHanders.js'
 import { changeActiveAddress, changePage, confirmDialog, removeTransactionOrSignedMessage, requestAccountsFromSigner, refreshPopupConfirmTransactionSimulation, confirmRequestAccess, changeInterceptorAccess, changeChainDialog, popupChangeActiveRpc, enableSimulationMode, addOrModifyAddressBookEntry, getAddressBookData, removeAddressBookEntry, refreshHomeData, interceptorAccessChangeAddressOrRefresh, refreshPopupConfirmTransactionMetadata, changeSettings, importSettings, exportSettings, setNewRpcList, simulateGovernanceContractExecutionOnPass, openNewTab, settingsOpened, changeAddOrModifyAddressWindowState, requestAbiAndNameFromBlockExplorer, openWebPage, disableInterceptor, requestNewHomeData, setEnsNameForHash, simulateGnosisSafeTransactionOnPass, retrieveWebsiteAccess, blockOrAllowExternalRequests, removeWebsiteAccess, allowOrPreventAddressAccessForWebsite, removeWebsiteAddressAccess, forceSetGasLimitForTransaction, changePreSimulationBlockTimeManipulation, setTransactionOrMessageBlockTimeManipulator, modifyMakeMeRich, requestMakeMeRichList, requestActiveAddresses, requestSimulationMode, requestLatestUnexpectedError, fetchSimulationStackRequestConfirmation, reportUnexpectedErrorInWindow, requestInterceptorSimulationInput, importSimulationStack, requestCompleteVisualizedSimulation, requestSimulationMetadata, requestIdentifyAddress, popupReadyAndListening } from './popupMessageHandlers.js'
 import { PASSTHROUGH_STATE, type ResolvedExecutionSimulationState, type ResolvedSimulationInput, type ResolvedSimulationState, type WebsiteCreatedEthereumUnsignedTransactionOrFailed, toResolvedExecutionSimulationState, toResolvedSimulationInput, toResolvedSimulationState } from '../types/visualizer-types.js'
@@ -229,6 +229,7 @@ async function handleRPCRequest(
 		case 'eth_signTypedData_v4': return await personalSign(ethereum, tokenPriceService, activeAddress, parsedRequest, request, website, websiteTabConnections, !forwardToSigner)
 		case 'wallet_switchEthereumChain': return await switchEthereumChain(ethereum, tokenPriceService, resetSimulationServices, websiteTabConnections, parsedRequest, request, settings.simulationMode, website)
 		case 'wallet_requestPermissions': return await getAccounts(activeAddress)
+		case 'wallet_revokePermissions': return await revokeWebsitePermissions(ethereum, tokenPriceService, resetSimulationServices, websiteTabConnections, website.websiteOrigin)
 		case 'wallet_getPermissions': return await getPermissions()
 		case 'eth_accounts': return await getAccounts(activeAddress)
 		case 'eth_requestAccounts': return await getAccounts(activeAddress)
@@ -387,8 +388,63 @@ function refusePublicInternalProviderMethod(websiteTabConnections: WebsiteTabCon
 	})
 }
 
+async function revokeWebsitePermissions(
+	ethereum: EthereumClientService,
+	tokenPriceService: TokenPriceService,
+	resetSimulationServices: ResetSimulationServices,
+	websiteTabConnections: WebsiteTabConnections,
+	websiteOrigin: string,
+) {
+	await updateWebsiteAccess((previousAccess) => previousAccess.map((access) => {
+		if (access.website.websiteOrigin !== websiteOrigin) return access
+		return { ...access, access: false, addressAccess: undefined }
+	}))
+	await updateWebsiteApprovalAccesses(ethereum, tokenPriceService, resetSimulationServices, websiteTabConnections, await getSettings(), false)
+	await sendPopupMessageToOpenWindows({ method: 'popup_websiteAccess_changed' })
+	return { type: 'result' as const, method: 'wallet_revokePermissions' as const, result: null }
+}
+
+function hasExactlyEthAccountsKey(value: unknown): value is { readonly eth_accounts: unknown } {
+	if (typeof value !== 'object' || value === null || Array.isArray(value)) return false
+	const keys = Object.keys(value)
+	return keys.length === 1 && keys[0] === 'eth_accounts'
+}
+
+function hasNoKeys(value: unknown) {
+	if (typeof value !== 'object' || value === null || Array.isArray(value)) return false
+	return Object.keys(value).length === 0
+}
+
+function isExactWalletRevokePermissionsRequest(request: InterceptedRequest) {
+	if (!('params' in request) || request.params === undefined || request.params.length !== 1) return false
+	const requestedPermissions = request.params[0]
+	if (!hasExactlyEthAccountsKey(requestedPermissions)) return false
+	return hasNoKeys(requestedPermissions.eth_accounts)
+}
+
+function parseWalletRevokePermissionsRequest(websiteTabConnections: WebsiteTabConnections, request: InterceptedRequest) {
+	const maybeParsedRequest = EthereumJsonRpcRequest.safeParse(request)
+	if (maybeParsedRequest.success && maybeParsedRequest.value.method === 'wallet_revokePermissions' && isExactWalletRevokePermissionsRequest(request)) return maybeParsedRequest.value
+	replyToInterceptedRequest(websiteTabConnections, {
+		type: 'result',
+		method: request.method,
+		uniqueRequestIdentifier: request.uniqueRequestIdentifier,
+		error: {
+			message: `Failed to parse RPC request: ${ JSON.stringify(serialize(InterceptedRequest, request)) }`,
+			code: METAMASK_ERROR_FAILED_TO_PARSE_REQUEST,
+		},
+	})
+	return undefined
+}
+
 export const handleInterceptedRequest = async (port: browser.runtime.Port | undefined, websiteOrigin: string, websitePromise: Promise<Website> | Website, ethereum: EthereumClientService, tokenPriceService: TokenPriceService, resetSimulationServices: ResetSimulationServices, socket: WebsiteSocket, request: InterceptedRequest, websiteTabConnections: WebsiteTabConnections, publishRpcConnectionStatus: PublishRpcConnectionStatus): Promise<unknown> => {
 	const settings = await getSettings()
+	if (request.method === 'wallet_revokePermissions') {
+		const parsedRequest = parseWalletRevokePermissionsRequest(websiteTabConnections, request)
+		if (parsedRequest === undefined) return
+		const result = await revokeWebsitePermissions(ethereum, tokenPriceService, resetSimulationServices, websiteTabConnections, websiteOrigin)
+		return replyToInterceptedRequest(websiteTabConnections, { ...getRequestWithDefinedParams(request), ...result })
+	}
 	const activeAddress = await getActiveAddress(settings, socket.tabId)
 	const access = verifyAccess(websiteTabConnections, socket, request.method === 'eth_requestAccounts' || request.method === 'eth_call' || request.method === 'eth_simulateV1', websiteOrigin, activeAddress, settings)
 	if (request.interceptorInternalRequest !== true && isInternalProviderMethod(request.method)) return refusePublicInternalProviderMethod(websiteTabConnections, request)

--- a/app/ts/background/background.ts
+++ b/app/ts/background/background.ts
@@ -20,7 +20,7 @@ import { InterceptedRequest, type UniqueRequestIdentifier, type WebsiteSocket } 
 import { getSimulationStackTargetHash } from '../utils/simulationStackTargets.js'
 import { replyToInterceptedRequest } from './messageSending.js'
 import { bumpPopupRefreshGeneration } from './popupRefreshGeneration.js'
-import { type EthGetStorageAtParams, EthereumJsonRpcRequest, type SendRawTransactionParams, type SendTransactionParams, SupportedEthereumJsonRpcRequestMethods, type WalletAddEthereumChain } from '../types/JsonRpc-types.js'
+import { type EthGetStorageAtParams, EthereumJsonRpcRequest, type SendRawTransactionParams, type SendTransactionParams, SupportedEthereumJsonRpcRequestMethods, type WalletAddEthereumChain, WalletRevokePermissions } from '../types/JsonRpc-types.js'
 import type { Website } from '../types/websiteAccessTypes.js'
 import type { ConfirmTransactionTransactionSingleVisualization } from '../types/accessRequest.js'
 import type { RpcNetwork } from '../types/rpc.js'
@@ -229,7 +229,6 @@ async function handleRPCRequest(
 		case 'eth_signTypedData_v4': return await personalSign(ethereum, tokenPriceService, activeAddress, parsedRequest, request, website, websiteTabConnections, !forwardToSigner)
 		case 'wallet_switchEthereumChain': return await switchEthereumChain(ethereum, tokenPriceService, resetSimulationServices, websiteTabConnections, parsedRequest, request, settings.simulationMode, website)
 		case 'wallet_requestPermissions': return await getAccounts(activeAddress)
-		case 'wallet_revokePermissions': return await revokeWebsitePermissions(ethereum, tokenPriceService, resetSimulationServices, websiteTabConnections, website.websiteOrigin)
 		case 'wallet_getPermissions': return await getPermissions()
 		case 'eth_accounts': return await getAccounts(activeAddress)
 		case 'eth_requestAccounts': return await getAccounts(activeAddress)
@@ -404,27 +403,9 @@ async function revokeWebsitePermissions(
 	return { type: 'result' as const, method: 'wallet_revokePermissions' as const, result: null }
 }
 
-function hasExactlyEthAccountsKey(value: unknown): value is { readonly eth_accounts: unknown } {
-	if (typeof value !== 'object' || value === null || Array.isArray(value)) return false
-	const keys = Object.keys(value)
-	return keys.length === 1 && keys[0] === 'eth_accounts'
-}
-
-function hasNoKeys(value: unknown) {
-	if (typeof value !== 'object' || value === null || Array.isArray(value)) return false
-	return Object.keys(value).length === 0
-}
-
-function isExactWalletRevokePermissionsRequest(request: InterceptedRequest) {
-	if (!('params' in request) || request.params === undefined || request.params.length !== 1) return false
-	const requestedPermissions = request.params[0]
-	if (!hasExactlyEthAccountsKey(requestedPermissions)) return false
-	return hasNoKeys(requestedPermissions.eth_accounts)
-}
-
 function parseWalletRevokePermissionsRequest(websiteTabConnections: WebsiteTabConnections, request: InterceptedRequest) {
-	const maybeParsedRequest = EthereumJsonRpcRequest.safeParse(request)
-	if (maybeParsedRequest.success && maybeParsedRequest.value.method === 'wallet_revokePermissions' && isExactWalletRevokePermissionsRequest(request)) return maybeParsedRequest.value
+	const maybeParsedRequest = WalletRevokePermissions.safeParse(request)
+	if (maybeParsedRequest.success) return maybeParsedRequest.value
 	replyToInterceptedRequest(websiteTabConnections, {
 		type: 'result',
 		method: request.method,

--- a/app/ts/types/JsonRpc-types.ts
+++ b/app/ts/types/JsonRpc-types.ts
@@ -424,7 +424,8 @@ export const EthereumJsonRpcRequest = funtypes.Union(
 	InterceptorError,
 )
 
-// should be same as the above list, except with `params: funtypes.Unknown`
+// Methods accepted by the provider. This mirrors EthereumJsonRpcRequest, plus
+// methods handled before normal RPC dispatch such as wallet_revokePermissions.
 export type SupportedEthereumJsonRpcRequestMethods = funtypes.Static<typeof SupportedEthereumJsonRpcRequestMethods>
 export const SupportedEthereumJsonRpcRequestMethods = funtypes.ReadonlyObject({
 	method: funtypes.Union(WalletRevokePermissions.fields.method, EthereumJsonRpcRequest.alternatives[0].fields.method, ...EthereumJsonRpcRequest.alternatives.map(x => x.fields.method)),

--- a/app/ts/types/JsonRpc-types.ts
+++ b/app/ts/types/JsonRpc-types.ts
@@ -277,10 +277,13 @@ const RequestPermissions = funtypes.ReadonlyObject({
 	params: funtypes.ReadonlyTuple( funtypes.ReadonlyObject({ eth_accounts: funtypes.ReadonlyObject({ }) }) )
 }).asReadonly()
 
-type RevokePermissions = funtypes.Static<typeof RevokePermissions>
-const RevokePermissions = funtypes.ReadonlyObject({
+const EmptyPermissionOptions = funtypes.Sealed(funtypes.ReadonlyObject({}))
+const WalletRevokePermissionsParams = funtypes.Sealed(funtypes.ReadonlyObject({ eth_accounts: EmptyPermissionOptions }), { deep: true })
+
+export type WalletRevokePermissions = funtypes.Static<typeof WalletRevokePermissions>
+export const WalletRevokePermissions = funtypes.ReadonlyObject({
 	method: funtypes.Literal('wallet_revokePermissions'),
-	params: funtypes.ReadonlyTuple( funtypes.ReadonlyObject({ eth_accounts: funtypes.ReadonlyObject({ }) }) )
+	params: funtypes.ReadonlyTuple(WalletRevokePermissionsParams)
 }).asReadonly()
 
 export type GetTransactionCount = funtypes.Static<typeof GetTransactionCount>
@@ -401,7 +404,6 @@ export const EthereumJsonRpcRequest = funtypes.Union(
 	OldSignTypedDataParams,
 	SwitchEthereumChainParams,
 	RequestPermissions,
-	RevokePermissions,
 	funtypes.ReadonlyObject({ method: funtypes.Literal('wallet_getPermissions') }),
 	funtypes.ReadonlyObject({ method: funtypes.Literal('eth_accounts') }),
 	funtypes.ReadonlyObject({ method: funtypes.Literal('eth_requestAccounts') }),
@@ -425,7 +427,7 @@ export const EthereumJsonRpcRequest = funtypes.Union(
 // should be same as the above list, except with `params: funtypes.Unknown`
 export type SupportedEthereumJsonRpcRequestMethods = funtypes.Static<typeof SupportedEthereumJsonRpcRequestMethods>
 export const SupportedEthereumJsonRpcRequestMethods = funtypes.ReadonlyObject({
-	method: funtypes.Union(EthereumJsonRpcRequest.alternatives[0].fields.method, ...EthereumJsonRpcRequest.alternatives.map(x => x.fields.method)),
+	method: funtypes.Union(WalletRevokePermissions.fields.method, EthereumJsonRpcRequest.alternatives[0].fields.method, ...EthereumJsonRpcRequest.alternatives.map(x => x.fields.method)),
 })
 
 export type OriginalSendRequestParameters = funtypes.Static<typeof OriginalSendRequestParameters>

--- a/app/ts/types/JsonRpc-types.ts
+++ b/app/ts/types/JsonRpc-types.ts
@@ -277,6 +277,12 @@ const RequestPermissions = funtypes.ReadonlyObject({
 	params: funtypes.ReadonlyTuple( funtypes.ReadonlyObject({ eth_accounts: funtypes.ReadonlyObject({ }) }) )
 }).asReadonly()
 
+type RevokePermissions = funtypes.Static<typeof RevokePermissions>
+const RevokePermissions = funtypes.ReadonlyObject({
+	method: funtypes.Literal('wallet_revokePermissions'),
+	params: funtypes.ReadonlyTuple( funtypes.ReadonlyObject({ eth_accounts: funtypes.ReadonlyObject({ }) }) )
+}).asReadonly()
+
 export type GetTransactionCount = funtypes.Static<typeof GetTransactionCount>
 export const GetTransactionCount = funtypes.ReadonlyObject({
 	method: funtypes.Literal('eth_getTransactionCount'),
@@ -395,6 +401,7 @@ export const EthereumJsonRpcRequest = funtypes.Union(
 	OldSignTypedDataParams,
 	SwitchEthereumChainParams,
 	RequestPermissions,
+	RevokePermissions,
 	funtypes.ReadonlyObject({ method: funtypes.Literal('wallet_getPermissions') }),
 	funtypes.ReadonlyObject({ method: funtypes.Literal('eth_accounts') }),
 	funtypes.ReadonlyObject({ method: funtypes.Literal('eth_requestAccounts') }),

--- a/app/ts/types/interceptor-messages.ts
+++ b/app/ts/types/interceptor-messages.ts
@@ -97,6 +97,7 @@ const NonForwardingRPCRequestSuccessfullReturnValue = funtypes.Union(
 	funtypes.ReadonlyObject({ method: funtypes.Literal('wallet_switchEthereumChain'), result: funtypes.Null }),
 	funtypes.ReadonlyObject({ method: funtypes.Literal('eth_accounts'), result: funtypes.ReadonlyArray(EthereumAddress) }),
 	funtypes.ReadonlyObject({ method: funtypes.Literal('wallet_getPermissions'), result: funtypes.ReadonlyTuple(funtypes.ReadonlyObject({ eth_accounts: funtypes.ReadonlyObject({}) })) }),
+	funtypes.ReadonlyObject({ method: funtypes.Literal('wallet_revokePermissions'), result: funtypes.Null }),
 	funtypes.ReadonlyObject({ method: funtypes.Literal('eth_gasPrice'), result: EthereumQuantity }),
 	funtypes.ReadonlyObject({ method: funtypes.Literal('eth_getTransactionCount'), result: EthereumQuantity }),
 	funtypes.ReadonlyObject({ method: funtypes.Literal('interceptor_getSimulationStack'), result: GetSimulationStackReply }),

--- a/test/tests/backgroundEthAccounts.test.ts
+++ b/test/tests/backgroundEthAccounts.test.ts
@@ -62,6 +62,12 @@ function installBrowserMock() {
 			async setBadgeText() { return undefined },
 			async setBadgeBackgroundColor() { return undefined },
 		},
+		declarativeNetRequest: {
+			async getDynamicRules() { return [] },
+			async getSessionRules() { return [] },
+			async updateDynamicRules() { return undefined },
+			async updateSessionRules() { return undefined },
+		},
 	} as unknown as typeof globalThis.browser
 	;(globalThis as typeof globalThis & { chrome: { runtime: { id: string } } }).chrome = { runtime: { id: 'test-extension' } }
 	;(globalThis as typeof globalThis & { location: Location }).location = { origin: '' } as unknown as Location
@@ -385,5 +391,147 @@ describe('background eth_accounts', () => {
 		assert.equal(requestAccountsReplies.at(-1)?.error?.code, 4100)
 		assert.equal(requestAccountsReplies.at(-1)?.error?.message, 'The requested method and/or account has not been authorized by the user.')
 		assert.deepEqual((await getTabState(socket.tabId)).signerAccounts, [])
+	})
+
+	test('wallet_revokePermissions revokes website account access and disconnects approved ports', async () => {
+		installBrowserMock()
+		const { handleInterceptedRequest, websiteSocketToString, changeSimulationMode, setUseSignersAddressAsActiveAddress, updateWebsiteAccess, getSettings } = await loadModules()
+		const websiteOrigin = 'https://example.test'
+		const website = { websiteOrigin, icon: undefined, title: undefined }
+		const account = 0x1111111111111111111111111111111111111111n
+		await changeSimulationMode({ simulationMode: true, activeSimulationAddress: account, activeSigningAddress: undefined })
+		await setUseSignersAddressAsActiveAddress(false)
+		await updateWebsiteAccess(() => [{ website, access: true, addressAccess: [{ address: account, access: true }] }])
+
+		const socket = { tabId: 1, connectionName: 0n }
+		const { port, messages } = createPort(socket.tabId)
+		const connectionKey = websiteSocketToString(socket)
+		const websiteTabConnections = new Map([[socket.tabId, { connections: {
+			[connectionKey]: { port, socket, websiteOrigin, approved: true, wantsToConnect: true },
+		} }]])
+		const { ethereum, tokenPriceService, resetSimulationServices } = createEthereumWithGetBlockCounter({ count: 0 })
+
+		await handleInterceptedRequest(port, websiteOrigin, website, ethereum, tokenPriceService, resetSimulationServices, socket, {
+			interceptorRequest: true,
+			usingInterceptorWithoutSigner: false,
+			uniqueRequestIdentifier: { requestId: 10, requestSocket: socket },
+			method: 'wallet_revokePermissions',
+			params: [{ eth_accounts: {} }],
+		}, websiteTabConnections, noopPublishRpcConnectionStatus)
+
+		assert.equal(messages.some((message) => message.method === 'disconnect'), true)
+		const revokeReplies = messages.filter((message) => message.method === 'wallet_revokePermissions' && message.requestId === 10)
+		assert.equal(revokeReplies.at(-1)?.result, null)
+		assert.equal(websiteTabConnections.get(socket.tabId)?.connections[connectionKey]?.approved, false)
+		const access = (await getSettings()).websiteAccess.find((entry) => entry.website.websiteOrigin === websiteOrigin)
+		assert.equal(access?.access, false)
+		assert.equal(access?.addressAccess, undefined)
+	})
+
+	test('wallet_revokePermissions succeeds when the website is already unauthorized', async () => {
+		installBrowserMock()
+		const { handleInterceptedRequest, websiteSocketToString, changeSimulationMode, setUseSignersAddressAsActiveAddress, updateWebsiteAccess, getSettings } = await loadModules()
+		const websiteOrigin = 'https://example.test'
+		const website = { websiteOrigin, icon: undefined, title: undefined }
+		const account = 0x1111111111111111111111111111111111111111n
+		await changeSimulationMode({ simulationMode: true, activeSimulationAddress: account, activeSigningAddress: undefined })
+		await setUseSignersAddressAsActiveAddress(false)
+		await updateWebsiteAccess(() => [{ website, access: false, addressAccess: undefined }])
+
+		const socket = { tabId: 1, connectionName: 0n }
+		const { port, messages } = createPort(socket.tabId)
+		const connectionKey = websiteSocketToString(socket)
+		const websiteTabConnections = new Map([[socket.tabId, { connections: {
+			[connectionKey]: { port, socket, websiteOrigin, approved: false, wantsToConnect: true },
+		} }]])
+		const { ethereum, tokenPriceService, resetSimulationServices } = createEthereumWithGetBlockCounter({ count: 0 })
+
+		await handleInterceptedRequest(port, websiteOrigin, website, ethereum, tokenPriceService, resetSimulationServices, socket, {
+			interceptorRequest: true,
+			usingInterceptorWithoutSigner: false,
+			uniqueRequestIdentifier: { requestId: 11, requestSocket: socket },
+			method: 'wallet_revokePermissions',
+			params: [{ eth_accounts: {} }],
+		}, websiteTabConnections, noopPublishRpcConnectionStatus)
+
+		const revokeReplies = messages.filter((message) => message.method === 'wallet_revokePermissions' && message.requestId === 11)
+		assert.equal(revokeReplies.at(-1)?.result, null)
+		assert.equal((await getSettings()).websiteAccess.find((entry) => entry.website.websiteOrigin === websiteOrigin)?.access, false)
+	})
+
+	test('wallet_revokePermissions succeeds when the Interceptor is disabled for the website', async () => {
+		installBrowserMock()
+		const { handleInterceptedRequest, websiteSocketToString, changeSimulationMode, setUseSignersAddressAsActiveAddress, updateWebsiteAccess, getSettings } = await loadModules()
+		const websiteOrigin = 'https://example.test'
+		const website = { websiteOrigin, icon: undefined, title: undefined }
+		const account = 0x1111111111111111111111111111111111111111n
+		await changeSimulationMode({ simulationMode: true, activeSimulationAddress: account, activeSigningAddress: undefined })
+		await setUseSignersAddressAsActiveAddress(false)
+		await updateWebsiteAccess(() => [{ website, access: true, addressAccess: [{ address: account, access: true }], interceptorDisabled: true }])
+
+		const socket = { tabId: 1, connectionName: 0n }
+		const { port, messages } = createPort(socket.tabId)
+		const connectionKey = websiteSocketToString(socket)
+		const websiteTabConnections = new Map([[socket.tabId, { connections: {
+			[connectionKey]: { port, socket, websiteOrigin, approved: false, wantsToConnect: true },
+		} }]])
+		const { ethereum, tokenPriceService, resetSimulationServices } = createEthereumWithGetBlockCounter({ count: 0 })
+
+		await handleInterceptedRequest(port, websiteOrigin, website, ethereum, tokenPriceService, resetSimulationServices, socket, {
+			interceptorRequest: true,
+			usingInterceptorWithoutSigner: false,
+			uniqueRequestIdentifier: { requestId: 12, requestSocket: socket },
+			method: 'wallet_revokePermissions',
+			params: [{ eth_accounts: {} }],
+		}, websiteTabConnections, noopPublishRpcConnectionStatus)
+
+		const revokeReplies = messages.filter((message) => message.method === 'wallet_revokePermissions' && message.requestId === 12)
+		assert.equal(revokeReplies.at(-1)?.result, null)
+		const access = (await getSettings()).websiteAccess.find((entry) => entry.website.websiteOrigin === websiteOrigin)
+		assert.equal(access?.access, false)
+		assert.equal(access?.addressAccess, undefined)
+		assert.equal(access?.interceptorDisabled, true)
+	})
+
+	test('wallet_revokePermissions rejects unsupported permission params without revoking access', async () => {
+		installBrowserMock()
+		const { handleInterceptedRequest, websiteSocketToString, changeSimulationMode, setUseSignersAddressAsActiveAddress, updateWebsiteAccess, getSettings } = await loadModules()
+		const websiteOrigin = 'https://example.test'
+		const website = { websiteOrigin, icon: undefined, title: undefined }
+		const account = 0x1111111111111111111111111111111111111111n
+		await changeSimulationMode({ simulationMode: true, activeSimulationAddress: account, activeSigningAddress: undefined })
+		await setUseSignersAddressAsActiveAddress(false)
+		await updateWebsiteAccess(() => [{ website, access: true, addressAccess: [{ address: account, access: true }] }])
+
+		const socket = { tabId: 1, connectionName: 0n }
+		const { port, messages } = createPort(socket.tabId)
+		const connectionKey = websiteSocketToString(socket)
+		const websiteTabConnections = new Map([[socket.tabId, { connections: {
+			[connectionKey]: { port, socket, websiteOrigin, approved: true, wantsToConnect: true },
+		} }]])
+		const { ethereum, tokenPriceService, resetSimulationServices } = createEthereumWithGetBlockCounter({ count: 0 })
+
+		const unsupportedParams = [
+			[{ wallet_snap: {} }],
+			[{ eth_accounts: {}, wallet_snap: {} }],
+			[{ eth_accounts: { foo: 1 } }],
+		]
+		for (const [index, params] of unsupportedParams.entries()) {
+			const requestId = 13 + index
+			await handleInterceptedRequest(port, websiteOrigin, website, ethereum, tokenPriceService, resetSimulationServices, socket, {
+				interceptorRequest: true,
+				usingInterceptorWithoutSigner: false,
+				uniqueRequestIdentifier: { requestId, requestSocket: socket },
+				method: 'wallet_revokePermissions',
+				params,
+			}, websiteTabConnections, noopPublishRpcConnectionStatus)
+
+			const revokeReplies = messages.filter((message) => message.method === 'wallet_revokePermissions' && message.requestId === requestId)
+			assert.equal(revokeReplies.at(-1)?.error?.code, -32700)
+			assert.equal(websiteTabConnections.get(socket.tabId)?.connections[connectionKey]?.approved, true)
+			const access = (await getSettings()).websiteAccess.find((entry) => entry.website.websiteOrigin === websiteOrigin)
+			assert.equal(access?.access, true)
+			assert.deepEqual(access?.addressAccess, [{ address: account, access: true }])
+		}
 	})
 })


### PR DESCRIPTION
## Summary
- Adds background handling for `wallet_revokePermissions` so a site can revoke its `eth_accounts` access.
- Validates the request shape explicitly and rejects unsupported permission payloads with a parse error.
- Updates RPC/type unions so revoke responses are recognized as `null` results.
- Expands background tests to cover revoking access, already-unauthorized sites, disabled interceptor state, and invalid params.

## Testing
- `bun test`
- `bun run setup-chrome`
- `bun run typecheck`
- `bun run lint`