### PR TITLE
Retry signer replies after MV2 reconnect

### DIFF
--- a/app/inpage/ts/listenContentScript.ts
+++ b/app/inpage/ts/listenContentScript.ts
@@ -3,6 +3,7 @@ const contentScriptListenerGlobalKey = Symbol.for('TheInterceptor.listenContentS
 function listenContentScript(connectionName: string | undefined, diagnosticsSource: 'content-script' | 'document-start') {
 	const INTERCEPTOR_BRIDGE_PORT_MESSAGE = 'interceptor_bridge_port'
 	const INTERCEPTOR_BRIDGE_REQUEST_MESSAGE = 'interceptor_bridge_request'
+	const INTERCEPTOR_BRIDGE_ACKNOWLEDGEMENT_MESSAGE = 'interceptor_bridge_acknowledgement'
 	const checkAndThrowRuntimeLastError = () => {
 		const error: browser.runtime._LastError | undefined | null = browser.runtime.lastError // firefox return `null` on no errors
 		if (error !== null && error !== undefined && error.message !== undefined) throw new Error(error.message)
@@ -123,9 +124,11 @@ function listenContentScript(connectionName: string | undefined, diagnosticsSour
 		|| error.message.includes('Extension context invalidated')
 	const isMissingContentScriptPortReceiverError = (error: Error) => error.message.includes('Could not establish connection. Receiving end does not exist')
 	const isTerminalContentScriptPortError = (error: Error) => error.message.includes('Extension context invalidated')
+	let inFlightBridgeMessage: ForwardedBridgeMessage | undefined
 	const markExtensionPortDisconnected = (port: browser.runtime.Port) => {
 		if (extensionPort !== port) return
 		extensionPort = undefined
+		inFlightBridgeMessage = undefined
 		pageHidden = true
 	}
 	let connect: () => browser.runtime.Port
@@ -167,12 +170,14 @@ function listenContentScript(connectionName: string | undefined, diagnosticsSour
 	}
 	const flushPendingBridgeMessages = (port: browser.runtime.Port) => {
 		while (extensionPort === port) {
+			if (inFlightBridgeMessage !== undefined) return
 			const message = pendingBridgeMessages[0]
 			if (message === undefined) return
+			inFlightBridgeMessage = message
 			try {
 				port.postMessage(message)
 				checkAndThrowRuntimeLastError()
-				pendingBridgeMessages.shift()
+				return
 			} catch (error: unknown) {
 				if (error instanceof Error && isIgnorableContentScriptPortError(error)) {
 					reconnectAfterPortFailure(port, error)
@@ -180,6 +185,7 @@ function listenContentScript(connectionName: string | undefined, diagnosticsSour
 				}
 				if (error instanceof Error && error.message.includes('User denied')) {
 					pendingBridgeMessages.shift()
+					inFlightBridgeMessage = undefined
 					continue
 				}
 				throw error
@@ -248,6 +254,7 @@ function listenContentScript(connectionName: string | undefined, diagnosticsSour
 		}
 		const previousExtensionPort = extensionPort
 		extensionPort = undefined
+		inFlightBridgeMessage = undefined
 		if (previousExtensionPort !== undefined) {
 			try {
 				previousExtensionPort.disconnect()
@@ -260,6 +267,22 @@ function listenContentScript(connectionName: string | undefined, diagnosticsSour
 
 		// forward all messages we get from the background script to the window so the page script can filter and process them
 		connectedExtensionPort.onMessage.addListener(messageEvent => {
+			if (
+				extensionPort === connectedExtensionPort
+				&& typeof messageEvent === 'object'
+				&& messageEvent !== null
+				&& 'type' in messageEvent
+				&& messageEvent.type === INTERCEPTOR_BRIDGE_ACKNOWLEDGEMENT_MESSAGE
+				&& 'requestId' in messageEvent
+				&& typeof messageEvent.requestId === 'number'
+			) {
+				const acknowledgedMessage = pendingBridgeMessages[0]
+				if (acknowledgedMessage?.data.requestId !== messageEvent.requestId) return
+				pendingBridgeMessages.shift()
+				inFlightBridgeMessage = undefined
+				flushPendingBridgeMessages(connectedExtensionPort)
+				return
+			}
 			if (typeof messageEvent !== 'object' || messageEvent === null || !('interceptorApproved' in messageEvent)) {
 				console.error('Malformed message:')
 				console.error(messageEvent)

--- a/app/inpage/ts/listenContentScript.ts
+++ b/app/inpage/ts/listenContentScript.ts
@@ -268,15 +268,14 @@ function listenContentScript(connectionName: string | undefined, diagnosticsSour
 
 		// forward all messages we get from the background script to the window so the page script can filter and process them
 		connectedExtensionPort.onMessage.addListener(messageEvent => {
-			if (
-				extensionPort === connectedExtensionPort
-				&& typeof messageEvent === 'object'
+			const isBridgeAcknowledgement = typeof messageEvent === 'object'
 				&& messageEvent !== null
 				&& 'type' in messageEvent
 				&& messageEvent.type === INTERCEPTOR_BRIDGE_ACKNOWLEDGEMENT_MESSAGE
 				&& 'requestId' in messageEvent
 				&& typeof messageEvent.requestId === 'number'
-			) {
+			if (isBridgeAcknowledgement) {
+				if (extensionPort !== connectedExtensionPort) return
 				const acknowledgedMessage = pendingBridgeMessages[0]
 				if (acknowledgedMessage?.data.requestId !== messageEvent.requestId) return
 				pendingBridgeMessages.shift()

--- a/app/inpage/ts/listenContentScript.ts
+++ b/app/inpage/ts/listenContentScript.ts
@@ -3,6 +3,7 @@ const contentScriptListenerGlobalKey = Symbol.for('TheInterceptor.listenContentS
 function listenContentScript(connectionName: string | undefined, diagnosticsSource: 'content-script' | 'document-start') {
 	const INTERCEPTOR_BRIDGE_PORT_MESSAGE = 'interceptor_bridge_port'
 	const INTERCEPTOR_BRIDGE_REQUEST_MESSAGE = 'interceptor_bridge_request'
+	// This non-module inpage build cannot import the canonical background constant from bridgeRequestDelivery.ts; contentScriptReconnect.test.ts enforces that both values match.
 	const INTERCEPTOR_BRIDGE_ACKNOWLEDGEMENT_MESSAGE = 'interceptor_bridge_acknowledgement'
 	const checkAndThrowRuntimeLastError = () => {
 		const error: browser.runtime._LastError | undefined | null = browser.runtime.lastError // firefox return `null` on no errors

--- a/app/ts/background/background-startup.ts
+++ b/app/ts/background/background-startup.ts
@@ -31,14 +31,14 @@ import { bumpPopupRefreshGeneration, initializePopupRefreshGeneration } from './
 import { flushPendingTerminalRepliesForConnectedPortWithRetry } from './terminalReplyDelivery.js'
 import { prunePendingTerminalRepliesForMissingTabs, removePendingTerminalRepliesForTab } from './pendingTerminalReplies.js'
 import { createRetriableTerminalStateRecovery } from './terminalStateRecovery.js'
-import { acknowledgeBridgeRequest } from './bridgeRequestDelivery.js'
+import { acknowledgeAndTrackBridgeRequest, INTERCEPTOR_BRIDGE_ACKNOWLEDGEMENT_MESSAGE } from './bridgeRequestDelivery.js'
 
 const websiteTabConnections = new Map<number, TabConnection>()
 let simulationServices: SimulationServices | undefined
 let resetActiveRpcNetwork: ResetSimulationServices | undefined
 const slowRpcRequests = new Map<string, SlowRpcRequest>()
+// Keep request watermarks across port reconnects so replayed messages are acknowledged without being handled twice. Tab removal clears them.
 const latestReceivedBridgeRequestIds = new Map<string, number>()
-const INTERCEPTOR_BRIDGE_ACKNOWLEDGEMENT_MESSAGE = 'interceptor_bridge_acknowledgement'
 
 function getSimulationServices() {
 	if (simulationServices === undefined) throw new Error('Simulation services are not initialized')
@@ -158,7 +158,7 @@ async function onContentScriptConnected(waitForStartup: () => Promise<{ resetAct
 					&& 'interceptorRequest' in payload.data
 				)) return
 				const rawMessage = RawInterceptedRequest.parse(payload.data)
-				const shouldHandleRequest = acknowledgeBridgeRequest(latestReceivedBridgeRequestIds, identifier, rawMessage.requestId, () => {
+				const shouldHandleRequest = acknowledgeAndTrackBridgeRequest(latestReceivedBridgeRequestIds, identifier, rawMessage.requestId, () => {
 					port.postMessage({ type: INTERCEPTOR_BRIDGE_ACKNOWLEDGEMENT_MESSAGE, requestId: rawMessage.requestId })
 					checkAndThrowRuntimeLastError()
 				})

--- a/app/ts/background/background-startup.ts
+++ b/app/ts/background/background-startup.ts
@@ -31,11 +31,14 @@ import { bumpPopupRefreshGeneration, initializePopupRefreshGeneration } from './
 import { flushPendingTerminalRepliesForConnectedPortWithRetry } from './terminalReplyDelivery.js'
 import { prunePendingTerminalRepliesForMissingTabs, removePendingTerminalRepliesForTab } from './pendingTerminalReplies.js'
 import { createRetriableTerminalStateRecovery } from './terminalStateRecovery.js'
+import { acknowledgeBridgeRequest } from './bridgeRequestDelivery.js'
 
 const websiteTabConnections = new Map<number, TabConnection>()
 let simulationServices: SimulationServices | undefined
 let resetActiveRpcNetwork: ResetSimulationServices | undefined
 const slowRpcRequests = new Map<string, SlowRpcRequest>()
+const latestReceivedBridgeRequestIds = new Map<string, number>()
+const INTERCEPTOR_BRIDGE_ACKNOWLEDGEMENT_MESSAGE = 'interceptor_bridge_acknowledgement'
 
 function getSimulationServices() {
 	if (simulationServices === undefined) throw new Error('Simulation services are not initialized')
@@ -104,6 +107,9 @@ const catchAllErrorsAndCall = async (func: () => Promise<unknown>) => {
 }
 
 browser.tabs.onRemoved.addListener(async (tabId: number) => await catchAllErrorsAndCall(async () => {
+	for (const socketIdentifier of latestReceivedBridgeRequestIds.keys()) {
+		if (socketIdentifier.startsWith(`${ tabId }-`)) latestReceivedBridgeRequestIds.delete(socketIdentifier)
+	}
 	await removeTabState(tabId)
 	await removePendingTerminalRepliesForTab(tabId)
 }))
@@ -151,8 +157,13 @@ async function onContentScriptConnected(waitForStartup: () => Promise<{ resetAct
 					&& payload.data !== null
 					&& 'interceptorRequest' in payload.data
 				)) return
+				const rawMessage = RawInterceptedRequest.parse(payload.data)
+				const shouldHandleRequest = acknowledgeBridgeRequest(latestReceivedBridgeRequestIds, identifier, rawMessage.requestId, () => {
+					port.postMessage({ type: INTERCEPTOR_BRIDGE_ACKNOWLEDGEMENT_MESSAGE, requestId: rawMessage.requestId })
+					checkAndThrowRuntimeLastError()
+				})
+				if (!shouldHandleRequest) return
 				await pendingRequestLimiter.execute(async () => {
-					const rawMessage = RawInterceptedRequest.parse(payload.data)
 					const { resetActiveRpcNetwork, simulationServices } = await waitForStartup()
 					const request = {
 						method: rawMessage.method,

--- a/app/ts/background/bridgeRequestDelivery.ts
+++ b/app/ts/background/bridgeRequestDelivery.ts
@@ -1,0 +1,13 @@
+export function acknowledgeBridgeRequest(
+	latestReceivedRequestIds: Map<string, number>,
+	socketIdentifier: string,
+	requestId: number,
+	acknowledge: () => void,
+): boolean {
+	const latestReceivedRequestId = latestReceivedRequestIds.get(socketIdentifier)
+	const requestWasAlreadyReceived = requestId >= 0 && latestReceivedRequestId !== undefined && requestId <= latestReceivedRequestId
+	acknowledge()
+	if (requestWasAlreadyReceived) return false
+	if (requestId >= 0) latestReceivedRequestIds.set(socketIdentifier, requestId)
+	return true
+}

--- a/app/ts/background/bridgeRequestDelivery.ts
+++ b/app/ts/background/bridgeRequestDelivery.ts
@@ -1,4 +1,6 @@
-export function acknowledgeBridgeRequest(
+export const INTERCEPTOR_BRIDGE_ACKNOWLEDGEMENT_MESSAGE = 'interceptor_bridge_acknowledgement'
+
+export function acknowledgeAndTrackBridgeRequest(
 	latestReceivedRequestIds: Map<string, number>,
 	socketIdentifier: string,
 	requestId: number,

--- a/app/ts/background/manifestV2Reconnect.ts
+++ b/app/ts/background/manifestV2Reconnect.ts
@@ -31,12 +31,16 @@ const requestManifestV2ContentScriptReconnect = async (socket: WebsiteSocket) =>
 	}
 }
 
-export async function attemptDeliveryAfterManifestV2Reconnect(websiteTabConnections: WebsiteTabConnections, message: InterceptedRequestForward, attemptDelivery: () => boolean | undefined | Promise<boolean | undefined>) {
-	const socket = message.uniqueRequestIdentifier.requestSocket
+export async function attemptSocketDeliveryAfterManifestV2Reconnect(websiteTabConnections: WebsiteTabConnections, socket: WebsiteSocket, attemptDelivery: () => boolean | undefined | Promise<boolean | undefined>) {
 	const previousPort = websiteTabConnections.get(socket.tabId)?.connections[websiteSocketToString(socket)]?.port
 	const delivered = await attemptDelivery()
-	if (delivered !== false || browser.runtime.getManifest().manifest_version !== 2 || message.type === 'doNotReply') return delivered
+	if (delivered !== false || browser.runtime.getManifest().manifest_version !== 2) return delivered
 	if (!await requestManifestV2ContentScriptReconnect(socket)) return false
 	if (!await waitForReplacementWebsiteConnection(websiteTabConnections, socket, previousPort)) return false
 	return await attemptDelivery()
+}
+
+export async function attemptDeliveryAfterManifestV2Reconnect(websiteTabConnections: WebsiteTabConnections, message: InterceptedRequestForward, attemptDelivery: () => boolean | undefined | Promise<boolean | undefined>) {
+	if (message.type === 'doNotReply') return await attemptDelivery()
+	return await attemptSocketDeliveryAfterManifestV2Reconnect(websiteTabConnections, message.uniqueRequestIdentifier.requestSocket, attemptDelivery)
 }

--- a/app/ts/background/messageSending.ts
+++ b/app/ts/background/messageSending.ts
@@ -4,7 +4,7 @@ import type { WebsiteTabConnections } from '../types/user-interface-types.js'
 import { websiteSocketToString } from './backgroundUtils.js'
 import { serialize } from '../types/wire-types.js'
 import { isIgnorablePortLifecycleError } from './contentScriptPortLifecycle.js'
-import { attemptDeliveryAfterManifestV2Reconnect } from './manifestV2Reconnect.js'
+import { attemptDeliveryAfterManifestV2Reconnect, attemptSocketDeliveryAfterManifestV2Reconnect } from './manifestV2Reconnect.js'
 
 function postMessageToPortIfConnected(port: browser.runtime.Port, message: InterceptorMessageToInpage) {
 	try {
@@ -49,7 +49,11 @@ export function sendSubscriptionReplyOrCallBack(websiteTabConnections: WebsiteTa
 		const connection = tabConnection.connections[socketAsString]
 		if (connection === undefined) throw new Error('connection was undefined')
 		if (socketAsString !== identifier) continue
-		postMessageToPortIfConnected(connection.port, { ...message, interceptorApproved: true })
+		return postMessageToPortIfConnected(connection.port, { ...message, interceptorApproved: true })
 	}
-	return true
+	return false
+}
+
+export async function sendSubscriptionReplyOrCallBackAfterManifestV2Reconnect(websiteTabConnections: WebsiteTabConnections, socket: WebsiteSocket, message: SubscriptionReplyOrCallBack) {
+	return await attemptSocketDeliveryAfterManifestV2Reconnect(websiteTabConnections, socket, () => sendSubscriptionReplyOrCallBack(websiteTabConnections, socket, message))
 }

--- a/app/ts/background/windows/interceptorAccess.ts
+++ b/app/ts/background/windows/interceptorAccess.ts
@@ -10,7 +10,7 @@ import { getActiveAddressEntry, getActiveAddresses } from '../metadataUtils.js'
 import { getSettings } from '../settings.js'
 import { getTabState, updatePendingAccessRequests, getPendingAccessRequests, clearPendingAccessRequests } from '../storageVariables.js'
 import type { InterceptedRequest, WebsiteSocket } from '../../utils/requests.js'
-import { replyToInterceptedRequest, sendSubscriptionReplyOrCallBack } from '../messageSending.js'
+import { replyToInterceptedRequest, sendSubscriptionReplyOrCallBackAfterManifestV2Reconnect } from '../messageSending.js'
 import type { PopupOrTabId, Website, WebsiteAccessArray } from '../../types/websiteAccessTypes.js'
 import type { PendingAccessRequest } from '../../types/accessRequest.js'
 import type { AddressBookEntries, AddressBookEntry } from '../../types/addressBookTypes.js'
@@ -144,7 +144,7 @@ export async function askForSignerAccountsFromSignerIfNotAvailable(websiteTabCon
 		const requestSignerAccountsMessage = requestAccounts
 			? { type: 'result' as const, method: 'request_signer_to_eth_requestAccounts' as const, result: [] as const }
 			: { type: 'result' as const, method: 'request_signer_to_eth_accounts' as const, result: [] as const }
-		const messageSent = sendSubscriptionReplyOrCallBack(websiteTabConnections, socket, requestSignerAccountsMessage)
+		const messageSent = await sendSubscriptionReplyOrCallBackAfterManifestV2Reconnect(websiteTabConnections, socket, requestSignerAccountsMessage)
 		if (messageSent) await future
 	} finally {
 		channel.removeEventListener('message', listener)

--- a/test/tests/bridgeRequestDelivery.test.ts
+++ b/test/tests/bridgeRequestDelivery.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, test } from 'bun:test'
-import { acknowledgeBridgeRequest } from '../../app/ts/background/bridgeRequestDelivery.js'
+import { acknowledgeAndTrackBridgeRequest } from '../../app/ts/background/bridgeRequestDelivery.js'
 
 describe('bridge request delivery', () => {
 	test('acknowledges each delivery and handles ordered request IDs only once', () => {
@@ -7,9 +7,9 @@ describe('bridge request delivery', () => {
 		const acknowledgements: number[] = []
 		const acknowledge = (requestId: number) => () => acknowledgements.push(requestId)
 
-		expect(acknowledgeBridgeRequest(latestReceivedRequestIds, 'socket', 1, acknowledge(1))).toBeTrue()
-		expect(acknowledgeBridgeRequest(latestReceivedRequestIds, 'socket', 1, acknowledge(1))).toBeFalse()
-		expect(acknowledgeBridgeRequest(latestReceivedRequestIds, 'socket', 2, acknowledge(2))).toBeTrue()
+		expect(acknowledgeAndTrackBridgeRequest(latestReceivedRequestIds, 'socket', 1, acknowledge(1))).toBeTrue()
+		expect(acknowledgeAndTrackBridgeRequest(latestReceivedRequestIds, 'socket', 1, acknowledge(1))).toBeFalse()
+		expect(acknowledgeAndTrackBridgeRequest(latestReceivedRequestIds, 'socket', 2, acknowledge(2))).toBeTrue()
 
 		expect(acknowledgements).toEqual([1, 1, 2])
 		expect(latestReceivedRequestIds.get('socket')).toBe(2)
@@ -19,19 +19,19 @@ describe('bridge request delivery', () => {
 		const latestReceivedRequestIds = new Map<string, number>()
 		const acknowledgementError = new Error('port disconnected')
 
-		expect(() => acknowledgeBridgeRequest(latestReceivedRequestIds, 'socket', 1, () => {
+		expect(() => acknowledgeAndTrackBridgeRequest(latestReceivedRequestIds, 'socket', 1, () => {
 			throw acknowledgementError
 		})).toThrow(acknowledgementError)
 		expect(latestReceivedRequestIds.has('socket')).toBeFalse()
-		expect(acknowledgeBridgeRequest(latestReceivedRequestIds, 'socket', 1, () => undefined)).toBeTrue()
+		expect(acknowledgeAndTrackBridgeRequest(latestReceivedRequestIds, 'socket', 1, () => undefined)).toBeTrue()
 	})
 
 	test('does not deduplicate diagnostic request ID -1', () => {
 		const latestReceivedRequestIds = new Map<string, number>()
 		let acknowledgementCount = 0
 
-		expect(acknowledgeBridgeRequest(latestReceivedRequestIds, 'socket', -1, () => acknowledgementCount++)).toBeTrue()
-		expect(acknowledgeBridgeRequest(latestReceivedRequestIds, 'socket', -1, () => acknowledgementCount++)).toBeTrue()
+		expect(acknowledgeAndTrackBridgeRequest(latestReceivedRequestIds, 'socket', -1, () => acknowledgementCount++)).toBeTrue()
+		expect(acknowledgeAndTrackBridgeRequest(latestReceivedRequestIds, 'socket', -1, () => acknowledgementCount++)).toBeTrue()
 
 		expect(acknowledgementCount).toBe(2)
 		expect(latestReceivedRequestIds.has('socket')).toBeFalse()

--- a/test/tests/bridgeRequestDelivery.test.ts
+++ b/test/tests/bridgeRequestDelivery.test.ts
@@ -1,0 +1,39 @@
+import { describe, expect, test } from 'bun:test'
+import { acknowledgeBridgeRequest } from '../../app/ts/background/bridgeRequestDelivery.js'
+
+describe('bridge request delivery', () => {
+	test('acknowledges each delivery and handles ordered request IDs only once', () => {
+		const latestReceivedRequestIds = new Map<string, number>()
+		const acknowledgements: number[] = []
+		const acknowledge = (requestId: number) => () => acknowledgements.push(requestId)
+
+		expect(acknowledgeBridgeRequest(latestReceivedRequestIds, 'socket', 1, acknowledge(1))).toBeTrue()
+		expect(acknowledgeBridgeRequest(latestReceivedRequestIds, 'socket', 1, acknowledge(1))).toBeFalse()
+		expect(acknowledgeBridgeRequest(latestReceivedRequestIds, 'socket', 2, acknowledge(2))).toBeTrue()
+
+		expect(acknowledgements).toEqual([1, 1, 2])
+		expect(latestReceivedRequestIds.get('socket')).toBe(2)
+	})
+
+	test('leaves a request eligible for retry when acknowledgement fails', () => {
+		const latestReceivedRequestIds = new Map<string, number>()
+		const acknowledgementError = new Error('port disconnected')
+
+		expect(() => acknowledgeBridgeRequest(latestReceivedRequestIds, 'socket', 1, () => {
+			throw acknowledgementError
+		})).toThrow(acknowledgementError)
+		expect(latestReceivedRequestIds.has('socket')).toBeFalse()
+		expect(acknowledgeBridgeRequest(latestReceivedRequestIds, 'socket', 1, () => undefined)).toBeTrue()
+	})
+
+	test('does not deduplicate diagnostic request ID -1', () => {
+		const latestReceivedRequestIds = new Map<string, number>()
+		let acknowledgementCount = 0
+
+		expect(acknowledgeBridgeRequest(latestReceivedRequestIds, 'socket', -1, () => acknowledgementCount++)).toBeTrue()
+		expect(acknowledgeBridgeRequest(latestReceivedRequestIds, 'socket', -1, () => acknowledgementCount++)).toBeTrue()
+
+		expect(acknowledgementCount).toBe(2)
+		expect(latestReceivedRequestIds.has('socket')).toBeFalse()
+	})
+})

--- a/test/tests/contentScriptReconnect.test.ts
+++ b/test/tests/contentScriptReconnect.test.ts
@@ -1,5 +1,6 @@
 import * as assert from 'assert'
 import { test } from 'bun:test'
+import { INTERCEPTOR_BRIDGE_ACKNOWLEDGEMENT_MESSAGE } from '../../app/ts/background/bridgeRequestDelivery.js'
 
 type ContentScriptMockState = {
 	readonly backgroundMessageListeners: ((message: unknown) => void)[]
@@ -135,7 +136,7 @@ async function verifyContentScriptReconnect(source: ContentScriptSource) {
 		assert.equal(getConnectionCount(), 3)
 		assert.equal(postedMessages.length, 1)
 		assert.equal(disconnectListeners.length, 3)
-		backgroundMessageListeners[2]?.({ type: 'interceptor_bridge_acknowledgement', requestId: 1 })
+		backgroundMessageListeners[2]?.({ type: INTERCEPTOR_BRIDGE_ACKNOWLEDGEMENT_MESSAGE, requestId: 1 })
 
 		disconnectListeners[1]?.()
 		assert.equal(getConnectionCount(), 3)
@@ -211,10 +212,54 @@ async function verifyUnacknowledgedRequestReplayedAfterDisconnect(source: Conten
 		assert.equal(postedMessages.length, 2)
 		assert.deepEqual(postedMessages[1], postedMessages[0])
 
-		backgroundMessageListeners[1]?.({ type: 'interceptor_bridge_acknowledgement', requestId: 1 })
+		backgroundMessageListeners[1]?.({ type: INTERCEPTOR_BRIDGE_ACKNOWLEDGEMENT_MESSAGE, requestId: 1 })
 		disconnectListeners[1]?.()
 		assert.equal(getConnectionCount(), 3)
 		assert.equal(postedMessages.length, 2)
+	})
+}
+
+async function verifyAcknowledgementAdvancesQueuedRequests(source: ContentScriptSource) {
+	await withContentScriptMock(source, async ({ backgroundMessageListeners, disconnectListeners, eventListeners, postedMessages, getConnectionCount }) => {
+		const channel = new MessageChannel()
+		dispatchWindowMessage(eventListeners, new MessageEvent('message', { data: { type: 'interceptor_bridge_port' }, ports: [channel.port2] }))
+		for (const requestId of [1, 2]) {
+			channel.port1.postMessage({
+				type: 'interceptor_bridge_request',
+				method: 'eth_sendTransaction',
+				params: [],
+				usingInterceptorWithoutSigner: false,
+				requestId,
+			})
+		}
+		await new Promise((resolve) => setTimeout(resolve, 0))
+
+		assert.equal(postedMessages.length, 1)
+		assert.deepEqual(postedMessages[0], { data: {
+			interceptorRequest: true,
+			method: 'eth_sendTransaction',
+			params: [],
+			usingInterceptorWithoutSigner: false,
+			requestId: 1,
+		} })
+		backgroundMessageListeners[0]?.({ type: INTERCEPTOR_BRIDGE_ACKNOWLEDGEMENT_MESSAGE, requestId: 2 })
+		assert.equal(postedMessages.length, 1)
+		backgroundMessageListeners[0]?.({ type: INTERCEPTOR_BRIDGE_ACKNOWLEDGEMENT_MESSAGE, requestId: 1 })
+		assert.equal(postedMessages.length, 2)
+		assert.deepEqual(postedMessages[1], { data: {
+			interceptorRequest: true,
+			method: 'eth_sendTransaction',
+			params: [],
+			usingInterceptorWithoutSigner: false,
+			requestId: 2,
+		} })
+		backgroundMessageListeners[0]?.({ type: INTERCEPTOR_BRIDGE_ACKNOWLEDGEMENT_MESSAGE, requestId: 2 })
+
+		disconnectListeners[0]?.()
+		assert.equal(getConnectionCount(), 2)
+		assert.equal(postedMessages.length, 2)
+		channel.port1.close()
+		channel.port2.close()
 	})
 }
 
@@ -241,6 +286,14 @@ if (process.env.INTERCEPTOR_CONTENT_SCRIPT_RECONNECT_TEST_CHILD === 'true') {
 
 	test('manifest v2 document-start replays an unacknowledged request after disconnect', async () => {
 		await verifyUnacknowledgedRequestReplayedAfterDisconnect('manifest-v2-document-start')
+	})
+
+	test('standalone content script advances queued requests only after the matching acknowledgement', async () => {
+		await verifyAcknowledgementAdvancesQueuedRequests('standalone-listener')
+	})
+
+	test('manifest v2 document-start advances queued requests only after the matching acknowledgement', async () => {
+		await verifyAcknowledgementAdvancesQueuedRequests('manifest-v2-document-start')
 	})
 
 	test('does not redefine a non-configurable legacy content script listener', async () => {

--- a/test/tests/contentScriptReconnect.test.ts
+++ b/test/tests/contentScriptReconnect.test.ts
@@ -263,6 +263,25 @@ async function verifyAcknowledgementAdvancesQueuedRequests(source: ContentScript
 	})
 }
 
+async function verifyStalePortAcknowledgementIsIgnored(source: ContentScriptSource) {
+	await withContentScriptMock(source, async ({ backgroundMessageListeners, disconnectListeners, postedMessages, getConnectionCount }) => {
+		disconnectListeners[0]?.()
+		assert.equal(getConnectionCount(), 2)
+
+		const originalConsoleError = console.error
+		const consoleErrors: unknown[][] = []
+		console.error = (...args: unknown[]) => consoleErrors.push(args)
+		try {
+			backgroundMessageListeners[0]?.({ type: INTERCEPTOR_BRIDGE_ACKNOWLEDGEMENT_MESSAGE, requestId: 1 })
+		} finally {
+			console.error = originalConsoleError
+		}
+
+		assert.deepEqual(consoleErrors, [])
+		assert.deepEqual(postedMessages, [])
+	})
+}
+
 if (process.env.INTERCEPTOR_CONTENT_SCRIPT_RECONNECT_TEST_CHILD === 'true') {
 	test('standalone content script recovers its background port without reconnect churn', async () => {
 		await verifyContentScriptReconnect('standalone-listener')
@@ -294,6 +313,14 @@ if (process.env.INTERCEPTOR_CONTENT_SCRIPT_RECONNECT_TEST_CHILD === 'true') {
 
 	test('manifest v2 document-start advances queued requests only after the matching acknowledgement', async () => {
 		await verifyAcknowledgementAdvancesQueuedRequests('manifest-v2-document-start')
+	})
+
+	test('standalone content script ignores acknowledgements from a stale port without diagnostics', async () => {
+		await verifyStalePortAcknowledgementIsIgnored('standalone-listener')
+	})
+
+	test('manifest v2 document-start ignores acknowledgements from a stale port without diagnostics', async () => {
+		await verifyStalePortAcknowledgementIsIgnored('manifest-v2-document-start')
 	})
 
 	test('does not redefine a non-configurable legacy content script listener', async () => {

--- a/test/tests/contentScriptReconnect.test.ts
+++ b/test/tests/contentScriptReconnect.test.ts
@@ -135,6 +135,7 @@ async function verifyContentScriptReconnect(source: ContentScriptSource) {
 		assert.equal(getConnectionCount(), 3)
 		assert.equal(postedMessages.length, 1)
 		assert.equal(disconnectListeners.length, 3)
+		backgroundMessageListeners[2]?.({ type: 'interceptor_bridge_acknowledgement', requestId: 1 })
 
 		disconnectListeners[1]?.()
 		assert.equal(getConnectionCount(), 3)
@@ -199,6 +200,24 @@ async function verifyRequestQueuedDuringReconnect(source: ContentScriptSource) {
 	})
 }
 
+async function verifyUnacknowledgedRequestReplayedAfterDisconnect(source: ContentScriptSource) {
+	await withContentScriptMock(source, async ({ backgroundMessageListeners, disconnectListeners, eventListeners, postedMessages, getConnectionCount }) => {
+		await dispatchBridgeRequest(eventListeners)
+		assert.equal(postedMessages.length, 1)
+
+		disconnectListeners[0]?.()
+
+		assert.equal(getConnectionCount(), 2)
+		assert.equal(postedMessages.length, 2)
+		assert.deepEqual(postedMessages[1], postedMessages[0])
+
+		backgroundMessageListeners[1]?.({ type: 'interceptor_bridge_acknowledgement', requestId: 1 })
+		disconnectListeners[1]?.()
+		assert.equal(getConnectionCount(), 3)
+		assert.equal(postedMessages.length, 2)
+	})
+}
+
 if (process.env.INTERCEPTOR_CONTENT_SCRIPT_RECONNECT_TEST_CHILD === 'true') {
 	test('standalone content script recovers its background port without reconnect churn', async () => {
 		await verifyContentScriptReconnect('standalone-listener')
@@ -214,6 +233,14 @@ if (process.env.INTERCEPTOR_CONTENT_SCRIPT_RECONNECT_TEST_CHILD === 'true') {
 
 	test('manifest v2 document-start queues requests while its background port reconnects', async () => {
 		await verifyRequestQueuedDuringReconnect('manifest-v2-document-start')
+	})
+
+	test('standalone content script replays an unacknowledged request after disconnect', async () => {
+		await verifyUnacknowledgedRequestReplayedAfterDisconnect('standalone-listener')
+	})
+
+	test('manifest v2 document-start replays an unacknowledged request after disconnect', async () => {
+		await verifyUnacknowledgedRequestReplayedAfterDisconnect('manifest-v2-document-start')
 	})
 
 	test('does not redefine a non-configurable legacy content script listener', async () => {

--- a/test/tests/messageSendingPortLifecycle.test.ts
+++ b/test/tests/messageSendingPortLifecycle.test.ts
@@ -1,6 +1,6 @@
 import * as assert from 'assert'
 import { describe, test } from 'bun:test'
-import { replyToInterceptedRequest, replyToInterceptedRequestAfterManifestV2Reconnect, sendSubscriptionReplyOrCallBackToPort } from '../../app/ts/background/messageSending.js'
+import { replyToInterceptedRequest, replyToInterceptedRequestAfterManifestV2Reconnect, sendSubscriptionReplyOrCallBack, sendSubscriptionReplyOrCallBackAfterManifestV2Reconnect, sendSubscriptionReplyOrCallBackToPort } from '../../app/ts/background/messageSending.js'
 import { websiteSocketToString } from '../../app/ts/background/backgroundUtils.js'
 
 function installBrowserMock() {
@@ -82,6 +82,24 @@ describe('background messageSending port lifecycle', () => {
 		assert.equal(replyToInterceptedRequest(new Map([[socket.tabId, { connections: {} }]]), message), false)
 	})
 
+	test('reports when a signer account request misses a disconnected content-script port', () => {
+		installBrowserMock()
+		const socket = { tabId: 1, connectionName: 0x123n }
+		const connectionKey = websiteSocketToString(socket)
+		const disconnectedPort = createPort(() => {
+			throw new Error('Attempting to use a disconnected port object')
+		})
+		const websiteTabConnections = new Map([[socket.tabId, { connections: {
+			[connectionKey]: { port: disconnectedPort, socket, websiteOrigin: 'https://example.test', approved: true, wantsToConnect: true },
+		} }]])
+
+		assert.equal(sendSubscriptionReplyOrCallBack(websiteTabConnections, socket, {
+			type: 'result',
+			method: 'request_signer_to_eth_requestAccounts',
+			result: [],
+		}), false)
+	})
+
 	test('requests an MV2 content-script reconnect and retries the exact signing route', async () => {
 		const socket = { tabId: 1, connectionName: 0x123n }
 		const connectionKey = websiteSocketToString(socket)
@@ -123,6 +141,46 @@ describe('background messageSending port lifecycle', () => {
 		assert.equal(await replyToInterceptedRequestAfterManifestV2Reconnect(websiteTabConnections, message), true)
 		assert.deepEqual(reconnectMessages, [{ method: 'interceptor_reconnect_content_script_port', connectionName: '0x123' }])
 		assert.equal(disconnectedPostAttempts, 1)
+		assert.equal(postedMessages.length, 1)
+	})
+
+	test('reconnects an MV2 content-script port before requesting signer accounts', async () => {
+		const socket = { tabId: 1, connectionName: 0x123n }
+		const connectionKey = websiteSocketToString(socket)
+		const postedMessages: unknown[] = []
+		const connectedPort = createPort((message) => { postedMessages.push(message) })
+		const disconnectedPort = createPort(() => {
+			throw new Error('Attempting to use a disconnected port object')
+		})
+		const websiteTabConnections = new Map<number, { connections: Record<string, { port: browser.runtime.Port, socket: typeof socket, websiteOrigin: string, approved: boolean, wantsToConnect: boolean }> }>([[socket.tabId, { connections: {
+			[connectionKey]: { port: disconnectedPort, socket, websiteOrigin: 'https://example.test', approved: true, wantsToConnect: true },
+		} }]])
+		const reconnectMessages: unknown[] = []
+		globalThis.browser = {
+			runtime: {
+				lastError: undefined,
+				getManifest: () => ({ manifest_version: 2 }),
+			},
+			tabs: {
+				async sendMessage(_tabId: number, message: unknown) {
+					reconnectMessages.push(message)
+					setTimeout(() => {
+						websiteTabConnections.set(socket.tabId, { connections: {
+							[connectionKey]: { port: connectedPort, socket, websiteOrigin: 'https://example.test', approved: true, wantsToConnect: true },
+						} })
+					}, 100)
+					return { reconnected: true }
+				},
+			},
+		} as unknown as typeof globalThis.browser
+		const message = {
+			type: 'result' as const,
+			method: 'request_signer_to_eth_requestAccounts' as const,
+			result: [] as const,
+		}
+
+		assert.equal(await sendSubscriptionReplyOrCallBackAfterManifestV2Reconnect(websiteTabConnections, socket, message), true)
+		assert.deepEqual(reconnectMessages, [{ method: 'interceptor_reconnect_content_script_port', connectionName: '0x123' }])
 		assert.equal(postedMessages.length, 1)
 	})
 


### PR DESCRIPTION
## Summary
- Retry signer account reply delivery after requesting an MV2 content-script reconnect.
- Split the reconnect retry path so signer reply delivery can reuse the socket-based reconnect logic.
- Update the access flow to await the reconnect-aware delivery helper.
- Add tests covering disconnected signer reply delivery and the MV2 reconnect retry path.

## Testing
- `bun test`
- `bun run setup-chrome`
- `bun run typecheck`
- `bun run lint`