### PR TITLE
Include EIP-7702 delegates in metadata and delegation UI

### DIFF
--- a/app/ts/background/metadataUtils.ts
+++ b/app/ts/background/metadataUtils.ts
@@ -222,6 +222,7 @@ export function getAddressesToIdentifyForVisualiserFromTransactions(events: Enri
 	for (const tx of simulationStateInput.flatMap((block) => block.transactions)) {
 		addressesToFetchMetadata.push(tx.signedTransaction.from)
 		if (tx.signedTransaction.to !== null) addressesToFetchMetadata.push(tx.signedTransaction.to)
+		if (tx.signedTransaction.type === '7702') addressesToFetchMetadata.push(...tx.signedTransaction.authorizationList.map((authorization) => authorization.address))
 	}
 
 	return Array.from(new Set<bigint>([...addressesToFetchMetadata, ETHEREUM_LOGS_LOGGER_ADDRESS]).values())

--- a/app/ts/components/simulationExplaining/Transactions.tsx
+++ b/app/ts/components/simulationExplaining/Transactions.tsx
@@ -97,10 +97,9 @@ function CompactDelegationAddress({ addressBookEntry }: { addressBookEntry: Addr
 	</div>
 }
 
-function DelegationNotice({ signer, authorizationList, addressMetadata, renameAddressCallBack }: {
+function DelegationNotice({ signer, delegates, renameAddressCallBack }: {
 	signer: AddressBookEntry
-	authorizationList: readonly { address: bigint }[]
-	addressMetadata: ReadonlySignal<readonly AddressBookEntry[]>
+	delegates: readonly AddressBookEntry[]
 	renameAddressCallBack: RenameAddressCallBack
 }) {
 	return <div class = 'delegation-flow-banner'>
@@ -124,10 +123,9 @@ function DelegationNotice({ signer, authorizationList, addressMetadata, renameAd
 				<DelegationFlowArrow />
 			</div>
 			<div class = 'delegation-flow-targets'>
-				{ authorizationList.map((authorization, index) => {
-					const entry = getAddressBookEntryOrAFiller(addressMetadata.value, authorization.address)
-					return <button type = 'button' class = 'delegation-flow-address-button' key = { `${ authorization.address.toString() }-${ index }` } onClick = { () => renameAddressCallBack(entry) }>
-						<CompactDelegationAddress addressBookEntry = { entry } />
+				{ delegates.map((delegate, index) => {
+					return <button type = 'button' class = 'delegation-flow-address-button' key = { `${ delegate.address.toString() }-${ index }` } onClick = { () => renameAddressCallBack(delegate) }>
+						<CompactDelegationAddress addressBookEntry = { delegate } />
 					</button>
 				}) }
 			</div>
@@ -142,15 +140,13 @@ function getDelegationNotice(
 ) {
 	if (transaction.type === '7702' && transaction.authorizationList.length > 0) return <DelegationNotice
 		signer = { transaction.from }
-		authorizationList = { transaction.authorizationList }
-		addressMetadata = { addressMetadata }
+		delegates = { transaction.authorizationList.map((authorization) => getAddressBookEntryOrAFiller(addressMetadata.value, authorization.address)) }
 		renameAddressCallBack = { renameAddressCallBack }
 	/>
 	if (transaction.delegationAddress === undefined) return undefined
 	return <DelegationNotice
 		signer = { transaction.from }
-		authorizationList = { [{ address: transaction.delegationAddress.address }] }
-		addressMetadata = { addressMetadata }
+		delegates = { [transaction.delegationAddress] }
 		renameAddressCallBack = { renameAddressCallBack }
 	/>
 }

--- a/test/tests/metadataAddressCoverage.test.ts
+++ b/test/tests/metadataAddressCoverage.test.ts
@@ -16,6 +16,7 @@ const TX_TO_ADDRESS = 0x6000000000000000000000000000000000000006n
 const INPUT_ADDRESS = 0x7000000000000000000000000000000000000007n
 const STRUCT_OWNER_ADDRESS = 0x8000000000000000000000000000000000000008n
 const STRUCT_TOKEN_ADDRESS = 0x9000000000000000000000000000000000000009n
+const DELEGATE_ADDRESS = 0xa00000000000000000000000000000000000000an
 
 const toAddressSet = (addresses: readonly bigint[]) => new Set(addresses.map((address) => addressString(address)))
 const ZERO_BLOCK_TIME_MANIPULATION = { type: 'AddToTimestamp', deltaToAdd: 0n, deltaUnit: 'Seconds' } satisfies SimulationStateInput[number]['blockTimeManipulation']
@@ -24,7 +25,43 @@ const simulationWebsite = { websiteOrigin: 'https://example.com', icon: undefine
 const simulationCreated = new Date('2024-01-01T00:00:00.000Z')
 const simulationOriginalRequestParameters: SendTransactionParams = { method: 'eth_sendTransaction', params: [{ from: TX_FROM_ADDRESS, to: TX_TO_ADDRESS, value: 0n, input: new Uint8Array() }] }
 
-const getAddressesForEvent = (event: EnrichedEthereumEvents[number]) => {
+function getSignedTransaction(delegateAddress: bigint | undefined): SimulationStateInput[number]['transactions'][number]['signedTransaction'] {
+	if (delegateAddress === undefined) return {
+		type: '1559',
+		from: TX_FROM_ADDRESS,
+		nonce: 0n,
+		maxFeePerGas: 1n,
+		maxPriorityFeePerGas: 1n,
+		gas: 21_000n,
+		to: TX_TO_ADDRESS,
+		value: 0n,
+		input: new Uint8Array(),
+		chainId: 1n,
+		hash: 1n,
+		v: 1n,
+		r: 1n,
+		s: 1n,
+	}
+	return {
+		type: '7702',
+		from: TX_FROM_ADDRESS,
+		nonce: 0n,
+		maxFeePerGas: 1n,
+		maxPriorityFeePerGas: 1n,
+		gas: 21_000n,
+		to: TX_TO_ADDRESS,
+		value: 0n,
+		input: new Uint8Array(),
+		chainId: 1n,
+		authorizationList: [{ chainId: 1n, address: delegateAddress, nonce: 0n, r: 1n, s: 1n, yParity: 'even' }],
+		hash: 1n,
+		yParity: 'even',
+		r: 1n,
+		s: 1n,
+	}
+}
+
+const getAddressesForEvent = (event: EnrichedEthereumEvents[number], delegateAddress?: bigint) => {
 	const inputData: readonly EnrichedEthereumInputData[] = [{
 		type: 'Parsed',
 		input: new Uint8Array(),
@@ -37,22 +74,7 @@ const getAddressesForEvent = (event: EnrichedEthereumEvents[number]) => {
 		blockTimeManipulation: ZERO_BLOCK_TIME_MANIPULATION,
 		simulateWithZeroBaseFee: false,
 		transactions: [{
-			signedTransaction: {
-				type: '1559',
-				from: TX_FROM_ADDRESS,
-				nonce: 0n,
-				maxFeePerGas: 1n,
-				maxPriorityFeePerGas: 1n,
-				gas: 21_000n,
-				to: TX_TO_ADDRESS,
-				value: 0n,
-				input: new Uint8Array(),
-				chainId: 1n,
-				hash: 1n,
-				v: 1n,
-				r: 1n,
-				s: 1n,
-			},
+			signedTransaction: getSignedTransaction(delegateAddress),
 			website: simulationWebsite,
 			created: simulationCreated,
 			originalRequestParameters: simulationOriginalRequestParameters,
@@ -71,6 +93,19 @@ function assertCommonAddresses(addresses: readonly bigint[]) {
 }
 
 describe('getAddressesToIdentifyForVisualiserFromTransactions', () => {
+	test('covers EIP-7702 delegation targets', () => {
+		const addresses = getAddressesForEvent({
+			type: 'NonParsed',
+			address: TOKEN_ADDRESS,
+			isParsed: 'NonParsed',
+			data: new Uint8Array(),
+			topics: [],
+		}, DELEGATE_ADDRESS)
+
+		assert.equal(toAddressSet(addresses).has(addressString(DELEGATE_ADDRESS)), true)
+		assertCommonAddresses(addresses)
+	})
+
 	test('covers ERC20 Transfer addresses from parsed args and the emitter address', () => {
 		const addresses = getAddressesForEvent({
 			type: 'TokenEvent',

--- a/test/tests/transactionImportanceBlockDelegation.test.tsx
+++ b/test/tests/transactionImportanceBlockDelegation.test.tsx
@@ -437,7 +437,7 @@ describe('TransactionImportanceBlock delegation notice', () => {
 			createDelegatedSelfCallTransaction({
 				events: [createNativeTransferEvent()],
 			}),
-			[senderEntry, delegateEntry, recipientEntry, nativeTokenEntry],
+			[senderEntry, recipientEntry, nativeTokenEntry],
 		)
 
 		assert.equal(dom.document.body.textContent?.includes('Delegated execution'), true)


### PR DESCRIPTION
## Summary
- Add EIP-7702 authorization targets to the metadata lookup set so delegate addresses get identified.
- Update the delegation notice UI to render actual delegate entries directly instead of resolving them from raw authorization addresses at click time.
- Expand coverage for 7702 delegation address discovery and adjust the delegation notice test expectations.

## Testing
- `bun test` — Not run
- `bun run setup-chrome` — Not run
- `bun run typecheck` — Not run
- `bun run lint` — Not run