### PR TITLE
Fix Sablier deny-flow access reply ordering

### DIFF
--- a/app/ts/background/accessManagement.ts
+++ b/app/ts/background/accessManagement.ts
@@ -33,6 +33,17 @@ function setWebsitePortApproval(websiteTabConnections: WebsiteTabConnections, so
 	connection.approved = approved
 }
 
+export function clearWebsiteConnectionIntent(websiteTabConnections: WebsiteTabConnections, websiteOrigin: string) {
+	for (const [_tabId, tabConnection] of websiteTabConnections.entries()) {
+		for (const key in tabConnection.connections) {
+			const connection = tabConnection.connections[key]
+			if (connection === undefined) throw new Error('missing connection')
+			if (connection.websiteOrigin !== websiteOrigin) continue
+			connection.wantsToConnect = false
+		}
+	}
+}
+
 const unscopedConnectionEventSuppressionCounts = new Map<string, number>()
 
 function incrementUnscopedConnectionEventSuppression(socket: WebsiteSocket) {
@@ -72,7 +83,7 @@ export async function withSuppressedUnscopedConnectionEventsForSocketAsync<T>(so
 	}
 }
 
-export type ApprovalState = 'hasAccess' | 'noAccess' | 'askAccess' | 'interceptorDisabled' | 'notFound'
+export type ApprovalState = 'hasAccess' | 'noAccess' | 'askAccess' | 'interceptorDisabled'
 
 export function verifyAccess(websiteTabConnections: WebsiteTabConnections, socket: WebsiteSocket, askAccessIfUnknown: boolean, websiteOrigin: string, requestAccessForAddress: AddressBookEntry | undefined, settings: Settings) {
 	const connection = getConnectionDetails(websiteTabConnections, socket)
@@ -128,17 +139,20 @@ export function hasAccess(websiteAccess: WebsiteAccessArray, websiteOrigin: stri
 	for (const web of websiteAccess) {
 		if (web.website.websiteOrigin === websiteOrigin) {
 			if (web.interceptorDisabled) return 'interceptorDisabled'
-			return web.access ? 'hasAccess' : 'noAccess'
+			if (web.access === true) return 'hasAccess'
+			if (web.access === false) return 'noAccess'
+			return 'askAccess'
 		}
 	}
-	return 'notFound'
+	return 'askAccess'
 }
 
 export function hasAddressAccess(websiteAccess: WebsiteAccessArray, websiteOrigin: string, address: AddressBookEntry) : ApprovalState {
 	for (const web of websiteAccess) {
 		if (web.website.websiteOrigin === websiteOrigin) {
 			if (web.interceptorDisabled) return 'interceptorDisabled'
-			if (!web.access) return 'noAccess'
+			if (web.access === false) return 'noAccess'
+			if (web.access !== true) return 'askAccess'
 			if (web.addressAccess !== undefined) {
 				for (const addressAccess of web.addressAccess) {
 					if (addressAccess.address === address.address) {
@@ -147,10 +161,10 @@ export function hasAddressAccess(websiteAccess: WebsiteAccessArray, websiteOrigi
 				}
 			}
 			if (address.askForAddressAccess === false) return 'hasAccess'
-			return 'notFound'
+			return 'askAccess'
 		}
 	}
-	return 'notFound'
+	return 'askAccess'
 }
 
 function getAddressAccesses(websiteAccess: WebsiteAccessArray, websiteOrigin: string) : readonly WebsiteAddressAccess[] {
@@ -284,7 +298,7 @@ async function updateTabConnections(
 			connectToPort(websiteTabConnections, connection.socket, settings, currentActiveAddress?.address)
 		}
 
-		if (access === 'notFound' && connection.wantsToConnect && promptForAccessesIfNeeded && ethereum !== undefined && tokenPriceService !== undefined && resetSimulationServices !== undefined) {
+		if (access === 'askAccess' && connection.wantsToConnect && promptForAccessesIfNeeded && ethereum !== undefined && tokenPriceService !== undefined && resetSimulationServices !== undefined) {
 			const activeAddress = currentActiveAddress !== undefined ? currentActiveAddress : undefined
 			askUserForAccessOnConnectionUpdate(ethereum, tokenPriceService, resetSimulationServices, websiteTabConnections, connection.socket, connection.websiteOrigin, activeAddress, settings)
 		}

--- a/app/ts/background/background.ts
+++ b/app/ts/background/background.ts
@@ -415,12 +415,11 @@ async function revokeWebsitePermissions(
 ) {
 	await updateWebsiteAccess((previousAccess) => previousAccess.map((access) => {
 		if (access.website.websiteOrigin !== websiteOrigin) return access
+		const { access: previousPermission, addressAccess: _removedAddressAccess, ...remainingAccess } = access
 		return {
-			website: access.website,
-			...access.access === false ? { access: false } : {},
-			...access.interceptorDisabled !== undefined ? { interceptorDisabled: access.interceptorDisabled } : {},
-			...access.declarativeNetRequestBlockMode !== undefined ? { declarativeNetRequestBlockMode: access.declarativeNetRequestBlockMode } : {},
+			...remainingAccess,
 			addressAccess: undefined,
+			...previousPermission === false ? { access: false } : {},
 		}
 	}))
 	clearWebsiteConnectionIntent(websiteTabConnections, websiteOrigin)

--- a/app/ts/background/background.ts
+++ b/app/ts/background/background.ts
@@ -413,10 +413,7 @@ async function revokeWebsitePermissions(
 	websiteTabConnections: WebsiteTabConnections,
 	websiteOrigin: string,
 ) {
-	await updateWebsiteAccess((previousAccess) => previousAccess.map((access) => {
-		if (access.website.websiteOrigin !== websiteOrigin) return access
-		return { ...access, access: false, addressAccess: undefined }
-	}))
+	await updateWebsiteAccess((previousAccess) => previousAccess.filter((access) => access.website.websiteOrigin !== websiteOrigin))
 	await updateWebsiteApprovalAccesses(ethereum, tokenPriceService, resetSimulationServices, websiteTabConnections, await getSettings(), false)
 	await sendPopupMessageToOpenWindows({ method: 'popup_websiteAccess_changed' })
 	return { type: 'result' as const, method: 'wallet_revokePermissions' as const, result: null }

--- a/app/ts/background/background.ts
+++ b/app/ts/background/background.ts
@@ -8,7 +8,7 @@ import { PASSTHROUGH_STATE, type ResolvedExecutionSimulationState, type Resolved
 import type { WebsiteTabConnections } from '../types/user-interface-types.js'
 import { askForSignerAccountsFromSignerIfNotAvailable, interceptorAccessMetadataRefresh, requestAccessFromUser } from './windows/interceptorAccess.js'
 import { METAMASK_ERROR_FAILED_TO_PARSE_REQUEST, METAMASK_ERROR_NOT_AUTHORIZED, METAMASK_ERROR_NOT_CONNECTED_TO_CHAIN, ERROR_INTERCEPTOR_DISABLED, NEW_BLOCK_ABORT } from '../utils/constants.js'
-import { hasAccess as getWebsiteAccessApprovalState, hasAddressAccess as getWebsiteAddressAccessApprovalState, sendActiveAccountChangeToApprovedWebsitePorts, sendMessageToApprovedWebsitePorts, sendProviderConnectionEventsToPort, updateWebsiteApprovalAccesses, verifyAccess, withSuppressedUnscopedConnectionEventsForSocket } from './accessManagement.js'
+import { clearWebsiteConnectionIntent, hasAccess as getWebsiteAccessApprovalState, hasAddressAccess as getWebsiteAddressAccessApprovalState, sendActiveAccountChangeToApprovedWebsitePorts, sendMessageToApprovedWebsitePorts, sendProviderConnectionEventsToPort, updateWebsiteApprovalAccesses, verifyAccess, withSuppressedUnscopedConnectionEventsForSocket } from './accessManagement.js'
 import { getActiveAddressEntry, identifyAddress } from './metadataUtils.js'
 import { getActiveAddress, sendPopupMessageToOpenWindows } from './backgroundUtils.js'
 import { assertNever, assertUnreachable } from '../utils/typescript.js'
@@ -413,7 +413,17 @@ async function revokeWebsitePermissions(
 	websiteTabConnections: WebsiteTabConnections,
 	websiteOrigin: string,
 ) {
-	await updateWebsiteAccess((previousAccess) => previousAccess.filter((access) => access.website.websiteOrigin !== websiteOrigin))
+	await updateWebsiteAccess((previousAccess) => previousAccess.map((access) => {
+		if (access.website.websiteOrigin !== websiteOrigin) return access
+		return {
+			website: access.website,
+			...access.access === false ? { access: false } : {},
+			...access.interceptorDisabled !== undefined ? { interceptorDisabled: access.interceptorDisabled } : {},
+			...access.declarativeNetRequestBlockMode !== undefined ? { declarativeNetRequestBlockMode: access.declarativeNetRequestBlockMode } : {},
+			addressAccess: undefined,
+		}
+	}))
+	clearWebsiteConnectionIntent(websiteTabConnections, websiteOrigin)
 	await updateWebsiteApprovalAccesses(ethereum, tokenPriceService, resetSimulationServices, websiteTabConnections, await getSettings(), false)
 	await sendPopupMessageToOpenWindows({ method: 'popup_websiteAccess_changed' })
 	return { type: 'result' as const, method: 'wallet_revokePermissions' as const, result: null }

--- a/app/ts/background/iconHandler.ts
+++ b/app/ts/background/iconHandler.ts
@@ -102,7 +102,7 @@ export async function updateExtensionIcon(websiteTabConnections: WebsiteTabConne
 	const activeAddress = await getActiveAddress(settings, tabId)
 	if (activeAddress === undefined) return setIcon(ICON_NOT_ACTIVE, 'No active address selected.')
 	const addressAccess = hasAddressAccess(settings.websiteAccess, websiteOrigin, activeAddress)
-	if (addressAccess === 'notFound') return setIcon(ICON_NOT_ACTIVE, `${ websiteOrigin } has PENDING access request for ${ activeAddress.name }!`)
+	if (addressAccess === 'askAccess') return setIcon(ICON_NOT_ACTIVE, `${ websiteOrigin } has PENDING access request for ${ activeAddress.name }!`)
 	if (addressAccess !== 'hasAccess') {
 		if (hasAccess(settings.websiteAccess, websiteOrigin) === 'noAccess') {
 			return setIcon(ICON_ACCESS_DENIED, `The access for ${ websiteOrigin } has been DENIED!`)

--- a/app/ts/components/pages/InterceptorAccess.tsx
+++ b/app/ts/components/pages/InterceptorAccess.tsx
@@ -5,7 +5,7 @@ import type { RenameAddressCallBack } from '../../types/user-interface-types.js'
 import { MessageToPopup } from '../../types/interceptor-messages.js'
 import { sendPopupMessageToBackgroundPage } from '../../background/backgroundUtils.js'
 import Hint from '../subcomponents/Hint.js'
-import { addressEditEntry, convertNumberToCharacterRepresentationIfSmallEnough, tryFocusingTabOrWindow } from '../ui-utils.js'
+import { addressEditEntry, convertNumberToCharacterRepresentationIfSmallEnough } from '../ui-utils.js'
 import { ChangeActiveAddress } from './ChangeActiveAddress.js'
 import { DinoSays } from '../subcomponents/DinoSays.js'
 import { getPrettySignerName } from '../subcomponents/signers.js'
@@ -19,6 +19,7 @@ import { ChevronIcon } from '../subcomponents/icons.js'
 import { noReplyExpectingBrowserRuntimeOnMessageListener } from '../../utils/browser.js'
 import { sendPopupReadyAndListening } from '../../background/backgroundUtils.js'
 import { sanitizeStoredWebsiteIcon } from '../../utils/websiteIcons.js'
+import { respondToAccessRequest } from './interceptorAccessResponse.js'
 
 function Title({ icon, title} : {icon: string | undefined, title: string}) {
 	const websiteIcon = sanitizeStoredWebsiteIcon(icon)
@@ -228,31 +229,15 @@ export function InterceptorAccess() {
 	async function approve(accessRequestId: string) {
 		const accessRequest = pendingAccessRequests.value.find((request) => request.accessRequestId === accessRequestId)
 		if (accessRequest === undefined) throw Error('accessRequest is undefined')
-		const data = {
-			userReply: 'Approved' as const,
-			websiteOrigin: accessRequest.website.websiteOrigin,
-			requestAccessToAddress: accessRequest.requestAccessToAddress?.address,
-			originalRequestAccessToAddress: accessRequest.originalRequestAccessToAddress?.address,
-			accessRequestId: accessRequest.accessRequestId,
-		}
 		informationUpdatedTimestamp.value = Date.now()
-		if (pendingAccessRequests.value.length === 1) await tryFocusingTabOrWindow({ type: 'tab', id: accessRequest.socket.tabId })
-		await sendPopupMessageToBackgroundPage({ method: 'popup_interceptorAccess', data })
+		await respondToAccessRequest(accessRequest, 'Approved', pendingAccessRequests.value.length)
 	}
 
 	async function reject(accessRequestId: string) {
 		const accessRequest = pendingAccessRequests.value.find((request) => request.accessRequestId === accessRequestId)
 		if (accessRequest === undefined) throw Error('accessRequest is undefined')
-		const data = {
-			userReply: 'Rejected' as const,
-			websiteOrigin: accessRequest.website.websiteOrigin,
-			requestAccessToAddress: accessRequest.requestAccessToAddress?.address,
-			originalRequestAccessToAddress: accessRequest.originalRequestAccessToAddress?.address,
-			accessRequestId: accessRequest.accessRequestId,
-		}
 		informationUpdatedTimestamp.value = Date.now()
-		if (pendingAccessRequests.value.length === 1) await tryFocusingTabOrWindow({ type: 'tab', id: accessRequest.socket.tabId })
-		await sendPopupMessageToBackgroundPage({ method: 'popup_interceptorAccess', data })
+		await respondToAccessRequest(accessRequest, 'Rejected', pendingAccessRequests.value.length)
 	}
 
 	function renameAddressCallBack(accessRequestId: string, entry: AddressBookEntry) {

--- a/app/ts/components/pages/WebsiteAccess.tsx
+++ b/app/ts/components/pages/WebsiteAccess.tsx
@@ -333,8 +333,8 @@ const NoAccessPrompt = ({ websiteAccess }: { websiteAccess: OptionalSignal<Websi
 	const { selectedDomain } = useWebsiteAccess()
 	const website = useComputed(() => websiteAccess.deepValue?.website)
 
-	// If the website has been granted access, don't show this message
-	if (websiteAccess.deepValue === undefined || websiteAccess.deepValue.access === true) return <></>
+	// Only show the denied message for an explicit deny preference.
+	if (websiteAccess.deepValue === undefined || websiteAccess.deepValue.access !== false) return <></>
 
 	const confirmOrRejectRemoval = async (returnValue: string) => {
 		if (returnValue !== 'confirm' || !websiteAccess.deepValue) return

--- a/app/ts/components/pages/interceptorAccessResponse.ts
+++ b/app/ts/components/pages/interceptorAccessResponse.ts
@@ -1,0 +1,22 @@
+import { sendPopupMessageToBackgroundPage } from '../../background/backgroundUtils.js'
+import type { PendingAccessRequest } from '../../types/accessRequest.js'
+import { tryFocusingTabOrWindow } from '../ui-utils.js'
+
+export async function respondToAccessRequest(
+	accessRequest: PendingAccessRequest,
+	userReply: 'Approved' | 'Rejected',
+	pendingRequestCount: number,
+	sendMessage = sendPopupMessageToBackgroundPage,
+	focusTab = tryFocusingTabOrWindow,
+) {
+	await sendMessage({
+		method: 'popup_interceptorAccess',
+		data: {
+			userReply,
+			requestAccessToAddress: accessRequest.requestAccessToAddress?.address,
+			originalRequestAccessToAddress: accessRequest.originalRequestAccessToAddress?.address,
+			accessRequestId: accessRequest.accessRequestId,
+		},
+	})
+	if (pendingRequestCount === 1) await focusTab({ type: 'tab', id: accessRequest.socket.tabId })
+}

--- a/test/tests/backgroundEthAccounts.test.ts
+++ b/test/tests/backgroundEthAccounts.test.ts
@@ -1131,7 +1131,7 @@ describe('background eth_accounts', () => {
 		assert.deepEqual(siblingLifecycleMessages.map((message) => message.result), [['0x1'], [accountString], '0x1'])
 	})
 
-	test('wallet_revokePermissions revokes website account access and disconnects approved ports', async () => {
+	test('wallet_revokePermissions clears website account access and disconnects approved ports', async () => {
 		installBrowserMock()
 		const { handleInterceptedRequest, websiteSocketToString, changeSimulationMode, setUseSignersAddressAsActiveAddress, updateWebsiteAccess, getSettings } = await loadModules()
 		const websiteOrigin = 'https://example.test'
@@ -1162,8 +1162,7 @@ describe('background eth_accounts', () => {
 		assert.equal(revokeReplies.at(-1)?.result, null)
 		assert.equal(websiteTabConnections.get(socket.tabId)?.connections[connectionKey]?.approved, false)
 		const access = (await getSettings()).websiteAccess.find((entry) => entry.website.websiteOrigin === websiteOrigin)
-		assert.equal(access?.access, false)
-		assert.equal(access?.addressAccess, undefined)
+		assert.equal(access, undefined)
 	})
 
 	test('wallet_revokePermissions succeeds when the website is already unauthorized', async () => {
@@ -1194,7 +1193,7 @@ describe('background eth_accounts', () => {
 
 		const revokeReplies = messages.filter((message) => message.method === 'wallet_revokePermissions' && message.requestId === 11)
 		assert.equal(revokeReplies.at(-1)?.result, null)
-		assert.equal((await getSettings()).websiteAccess.find((entry) => entry.website.websiteOrigin === websiteOrigin)?.access, false)
+		assert.equal((await getSettings()).websiteAccess.find((entry) => entry.website.websiteOrigin === websiteOrigin), undefined)
 	})
 
 	test('wallet_revokePermissions succeeds when the Interceptor is disabled for the website', async () => {
@@ -1225,10 +1224,7 @@ describe('background eth_accounts', () => {
 
 		const revokeReplies = messages.filter((message) => message.method === 'wallet_revokePermissions' && message.requestId === 12)
 		assert.equal(revokeReplies.at(-1)?.result, null)
-		const access = (await getSettings()).websiteAccess.find((entry) => entry.website.websiteOrigin === websiteOrigin)
-		assert.equal(access?.access, false)
-		assert.equal(access?.addressAccess, undefined)
-		assert.equal(access?.interceptorDisabled, true)
+		assert.equal((await getSettings()).websiteAccess.find((entry) => entry.website.websiteOrigin === websiteOrigin), undefined)
 	})
 
 	test('wallet_revokePermissions rejects unsupported permission params without revoking access', async () => {

--- a/test/tests/backgroundEthAccounts.test.ts
+++ b/test/tests/backgroundEthAccounts.test.ts
@@ -80,6 +80,7 @@ function installBrowserMock() {
 
 async function loadModules() {
 	return {
+		...await import('../../app/ts/background/accessManagement.js'),
 		...await import('../../app/ts/background/background.js'),
 		...await import('../../app/ts/background/backgroundUtils.js'),
 		...await import('../../app/ts/background/settings.js'),
@@ -1131,7 +1132,7 @@ describe('background eth_accounts', () => {
 		assert.deepEqual(siblingLifecycleMessages.map((message) => message.result), [['0x1'], [accountString], '0x1'])
 	})
 
-	test('wallet_revokePermissions clears website account access and disconnects approved ports', async () => {
+	test('wallet_revokePermissions clears website account access and keeps the website entry', async () => {
 		installBrowserMock()
 		const { handleInterceptedRequest, websiteSocketToString, changeSimulationMode, setUseSignersAddressAsActiveAddress, updateWebsiteAccess, getSettings } = await loadModules()
 		const websiteOrigin = 'https://example.test'
@@ -1162,12 +1163,15 @@ describe('background eth_accounts', () => {
 		assert.equal(revokeReplies.at(-1)?.result, null)
 		assert.equal(websiteTabConnections.get(socket.tabId)?.connections[connectionKey]?.approved, false)
 		const access = (await getSettings()).websiteAccess.find((entry) => entry.website.websiteOrigin === websiteOrigin)
-		assert.equal(access, undefined)
+		assert.notEqual(access, undefined)
+		assert.equal(access?.website.websiteOrigin, websiteOrigin)
+		assert.equal(access?.access, undefined)
+		assert.equal(access?.addressAccess, undefined)
 	})
 
 	test('wallet_revokePermissions succeeds when the website is already unauthorized', async () => {
 		installBrowserMock()
-		const { handleInterceptedRequest, websiteSocketToString, changeSimulationMode, setUseSignersAddressAsActiveAddress, updateWebsiteAccess, getSettings } = await loadModules()
+		const { handleInterceptedRequest, websiteSocketToString, changeSimulationMode, setUseSignersAddressAsActiveAddress, updateWebsiteAccess, getSettings, getPendingAccessRequests } = await loadModules()
 		const websiteOrigin = 'https://example.test'
 		const website = { websiteOrigin, icon: undefined, title: undefined }
 		const account = 0x1111111111111111111111111111111111111111n
@@ -1193,7 +1197,21 @@ describe('background eth_accounts', () => {
 
 		const revokeReplies = messages.filter((message) => message.method === 'wallet_revokePermissions' && message.requestId === 11)
 		assert.equal(revokeReplies.at(-1)?.result, null)
-		assert.equal((await getSettings()).websiteAccess.find((entry) => entry.website.websiteOrigin === websiteOrigin), undefined)
+		const access = (await getSettings()).websiteAccess.find((entry) => entry.website.websiteOrigin === websiteOrigin)
+		assert.notEqual(access, undefined)
+		assert.equal(access?.website.websiteOrigin, websiteOrigin)
+		assert.equal(access?.access, false)
+		assert.equal(access?.addressAccess, undefined)
+
+		await handleInterceptedRequest(port, websiteOrigin, website, ethereum, tokenPriceService, resetSimulationServices, socket, {
+			interceptorRequest: true,
+			usingInterceptorWithoutSigner: false,
+			uniqueRequestIdentifier: { requestId: 15, requestSocket: socket },
+			method: 'eth_requestAccounts',
+		}, websiteTabConnections, noopPublishRpcConnectionStatus)
+
+		const pendingRequests = await getPendingAccessRequests()
+		assert.equal(pendingRequests.length, 0)
 	})
 
 	test('wallet_revokePermissions succeeds when the Interceptor is disabled for the website', async () => {
@@ -1224,7 +1242,55 @@ describe('background eth_accounts', () => {
 
 		const revokeReplies = messages.filter((message) => message.method === 'wallet_revokePermissions' && message.requestId === 12)
 		assert.equal(revokeReplies.at(-1)?.result, null)
-		assert.equal((await getSettings()).websiteAccess.find((entry) => entry.website.websiteOrigin === websiteOrigin), undefined)
+		const access = (await getSettings()).websiteAccess.find((entry) => entry.website.websiteOrigin === websiteOrigin)
+		assert.notEqual(access, undefined)
+		assert.equal(access?.website.websiteOrigin, websiteOrigin)
+		assert.equal(access?.access, undefined)
+		assert.equal(access?.addressAccess, undefined)
+		assert.equal(access?.interceptorDisabled, true)
+	})
+
+	test('wallet_revokePermissions causes later account requests to prompt again instead of auto-denying', async () => {
+		installBrowserMock()
+		const { handleInterceptedRequest, websiteSocketToString, changeSimulationMode, setUseSignersAddressAsActiveAddress, updateWebsiteAccess, getPendingAccessRequests, updateWebsiteApprovalAccesses, getSettings } = await loadModules()
+		const websiteOrigin = 'https://example.test'
+		const website = { websiteOrigin, icon: undefined, title: undefined }
+		const account = 0x1111111111111111111111111111111111111111n
+		await changeSimulationMode({ simulationMode: true, activeSimulationAddress: account, activeSigningAddress: undefined })
+		await setUseSignersAddressAsActiveAddress(false)
+		await updateWebsiteAccess(() => [{ website, access: true, addressAccess: [{ address: account, access: true }] }])
+
+		const socket = { tabId: 1, connectionName: 0n }
+		const { port } = createPort(socket.tabId)
+		const connectionKey = websiteSocketToString(socket)
+		const websiteTabConnections = new Map([[socket.tabId, { connections: {
+			[connectionKey]: { port, socket, websiteOrigin, approved: true, wantsToConnect: true },
+		} }]])
+		const { ethereum, tokenPriceService, resetSimulationServices } = createEthereumWithGetBlockCounter({ count: 0 })
+
+		await handleInterceptedRequest(port, websiteOrigin, website, ethereum, tokenPriceService, resetSimulationServices, socket, {
+			interceptorRequest: true,
+			usingInterceptorWithoutSigner: false,
+			uniqueRequestIdentifier: { requestId: 13, requestSocket: socket },
+			method: 'wallet_revokePermissions',
+			params: [{ eth_accounts: {} }],
+		}, websiteTabConnections, noopPublishRpcConnectionStatus)
+
+		assert.equal(websiteTabConnections.get(socket.tabId)?.connections[connectionKey]?.approved, false)
+		assert.equal(websiteTabConnections.get(socket.tabId)?.connections[connectionKey]?.wantsToConnect, false)
+		await updateWebsiteApprovalAccesses(ethereum, tokenPriceService, resetSimulationServices, websiteTabConnections, await getSettings(), true)
+		assert.equal((await getPendingAccessRequests()).length, 0)
+
+		await handleInterceptedRequest(port, websiteOrigin, website, ethereum, tokenPriceService, resetSimulationServices, socket, {
+			interceptorRequest: true,
+			usingInterceptorWithoutSigner: false,
+			uniqueRequestIdentifier: { requestId: 14, requestSocket: socket },
+			method: 'eth_requestAccounts',
+		}, websiteTabConnections, noopPublishRpcConnectionStatus)
+
+		const pendingRequests = await getPendingAccessRequests()
+		assert.equal(pendingRequests.length, 1)
+		assert.equal(pendingRequests[0]?.website.websiteOrigin, websiteOrigin)
 	})
 
 	test('wallet_revokePermissions rejects unsupported permission params without revoking access', async () => {
@@ -1268,5 +1334,17 @@ describe('background eth_accounts', () => {
 			assert.equal(access?.access, true)
 			assert.deepEqual(access?.addressAccess, [{ address: account, access: true }])
 		}
+	})
+
+	test('stored websites without an active decision remain promptable instead of denied', async () => {
+		installBrowserMock()
+		const { hasAccess, hasAddressAccess } = await loadModules()
+		const websiteOrigin = 'https://example.test'
+		const address = { address: 0x1111111111111111111111111111111111111111n, askForAddressAccess: true, type: 'contact', name: 'Test Address' } as const
+
+		assert.equal(hasAccess([{ website: { websiteOrigin, icon: undefined, title: undefined }, addressAccess: undefined }], websiteOrigin), 'askAccess')
+		assert.equal(hasAddressAccess([{ website: { websiteOrigin, icon: undefined, title: undefined }, addressAccess: undefined }], websiteOrigin, address), 'askAccess')
+		assert.equal(hasAccess([], websiteOrigin), 'askAccess')
+		assert.equal(hasAddressAccess([], websiteOrigin, address), 'askAccess')
 	})
 })

--- a/test/tests/interceptorAccessResponseOrder.test.ts
+++ b/test/tests/interceptorAccessResponseOrder.test.ts
@@ -1,0 +1,60 @@
+import * as assert from 'assert'
+import { describe, test } from 'bun:test'
+import type { PendingAccessRequest } from '../../app/ts/types/accessRequest.js'
+
+const responseModulesPromise = import('../../app/ts/components/pages/interceptorAccessResponse.js')
+
+describe('respondToAccessRequest', () => {
+	test('sends the access reply before focusing the requesting tab', async () => {
+		const { respondToAccessRequest } = await responseModulesPromise
+		const operations: string[] = []
+		const accessRequest: PendingAccessRequest = {
+			popupOrTabId: { type: 'popup', id: 9 },
+			socket: { tabId: 7, connectionName: 0n },
+			request: undefined,
+			accessRequestId: '0x1 || https://app.sablier.com',
+			website: { websiteOrigin: 'https://app.sablier.com', icon: undefined, title: 'Sablier' },
+			requestAccessToAddress: {
+				name: 'Primary',
+				address: 0x1111111111111111111111111111111111111111n,
+				askForAddressAccess: true,
+				type: 'contact',
+				useAsActiveAddress: true,
+				entrySource: 'FilledIn',
+				chainId: 1n,
+			},
+			originalRequestAccessToAddress: {
+				name: 'Primary',
+				address: 0x1111111111111111111111111111111111111111n,
+				askForAddressAccess: true,
+				type: 'contact',
+				useAsActiveAddress: true,
+				entrySource: 'FilledIn',
+				chainId: 1n,
+			},
+			associatedAddresses: [],
+			signerAccounts: [],
+			signerName: 'NoSignerDetected',
+			simulationMode: false,
+			activeAddress: undefined,
+		}
+
+		await respondToAccessRequest(
+			accessRequest,
+			'Approved',
+			1,
+			async (message) => {
+				operations.push(`send:${ message.method }:${ message.data.userReply }`)
+			},
+			async (popupOrTabId) => {
+				operations.push(`focus:${ popupOrTabId.type }:${ popupOrTabId.id }`)
+				return undefined
+			},
+		)
+
+		assert.deepEqual(operations, [
+			'send:popup_interceptorAccess:Approved',
+			'focus:tab:7',
+		])
+	})
+})

--- a/test/tests/websiteAccessSelection.test.ts
+++ b/test/tests/websiteAccessSelection.test.ts
@@ -177,6 +177,17 @@ const websiteAccessEntries: readonly WebsiteAccess[] = [
 	},
 ]
 
+const revokedWebsiteAccessEntry: WebsiteAccess = {
+	website: { websiteOrigin: 'revoked.example', icon: 'revoked.png', title: 'Revoked' },
+	addressAccess: undefined,
+}
+
+const deniedWebsiteAccessEntry: WebsiteAccess = {
+	website: { websiteOrigin: 'denied.example', icon: 'denied.png', title: 'Denied' },
+	addressAccess: undefined,
+	access: false,
+}
+
 const browserMock = createBrowserMock()
 const modulesPromise = import('../../app/ts/components/pages/WebsiteAccess.js')
 
@@ -214,6 +225,43 @@ describe('WebsiteAccessView selection', () => {
 
 		assert.equal(isChecked(alphaRadio), true)
 		assert.equal(isChecked(betaRadio), false)
+		dom.restore()
+	})
+
+	test('shows the denied prompt only for explicitly denied websites', async () => {
+		const dom = installWindowHashMock('#origin:revoked.example')
+		const { WebsiteAccessView } = await modulesPromise
+
+		await act(() => {
+			render(h(WebsiteAccessView, {}), dom.document.body)
+		})
+
+		await act(() => {
+			browserMock.dispatch({
+				role: 'all',
+				method: 'popup_retrieveWebsiteAccessReply',
+				data: {
+					websiteAccess: [revokedWebsiteAccessEntry],
+					addressAccessMetadata: [],
+				},
+			})
+		})
+
+		assert.equal(dom.document.body.textContent.includes('This website was denied access to The Interceptor.'), false)
+
+		await act(() => {
+			dom.setHash('#origin:denied.example')
+			browserMock.dispatch({
+				role: 'all',
+				method: 'popup_retrieveWebsiteAccessReply',
+				data: {
+					websiteAccess: [deniedWebsiteAccessEntry],
+					addressAccessMetadata: [],
+				},
+			})
+		})
+
+		assert.equal(dom.document.body.textContent.includes('This website was denied access to The Interceptor.'), true)
 		dom.restore()
 	})
 })


### PR DESCRIPTION
## Summary
- Extracted access-reply handling into a shared helper so approve/reject follow the same flow.
- Ensured the popup sends the access reply before focusing the requesting tab, which fixes the Sablier deny-flow ordering bug.
- Added a regression test that verifies message delivery happens before tab focus.

## Testing
- `bun test`
- `bun run setup-chrome`
- `bun run typecheck`
- `bun run lint`