### PR TITLE
Fix Safe account synchronization and connection request recovery

### DIFF
--- a/app/inpage/ts/inpage.ts
+++ b/app/inpage/ts/inpage.ts
@@ -126,6 +126,7 @@ type BridgeRequest = {
 	readonly usingInterceptorWithoutSigner: boolean
 	readonly requestId: number
 	readonly internal?: true
+	readonly replayOnDisconnect?: true
 }
 
 const isMessageCandidate = (value: unknown): value is InterceptorApprovedMessageCandidate => typeof value === 'object' && value !== null
@@ -586,6 +587,7 @@ class InterceptorMessageListener {
 	private readonly sendMessageToBackgroundPage = async (messageMethodAndParams: MessageMethodAndParams) => {
 		this.requestId++
 		const pendingRequestId = this.requestId
+		const replayOnDisconnect = messageMethodAndParams.internal !== true && messageMethodAndParams.method === 'eth_requestAccounts'
 		const future = new InterceptorFuture<unknown>()
 		this.outstandingRequests.set(pendingRequestId, {
 			future,
@@ -601,6 +603,7 @@ class InterceptorMessageListener {
 				usingInterceptorWithoutSigner: this.signerWindowEthereumRequest === undefined,
 				requestId: pendingRequestId,
 				...(messageMethodAndParams.internal === true ? { internal: true as const } : {}),
+				...(replayOnDisconnect ? { replayOnDisconnect: true as const } : {}),
 			}
 			this.extensionMessagePort.postMessage(message)
 			return await future

--- a/app/inpage/ts/listenContentScript.ts
+++ b/app/inpage/ts/listenContentScript.ts
@@ -125,16 +125,33 @@ function listenContentScript(connectionName: string | undefined, diagnosticsSour
 		|| error.message.includes('Extension context invalidated')
 	const isMissingContentScriptPortReceiverError = (error: Error) => error.message.includes('Could not establish connection. Receiving end does not exist')
 	const isTerminalContentScriptPortError = (error: Error) => error.message.includes('Extension context invalidated')
+	const pendingBridgeMessages: ForwardedBridgeMessage[] = []
+	// An MV3 worker can be suspended while the signer approval is open. Retain the original dapp request until its terminal reply.
+	const unsettledAccountConnectionRequests = new Map<number, ForwardedBridgeMessage>()
+	const getSettledAccountConnectionRequestId = (message: unknown) => {
+		if (typeof message !== 'object' || message === null) return undefined
+		if (!('type' in message) || message.type !== 'result') return undefined
+		if (!('requestId' in message) || typeof message.requestId !== 'number') return undefined
+		if (!('method' in message) || (message.method !== 'eth_accounts' && message.method !== 'eth_requestAccounts')) return undefined
+		return message.requestId
+	}
 	let inFlightBridgeMessage: ForwardedBridgeMessage | undefined
+	const queueUnsettledAccountConnectionRequestsForReplay = () => {
+		const queuedRequestIds = new Set(pendingBridgeMessages.map((message) => message.data.requestId))
+		for (const [requestId, message] of unsettledAccountConnectionRequests) {
+			if (queuedRequestIds.has(requestId)) continue
+			pendingBridgeMessages.push(message)
+		}
+	}
 	const markExtensionPortDisconnected = (port: browser.runtime.Port) => {
 		if (extensionPort !== port) return
 		extensionPort = undefined
 		inFlightBridgeMessage = undefined
+		queueUnsettledAccountConnectionRequestsForReplay()
 		pageHidden = true
 	}
 	let connect: () => browser.runtime.Port
 	let reconnectTimer: ReturnType<typeof setTimeout> | undefined
-	const pendingBridgeMessages: ForwardedBridgeMessage[] = []
 	const scheduleReconnect = () => {
 		if (reconnectTimer !== undefined) return
 		reconnectTimer = setTimeout(() => {
@@ -185,7 +202,8 @@ function listenContentScript(connectionName: string | undefined, diagnosticsSour
 					return
 				}
 				if (error instanceof Error && error.message.includes('User denied')) {
-					pendingBridgeMessages.shift()
+					const discardedMessage = pendingBridgeMessages.shift()
+					if (discardedMessage !== undefined) unsettledAccountConnectionRequests.delete(discardedMessage.data.requestId)
 					inFlightBridgeMessage = undefined
 					continue
 				}
@@ -217,6 +235,9 @@ function listenContentScript(connectionName: string | undefined, diagnosticsSour
 			requestId: data.requestId,
 			...(data.internal === true ? { interceptorInternalRequest: true as const } : {}),
 		} }
+		if (data.method === 'eth_requestAccounts' && data.internal !== true) {
+			unsettledAccountConnectionRequests.set(data.requestId, message)
+		}
 		pendingBridgeMessages.push(message)
 		const currentExtensionPort = extensionPort
 		if (currentExtensionPort === undefined) {
@@ -296,6 +317,8 @@ function listenContentScript(connectionName: string | undefined, diagnosticsSour
 				}
 				inpagePort.postMessage(messageEvent)
 				checkAndThrowRuntimeLastError()
+				const settledAccountConnectionRequestId = getSettledAccountConnectionRequestId(messageEvent)
+				if (settledAccountConnectionRequestId !== undefined) unsettledAccountConnectionRequests.delete(settledAccountConnectionRequestId)
 			} catch (error) {
 				console.error(error)
 			}

--- a/app/inpage/ts/listenContentScript.ts
+++ b/app/inpage/ts/listenContentScript.ts
@@ -47,6 +47,7 @@ function listenContentScript(connectionName: string | undefined, diagnosticsSour
 		readonly usingInterceptorWithoutSigner?: unknown
 		readonly requestId?: unknown
 		readonly internal?: unknown
+		readonly replayOnDisconnect?: unknown
 	}
 
 	const isForwardedDiagnosticsRecord = (value: unknown): value is Record<string, unknown> => typeof value === 'object' && value !== null
@@ -58,6 +59,7 @@ function listenContentScript(connectionName: string | undefined, diagnosticsSour
 		readonly usingInterceptorWithoutSigner: boolean
 		readonly requestId: number
 		readonly internal?: true
+		readonly replayOnDisconnect?: true
 	} => {
 		if (!isBridgeRequestCandidate(value)) return false
 		if (value.type !== INTERCEPTOR_BRIDGE_REQUEST_MESSAGE) return false
@@ -66,9 +68,11 @@ function listenContentScript(connectionName: string | undefined, diagnosticsSour
 		if (typeof value.usingInterceptorWithoutSigner !== 'boolean') return false
 		if (typeof value.requestId !== 'number') return false
 		if (value.internal !== undefined && value.internal !== true) return false
+		if (value.replayOnDisconnect !== undefined && value.replayOnDisconnect !== true) return false
 		return true
 	}
 	type ForwardedBridgeMessage = {
+		readonly replayOnDisconnect: boolean
 		readonly data: {
 			readonly interceptorRequest: true
 			readonly method: string
@@ -126,28 +130,45 @@ function listenContentScript(connectionName: string | undefined, diagnosticsSour
 	const isMissingContentScriptPortReceiverError = (error: Error) => error.message.includes('Could not establish connection. Receiving end does not exist')
 	const isTerminalContentScriptPortError = (error: Error) => error.message.includes('Extension context invalidated')
 	const pendingBridgeMessages: ForwardedBridgeMessage[] = []
-	// An MV3 worker can be suspended while the signer approval is open. Retain the original dapp request until its terminal reply.
-	const unsettledAccountConnectionRequests = new Map<number, ForwardedBridgeMessage>()
-	const getSettledAccountConnectionRequestId = (message: unknown) => {
+	// Replay and settlement are transport metadata supplied by the inpage and background layers; this proxy does not infer RPC semantics.
+	const unsettledReplayableRequests = new Map<number, ForwardedBridgeMessage>()
+	const getSettledBridgeRequestId = (message: unknown) => {
 		if (typeof message !== 'object' || message === null) return undefined
-		if (!('type' in message) || message.type !== 'result') return undefined
 		if (!('requestId' in message) || typeof message.requestId !== 'number') return undefined
-		if (!('method' in message) || (message.method !== 'eth_accounts' && message.method !== 'eth_requestAccounts')) return undefined
+		if (!('bridgeRequestSettled' in message) || message.bridgeRequestSettled !== true) return undefined
 		return message.requestId
 	}
+	const withoutBridgeSettlementMarker = (message: unknown) => {
+		if (typeof message !== 'object' || message === null || !('bridgeRequestSettled' in message)) return message
+		const { bridgeRequestSettled: _bridgeRequestSettled, ...messageWithoutSettlementMarker } = message
+		return messageWithoutSettlementMarker
+	}
 	let inFlightBridgeMessage: ForwardedBridgeMessage | undefined
-	const queueUnsettledAccountConnectionRequestsForReplay = () => {
+	const settleReplayableRequest = (requestId: number) => {
+		const settledRequest = unsettledReplayableRequests.get(requestId)
+		if (settledRequest === undefined) return
+		unsettledReplayableRequests.delete(requestId)
+		const queuedRequestIndex = pendingBridgeMessages.indexOf(settledRequest)
+		if (queuedRequestIndex === -1) return
+		const settledRequestWasInFlight = pendingBridgeMessages[queuedRequestIndex] === inFlightBridgeMessage
+		pendingBridgeMessages.splice(queuedRequestIndex, 1)
+		if (!settledRequestWasInFlight) return
+		inFlightBridgeMessage = undefined
+		if (extensionPort !== undefined) flushPendingBridgeMessages(extensionPort)
+	}
+	const queueUnsettledReplayableRequests = () => {
 		const queuedRequestIds = new Set(pendingBridgeMessages.map((message) => message.data.requestId))
-		for (const [requestId, message] of unsettledAccountConnectionRequests) {
+		for (const [requestId, message] of unsettledReplayableRequests) {
 			if (queuedRequestIds.has(requestId)) continue
 			pendingBridgeMessages.push(message)
 		}
+		pendingBridgeMessages.sort((first, second) => first.data.requestId - second.data.requestId)
 	}
 	const markExtensionPortDisconnected = (port: browser.runtime.Port) => {
 		if (extensionPort !== port) return
 		extensionPort = undefined
 		inFlightBridgeMessage = undefined
-		queueUnsettledAccountConnectionRequestsForReplay()
+		queueUnsettledReplayableRequests()
 		pageHidden = true
 	}
 	let connect: () => browser.runtime.Port
@@ -193,7 +214,7 @@ function listenContentScript(connectionName: string | undefined, diagnosticsSour
 			if (message === undefined) return
 			inFlightBridgeMessage = message
 			try {
-				port.postMessage(message)
+				port.postMessage({ data: message.data })
 				checkAndThrowRuntimeLastError()
 				return
 			} catch (error: unknown) {
@@ -203,7 +224,7 @@ function listenContentScript(connectionName: string | undefined, diagnosticsSour
 				}
 				if (error instanceof Error && error.message.includes('User denied')) {
 					const discardedMessage = pendingBridgeMessages.shift()
-					if (discardedMessage !== undefined) unsettledAccountConnectionRequests.delete(discardedMessage.data.requestId)
+					if (discardedMessage !== undefined) unsettledReplayableRequests.delete(discardedMessage.data.requestId)
 					inFlightBridgeMessage = undefined
 					continue
 				}
@@ -227,7 +248,7 @@ function listenContentScript(connectionName: string | undefined, diagnosticsSour
 
 	const forwardInpageMessageToBackground = (data: unknown) => {
 		if (!isBridgeRequest(data)) return
-		const message: ForwardedBridgeMessage = { data: {
+		const message: ForwardedBridgeMessage = { replayOnDisconnect: data.replayOnDisconnect === true, data: {
 			interceptorRequest: true,
 			method: data.method,
 			...(data.params !== undefined ? { params: data.params } : {}),
@@ -235,9 +256,7 @@ function listenContentScript(connectionName: string | undefined, diagnosticsSour
 			requestId: data.requestId,
 			...(data.internal === true ? { interceptorInternalRequest: true as const } : {}),
 		} }
-		if (data.method === 'eth_requestAccounts' && data.internal !== true) {
-			unsettledAccountConnectionRequests.set(data.requestId, message)
-		}
+		if (message.replayOnDisconnect) unsettledReplayableRequests.set(data.requestId, message)
 		pendingBridgeMessages.push(message)
 		const currentExtensionPort = extensionPort
 		if (currentExtensionPort === undefined) {
@@ -315,10 +334,10 @@ function listenContentScript(connectionName: string | undefined, diagnosticsSour
 					reportInterceptorError(createForwardedDiagnosticsFromRaw(diagnosticsSource, 'forward background message', 'Inpage MessagePort is not connected', messageEvent, getForwardedDiagnosticsRequestContext(messageEvent)))
 					return
 				}
-				inpagePort.postMessage(messageEvent)
+				inpagePort.postMessage(withoutBridgeSettlementMarker(messageEvent))
 				checkAndThrowRuntimeLastError()
-				const settledAccountConnectionRequestId = getSettledAccountConnectionRequestId(messageEvent)
-				if (settledAccountConnectionRequestId !== undefined) unsettledAccountConnectionRequests.delete(settledAccountConnectionRequestId)
+				const settledBridgeRequestId = getSettledBridgeRequestId(messageEvent)
+				if (settledBridgeRequestId !== undefined) settleReplayableRequest(settledBridgeRequestId)
 			} catch (error) {
 				console.error(error)
 			}

--- a/app/ts/background/accessManagement.ts
+++ b/app/ts/background/accessManagement.ts
@@ -250,6 +250,9 @@ function disconnectFromPort(
 	socket: WebsiteSocket,
 ): false {
 	setWebsitePortApproval(websiteTabConnections, socket, false)
+	// Account access can be revoked without the provider losing chain connectivity.
+	// Notify account listeners before the legacy disconnect event so dapps clear stale account state.
+	sendSubscriptionReplyOrCallBack(websiteTabConnections, socket, { type: 'result' as const, method: 'accountsChanged', result: [] })
 	sendSubscriptionReplyOrCallBack(websiteTabConnections, socket, { type: 'result' as const, method: 'disconnect', result: [] })
 	return false
 }
@@ -300,7 +303,7 @@ async function updateTabConnections(
 
 		if (access === 'askAccess' && connection.wantsToConnect && promptForAccessesIfNeeded && ethereum !== undefined && tokenPriceService !== undefined && resetSimulationServices !== undefined) {
 			const activeAddress = currentActiveAddress !== undefined ? currentActiveAddress : undefined
-			askUserForAccessOnConnectionUpdate(ethereum, tokenPriceService, resetSimulationServices, websiteTabConnections, connection.socket, connection.websiteOrigin, activeAddress, settings)
+			await askUserForAccessOnConnectionUpdate(ethereum, tokenPriceService, resetSimulationServices, websiteTabConnections, connection.socket, connection.websiteOrigin, activeAddress, settings)
 		}
 	}
 	return iconRefreshTargets

--- a/app/ts/background/background.ts
+++ b/app/ts/background/background.ts
@@ -344,7 +344,7 @@ export async function changeActiveAddressAndChain(
 			}
 		}
 		// inform website about this only after we have updated simulation, as they often query the balance right after
-		sendActiveAccountChangeToApprovedWebsitePorts(websiteTabConnections, await getSettings())
+		await sendActiveAccountChangeToApprovedWebsitePorts(websiteTabConnections, await getSettings())
 	})
 }
 

--- a/app/ts/background/messageSending.ts
+++ b/app/ts/background/messageSending.ts
@@ -28,7 +28,12 @@ export function replyToInterceptedRequest(websiteTabConnections: WebsiteTabConne
 		const connection = tabConnection.connections[socketAsString]
 		if (connection === undefined) throw new Error('connection was undefined')
 		if (socketAsString !== identifier) continue
-		return postMessageToPortIfConnected(connection.port, { ...message, interceptorApproved: true, requestId: message.uniqueRequestIdentifier.requestId })
+		return postMessageToPortIfConnected(connection.port, {
+			...message,
+			interceptorApproved: true,
+			requestId: message.uniqueRequestIdentifier.requestId,
+			...(message.type === 'result' ? { bridgeRequestSettled: true as const } : {}),
+		})
 	}
 	return false
 }

--- a/app/ts/background/windows/interceptorAccess.ts
+++ b/app/ts/background/windows/interceptorAccess.ts
@@ -9,7 +9,7 @@ import { INTERNAL_CHANNEL_NAME, createInternalMessageListener, getHtmlFile, send
 import { getActiveAddressEntry, getActiveAddresses } from '../metadataUtils.js'
 import { getSettings } from '../settings.js'
 import { getTabState, updatePendingAccessRequests, getPendingAccessRequests, clearPendingAccessRequests } from '../storageVariables.js'
-import type { InterceptedRequest, WebsiteSocket } from '../../utils/requests.js'
+import { doesUniqueRequestIdentifiersMatch, type InterceptedRequest, type WebsiteSocket } from '../../utils/requests.js'
 import { replyToInterceptedRequest, sendSubscriptionReplyOrCallBackAfterManifestV2Reconnect } from '../messageSending.js'
 import type { PopupOrTabId, Website, WebsiteAccessArray } from '../../types/websiteAccessTypes.js'
 import type { PendingAccessRequest } from '../../types/accessRequest.js'
@@ -218,15 +218,21 @@ export async function requestAccessFromUser(
 			if (previousRequests.length !== 0) {
 				const previousRequest = previousRequests[0]
 				if (previousRequest === undefined) throw new Error('missing previous request')
-				if (await getPopupOrTabById(previousRequest.popupOrTabId) !== undefined) {
-					return true
+				const existingPopupOrTab = await getPopupOrTabById(previousRequest.popupOrTabId)
+				if (existingPopupOrTab !== undefined) {
+					if (openedDialog === undefined) {
+						addWindowTabListeners(onCloseWindowCallback, onCloseTabCallback)
+						openedDialog = { popupOrTab: existingPopupOrTab, onClosePopup: onCloseWindowCallback, onCloseTab: onCloseTabCallback }
+					}
+					return previousRequests
 				}
 				await clearPendingAccessRequests()
 			}
-			return false
+			return []
 		}
 
-		const justAddToPending = await verifyPendingRequests()
+		const previousPendingRequests = await verifyPendingRequests()
+		const justAddToPending = previousPendingRequests.length !== 0
 		const hasAccess = verifyAccessForCurrentRequest(await getSettings())
 		if (hasAccess === 'hasAccess') { // we already have access, just reply with the gate keeped request right away
 			if (request !== undefined) {
@@ -236,6 +242,13 @@ export async function requestAccessFromUser(
 			return undefined
 		}
 		if (hasAccess !== 'askAccess') return undefined
+		const replayedPendingRequest = request === undefined ? undefined : previousPendingRequests.find((pendingRequest) => {
+			return pendingRequest.request !== undefined && doesUniqueRequestIdentifiersMatch(pendingRequest.request.uniqueRequestIdentifier, request.uniqueRequestIdentifier)
+		})
+		if (replayedPendingRequest !== undefined) {
+			if (openedDialog !== undefined) await tryFocusingTabOrWindow(openedDialog.popupOrTab)
+			return undefined
+		}
 		if (!justAddToPending) {
 			addWindowTabListeners(onCloseWindowCallback, onCloseTabCallback)
 			const popupOrTab = await openPopupOrTab({

--- a/app/ts/types/interceptor-messages.ts
+++ b/app/ts/types/interceptor-messages.ts
@@ -180,6 +180,7 @@ export const SubscriptionReplyOrCallBack = funtypes.Intersect(
 type InterceptedRequestForwardWithRequestId = funtypes.Static<typeof InterceptedRequestForwardWithRequestId>
 const InterceptedRequestForwardWithRequestId = funtypes.Intersect(
 	funtypes.ReadonlyObject({ requestId: funtypes.Number }),
+	funtypes.ReadonlyPartial({ bridgeRequestSettled: funtypes.Literal(true) }),
 	funtypes.Union(RPCReply, funtypes.Intersect(funtypes.ReadonlyObject({ type: funtypes.Literal('result') }), InpageScriptRequestWithoutIdentifier)),
 )
 

--- a/test/tests/backgroundEthAccounts.test.ts
+++ b/test/tests/backgroundEthAccounts.test.ts
@@ -43,7 +43,7 @@ function installBrowserMock() {
 		tabs: {
 			async query() { return [] },
 			async create() { return { id: 2, active: true } },
-			async get(tabId: number) { return { id: tabId, active: true } },
+			async get(tabId: number) { return { id: tabId, active: true, status: 'complete' as const } },
 			async update() { return undefined },
 			async remove() { return undefined },
 			onUpdated: { addListener: (_listener: Listener) => undefined, removeListener: (_listener: Listener) => undefined },
@@ -1714,6 +1714,97 @@ describe('background eth_accounts', () => {
 		}])
 	})
 
+	test('delivers accountsChanged before an approved active-address switch resolves', async () => {
+		installBrowserMock()
+		const { changeActiveAddressAndChain, websiteSocketToString, changeSimulationMode, setUseSignersAddressAsActiveAddress, updateWebsiteAccess } = await loadModules()
+		const websiteOrigin = 'https://app.safe.global'
+		const website = { websiteOrigin, icon: undefined, title: undefined }
+		const previousAccount = 0x1111111111111111111111111111111111111111n
+		const nextAccount = 0x2222222222222222222222222222222222222222n
+		await changeSimulationMode({ simulationMode: true, activeSimulationAddress: previousAccount, activeSigningAddress: undefined })
+		await setUseSignersAddressAsActiveAddress(false)
+		await updateWebsiteAccess(() => [{
+			website,
+			access: true,
+			addressAccess: [{ address: previousAccount, access: true }, { address: nextAccount, access: true }],
+		}])
+
+		const socket = { tabId: 171, connectionName: 171n }
+		const { port, messages } = createPort(socket.tabId)
+		const connectionKey = websiteSocketToString(socket)
+		const websiteTabConnections = new Map([[socket.tabId, { connections: {
+			[connectionKey]: { port, socket, websiteOrigin, approved: true, wantsToConnect: true },
+		} }]])
+		const { ethereum, tokenPriceService, resetSimulationServices } = createEthereumWithGetBlockCounter({ count: 0 })
+
+		await changeActiveAddressAndChain(ethereum, tokenPriceService, resetSimulationServices, websiteTabConnections, {
+			simulationMode: true,
+			activeAddress: nextAccount,
+		})
+
+		assert.deepEqual(messages.map((message) => message.method), ['accountsChanged'])
+		assert.deepEqual(messages[0]?.result, ['0x2222222222222222222222222222222222222222'])
+	})
+
+	test('clears dapp accounts and finishes opening access approval when the active address is unapproved', async () => {
+		installBrowserMock()
+		const {
+			changeActiveAddressAndChain,
+			websiteSocketToString,
+			changeSimulationMode,
+			setUseSignersAddressAsActiveAddress,
+			updateWebsiteAccess,
+			getPendingAccessRequests,
+			clearPendingAccessRequests,
+			resolveInterceptorAccess,
+		} = await loadModules()
+		const websiteOrigin = 'https://app.safe.global'
+		const website = { websiteOrigin, icon: undefined, title: undefined }
+		const previousAccount = 0x3333333333333333333333333333333333333333n
+		const nextAccount = 0x4444444444444444444444444444444444444444n
+		await changeSimulationMode({ simulationMode: true, activeSimulationAddress: previousAccount, activeSigningAddress: undefined })
+		await setUseSignersAddressAsActiveAddress(false)
+		await updateWebsiteAccess(() => [{
+			website,
+			access: true,
+			addressAccess: [{ address: previousAccount, access: true }],
+		}])
+
+		const socket = { tabId: 172, connectionName: 172n }
+		const { port, messages } = createPort(socket.tabId)
+		const connectionKey = websiteSocketToString(socket)
+		const websiteTabConnections = new Map([[socket.tabId, { connections: {
+			[connectionKey]: { port, socket, websiteOrigin, approved: true, wantsToConnect: true },
+		} }]])
+		const { ethereum, tokenPriceService, resetSimulationServices } = createEthereumWithGetBlockCounter({ count: 0 })
+
+		await changeActiveAddressAndChain(ethereum, tokenPriceService, resetSimulationServices, websiteTabConnections, {
+			simulationMode: true,
+			activeAddress: nextAccount,
+		})
+
+		assert.deepEqual(messages.map((message) => message.method), ['accountsChanged', 'disconnect'])
+		assert.deepEqual(messages[0]?.result, [])
+		assert.equal(websiteTabConnections.get(socket.tabId)?.connections[connectionKey]?.approved, false)
+		const pendingRequest = (await getPendingAccessRequests()).find((request) => request.requestAccessToAddress?.address === nextAccount)
+		if (pendingRequest === undefined) throw new Error('Missing address access request')
+		assert.equal(pendingRequest.requestAccessToAddress?.address, nextAccount)
+		await resolveInterceptorAccess(
+			ethereum,
+			tokenPriceService,
+			resetSimulationServices,
+			websiteTabConnections,
+			{
+				userReply: 'Rejected',
+				requestAccessToAddress: pendingRequest.requestAccessToAddress?.address,
+				originalRequestAccessToAddress: pendingRequest.originalRequestAccessToAddress?.address,
+				accessRequestId: pendingRequest.accessRequestId,
+			},
+			noopPublishRpcConnectionStatus,
+		)
+		await clearPendingAccessRequests()
+	})
+
 	test('wallet_revokePermissions clears website account access and keeps the website entry', async () => {
 		installBrowserMock()
 		const { handleInterceptedRequest, websiteSocketToString, changeSimulationMode, setUseSignersAddressAsActiveAddress, updateWebsiteAccess, getSettings } = await loadModules()
@@ -1740,7 +1831,9 @@ describe('background eth_accounts', () => {
 			params: [{ eth_accounts: {} }],
 		}, websiteTabConnections, noopPublishRpcConnectionStatus)
 
-		assert.equal(messages.some((message) => message.method === 'disconnect'), true)
+		const accessLossEvents = messages.filter((message) => message.method === 'accountsChanged' || message.method === 'disconnect')
+		assert.deepEqual(accessLossEvents.map((message) => message.method), ['accountsChanged', 'disconnect'])
+		assert.deepEqual(accessLossEvents[0]?.result, [])
 		const revokeReplies = messages.filter((message) => message.method === 'wallet_revokePermissions' && message.requestId === 10)
 		assert.equal(revokeReplies.at(-1)?.result, null)
 		assert.equal(websiteTabConnections.get(socket.tabId)?.connections[connectionKey]?.approved, false)

--- a/test/tests/backgroundEthAccounts.test.ts
+++ b/test/tests/backgroundEthAccounts.test.ts
@@ -1011,6 +1011,91 @@ describe('background eth_accounts', () => {
 		assert.deepEqual(messages.filter((message) => message.method === 'eth_accounts' && message.requestId === 11).at(-1)?.result, ['0x6666666666666666666666666666666666666666'])
 	})
 
+	test('reuses a persisted access dialog when the same eth_requestAccounts is replayed after restart', async () => {
+		installBrowserMock()
+		const {
+			websiteSocketToString,
+			changeSimulationMode,
+			setUseSignersAddressAsActiveAddress,
+			updateWebsiteAccess,
+			getPendingAccessRequests,
+			getSettings,
+		} = await loadModules()
+		const { getActiveAddressEntry } = await import('../../app/ts/background/metadataUtils.js')
+		const firstWorkerAccess = await import('../../app/ts/background/windows/interceptorAccess.js?access-dialog-worker-before-restart')
+		const restartedWorkerAccess = await import('../../app/ts/background/windows/interceptorAccess.js?access-dialog-worker-after-restart')
+		const websiteOrigin = 'https://app.safe.global'
+		const website = { websiteOrigin, icon: undefined, title: undefined }
+		const account = 0x6677667766776677667766776677667766776677n
+		const accountString = '0x6677667766776677667766776677667766776677'
+		await changeSimulationMode({ simulationMode: true, activeSimulationAddress: account, activeSigningAddress: undefined })
+		await setUseSignersAddressAsActiveAddress(false)
+		await updateWebsiteAccess(() => [{ website, access: true, addressAccess: undefined }])
+
+		const socket = { tabId: 1, connectionName: 0n }
+		const { port, messages } = createPort(socket.tabId)
+		const connectionKey = websiteSocketToString(socket)
+		const websiteTabConnections = new Map([[socket.tabId, { connections: {
+			[connectionKey]: { port, socket, websiteOrigin, approved: false, wantsToConnect: true },
+		} }]])
+		const { ethereum, tokenPriceService, resetSimulationServices } = createEthereumWithGetBlockCounter({ count: 0 })
+		const request = {
+			interceptorRequest: true,
+			usingInterceptorWithoutSigner: false,
+			uniqueRequestIdentifier: { requestId: 111, requestSocket: socket },
+			method: 'eth_requestAccounts',
+		} as const
+		const requestAccessToAddress = await getActiveAddressEntry(account)
+		const settings = await getSettings()
+
+		await firstWorkerAccess.requestAccessFromUser(
+			ethereum,
+			tokenPriceService,
+			resetSimulationServices,
+			websiteTabConnections,
+			socket,
+			website,
+			request,
+			requestAccessToAddress,
+			settings,
+			account,
+			noopPublishRpcConnectionStatus,
+		)
+		await restartedWorkerAccess.requestAccessFromUser(
+			ethereum,
+			tokenPriceService,
+			resetSimulationServices,
+			websiteTabConnections,
+			socket,
+			website,
+			request,
+			requestAccessToAddress,
+			settings,
+			account,
+			noopPublishRpcConnectionStatus,
+		)
+
+		assert.equal((await getPendingAccessRequests()).length, 1)
+		assert.equal(messages.some((message) => message.requestId === 111), false)
+		const pendingRequest = (await getPendingAccessRequests())[0]
+		if (pendingRequest === undefined) throw new Error('Missing pending request after worker restart')
+		await restartedWorkerAccess.resolveInterceptorAccess(
+			ethereum,
+			tokenPriceService,
+			resetSimulationServices,
+			websiteTabConnections,
+			{
+				userReply: 'Approved',
+				requestAccessToAddress: pendingRequest.requestAccessToAddress?.address,
+				originalRequestAccessToAddress: pendingRequest.originalRequestAccessToAddress?.address,
+				accessRequestId: pendingRequest.accessRequestId,
+			},
+			noopPublishRpcConnectionStatus,
+		)
+
+		assert.deepEqual(messages.filter((message) => message.method === 'eth_accounts' && message.requestId === 111).map((message) => message.result), [[accountString]])
+	})
+
 	test('uses refreshed website access after signer account discovery', async () => {
 		installBrowserMock()
 		const {

--- a/test/tests/contentScriptReconnect.test.ts
+++ b/test/tests/contentScriptReconnect.test.ts
@@ -1,6 +1,6 @@
 import * as assert from 'assert'
 import { test } from 'bun:test'
-import { INTERCEPTOR_BRIDGE_ACKNOWLEDGEMENT_MESSAGE } from '../../app/ts/background/bridgeRequestDelivery.js'
+import { acknowledgeAndTrackBridgeRequest, INTERCEPTOR_BRIDGE_ACKNOWLEDGEMENT_MESSAGE } from '../../app/ts/background/bridgeRequestDelivery.js'
 
 type ContentScriptMockState = {
 	readonly backgroundMessageListeners: ((message: unknown) => void)[]
@@ -105,8 +105,17 @@ function dispatchWindowMessage(eventListeners: Map<string, EventListenerOrEventL
 	}
 }
 
-async function dispatchBridgeRequest(eventListeners: Map<string, EventListenerOrEventListenerObject[]>, method = 'eth_sendTransaction') {
+function getPostedBridgeRequestId(value: unknown) {
+	if (typeof value !== 'object' || value === null || !('data' in value)) return undefined
+	const data = value.data
+	if (typeof data !== 'object' || data === null || !('requestId' in data) || typeof data.requestId !== 'number') return undefined
+	return data.requestId
+}
+
+async function dispatchBridgeRequest(eventListeners: Map<string, EventListenerOrEventListenerObject[]>, method = 'eth_sendTransaction', replayOnDisconnect = false, keepBridgeOpen = false) {
 	const channel = new MessageChannel()
+	const receivedMessages: unknown[] = []
+	channel.port1.onmessage = (event: MessageEvent<unknown>) => receivedMessages.push(event.data)
 	dispatchWindowMessage(eventListeners, new MessageEvent('message', { data: { type: 'interceptor_bridge_port' }, ports: [channel.port2] }))
 	channel.port1.postMessage({
 		type: 'interceptor_bridge_request',
@@ -114,10 +123,15 @@ async function dispatchBridgeRequest(eventListeners: Map<string, EventListenerOr
 		params: [],
 		usingInterceptorWithoutSigner: false,
 		requestId: 1,
+		...(replayOnDisconnect ? { replayOnDisconnect: true } : {}),
 	})
 	await new Promise((resolve) => setTimeout(resolve, 0))
-	channel.port1.close()
-	channel.port2.close()
+	const close = () => {
+		channel.port1.close()
+		channel.port2.close()
+	}
+	if (!keepBridgeOpen) close()
+	return { receivedMessages, close }
 }
 
 async function verifyContentScriptReconnect(source: ContentScriptSource) {
@@ -219,13 +233,19 @@ async function verifyUnacknowledgedRequestReplayedAfterDisconnect(source: Conten
 	})
 }
 
-async function verifyAcknowledgedAccountRequestReplayedUntilTerminalReply(source: ContentScriptSource) {
+async function verifyAcknowledgedReplayableRequestReplayedUntilMarkedSettled(source: ContentScriptSource) {
 	await withContentScriptMock(source, async ({ backgroundMessageListeners, disconnectListeners, eventListeners, postedMessages, getConnectionCount }) => {
-		await dispatchBridgeRequest(eventListeners, 'eth_requestAccounts')
+		const inpageBridge = await dispatchBridgeRequest(eventListeners, 'example_replayableMethod', true, true)
 		assert.equal(postedMessages.length, 1)
+		assert.deepEqual(postedMessages[0], { data: {
+			interceptorRequest: true,
+			method: 'example_replayableMethod',
+			params: [],
+			usingInterceptorWithoutSigner: false,
+			requestId: 1,
+		} })
 		backgroundMessageListeners[0]?.({ type: INTERCEPTOR_BRIDGE_ACKNOWLEDGEMENT_MESSAGE, requestId: 1 })
-		backgroundMessageListeners[0]?.({ interceptorApproved: true, type: 'result', method: 'connect', requestId: 1, result: ['0x1'] })
-		backgroundMessageListeners[0]?.({ interceptorApproved: true, type: 'result', method: 'accountsChanged', requestId: 1, result: ['0x1111111111111111111111111111111111111111'] })
+		backgroundMessageListeners[0]?.({ interceptorApproved: true, type: 'result', method: 'example_intermediateEvent', requestId: 1, result: [] })
 
 		disconnectListeners[0]?.()
 
@@ -236,11 +256,99 @@ async function verifyAcknowledgedAccountRequestReplayedUntilTerminalReply(source
 		backgroundMessageListeners[1]?.({
 			interceptorApproved: true,
 			type: 'result',
-			method: 'eth_accounts',
+			method: 'example_terminalReply',
 			requestId: 1,
-			result: ['0x1111111111111111111111111111111111111111'],
+			result: [],
+			bridgeRequestSettled: true,
+		})
+		await new Promise((resolve) => setTimeout(resolve, 0))
+		assert.deepEqual(inpageBridge.receivedMessages.at(-1), {
+			interceptorApproved: true,
+			type: 'result',
+			method: 'example_terminalReply',
+			requestId: 1,
+			result: [],
 		})
 
+		disconnectListeners[1]?.()
+
+		assert.equal(getConnectionCount(), 3)
+		assert.equal(postedMessages.length, 2)
+		inpageBridge.close()
+	})
+}
+
+async function verifyRpcMethodDoesNotImplicitlyEnableReplay(source: ContentScriptSource) {
+	await withContentScriptMock(source, async ({ backgroundMessageListeners, disconnectListeners, eventListeners, postedMessages, getConnectionCount }) => {
+		await dispatchBridgeRequest(eventListeners, 'eth_requestAccounts')
+		assert.equal(postedMessages.length, 1)
+		backgroundMessageListeners[0]?.({ type: INTERCEPTOR_BRIDGE_ACKNOWLEDGEMENT_MESSAGE, requestId: 1 })
+
+		disconnectListeners[0]?.()
+
+		assert.equal(getConnectionCount(), 2)
+		assert.equal(postedMessages.length, 1)
+	})
+}
+
+async function verifyRetainedRequestsReplayBeforeNewerPendingRequests(source: ContentScriptSource) {
+	await withContentScriptMock(source, async ({ backgroundMessageListeners, disconnectListeners, eventListeners, postedMessages }) => {
+		const channel = new MessageChannel()
+		dispatchWindowMessage(eventListeners, new MessageEvent('message', { data: { type: 'interceptor_bridge_port' }, ports: [channel.port2] }))
+		channel.port1.postMessage({
+			type: 'interceptor_bridge_request',
+			method: 'example_replayableMethod',
+			params: [],
+			usingInterceptorWithoutSigner: false,
+			requestId: 1,
+			replayOnDisconnect: true,
+		})
+		await new Promise((resolve) => setTimeout(resolve, 0))
+		backgroundMessageListeners[0]?.({ type: INTERCEPTOR_BRIDGE_ACKNOWLEDGEMENT_MESSAGE, requestId: 1 })
+		channel.port1.postMessage({
+			type: 'interceptor_bridge_request',
+			method: 'example_pendingMethod',
+			params: [],
+			usingInterceptorWithoutSigner: false,
+			requestId: 2,
+		})
+		await new Promise((resolve) => setTimeout(resolve, 0))
+		assert.deepEqual(postedMessages.map(getPostedBridgeRequestId), [1, 2])
+
+		disconnectListeners[0]?.()
+
+		assert.deepEqual(postedMessages.map(getPostedBridgeRequestId), [1, 2, 1])
+		backgroundMessageListeners[1]?.({ type: INTERCEPTOR_BRIDGE_ACKNOWLEDGEMENT_MESSAGE, requestId: 1 })
+		assert.deepEqual(postedMessages.map(getPostedBridgeRequestId), [1, 2, 1, 2])
+
+		const latestReceivedRequestIds = new Map<string, number>()
+		const replayHandling = postedMessages.slice(2).map((message) => {
+			const requestId = getPostedBridgeRequestId(message)
+			if (requestId === undefined) throw new Error('Missing replayed bridge request ID')
+			return acknowledgeAndTrackBridgeRequest(latestReceivedRequestIds, 'replacement-socket', requestId, () => undefined)
+		})
+		assert.deepEqual(replayHandling, [true, true])
+		channel.port1.close()
+		channel.port2.close()
+	})
+}
+
+async function verifySettlementRemovesInFlightReplay(source: ContentScriptSource, settleFromStalePort: boolean) {
+	await withContentScriptMock(source, async ({ backgroundMessageListeners, disconnectListeners, eventListeners, postedMessages, getConnectionCount }) => {
+		await dispatchBridgeRequest(eventListeners, 'example_replayableMethod', true)
+		backgroundMessageListeners[0]?.({ type: INTERCEPTOR_BRIDGE_ACKNOWLEDGEMENT_MESSAGE, requestId: 1 })
+		disconnectListeners[0]?.()
+		assert.equal(postedMessages.length, 2)
+
+		const settlementPortIndex = settleFromStalePort ? 0 : 1
+		backgroundMessageListeners[settlementPortIndex]?.({
+			interceptorApproved: true,
+			type: 'result',
+			method: 'example_terminalReply',
+			requestId: 1,
+			result: [],
+			bridgeRequestSettled: true,
+		})
 		disconnectListeners[1]?.()
 
 		assert.equal(getConnectionCount(), 3)
@@ -336,12 +444,44 @@ if (process.env.INTERCEPTOR_CONTENT_SCRIPT_RECONNECT_TEST_CHILD === 'true') {
 		await verifyUnacknowledgedRequestReplayedAfterDisconnect('manifest-v2-document-start')
 	})
 
-	test('standalone content script replays an acknowledged account request until its terminal reply', async () => {
-		await verifyAcknowledgedAccountRequestReplayedUntilTerminalReply('standalone-listener')
+	test('standalone content script replays an acknowledged flagged request until a marked terminal reply', async () => {
+		await verifyAcknowledgedReplayableRequestReplayedUntilMarkedSettled('standalone-listener')
 	})
 
-	test('manifest v2 document-start replays an acknowledged account request until its terminal reply', async () => {
-		await verifyAcknowledgedAccountRequestReplayedUntilTerminalReply('manifest-v2-document-start')
+	test('manifest v2 document-start replays an acknowledged flagged request until a marked terminal reply', async () => {
+		await verifyAcknowledgedReplayableRequestReplayedUntilMarkedSettled('manifest-v2-document-start')
+	})
+
+	test('standalone content script does not infer replay policy from the RPC method', async () => {
+		await verifyRpcMethodDoesNotImplicitlyEnableReplay('standalone-listener')
+	})
+
+	test('manifest v2 document-start does not infer replay policy from the RPC method', async () => {
+		await verifyRpcMethodDoesNotImplicitlyEnableReplay('manifest-v2-document-start')
+	})
+
+	test('standalone content script replays retained requests before newer pending requests', async () => {
+		await verifyRetainedRequestsReplayBeforeNewerPendingRequests('standalone-listener')
+	})
+
+	test('manifest v2 document-start replays retained requests before newer pending requests', async () => {
+		await verifyRetainedRequestsReplayBeforeNewerPendingRequests('manifest-v2-document-start')
+	})
+
+	test('standalone content script removes an in-flight replay when its terminal reply arrives before acknowledgement', async () => {
+		await verifySettlementRemovesInFlightReplay('standalone-listener', false)
+	})
+
+	test('manifest v2 document-start removes an in-flight replay when its terminal reply arrives before acknowledgement', async () => {
+		await verifySettlementRemovesInFlightReplay('manifest-v2-document-start', false)
+	})
+
+	test('standalone content script accepts settlement from a stale port while the replay is in flight', async () => {
+		await verifySettlementRemovesInFlightReplay('standalone-listener', true)
+	})
+
+	test('manifest v2 document-start accepts settlement from a stale port while the replay is in flight', async () => {
+		await verifySettlementRemovesInFlightReplay('manifest-v2-document-start', true)
 	})
 
 	test('standalone content script advances queued requests only after the matching acknowledgement', async () => {

--- a/test/tests/contentScriptReconnect.test.ts
+++ b/test/tests/contentScriptReconnect.test.ts
@@ -105,12 +105,12 @@ function dispatchWindowMessage(eventListeners: Map<string, EventListenerOrEventL
 	}
 }
 
-async function dispatchBridgeRequest(eventListeners: Map<string, EventListenerOrEventListenerObject[]>) {
+async function dispatchBridgeRequest(eventListeners: Map<string, EventListenerOrEventListenerObject[]>, method = 'eth_sendTransaction') {
 	const channel = new MessageChannel()
 	dispatchWindowMessage(eventListeners, new MessageEvent('message', { data: { type: 'interceptor_bridge_port' }, ports: [channel.port2] }))
 	channel.port1.postMessage({
 		type: 'interceptor_bridge_request',
-		method: 'eth_sendTransaction',
+		method,
 		params: [],
 		usingInterceptorWithoutSigner: false,
 		requestId: 1,
@@ -219,6 +219,35 @@ async function verifyUnacknowledgedRequestReplayedAfterDisconnect(source: Conten
 	})
 }
 
+async function verifyAcknowledgedAccountRequestReplayedUntilTerminalReply(source: ContentScriptSource) {
+	await withContentScriptMock(source, async ({ backgroundMessageListeners, disconnectListeners, eventListeners, postedMessages, getConnectionCount }) => {
+		await dispatchBridgeRequest(eventListeners, 'eth_requestAccounts')
+		assert.equal(postedMessages.length, 1)
+		backgroundMessageListeners[0]?.({ type: INTERCEPTOR_BRIDGE_ACKNOWLEDGEMENT_MESSAGE, requestId: 1 })
+		backgroundMessageListeners[0]?.({ interceptorApproved: true, type: 'result', method: 'connect', requestId: 1, result: ['0x1'] })
+		backgroundMessageListeners[0]?.({ interceptorApproved: true, type: 'result', method: 'accountsChanged', requestId: 1, result: ['0x1111111111111111111111111111111111111111'] })
+
+		disconnectListeners[0]?.()
+
+		assert.equal(getConnectionCount(), 2)
+		assert.equal(postedMessages.length, 2)
+		assert.deepEqual(postedMessages[1], postedMessages[0])
+		backgroundMessageListeners[1]?.({ type: INTERCEPTOR_BRIDGE_ACKNOWLEDGEMENT_MESSAGE, requestId: 1 })
+		backgroundMessageListeners[1]?.({
+			interceptorApproved: true,
+			type: 'result',
+			method: 'eth_accounts',
+			requestId: 1,
+			result: ['0x1111111111111111111111111111111111111111'],
+		})
+
+		disconnectListeners[1]?.()
+
+		assert.equal(getConnectionCount(), 3)
+		assert.equal(postedMessages.length, 2)
+	})
+}
+
 async function verifyAcknowledgementAdvancesQueuedRequests(source: ContentScriptSource) {
 	await withContentScriptMock(source, async ({ backgroundMessageListeners, disconnectListeners, eventListeners, postedMessages, getConnectionCount }) => {
 		const channel = new MessageChannel()
@@ -305,6 +334,14 @@ if (process.env.INTERCEPTOR_CONTENT_SCRIPT_RECONNECT_TEST_CHILD === 'true') {
 
 	test('manifest v2 document-start replays an unacknowledged request after disconnect', async () => {
 		await verifyUnacknowledgedRequestReplayedAfterDisconnect('manifest-v2-document-start')
+	})
+
+	test('standalone content script replays an acknowledged account request until its terminal reply', async () => {
+		await verifyAcknowledgedAccountRequestReplayedUntilTerminalReply('standalone-listener')
+	})
+
+	test('manifest v2 document-start replays an acknowledged account request until its terminal reply', async () => {
+		await verifyAcknowledgedAccountRequestReplayedUntilTerminalReply('manifest-v2-document-start')
 	})
 
 	test('standalone content script advances queued requests only after the matching acknowledgement', async () => {

--- a/test/tests/inpageSignerBridge.test.ts
+++ b/test/tests/inpageSignerBridge.test.ts
@@ -3,7 +3,7 @@ import { describe, test } from 'bun:test'
 
 type WindowEvent = { type: string, data?: unknown, detail?: unknown, ports?: readonly MessagePort[] }
 type Listener = (event: WindowEvent) => void
-type InpageRequest = { readonly method: string, readonly requestId: number, readonly params?: readonly unknown[], readonly internal?: true }
+type InpageRequest = { readonly method: string, readonly requestId: number, readonly params?: readonly unknown[], readonly internal?: true, readonly replayOnDisconnect?: true }
 type FakeWindowOptions = {
 	readonly onConnectedToSignerRequest?: () => void
 	readonly handleRequest?: (request: InpageRequest, sendBackgroundMessage: (data: unknown) => void) => boolean
@@ -21,11 +21,13 @@ function parseInpageRequest(value: unknown): InpageRequest | undefined {
 	if (typeof value.requestId !== 'number') return undefined
 	if (typeof value.usingInterceptorWithoutSigner !== 'boolean') return undefined
 	if (value.internal !== undefined && value.internal !== true) return undefined
+	if (value.replayOnDisconnect !== undefined && value.replayOnDisconnect !== true) return undefined
 	return {
 		method: value.method,
 		requestId: value.requestId,
 		...(Array.isArray(value.params) ? { params: value.params } : {}),
 		...(value.internal === true ? { internal: true as const } : {}),
+		...(value.replayOnDisconnect === true ? { replayOnDisconnect: true as const } : {}),
 	}
 }
 
@@ -283,6 +285,50 @@ async function withFakeInpageWindow<T>(fakeWindow: ReturnType<typeof createFakeW
 }
 
 describe('inpage signer bridge', () => {
+	test('annotates only public eth_requestAccounts requests for replay after disconnect', async () => {
+		const bridgeRequests: InpageRequest[] = []
+		const account = '0x1111111111111111111111111111111111111111'
+		const transactionHash = '0x1111111111111111111111111111111111111111111111111111111111111111'
+		const { fakeWindow } = createFakeWindow({
+			handleRequest: (request, sendBackgroundMessageForRequest) => {
+				bridgeRequests.push(request)
+				if (request.method === 'eth_requestAccounts') {
+					sendBackgroundMessageForRequest({
+						interceptorApproved: true,
+						requestId: request.requestId,
+						type: 'result',
+						method: 'eth_accounts',
+						result: [account],
+					})
+					return true
+				}
+				if (request.method === 'eth_sendTransaction') {
+					sendBackgroundMessageForRequest({
+						interceptorApproved: true,
+						requestId: request.requestId,
+						type: 'result',
+						method: request.method,
+						result: transactionHash,
+					})
+					return true
+				}
+				return false
+			},
+		})
+
+		await withFakeInpageWindow(fakeWindow, '../../app/inpage/ts/inpage.js?bridge-replay-annotation', async () => {
+			const provider = fakeWindow.ethereum as { request: (payload: { method: string, params?: readonly unknown[] }) => Promise<unknown> }
+			assert.deepEqual(await provider.request({ method: 'eth_requestAccounts' }), [account])
+			assert.equal(await provider.request({ method: 'eth_sendTransaction', params: [{ from: account }] }), transactionHash)
+		})
+
+		const accountRequest = bridgeRequests.find((request) => request.method === 'eth_requestAccounts')
+		const transactionRequest = bridgeRequests.find((request) => request.method === 'eth_sendTransaction')
+		assert.equal(accountRequest?.replayOnDisconnect, true)
+		assert.equal(transactionRequest?.replayOnDisconnect, undefined)
+		assert.equal(bridgeRequests.filter((request) => request.internal === true).every((request) => request.replayOnDisconnect === undefined), true)
+	})
+
 	test('ignores replayed terminal replies after the original request settles', async () => {
 		let capturedRequest: InpageRequest | undefined
 		const { fakeWindow, interceptorErrorPayloads, sendBackgroundMessage } = createFakeWindow({

--- a/test/tests/inpageSignerBridge.test.ts
+++ b/test/tests/inpageSignerBridge.test.ts
@@ -1019,13 +1019,15 @@ describe('inpage signer bridge', () => {
 				return true
 			},
 		})
-		const { fakeWindow, signerRequests } = createdWindow
+		const { fakeWindow, signerRequests, sendBackgroundMessage } = createdWindow
 		exposedWindow = fakeWindow
 
 		await withFakeInpageWindow(fakeWindow, '../../app/inpage/ts/inpage.js?selected-address-mutation-mask', async () => {
 			const provider = fakeWindow.ethereum as {
 				request: (payload: { method: string, params?: readonly unknown[] }) => Promise<unknown>
 				send: (payload: { id: string | number | null, method: string, params: readonly unknown[] }, callback?: undefined) => { readonly result: unknown }
+				on: (eventName: string, callback: (value: unknown) => void) => void
+				isConnected: () => boolean
 				selectedAddress?: string
 			}
 			await waitFor(() => signerRequests.includes('eth_chainId'))
@@ -1074,6 +1076,25 @@ describe('inpage signer bridge', () => {
 			await waitFor(() => provider.selectedAddress === signerAccount)
 			assert.deepEqual(provider.send({ id: 3, method: 'eth_accounts', params: [] }).result, [signerAccount])
 			assert.deepEqual((fakeWindow as { web3?: { accounts?: unknown } }).web3?.accounts, [signerAccount])
+
+			const accountEvents: unknown[] = []
+			provider.on('accountsChanged', (accounts) => accountEvents.push(accounts))
+			sendBackgroundMessage({
+				interceptorApproved: true,
+				type: 'result',
+				method: 'accountsChanged',
+				result: [],
+			})
+			sendBackgroundMessage({
+				interceptorApproved: true,
+				type: 'result',
+				method: 'disconnect',
+				result: [],
+			})
+			await waitFor(() => provider.selectedAddress === undefined && !provider.isConnected())
+			assert.deepEqual(accountEvents, [[]])
+			assert.deepEqual(provider.send({ id: 4, method: 'eth_accounts', params: [] }).result, [])
+			assert.deepEqual((fakeWindow as { web3?: { accounts?: unknown } }).web3?.accounts, [])
 		})
 	})
 

--- a/test/tests/messageSendingPortLifecycle.test.ts
+++ b/test/tests/messageSendingPortLifecycle.test.ts
@@ -218,6 +218,35 @@ describe('background messageSending port lifecycle', () => {
 		}
 	})
 
+	test('marks direct result replies as bridge settlements but not request-scoped callbacks', () => {
+		installBrowserMock()
+		const socket = { tabId: 1, connectionName: 0n }
+		const postedMessages: unknown[] = []
+		const port = createPort((message) => postedMessages.push(message))
+		const connectionKey = websiteSocketToString(socket)
+		const websiteTabConnections = new Map([[socket.tabId, { connections: {
+			[connectionKey]: { port, socket, websiteOrigin: 'https://example.test', approved: true, wantsToConnect: true },
+		} }]])
+
+		replyToInterceptedRequest(websiteTabConnections, {
+			type: 'result',
+			method: 'eth_accounts',
+			result: [],
+			uniqueRequestIdentifier: { requestId: 7, requestSocket: socket },
+		})
+		sendSubscriptionReplyOrCallBack(websiteTabConnections, socket, {
+			type: 'result',
+			method: 'accountsChanged',
+			result: [],
+			requestId: 7,
+		})
+
+		const terminalReply = postedMessages[0]
+		const intermediateEvent = postedMessages[1]
+		assert.equal(typeof terminalReply === 'object' && terminalReply !== null && 'bridgeRequestSettled' in terminalReply && terminalReply.bridgeRequestSettled === true, true)
+		assert.equal(typeof intermediateEvent === 'object' && intermediateEvent !== null && 'bridgeRequestSettled' in intermediateEvent, false)
+	})
+
 	test('keeps standalone eth_accounts bridge replies free of console warnings', () => {
 		installBrowserMock()
 		const warnings: unknown[][] = []


### PR DESCRIPTION
## Summary
- Keep public `eth_requestAccounts` requests pending across content-script port reconnects until a terminal reply arrives, covering both the MV2 document-start and MV3 listener paths.
- Keep the content-script proxy method-agnostic: the inpage semantic layer marks replayable requests, the background reply layer marks terminal settlement, and the proxy strips both transport annotations at their boundaries.
- Reconcile an exact replay with an existing Interceptor access request so it reuses the pending dialog instead of opening a duplicate or returning an already-pending error.
- Await active-account propagation so dapps such as Safe receive `accountsChanged` before the account switch completes.
- Emit `accountsChanged([])` before the legacy `disconnect` event when account access is revoked, clearing stale in-page account state.
- Add regression coverage for generic replay policy, metadata stripping, reconnect ordering, in-flight and stale-port settlement, persisted access dialogs, account switches, and revocation ordering.

## Safety and scope
- Post-acknowledgement replay remains limited to public `eth_requestAccounts`; acknowledged transaction and signature requests are not replayed.
- Retained requests replay in request-ID order for compatibility with background deduplication, and a terminal reply removes even an in-flight replay.
- A separate Brave MV2 signer-readiness race was identified during follow-up: a signer account request can currently arrive before wallet-provider discovery finishes. That follow-up is not included, so this PR does not claim to resolve every Brave MV2 first-click failure.

## Testing
- `bun test` — 599 passed, 0 failed
- `bun run setup-chrome` — passed
- `bun run typecheck` — passed
- `bun run lint` — passed
- `bun run test:chrome-communication` — passed
- Focused account/reconnect suites — 87 passed, 0 failed