### PR TITLE
Fix MetaMask On Click connections and restore MV2 provider injection

### DIFF
--- a/app/inpage/ts/inpage.ts
+++ b/app/inpage/ts/inpage.ts
@@ -1,6 +1,5 @@
 const METAMASK_ERROR_USER_REJECTED_REQUEST = 4001
 const METAMASK_ERROR_PROVIDER_DISCONNECTED = 4900
-const METAMASK_ERROR_CHAIN_NOT_ADDED_TO_METAMASK = 4902
 const METAMASK_ERROR_BLANKET_ERROR = -32603
 const METAMASK_METHOD_NOT_SUPPORTED = -32004
 const METAMASK_INVALID_METHOD_PARAMS = -32602
@@ -247,7 +246,17 @@ type LegacyJsonRpcCallback = (error: IJsonRpcError | null, response: JsonRpcResp
 
 type SignerAccountsReply =
 	| { readonly type: 'success', readonly accounts: readonly string[], readonly requestAccounts: boolean }
-	| { readonly type: 'error', readonly error: { readonly code: number, readonly message: string, readonly data?: unknown }, readonly requestAccounts: boolean }
+	| { readonly type: 'error', readonly error: { readonly code: number, readonly message: string, readonly data?: unknown }, readonly requestAccounts: boolean, readonly signerUnavailable?: true }
+
+type SignerAccountsResolution = {
+	readonly signerProviderGeneration: number
+	readonly reply: SignerAccountsReply
+}
+
+type SignerProviderRequestOutcome =
+	| { readonly type: 'success', readonly reply: unknown, readonly signerProviderGeneration: number }
+	| { readonly type: 'error', readonly error: unknown, readonly signerProviderGeneration: number }
+	| { readonly type: 'providerChanged', readonly signerProviderGeneration: number }
 
 type AnyCallBack =  ((message: ProviderMessage) => void)
 	| ((connectInfo: ProviderConnectInfo) => void)
@@ -468,7 +477,10 @@ class InterceptorMessageListener {
 	private announcedMetaMaskUuid: string | undefined = undefined
 	private acceptingAnnouncedMetaMaskProviders = false
 	private signerSelectionGeneration = 0
-	private signerConnectionTransition: Promise<void> = Promise.resolve()
+	private signerProviderGeneration = 0
+	private latestSignerConnectionTransition: Promise<void> = Promise.resolve()
+	private readonly signerConnectionTransitionChangeWaiters = new Set<InterceptorFuture<void>>()
+	private readonly signerProviderChangeWaiters = new Set<InterceptorFuture<void>>()
 	private readonly signerAvailabilityWaiters = new Set<InterceptorFuture<void>>()
 	private readonly metaMaskAvailabilityWaiters = new Set<InterceptorFuture<void>>()
 	private signerDiscoveryRetryTimer: ReturnType<typeof setTimeout> | undefined = undefined
@@ -487,7 +499,7 @@ class InterceptorMessageListener {
 	private web3AccountsControlled = false
 
 	private signerAccounts: string[] = []
-	private pendingSignerAddressRequest: InterceptorFuture<SignerAccountsReply> | undefined = undefined
+	private pendingSignerAddressRequest: Promise<SignerAccountsResolution> | undefined = undefined
 
 	public constructor() {
 		this.connectToContentScript()
@@ -707,7 +719,7 @@ class InterceptorMessageListener {
 				if (!InterceptorMessageListener.isStringArray([...accounts])) return
 				this.signerAccounts = [...accounts]
 				if (this.pendingSignerAddressRequest !== undefined) return
-				this.sendInternalMessageToBackgroundPage({ method: 'eth_accounts_reply', params: [{ type: 'success', accounts: this.signerAccounts, requestAccounts: false }] })
+				this.sendInternalMessageToBackgroundPage({ method: 'eth_accounts_reply', params: [{ type: 'success', accounts: this.signerAccounts, requestAccounts: false, signerProviderGeneration: this.signerProviderGeneration }] })
 			})
 			register('connect', (_connectInfo: ProviderConnectInfo) => {
 				if (this.signerWindowEthereumProvider !== provider) return
@@ -715,12 +727,13 @@ class InterceptorMessageListener {
 			})
 			register('disconnect', (_error: ProviderRpcError) => {
 				if (this.signerWindowEthereumProvider !== provider) return
-				this.sendInternalMessageToBackgroundPage({ method: 'connected_to_signer', params: [false, signerName] })
+				const signerProviderGeneration = this.advanceSignerProviderGeneration()
+				this.sendInternalMessageToBackgroundPage({ method: 'connected_to_signer', params: [false, signerName, signerProviderGeneration] })
 			})
 			register('chainChanged', (chainId: string) => {
 				if (this.signerWindowEthereumProvider !== provider) return
 				// TODO: this is a hack to get coinbase working that calls this numbers in base 10 instead of in base 16
-				const params = /\d/.test(chainId) ? [`0x${parseInt(chainId).toString(16)}`] : [chainId]
+				const params = /\d/.test(chainId) ? [`0x${parseInt(chainId).toString(16)}`, this.signerProviderGeneration] : [chainId, this.signerProviderGeneration]
 				this.sendInternalMessageToBackgroundPage({ method: 'signer_chainChanged', params })
 			})
 			this.subscribedSignerProviders.add(provider)
@@ -767,9 +780,17 @@ class InterceptorMessageListener {
 	}
 
 	private readonly setSignerProvider = (provider: WindowEthereum | undefined, request: EthereumRequest | undefined, fallbackRequest: EthereumRequest | undefined = undefined) => {
+		if (this.signerWindowEthereumProvider !== provider) this.advanceSignerProviderGeneration()
 		this.signerWindowEthereumProvider = provider
 		this.signerWindowEthereumRequest = request
 		this.fallbackSignerWindowEthereumRequest = fallbackRequest
+	}
+
+	private readonly advanceSignerProviderGeneration = () => {
+		this.signerProviderGeneration++
+		for (const waiter of this.signerProviderChangeWaiters) waiter.resolve(undefined)
+		this.signerProviderChangeWaiters.clear()
+		return this.signerProviderGeneration
 	}
 
 	private readonly discoverAnnouncedMetaMaskProvider = () => {
@@ -828,18 +849,6 @@ class InterceptorMessageListener {
 			if (timeout !== undefined) clearTimeout(timeout)
 		}
 		return this.signerWindowEthereumRequest !== undefined
-	}
-
-	private readonly replyWithUnavailableSignerAccounts = async (requestAccounts: boolean) => {
-		return await this.sendInternalMessageToBackgroundPage({
-			method: 'eth_accounts_reply',
-			params: [{
-				type: 'error',
-				requestAccounts,
-				signerUnavailable: true,
-				error: { code: METAMASK_ERROR_PROVIDER_DISCONNECTED, message: 'No signer wallet is available to this page. Enable your wallet extension for this site, then try again.' },
-			}],
-		})
 	}
 
 	private readonly findPreparedLegacyMetaMaskProvider = (injectedWindowEthereum: WindowEthereum) => {
@@ -1008,78 +1017,114 @@ class InterceptorMessageListener {
 
 	private readonly WindowEthereumEnable = async () => this.WindowEthereumRequest({ method: 'eth_requestAccounts' })
 
-	// attempts to call signer for eth_accounts
-	private readonly getAccountsFromSigner = async () => {
-		if (!await this.waitForSignerAvailability()) return await this.replyWithUnavailableSignerAccounts(false)
-		try {
-			const reply = await this.requestFromSigner({ method: 'eth_accounts', params: [] })
-			if (!Array.isArray(reply)) throw new Error('Signer returned something else than an array')
-			if (!InterceptorMessageListener.isStringArray(reply)) throw new Error('Signer did not return a string array')
-			this.signerAccounts = reply
-			await this.sendInternalMessageToBackgroundPage({ method: 'eth_accounts_reply', params: [{ type: 'success', accounts: this.signerAccounts, requestAccounts: false }] })
-			return
-		} catch (error: unknown) {
-			if (InterceptorMessageListener.getErrorCodeAndMessage(error)) return await this.sendInternalMessageToBackgroundPage({ method: 'eth_accounts_reply', params: [{ type: 'error', requestAccounts: false, error }] })
-			const errorCode = InterceptorMessageListener.getErrorCode(error)
-			if (errorCode !== undefined) return await this.sendInternalMessageToBackgroundPage({ method: 'eth_accounts_reply', params: [{ type: 'error', requestAccounts: false, error: { message: InterceptorMessageListener.getFallbackErrorMessage(errorCode), code: errorCode } }] })
-			if (error instanceof Error) return await this.sendInternalMessageToBackgroundPage({ method: 'eth_accounts_reply', params: [{ type: 'error', requestAccounts: false, error: { message: error.message, code: METAMASK_ERROR_BLANKET_ERROR } }] })
-			return await this.sendInternalMessageToBackgroundPage({ method: 'eth_accounts_reply', params: [{ type: 'error', requestAccounts: false, error: { message: 'unknown error', code: METAMASK_ERROR_BLANKET_ERROR } }] })
-		}
-	}
-
 	private static isStringArray(arr: unknown[]): arr is string[] {
 		return arr.every(item => typeof item === 'string');
 	}
 
+	private readonly getSignerAccountsErrorReply = (error: unknown, requestAccounts: boolean): SignerAccountsReply => {
+		if (InterceptorMessageListener.getErrorCodeAndMessage(error)) return { type: 'error', requestAccounts, error }
+		const errorCode = InterceptorMessageListener.getErrorCode(error)
+		if (errorCode !== undefined) return { type: 'error', requestAccounts, error: { message: InterceptorMessageListener.getFallbackErrorMessage(errorCode), code: errorCode } }
+		if (error instanceof Error) return { type: 'error', requestAccounts, error: { message: error.message, code: METAMASK_ERROR_BLANKET_ERROR } }
+		return { type: 'error', requestAccounts, error: { message: 'unknown error', code: METAMASK_ERROR_BLANKET_ERROR } }
+	}
+
+	private readonly requestFromCurrentSigner = async (methodAndParams: { readonly method: string, readonly params?: readonly unknown[] }, allowRequestAccountsFallbackToRoot = false): Promise<SignerProviderRequestOutcome> => {
+		const signerProviderGeneration = this.signerProviderGeneration
+		const providerChange = new InterceptorFuture<void>()
+		this.signerProviderChangeWaiters.add(providerChange)
+		const signerRequest: Promise<SignerProviderRequestOutcome> = this.requestFromSigner(methodAndParams, allowRequestAccountsFallbackToRoot).then(
+			(reply): SignerProviderRequestOutcome => ({ type: 'success', reply, signerProviderGeneration }),
+			(error: unknown): SignerProviderRequestOutcome => ({ type: 'error', error, signerProviderGeneration }),
+		)
+		const providerChanged = Promise.resolve(providerChange).then((): SignerProviderRequestOutcome => ({ type: 'providerChanged', signerProviderGeneration }))
+		try {
+			const outcome = await Promise.race([signerRequest, providerChanged])
+			if (signerProviderGeneration !== this.signerProviderGeneration) return { type: 'providerChanged', signerProviderGeneration }
+			return outcome
+		} finally {
+			this.signerProviderChangeWaiters.delete(providerChange)
+		}
+	}
+
+	private readonly resolveSignerAccountsFromCurrentProvider = async (requestAccounts: boolean): Promise<SignerAccountsResolution> => {
+		for (;;) {
+			const signerAvailable = await this.waitForSignerAvailability()
+			const signerProviderGeneration = this.signerProviderGeneration
+			if (!signerAvailable) {
+				return {
+					signerProviderGeneration,
+					reply: {
+						type: 'error',
+						requestAccounts,
+						signerUnavailable: true,
+						error: { code: METAMASK_ERROR_PROVIDER_DISCONNECTED, message: 'No signer wallet is available to this page. Enable your wallet extension for this site, then try again.' },
+					},
+				}
+			}
+			const method = requestAccounts ? 'eth_requestAccounts' : 'eth_accounts'
+			const outcome = await this.requestFromCurrentSigner({ method, params: [] }, requestAccounts)
+			if (outcome.type === 'providerChanged') continue
+			if (outcome.type === 'error') return { signerProviderGeneration: outcome.signerProviderGeneration, reply: this.getSignerAccountsErrorReply(outcome.error, requestAccounts) }
+			const reply = outcome.reply
+			if (!Array.isArray(reply)) return { signerProviderGeneration, reply: this.getSignerAccountsErrorReply(new Error('Signer returned something else than an array'), requestAccounts) }
+			if (!InterceptorMessageListener.isStringArray(reply)) return { signerProviderGeneration, reply: this.getSignerAccountsErrorReply(new Error('Signer did not return a string array'), requestAccounts) }
+			this.signerAccounts = reply
+			return { signerProviderGeneration, reply: { type: 'success', accounts: this.signerAccounts, requestAccounts } }
+		}
+	}
+
+	private readonly sendSignerAccountsResolution = async (resolution: SignerAccountsResolution) => {
+		await this.waitForLatestSignerConnectionTransition()
+		if (resolution.signerProviderGeneration !== this.signerProviderGeneration) return false
+		await this.sendInternalMessageToBackgroundPage({ method: 'eth_accounts_reply', params: [{ ...resolution.reply, signerProviderGeneration: resolution.signerProviderGeneration }] })
+		return true
+	}
+
+	// attempts to call signer for eth_accounts
+	private readonly getAccountsFromSigner = async () => {
+		for (;;) {
+			const resolution = await this.resolveSignerAccountsFromCurrentProvider(false)
+			if (await this.sendSignerAccountsResolution(resolution)) return
+		}
+	}
+
+	private readonly getSharedSignerAccountsResolution = async () => {
+		const existingRequest = this.pendingSignerAddressRequest
+		if (existingRequest !== undefined) return await existingRequest
+		const pendingRequest = this.resolveSignerAccountsFromCurrentProvider(true)
+		this.pendingSignerAddressRequest = pendingRequest
+		try {
+			return await pendingRequest
+		} finally {
+			if (this.pendingSignerAddressRequest === pendingRequest) this.pendingSignerAddressRequest = undefined
+		}
+	}
+
 	// attempts to call signer for eth_requestAccounts
 	private readonly requestAccountsFromSigner = async () => {
-		if (!await this.waitForSignerAvailability()) return await this.replyWithUnavailableSignerAccounts(true)
-		if (this.pendingSignerAddressRequest !== undefined) {
-			const pendingReply = await this.pendingSignerAddressRequest
-			await this.sendInternalMessageToBackgroundPage({ method: 'eth_accounts_reply', params: [pendingReply] })
-			return
-		}
-		this.pendingSignerAddressRequest = new InterceptorFuture()
-		try {
-			const reply = await this.requestFromSigner({ method: 'eth_requestAccounts', params: [] }, true)
-			if (!Array.isArray(reply)) throw new Error('Signer returned something else than an array')
-			if (!InterceptorMessageListener.isStringArray(reply)) throw new Error('Signer did not return a string array')
-			this.signerAccounts = reply
-			const signerReply = { type: 'success', accounts: this.signerAccounts, requestAccounts: true } as const
-			this.pendingSignerAddressRequest.resolve(signerReply)
-			await this.sendInternalMessageToBackgroundPage({ method: 'eth_accounts_reply', params: [signerReply] })
-			return
-		} catch (error: unknown) {
-			const errorCode = InterceptorMessageListener.getErrorCode(error)
-			const signerReply = InterceptorMessageListener.getErrorCodeAndMessage(error)
-				? { type: 'error', requestAccounts: true, error } as const
-				: errorCode !== undefined
-					? { type: 'error', requestAccounts: true, error: { message: InterceptorMessageListener.getFallbackErrorMessage(errorCode), code: errorCode } } as const
-					: error instanceof Error
-						? { type: 'error', requestAccounts: true, error: { message: error.message, code: METAMASK_ERROR_BLANKET_ERROR } } as const
-						: { type: 'error', requestAccounts: true, error: { message: 'unknown error', code: METAMASK_ERROR_BLANKET_ERROR } } as const
-			this.pendingSignerAddressRequest.resolve(signerReply)
-			return await this.sendInternalMessageToBackgroundPage({ method: 'eth_accounts_reply', params: [signerReply] })
-		} finally {
-			this.pendingSignerAddressRequest = undefined
+		for (;;) {
+			const resolution = await this.getSharedSignerAccountsResolution()
+			if (await this.sendSignerAccountsResolution(resolution)) return
 		}
 	}
 
 	private readonly requestChainIdFromSigner = async () => {
 		if (this.signerWindowEthereumRequest === undefined) return
-		try {
-			const reply = await this.requestFromSigner({ method: 'eth_chainId', params: [] })
+		const outcome = await this.requestFromCurrentSigner({ method: 'eth_chainId', params: [] })
+		if (outcome.type === 'providerChanged') return
+		if (outcome.type === 'success') {
+			const reply = outcome.reply
 			if (typeof reply !== 'string') {
 				this.reportInterceptorError(serializeForwardedDiagnostics('inpage', 'request signer chain id', new Error('Signer eth_chainId returned a non-string reply.'), { requestMethod: 'eth_chainId' }))
 				return
 			}
-			return await this.sendInternalMessageToBackgroundPage({ method: 'signer_chainChanged', params: [ reply ] })
-		} catch(error: unknown) {
-			console.error('failed to get chain Id from signer')
-			console.error(error)
-			this.reportInterceptorError(serializeForwardedDiagnostics('inpage', 'request signer chain id', error, { requestMethod: 'eth_chainId' }))
-			return undefined
+			return await this.sendInternalMessageToBackgroundPage({ method: 'signer_chainChanged', params: [reply, outcome.signerProviderGeneration] })
 		}
+		console.error('failed to get chain Id from signer')
+		console.error(outcome.error)
+		this.reportInterceptorError(serializeForwardedDiagnostics('inpage', 'request signer chain id', outcome.error, { requestMethod: 'eth_chainId' }))
+		return undefined
 	}
 
 	private static readonly getErrorCodeAndMessage = (error: unknown): error is { code: number, message: string } => {
@@ -1111,18 +1156,39 @@ class InterceptorMessageListener {
 	}
 
 	private readonly requestChangeChainFromSigner = async (chainId: string) => {
-		if (this.signerWindowEthereumRequest === undefined) return
-
-		try {
-			const reply = await this.requestFromSigner({ method: 'wallet_switchEthereumChain', params: [ { chainId } ] })
-			if (reply !== null) return
-			await this.sendInternalMessageToBackgroundPage({ method: 'wallet_switchEthereumChain_reply', params: [ { accept: true, chainId: chainId } ] })
-		} catch (error: unknown) {
-			if (InterceptorMessageListener.getErrorCodeAndMessage(error) && (error.code === METAMASK_ERROR_USER_REJECTED_REQUEST || error.code === METAMASK_ERROR_CHAIN_NOT_ADDED_TO_METAMASK)) {
-				await this.sendInternalMessageToBackgroundPage({ method: 'wallet_switchEthereumChain_reply', params: [ { accept: false, chainId: chainId, error } ] })
-			}
-			throw error
+		if (this.signerWindowEthereumRequest === undefined) {
+			await this.sendInternalMessageToBackgroundPage({
+				method: 'wallet_switchEthereumChain_reply',
+				params: [{
+					accept: false,
+					chainId,
+					signerProviderGeneration: this.signerProviderGeneration,
+					error: { code: METAMASK_ERROR_PROVIDER_DISCONNECTED, message: 'No signer wallet is available to this page. Enable your wallet extension for this site, then try again.' },
+				}],
+			})
+			return
 		}
+
+		const outcome = await this.requestFromCurrentSigner({ method: 'wallet_switchEthereumChain', params: [{ chainId }] })
+		if (outcome.type === 'success') {
+			const params = outcome.reply === null
+				? { accept: true as const, chainId, signerProviderGeneration: outcome.signerProviderGeneration }
+				: {
+					accept: false as const,
+					chainId,
+					signerProviderGeneration: outcome.signerProviderGeneration,
+					error: { code: METAMASK_ERROR_BLANKET_ERROR, message: 'Signer returned an invalid wallet_switchEthereumChain reply.' },
+				}
+			await this.sendInternalMessageToBackgroundPage({ method: 'wallet_switchEthereumChain_reply', params: [params] })
+			return
+		}
+		const error = outcome.type === 'providerChanged'
+			? { code: METAMASK_ERROR_PROVIDER_DISCONNECTED, message: 'Signer connection changed before the previous wallet replied.' }
+			: this.normalizeSignerErrorForBackground(outcome.error)
+		await this.sendInternalMessageToBackgroundPage({
+			method: 'wallet_switchEthereumChain_reply',
+			params: [{ accept: false, chainId, error, signerProviderGeneration: outcome.signerProviderGeneration }],
+		})
 	}
 
 	private readonly handleReplyRequest = async(replyRequest: InterceptedRequestForwardWithResult) => {
@@ -1205,6 +1271,7 @@ class InterceptorMessageListener {
 				case 'request_signer_to_eth_requestAccounts': return await this.requestAccountsFromSigner()
 				case 'request_signer_to_eth_accounts': return await this.getAccountsFromSigner()
 				case 'request_signer_to_wallet_switchEthereumChain': return await this.requestChangeChainFromSigner(replyRequest.result as string)
+				case 'request_signer_connection_status': return await this.connectToSigner(this.signerName)
 				case 'request_signer_chainId': return await this.requestChainIdFromSigner()
 				default: break
 			}
@@ -1315,11 +1382,14 @@ class InterceptorMessageListener {
 			if (this.signerWindowEthereumRequest === undefined) throw new Error('Interceptor is in wallet mode and should not forward to an external wallet')
 
 			const sendToSignerWithCatchError = async () => {
-				try {
-					const reply = await this.requestFromSigner({ method: forwardRequest.method, params: 'params' in forwardRequest ? forwardRequest.params : [] })
-					return { success: true as const, forwardRequest, reply }
-				} catch(error: unknown) {
-					return { success: false as const, forwardRequest, error: this.normalizeSignerErrorForBackground(error) }
+				const outcome = await this.requestFromCurrentSigner({ method: forwardRequest.method, params: 'params' in forwardRequest ? forwardRequest.params : [] })
+				if (outcome.type === 'success') return { success: true as const, forwardRequest, reply: outcome.reply, signerProviderGeneration: outcome.signerProviderGeneration }
+				if (outcome.type === 'error') return { success: false as const, forwardRequest, error: this.normalizeSignerErrorForBackground(outcome.error), signerProviderGeneration: outcome.signerProviderGeneration }
+				return {
+					success: false as const,
+					forwardRequest,
+					error: { code: METAMASK_ERROR_PROVIDER_DISCONNECTED, message: 'Signer connection changed before the previous wallet replied.' },
+					signerProviderGeneration: outcome.signerProviderGeneration,
 				}
 			}
 			const signerReply = await sendToSignerWithCatchError()
@@ -1371,6 +1441,7 @@ class InterceptorMessageListener {
 
 	private readonly connectToSigner = (signerName: Signer) => {
 		this.signerName = signerName
+		const signerProviderGeneration = this.advanceSignerProviderGeneration()
 		if (this.signerWindowEthereumRequest !== undefined) {
 			for (const waiter of this.signerAvailabilityWaiters) waiter.resolve(undefined)
 			this.signerAvailabilityWaiters.clear()
@@ -1382,7 +1453,7 @@ class InterceptorMessageListener {
 		}
 		const selectionGeneration = ++this.signerSelectionGeneration
 		const connectToSigner = async (): Promise<{ metamaskCompatibilityMode: boolean }> => {
-			const connectSignerReply = await this.sendInternalMessageToBackgroundPage({ method: 'connected_to_signer', params: [signerName !== 'NoSigner', signerName] })
+			const connectSignerReply = await this.sendInternalMessageToBackgroundPage({ method: 'connected_to_signer', params: [signerName !== 'NoSigner', signerName, signerProviderGeneration] })
 			if (typeof connectSignerReply === 'object' && connectSignerReply !== null
 				&& 'metamaskCompatibilityMode' in connectSignerReply && connectSignerReply.metamaskCompatibilityMode !== null
 				&& connectSignerReply.metamaskCompatibilityMode !== undefined && typeof connectSignerReply.metamaskCompatibilityMode === 'boolean') {
@@ -1397,9 +1468,32 @@ class InterceptorMessageListener {
 			this.enableMetamaskCompatibilityMode(connection.metamaskCompatibilityMode)
 			if (signerName !== 'NoSigner') await this.requestChainIdFromSigner()
 		}
-		const transition = this.signerConnectionTransition.then(completeTransition, completeTransition)
-		this.signerConnectionTransition = transition
+		// A fresh status report must not wait behind an older bridge request whose reply may have been lost
+		// during a background-worker or content-port replacement. The generation checks on both sides make
+		// late replies from superseded reports harmless.
+		const transition = completeTransition().catch((error: unknown) => {
+			this.reportSignerDiscoveryError('report signer connection status', error)
+		})
+		this.latestSignerConnectionTransition = transition
+		for (const waiter of this.signerConnectionTransitionChangeWaiters) waiter.resolve(undefined)
+		this.signerConnectionTransitionChangeWaiters.clear()
 		return transition
+	}
+
+	private readonly waitForLatestSignerConnectionTransition = async () => {
+		for (;;) {
+			const transition = this.latestSignerConnectionTransition
+			const transitionChanged = new InterceptorFuture<void>()
+			this.signerConnectionTransitionChangeWaiters.add(transitionChanged)
+			try {
+				await Promise.race([transition, Promise.resolve(transitionChanged)])
+			} finally {
+				this.signerConnectionTransitionChangeWaiters.delete(transitionChanged)
+			}
+			if (transition !== this.latestSignerConnectionTransition) continue
+			await transition
+			return
+		}
 	}
 
 	private readonly unsupportedMethods = (windowEthereum: WindowEthereum & UnsupportedWindowEthereumMethods | undefined) => {

--- a/app/inpage/ts/inpage.ts
+++ b/app/inpage/ts/inpage.ts
@@ -836,6 +836,7 @@ class InterceptorMessageListener {
 			params: [{
 				type: 'error',
 				requestAccounts,
+				signerUnavailable: true,
 				error: { code: METAMASK_ERROR_PROVIDER_DISCONNECTED, message: 'No signer wallet is available to this page. Enable your wallet extension for this site, then try again.' },
 			}],
 		})
@@ -1381,7 +1382,7 @@ class InterceptorMessageListener {
 		}
 		const selectionGeneration = ++this.signerSelectionGeneration
 		const connectToSigner = async (): Promise<{ metamaskCompatibilityMode: boolean }> => {
-			const connectSignerReply = await this.sendInternalMessageToBackgroundPage({ method: 'connected_to_signer', params: [true, signerName] })
+			const connectSignerReply = await this.sendInternalMessageToBackgroundPage({ method: 'connected_to_signer', params: [signerName !== 'NoSigner', signerName] })
 			if (typeof connectSignerReply === 'object' && connectSignerReply !== null
 				&& 'metamaskCompatibilityMode' in connectSignerReply && connectSignerReply.metamaskCompatibilityMode !== null
 				&& connectSignerReply.metamaskCompatibilityMode !== undefined && typeof connectSignerReply.metamaskCompatibilityMode === 'boolean') {

--- a/app/inpage/ts/inpage.ts
+++ b/app/inpage/ts/inpage.ts
@@ -836,7 +836,7 @@ class InterceptorMessageListener {
 			params: [{
 				type: 'error',
 				requestAccounts,
-				error: { code: METAMASK_ERROR_PROVIDER_DISCONNECTED, message: 'No signer wallet became available for this page.' },
+				error: { code: METAMASK_ERROR_PROVIDER_DISCONNECTED, message: 'No signer wallet is available to this page. Enable your wallet extension for this site, then try again.' },
 			}],
 		})
 	}

--- a/app/inpage/ts/inpage.ts
+++ b/app/inpage/ts/inpage.ts
@@ -5,6 +5,7 @@ const METAMASK_ERROR_BLANKET_ERROR = -32603
 const METAMASK_METHOD_NOT_SUPPORTED = -32004
 const METAMASK_INVALID_METHOD_PARAMS = -32602
 const SIGNER_DISCOVERY_TIMEOUT_MS = 3000
+const SIGNER_DISCOVERY_RETRY_INTERVAL_MS = 100
 
 interface IJsonRpcSuccess<TResult> {
 	readonly jsonrpc: '2.0'
@@ -469,6 +470,8 @@ class InterceptorMessageListener {
 	private signerSelectionGeneration = 0
 	private signerConnectionTransition: Promise<void> = Promise.resolve()
 	private readonly signerAvailabilityWaiters = new Set<InterceptorFuture<void>>()
+	private readonly metaMaskAvailabilityWaiters = new Set<InterceptorFuture<void>>()
+	private signerDiscoveryRetryTimer: ReturnType<typeof setTimeout> | undefined = undefined
 
 	private readonly outstandingRequests: Map<number, OutstandingRequest> = new Map()
 
@@ -767,9 +770,6 @@ class InterceptorMessageListener {
 		this.signerWindowEthereumProvider = provider
 		this.signerWindowEthereumRequest = request
 		this.fallbackSignerWindowEthereumRequest = fallbackRequest
-		if (request === undefined) return
-		for (const waiter of this.signerAvailabilityWaiters) waiter.resolve(undefined)
-		this.signerAvailabilityWaiters.clear()
 	}
 
 	private readonly discoverAnnouncedMetaMaskProvider = () => {
@@ -786,12 +786,36 @@ class InterceptorMessageListener {
 		}
 	}
 
+	private readonly stopSignerDiscoveryRetries = () => {
+		if (this.signerDiscoveryRetryTimer === undefined) return
+		clearTimeout(this.signerDiscoveryRetryTimer)
+		this.signerDiscoveryRetryTimer = undefined
+	}
+
+	private readonly scheduleSignerDiscoveryRetry = () => {
+		const waitingForAnySigner = this.signerAvailabilityWaiters.size > 0 && this.signerWindowEthereumRequest === undefined
+		const waitingForMetaMaskInsteadOfBrave = this.metaMaskAvailabilityWaiters.size > 0 && this.signerName === 'Brave'
+		if (this.signerDiscoveryRetryTimer !== undefined || (!waitingForAnySigner && !waitingForMetaMaskInsteadOfBrave)) return
+		// A late wallet may start answering EIP-6963 requests without successfully replacing window.ethereum or dispatching ethereum#initialized.
+		this.signerDiscoveryRetryTimer = setTimeout(() => {
+			this.signerDiscoveryRetryTimer = undefined
+			const stillWaitingForAnySigner = this.signerAvailabilityWaiters.size > 0 && this.signerWindowEthereumRequest === undefined
+			const stillWaitingForMetaMaskInsteadOfBrave = this.metaMaskAvailabilityWaiters.size > 0 && this.signerName === 'Brave'
+			if (!stillWaitingForAnySigner && !stillWaitingForMetaMaskInsteadOfBrave) return
+			this.discoverAnnouncedMetaMaskProvider()
+			this.scheduleSignerDiscoveryRetry()
+		}, SIGNER_DISCOVERY_RETRY_INTERVAL_MS)
+	}
+
 	private readonly waitForSignerAvailability = async () => {
-		if (this.signerWindowEthereumRequest === undefined && this.signerName === 'NoSigner') this.discoverAnnouncedMetaMaskProvider()
-		if (this.signerWindowEthereumRequest !== undefined) return true
+		if (this.signerName === 'NoSigner' || this.signerName === 'Brave') this.discoverAnnouncedMetaMaskProvider()
+		const waitForMetaMaskInsteadOfBrave = this.signerName === 'Brave'
+		if (this.signerWindowEthereumRequest !== undefined && !waitForMetaMaskInsteadOfBrave) return true
 
 		const signerAvailability = new InterceptorFuture<void>()
-		this.signerAvailabilityWaiters.add(signerAvailability)
+		const waiters = waitForMetaMaskInsteadOfBrave ? this.metaMaskAvailabilityWaiters : this.signerAvailabilityWaiters
+		waiters.add(signerAvailability)
+		this.scheduleSignerDiscoveryRetry()
 		let timeout: ReturnType<typeof setTimeout> | undefined
 		try {
 			await Promise.race([
@@ -799,7 +823,8 @@ class InterceptorMessageListener {
 				new Promise<void>((resolve) => { timeout = setTimeout(resolve, SIGNER_DISCOVERY_TIMEOUT_MS) }),
 			])
 		} finally {
-			this.signerAvailabilityWaiters.delete(signerAvailability)
+			waiters.delete(signerAvailability)
+			if (this.signerAvailabilityWaiters.size === 0 && this.metaMaskAvailabilityWaiters.size === 0) this.stopSignerDiscoveryRetries()
 			if (timeout !== undefined) clearTimeout(timeout)
 		}
 		return this.signerWindowEthereumRequest !== undefined
@@ -1345,6 +1370,15 @@ class InterceptorMessageListener {
 
 	private readonly connectToSigner = (signerName: Signer) => {
 		this.signerName = signerName
+		if (this.signerWindowEthereumRequest !== undefined) {
+			for (const waiter of this.signerAvailabilityWaiters) waiter.resolve(undefined)
+			this.signerAvailabilityWaiters.clear()
+			if (signerName === 'MetaMask') {
+				for (const waiter of this.metaMaskAvailabilityWaiters) waiter.resolve(undefined)
+				this.metaMaskAvailabilityWaiters.clear()
+			}
+			if (this.signerAvailabilityWaiters.size === 0 && this.metaMaskAvailabilityWaiters.size === 0) this.stopSignerDiscoveryRetries()
+		}
 		const selectionGeneration = ++this.signerSelectionGeneration
 		const connectToSigner = async (): Promise<{ metamaskCompatibilityMode: boolean }> => {
 			const connectSignerReply = await this.sendInternalMessageToBackgroundPage({ method: 'connected_to_signer', params: [true, signerName] })
@@ -1407,7 +1441,7 @@ class InterceptorMessageListener {
 
 	public readonly handleEthereumInitialized = () => {
 		this.injectEthereumIntoWindow()
-		if (this.signerName === 'NoSigner') this.discoverAnnouncedMetaMaskProvider()
+		if (this.signerName === 'NoSigner' || this.signerName === 'Brave') this.discoverAnnouncedMetaMaskProvider()
 	}
 
 	public readonly injectEthereumIntoWindow = () => {

--- a/app/inpage/ts/inpage.ts
+++ b/app/inpage/ts/inpage.ts
@@ -1,8 +1,10 @@
 const METAMASK_ERROR_USER_REJECTED_REQUEST = 4001
+const METAMASK_ERROR_PROVIDER_DISCONNECTED = 4900
 const METAMASK_ERROR_CHAIN_NOT_ADDED_TO_METAMASK = 4902
 const METAMASK_ERROR_BLANKET_ERROR = -32603
 const METAMASK_METHOD_NOT_SUPPORTED = -32004
 const METAMASK_INVALID_METHOD_PARAMS = -32602
+const SIGNER_DISCOVERY_TIMEOUT_MS = 3000
 
 interface IJsonRpcSuccess<TResult> {
 	readonly jsonrpc: '2.0'
@@ -466,6 +468,7 @@ class InterceptorMessageListener {
 	private acceptingAnnouncedMetaMaskProviders = false
 	private signerSelectionGeneration = 0
 	private signerConnectionTransition: Promise<void> = Promise.resolve()
+	private readonly signerAvailabilityWaiters = new Set<InterceptorFuture<void>>()
 
 	private readonly outstandingRequests: Map<number, OutstandingRequest> = new Map()
 
@@ -760,6 +763,59 @@ class InterceptorMessageListener {
 		}
 	}
 
+	private readonly setSignerProvider = (provider: WindowEthereum | undefined, request: EthereumRequest | undefined, fallbackRequest: EthereumRequest | undefined = undefined) => {
+		this.signerWindowEthereumProvider = provider
+		this.signerWindowEthereumRequest = request
+		this.fallbackSignerWindowEthereumRequest = fallbackRequest
+		if (request === undefined) return
+		for (const waiter of this.signerAvailabilityWaiters) waiter.resolve(undefined)
+		this.signerAvailabilityWaiters.clear()
+	}
+
+	private readonly discoverAnnouncedMetaMaskProvider = () => {
+		if (this.acceptingAnnouncedMetaMaskProviders) return
+		window.addEventListener('eip6963:announceProvider', this.useAnnouncedMetaMaskProvider)
+		this.acceptingAnnouncedMetaMaskProviders = true
+		try {
+			window.dispatchEvent(new Event('eip6963:requestProvider'))
+		} catch (error: unknown) {
+			this.reportSignerDiscoveryError('request EIP-6963 signer providers', error)
+		} finally {
+			this.acceptingAnnouncedMetaMaskProviders = false
+			window.removeEventListener('eip6963:announceProvider', this.useAnnouncedMetaMaskProvider)
+		}
+	}
+
+	private readonly waitForSignerAvailability = async () => {
+		if (this.signerWindowEthereumRequest === undefined && this.signerName === 'NoSigner') this.discoverAnnouncedMetaMaskProvider()
+		if (this.signerWindowEthereumRequest !== undefined) return true
+
+		const signerAvailability = new InterceptorFuture<void>()
+		this.signerAvailabilityWaiters.add(signerAvailability)
+		let timeout: ReturnType<typeof setTimeout> | undefined
+		try {
+			await Promise.race([
+				Promise.resolve(signerAvailability),
+				new Promise<void>((resolve) => { timeout = setTimeout(resolve, SIGNER_DISCOVERY_TIMEOUT_MS) }),
+			])
+		} finally {
+			this.signerAvailabilityWaiters.delete(signerAvailability)
+			if (timeout !== undefined) clearTimeout(timeout)
+		}
+		return this.signerWindowEthereumRequest !== undefined
+	}
+
+	private readonly replyWithUnavailableSignerAccounts = async (requestAccounts: boolean) => {
+		return await this.sendInternalMessageToBackgroundPage({
+			method: 'eth_accounts_reply',
+			params: [{
+				type: 'error',
+				requestAccounts,
+				error: { code: METAMASK_ERROR_PROVIDER_DISCONNECTED, message: 'No signer wallet became available for this page.' },
+			}],
+		})
+	}
+
 	private readonly findPreparedLegacyMetaMaskProvider = (injectedWindowEthereum: WindowEthereum) => {
 		let providers: readonly unknown[] | undefined
 		try {
@@ -809,9 +865,7 @@ class InterceptorMessageListener {
 		const preparedSigner = this.prepareSignerProvider(provider, 'MetaMask')
 		if (preparedSigner === undefined) return
 		this.announcedMetaMaskUuid = info.uuid
-		this.signerWindowEthereumProvider = preparedSigner.provider
-		this.signerWindowEthereumRequest = preparedSigner.request
-		this.fallbackSignerWindowEthereumRequest = undefined
+		this.setSignerProvider(preparedSigner.provider, preparedSigner.request)
 		this.connected = preparedSigner.connected
 		this.connectToSigner('MetaMask')
 	}
@@ -930,7 +984,7 @@ class InterceptorMessageListener {
 
 	// attempts to call signer for eth_accounts
 	private readonly getAccountsFromSigner = async () => {
-		if (this.signerWindowEthereumRequest === undefined) return
+		if (!await this.waitForSignerAvailability()) return await this.replyWithUnavailableSignerAccounts(false)
 		try {
 			const reply = await this.requestFromSigner({ method: 'eth_accounts', params: [] })
 			if (!Array.isArray(reply)) throw new Error('Signer returned something else than an array')
@@ -953,7 +1007,7 @@ class InterceptorMessageListener {
 
 	// attempts to call signer for eth_requestAccounts
 	private readonly requestAccountsFromSigner = async () => {
-		if (this.signerWindowEthereumRequest === undefined) return
+		if (!await this.waitForSignerAvailability()) return await this.replyWithUnavailableSignerAccounts(true)
 		if (this.pendingSignerAddressRequest !== undefined) {
 			const pendingReply = await this.pendingSignerAddressRequest
 			await this.sendInternalMessageToBackgroundPage({ method: 'eth_accounts_reply', params: [pendingReply] })
@@ -1333,7 +1387,6 @@ class InterceptorMessageListener {
 
 	private readonly onPageLoad = () => {
 		const interceptorMessageListener = this
-		window.addEventListener('eip6963:announceProvider', this.useAnnouncedMetaMaskProvider)
 		function announceProvider() {
 			const info: EIP6963ProviderInfo = {
 				uuid: '200ecd95-afe4-4684-bce7-0f2f8bdd3498',
@@ -1349,13 +1402,12 @@ class InterceptorMessageListener {
 		}
 		window.addEventListener('eip6963:requestProvider', () => { announceProvider() } )
 		announceProvider()
-		this.acceptingAnnouncedMetaMaskProviders = true
-		try {
-			window.dispatchEvent(new Event('eip6963:requestProvider'))
-		} finally {
-			this.acceptingAnnouncedMetaMaskProviders = false
-			window.removeEventListener('eip6963:announceProvider', this.useAnnouncedMetaMaskProvider)
-		}
+		this.discoverAnnouncedMetaMaskProvider()
+	}
+
+	public readonly handleEthereumInitialized = () => {
+		this.injectEthereumIntoWindow()
+		if (this.signerName === 'NoSigner') this.discoverAnnouncedMetaMaskProvider()
 	}
 
 	public readonly injectEthereumIntoWindow = () => {
@@ -1380,9 +1432,7 @@ class InterceptorMessageListener {
 		const useNoSigner = () => {
 			inpageWindow.ethereum = this.createInterceptorProvider(undefined)
 			this.connected = true
-			this.signerWindowEthereumProvider = undefined
-			this.signerWindowEthereumRequest = undefined
-			this.fallbackSignerWindowEthereumRequest = undefined
+			this.setSignerProvider(undefined, undefined)
 			this.connectToSigner('NoSigner')
 		}
 		let rootIsInterceptor = false
@@ -1416,9 +1466,7 @@ class InterceptorMessageListener {
 				try { fallbackRequest = injectedWindowEthereum.request.bind(injectedWindowEthereum) } catch (error: unknown) { this.reportSignerDiscoveryError('bind root fallback signer request', error) }
 			}
 			this.connected = preparedSigner.connected
-			this.signerWindowEthereumProvider = preparedSigner.provider
-			this.signerWindowEthereumRequest = preparedSigner.request
-			this.fallbackSignerWindowEthereumRequest = fallbackRequest
+			this.setSignerProvider(preparedSigner.provider, preparedSigner.request, fallbackRequest)
 			inpageWindow.ethereum = this.createInterceptorProvider(preparedSigner.provider)
 			this.installControlledAccountCompatibilityProperties()
 			this.connectToSigner(signerName)
@@ -1431,9 +1479,7 @@ class InterceptorMessageListener {
 		}
 		const fallbackSignerWindowEthereum = preparedRootSigner.provider
 		const fallbackSignerName = preparedMetaMaskProvider === undefined ? rootSignerName : 'MetaMask'
-		this.signerWindowEthereumProvider = fallbackSignerWindowEthereum
-		this.signerWindowEthereumRequest = preparedRootSigner.request // store the request object to signer
-		this.fallbackSignerWindowEthereumRequest = undefined
+		this.setSignerProvider(fallbackSignerWindowEthereum, preparedRootSigner.request)
 		this.connected = preparedRootSigner.connected
 		// we cannot inject window.ethereum alone here as it seems like window.ethereum is cached (maybe ethers.js does that?)
 		if (fallbackSignerWindowEthereum !== injectedWindowEthereum || this.hasNonConfigurableAccountCompatibilityProperty()) {
@@ -1452,11 +1498,7 @@ function injectInterceptor() {
 	window.addEventListener('message', interceptorMessageListener.onWindowMessage)
 
 	// keep listening for other wallets that announce themselves and reinject without patching dispatchEvent
-	const onEthereumInitialized = () => {
-		if (inpageWindow.ethereum?.isInterceptor) return
-		interceptorMessageListener.injectEthereumIntoWindow()
-	}
-	window.addEventListener('ethereum#initialized', onEthereumInitialized)
+	window.addEventListener('ethereum#initialized', interceptorMessageListener.handleEthereumInitialized)
 	window.dispatchEvent(new Event('ethereum#initialized'))
 }
 

--- a/app/inpage/ts/listenContentScript.ts
+++ b/app/inpage/ts/listenContentScript.ts
@@ -395,4 +395,9 @@ function listenContentScript(connectionName: string | undefined, diagnosticsSour
 		console.error(error)
 	}
 }
-Object.defineProperty(globalThis, contentScriptListenerGlobalKey, { configurable: true, value: listenContentScript })
+
+function registerContentScriptListener() {
+	Object.defineProperty(globalThis, contentScriptListenerGlobalKey, { configurable: true, value: listenContentScript })
+}
+
+registerContentScriptListener()

--- a/app/manifestV2.json
+++ b/app/manifestV2.json
@@ -31,6 +31,11 @@
 		"webRequest",
 		"webRequestBlocking"
 	],
-	"web_accessible_resources": ["inpage/js/inpage.js"],
+	"web_accessible_resources": [
+		"vendor/webextension-polyfill/dist/browser-polyfill.js",
+		"inpage/js/listenContentScript.js",
+		"inpage/js/document_start.js",
+		"inpage/js/inpage.js"
+	],
 	"content_security_policy": "object-src 'self'; script-src 'self'"
 }

--- a/app/ts/background/accessManagement.ts
+++ b/app/ts/background/accessManagement.ts
@@ -19,6 +19,7 @@ import type { ResetSimulationServices } from '../simulation/serviceLifecycle.js'
 import { mergeStoredWebsiteMetadata } from '../utils/websiteIcons.js'
 import { reportUnexpectedError } from '../utils/errors.js'
 import { bumpPopupRefreshGeneration } from './popupRefreshGeneration.js'
+import { getConfirmedSignerStateToken, isSignerStateTokenCurrent } from './signerStateOwnership.js'
 
 function getConnectionDetails(websiteTabConnections: WebsiteTabConnections, socket: WebsiteSocket) {
 	const identifier = websiteSocketToString(socket)
@@ -125,7 +126,7 @@ export async function sendActiveAccountChangeToApprovedWebsitePorts(websiteTabCo
 			if (connection === undefined) throw new Error('missing connection')
 			if (!connection.approved) continue
 			if (!shouldSendUnscopedConnectionEvents(connection.socket)) continue
-			const activeAddress = await getActiveAddressForDomain(connection.websiteOrigin, settings, connection.socket)
+			const activeAddress = await getActiveAddressForDomain(websiteTabConnections, connection.websiteOrigin, settings, connection.socket)
 			sendSubscriptionReplyOrCallBack(websiteTabConnections, connection.socket, {
 				type: 'result' as const,
 				method: 'accountsChanged',
@@ -211,8 +212,16 @@ export async function setAccess(website: Website, access: boolean, address: bigi
 
 // gets active address if the website has been give access for it, otherwise returns undefined
 // this is to guard websites from seeing addresses without access
-async function getActiveAddressForDomain(websiteOrigin: string, settings: Settings, socket: WebsiteSocket) {
-	const activeAddress = await getActiveAddress(settings, socket.tabId)
+async function getActiveAddressForCurrentSignerState(websiteTabConnections: WebsiteTabConnections, settings: Settings, tabId: number) {
+	if (settings.simulationMode && !settings.useSignersAddressAsActiveAddress) return await getActiveAddress(settings, tabId)
+	const signerStateToken = getConfirmedSignerStateToken(websiteTabConnections, tabId)
+	if (signerStateToken === undefined) return undefined
+	const activeAddress = await getActiveAddress(settings, tabId)
+	return isSignerStateTokenCurrent(websiteTabConnections, signerStateToken) ? activeAddress : undefined
+}
+
+async function getActiveAddressForDomain(websiteTabConnections: WebsiteTabConnections, websiteOrigin: string, settings: Settings, socket: WebsiteSocket) {
+	const activeAddress = await getActiveAddressForCurrentSignerState(websiteTabConnections, settings, socket.tabId)
 	if (activeAddress === undefined) return undefined
 	const hasAccess = hasAddressAccess(settings.websiteAccess, websiteOrigin, activeAddress)
 	if (hasAccess === 'hasAccess') return activeAddress
@@ -291,7 +300,7 @@ async function updateTabConnections(
 	for (const key in tabConnection.connections) {
 		const connection = tabConnection.connections[key]
 		if (connection === undefined) throw new Error('missing connection')
-		const currentActiveAddress = await getActiveAddress(settings, connection.socket.tabId)
+		const currentActiveAddress = await getActiveAddressForCurrentSignerState(websiteTabConnections, settings, connection.socket.tabId)
 		addIconRefreshTarget(iconRefreshTargets, connection.socket.tabId, connection.websiteOrigin)
 		const access = currentActiveAddress ? hasAddressAccess(settings.websiteAccess, connection.websiteOrigin, currentActiveAddress) : hasAccess(settings.websiteAccess, connection.websiteOrigin)
 

--- a/app/ts/background/accessManagement.ts
+++ b/app/ts/background/accessManagement.ts
@@ -19,7 +19,7 @@ import type { ResetSimulationServices } from '../simulation/serviceLifecycle.js'
 import { mergeStoredWebsiteMetadata } from '../utils/websiteIcons.js'
 import { reportUnexpectedError } from '../utils/errors.js'
 import { bumpPopupRefreshGeneration } from './popupRefreshGeneration.js'
-import { getConfirmedSignerStateToken, isSignerStateTokenCurrent } from './signerStateOwnership.js'
+import { getActiveAddressForCurrentSignerState } from './signerStateOwnership.js'
 
 function getConnectionDetails(websiteTabConnections: WebsiteTabConnections, socket: WebsiteSocket) {
 	const identifier = websiteSocketToString(socket)
@@ -212,16 +212,8 @@ export async function setAccess(website: Website, access: boolean, address: bigi
 
 // gets active address if the website has been give access for it, otherwise returns undefined
 // this is to guard websites from seeing addresses without access
-async function getActiveAddressForCurrentSignerState(websiteTabConnections: WebsiteTabConnections, settings: Settings, tabId: number) {
-	if (settings.simulationMode && !settings.useSignersAddressAsActiveAddress) return await getActiveAddress(settings, tabId)
-	const signerStateToken = getConfirmedSignerStateToken(websiteTabConnections, tabId)
-	if (signerStateToken === undefined) return undefined
-	const activeAddress = await getActiveAddress(settings, tabId)
-	return isSignerStateTokenCurrent(websiteTabConnections, signerStateToken) ? activeAddress : undefined
-}
-
 async function getActiveAddressForDomain(websiteTabConnections: WebsiteTabConnections, websiteOrigin: string, settings: Settings, socket: WebsiteSocket) {
-	const activeAddress = await getActiveAddressForCurrentSignerState(websiteTabConnections, settings, socket.tabId)
+	const activeAddress = await getActiveAddressForCurrentSignerState(websiteTabConnections, settings, socket.tabId, async () => await getActiveAddress(settings, socket.tabId))
 	if (activeAddress === undefined) return undefined
 	const hasAccess = hasAddressAccess(settings.websiteAccess, websiteOrigin, activeAddress)
 	if (hasAccess === 'hasAccess') return activeAddress
@@ -300,7 +292,12 @@ async function updateTabConnections(
 	for (const key in tabConnection.connections) {
 		const connection = tabConnection.connections[key]
 		if (connection === undefined) throw new Error('missing connection')
-		const currentActiveAddress = await getActiveAddressForCurrentSignerState(websiteTabConnections, settings, connection.socket.tabId)
+		const currentActiveAddress = await getActiveAddressForCurrentSignerState(
+			websiteTabConnections,
+			settings,
+			connection.socket.tabId,
+			async () => await getActiveAddress(settings, connection.socket.tabId),
+		)
 		addIconRefreshTarget(iconRefreshTargets, connection.socket.tabId, connection.websiteOrigin)
 		const access = currentActiveAddress ? hasAddressAccess(settings.websiteAccess, connection.websiteOrigin, currentActiveAddress) : hasAccess(settings.websiteAccess, connection.websiteOrigin)
 

--- a/app/ts/background/background-startup.ts
+++ b/app/ts/background/background-startup.ts
@@ -32,6 +32,8 @@ import { flushPendingTerminalRepliesForConnectedPortWithRetry } from './terminal
 import { prunePendingTerminalRepliesForMissingTabs, removePendingTerminalRepliesForTab } from './pendingTerminalReplies.js'
 import { createRetriableTerminalStateRecovery } from './terminalStateRecovery.js'
 import { acknowledgeAndTrackBridgeRequest, INTERCEPTOR_BRIDGE_ACKNOWLEDGEMENT_MESSAGE } from './bridgeRequestDelivery.js'
+import { registerWebsiteConnectionAndProvisionallyClaimSignerState } from './signerStateOwnership.js'
+import { sendSubscriptionReplyOrCallBackToPort } from './messageSending.js'
 
 const websiteTabConnections = new Map<number, TabConnection>()
 let simulationServices: SimulationServices | undefined
@@ -136,14 +138,14 @@ async function onContentScriptConnected(waitForStartup: () => Promise<{ resetAct
 	})()
 	silenceChromeUnCaughtPromise(websitePromise)
 
-	const tabConnection = websiteTabConnections.get(socket.tabId)
 	const newConnection = { port, socket, websiteOrigin, approved: false, wantsToConnect: false }
+	const isTopFrame = port.sender.frameId === undefined || port.sender.frameId === 0
 
 	const listenersRegistered = tryRegisterContentScriptPortListeners(
 		port,
 		() => {
 			catchAllErrorsAndCall(async () => {
-				removeWebsiteTabConnection(websiteTabConnections, socket, port)
+				await removeWebsiteTabConnection(websiteTabConnections, socket, port)
 			})
 		},
 		(payload) => {
@@ -181,10 +183,8 @@ async function onContentScriptConnected(waitForStartup: () => Promise<{ resetAct
 	)
 	if (!listenersRegistered) return
 
-	if (tabConnection === undefined) {
-		websiteTabConnections.set(socket.tabId, {
-			connections: { [identifier]: newConnection },
-		})
+	const registration = await registerWebsiteConnectionAndProvisionallyClaimSignerState(websiteTabConnections, socket, newConnection, isTopFrame)
+	if (registration.createdTabConnection) {
 		await updateTabState(socket.tabId, (previousState: TabState) => {
 			return modifyObject(previousState, {
 				website: { websiteOrigin, icon: undefined, title: undefined },
@@ -192,8 +192,9 @@ async function onContentScriptConnected(waitForStartup: () => Promise<{ resetAct
 			})
 		})
 		void catchAllErrorsAndCall(async () => updateExtensionIcon(websiteTabConnections, socket.tabId, websiteOrigin, bumpPopupRefreshGeneration()))
-	} else {
-		tabConnection.connections[identifier] = newConnection
+	}
+	if (registration.provisionallyClaimedSignerState) {
+		sendSubscriptionReplyOrCallBackToPort(port, { type: 'result', method: 'request_signer_connection_status', result: [] })
 	}
 	await flushPendingTerminalRepliesForConnectedPortWithRetry(websiteTabConnections, socket, port)
 	try {

--- a/app/ts/background/background.ts
+++ b/app/ts/background/background.ts
@@ -7,7 +7,7 @@ import { changeActiveAddress, changePage, confirmDialog, removeTransactionOrSign
 import { PASSTHROUGH_STATE, type ResolvedExecutionSimulationState, type ResolvedSimulationInput, type ResolvedSimulationState, type WebsiteCreatedEthereumUnsignedTransactionOrFailed, toResolvedExecutionSimulationState, toResolvedSimulationInput, toResolvedSimulationState } from '../types/visualizer-types.js'
 import type { WebsiteTabConnections } from '../types/user-interface-types.js'
 import { askForSignerAccountsFromSignerIfNotAvailable, interceptorAccessMetadataRefresh, requestAccessFromUser } from './windows/interceptorAccess.js'
-import { METAMASK_ERROR_FAILED_TO_PARSE_REQUEST, METAMASK_ERROR_NOT_AUTHORIZED, METAMASK_ERROR_NOT_CONNECTED_TO_CHAIN, METAMASK_ERROR_PROVIDER_DISCONNECTED, ERROR_INTERCEPTOR_DISABLED, NEW_BLOCK_ABORT } from '../utils/constants.js'
+import { METAMASK_ERROR_FAILED_TO_PARSE_REQUEST, METAMASK_ERROR_NOT_AUTHORIZED, METAMASK_ERROR_NOT_CONNECTED_TO_CHAIN, METAMASK_ERROR_PROVIDER_DISCONNECTED, METAMASK_ERROR_USER_REJECTED_REQUEST, ERROR_INTERCEPTOR_DISABLED, NEW_BLOCK_ABORT } from '../utils/constants.js'
 import { clearWebsiteConnectionIntent, hasAccess as getWebsiteAccessApprovalState, hasAddressAccess as getWebsiteAddressAccessApprovalState, persistWebsiteAccessChange, sendActiveAccountChangeToApprovedWebsitePorts, sendMessageToApprovedWebsitePorts, sendProviderConnectionEventsToPort, updateWebsiteApprovalAccesses, verifyAccess, withSuppressedUnscopedConnectionEventsForSocket } from './accessManagement.js'
 import { getActiveAddressEntry, identifyAddress } from './metadataUtils.js'
 import { getActiveAddress, sendPopupMessageToOpenWindows } from './backgroundUtils.js'
@@ -515,12 +515,21 @@ async function discoverAccountRequestAddressContext(
 }
 
 const isSignerProviderDisconnectedError = (error: ErrorWithCodeAndOptionalData | undefined): error is ErrorWithCodeAndOptionalData => error?.code === METAMASK_ERROR_PROVIDER_DISCONNECTED
+const isSignerAccountAccessRejectedError = (error: ErrorWithCodeAndOptionalData | undefined): error is ErrorWithCodeAndOptionalData => error?.code === METAMASK_ERROR_USER_REJECTED_REQUEST
+const isTerminalSignerAccountConnectionError = (error: ErrorWithCodeAndOptionalData | undefined): error is ErrorWithCodeAndOptionalData => {
+	return isSignerProviderDisconnectedError(error) || isSignerAccountAccessRejectedError(error)
+}
 
 function replyWithSignerAccountError(websiteTabConnections: WebsiteTabConnections, request: InterceptedRequest, error: ErrorWithCodeAndOptionalData) {
+	// Injected-wallet connection UIs commonly treat 4001 as the only terminal account-access failure.
+	// Keep the more precise 4900 internally, but expose unavailable page-level wallet access as a rejected interactive connection.
+	const publicError = isAccountConnectionMethod(request.method) && isSignerProviderDisconnectedError(error)
+		? { ...error, code: METAMASK_ERROR_USER_REJECTED_REQUEST }
+		: error
 	return replyToInterceptedRequest(websiteTabConnections, {
 		type: 'result',
 		...getRequestWithDefinedParams(request),
-		error,
+		error: publicError,
 	})
 }
 
@@ -550,7 +559,7 @@ export const handleInterceptedRequest = async (port: browser.runtime.Port | unde
 		return replyToInterceptedRequest(websiteTabConnections, message)
 	}
 	const { settings, activeAddress, requestedSignerAccountsForSiteAccess, signerAccountError } = await discoverAccountRequestAddressContext(websiteTabConnections, socket, request, websiteOrigin)
-	if (isSignerProviderDisconnectedError(signerAccountError)) return replyWithSignerAccountError(websiteTabConnections, request, signerAccountError)
+	if (isTerminalSignerAccountConnectionError(signerAccountError)) return replyWithSignerAccountError(websiteTabConnections, request, signerAccountError)
 	if (requestedSignerAccountsForSiteAccess && activeAddress === undefined) {
 		if (getWebsiteAccessApprovalState(settings.websiteAccess, websiteOrigin) === 'interceptorDisabled') return replyToInterceptedRequest(websiteTabConnections, { type: 'result', ...getRequestWithDefinedParams(request), ...ERROR_INTERCEPTOR_DISABLED })
 		return refuseAccess(websiteTabConnections, request)
@@ -572,7 +581,7 @@ export const handleInterceptedRequest = async (port: browser.runtime.Port | unde
 		// user has granted access to the site, but not to this account and the application is requesting accounts
 		if (requestedSignerAccountsForSiteAccess) return refuseAccess(websiteTabConnections, request)
 		const signerAccountsResult = await askForSignerAccountsFromSignerIfNotAvailable(websiteTabConnections, socket, true)
-		if (isSignerProviderDisconnectedError(signerAccountsResult.error)) return replyWithSignerAccountError(websiteTabConnections, request, signerAccountsResult.error)
+		if (isTerminalSignerAccountConnectionError(signerAccountsResult.error)) return replyWithSignerAccountError(websiteTabConnections, request, signerAccountsResult.error)
 		if (signerAccountsResult.accounts.length === 0) return refuseAccess(websiteTabConnections, request)
 		const result: unknown = await handleInterceptedRequest(port, websiteOrigin, websitePromise, ethereum, tokenPriceService, resetSimulationServices, socket, request, websiteTabConnections, publishRpcConnectionStatus)
 		return result

--- a/app/ts/background/background.ts
+++ b/app/ts/background/background.ts
@@ -37,7 +37,7 @@ import type { TokenPriceService } from '../simulation/services/priceEstimator.js
 import type { ResetSimulationServices } from '../simulation/serviceLifecycle.js'
 import { isAccountConnectionMethod, isAccountOnlyMethod } from './accountRequestMethods.js'
 import type { ErrorWithCodeAndOptionalData } from '../types/error.js'
-import { getConfirmedSignerStateToken, isSignerStateTokenCurrent, sendCallbackToConfirmedSignerOwner } from './signerStateOwnership.js'
+import { getActiveAddressForCurrentSignerState, getConfirmedSignerStateToken, isSignerStateTokenCurrent, sendCallbackToConfirmedSignerOwner } from './signerStateOwnership.js'
 
 const simulationAbortController = new AbortController()
 const JSON_RPC_METHOD_NOT_FOUND = -32601
@@ -507,11 +507,7 @@ function parseWalletRevokePermissionsRequest(websiteTabConnections: WebsiteTabCo
 }
 
 async function getActiveAddressForRequest(settings: Settings, websiteTabConnections: WebsiteTabConnections, tabId: number) {
-	if (settings.simulationMode && !settings.useSignersAddressAsActiveAddress) return await getActiveAddress(settings, tabId)
-	const signerStateToken = getConfirmedSignerStateToken(websiteTabConnections, tabId)
-	if (signerStateToken === undefined) return undefined
-	const activeAddress = await getActiveAddress(settings, tabId)
-	return isSignerStateTokenCurrent(websiteTabConnections, signerStateToken) ? activeAddress : undefined
+	return await getActiveAddressForCurrentSignerState(websiteTabConnections, settings, tabId, async () => await getActiveAddress(settings, tabId))
 }
 
 async function discoverAccountRequestAddressContext(

--- a/app/ts/background/background.ts
+++ b/app/ts/background/background.ts
@@ -37,6 +37,7 @@ import type { TokenPriceService } from '../simulation/services/priceEstimator.js
 import type { ResetSimulationServices } from '../simulation/serviceLifecycle.js'
 import { isAccountConnectionMethod, isAccountOnlyMethod } from './accountRequestMethods.js'
 import type { ErrorWithCodeAndOptionalData } from '../types/error.js'
+import { getConfirmedSignerStateToken, isSignerStateTokenCurrent, sendCallbackToConfirmedSignerOwner } from './signerStateOwnership.js'
 
 const simulationAbortController = new AbortController()
 const JSON_RPC_METHOD_NOT_FOUND = -32601
@@ -347,14 +348,25 @@ export async function changeActiveAddressAndChain(
 	})
 }
 
-export async function changeActiveRpc(ethereum: EthereumClientService, tokenPriceService: TokenPriceService, resetSimulationServices: ResetSimulationServices, websiteTabConnections: WebsiteTabConnections, rpcNetwork: RpcNetwork, simulationMode: boolean) {
-	// allow switching RPC only if we are in simulation mode, or that chain id would not change
-	if (simulationMode || rpcNetwork.chainId === (await getSettings()).activeRpcNetwork.chainId) return await changeActiveAddressAndChain(ethereum, tokenPriceService, resetSimulationServices, websiteTabConnections, { simulationMode, rpcNetwork })
-	sendMessageToApprovedWebsitePorts(websiteTabConnections, { method: 'request_signer_to_wallet_switchEthereumChain', result: rpcNetwork.chainId })
+export async function changeActiveRpc(ethereum: EthereumClientService, tokenPriceService: TokenPriceService, resetSimulationServices: ResetSimulationServices, websiteTabConnections: WebsiteTabConnections, rpcNetwork: RpcNetwork, simulationMode: boolean, signerTabId: number | undefined) {
+	if (simulationMode) {
+		await changeActiveAddressAndChain(ethereum, tokenPriceService, resetSimulationServices, websiteTabConnections, { simulationMode, rpcNetwork })
+		return { type: 'completedLocally' as const }
+	}
+	// The signer already confirmed this chain through chainChanged, so no wallet request is needed.
+	if (rpcNetwork.chainId === (await getSettings()).activeRpcNetwork.chainId) {
+		await changeActiveAddressAndChain(ethereum, tokenPriceService, resetSimulationServices, websiteTabConnections, { simulationMode, rpcNetwork })
+		return { type: 'signerRequestNotNeeded' as const }
+	}
+	const signerStateToken = signerTabId !== undefined
+		&& sendCallbackToConfirmedSignerOwner(websiteTabConnections, signerTabId, { method: 'request_signer_to_wallet_switchEthereumChain', result: rpcNetwork.chainId })
 	const settings = await getSettings()
 	const popupRefreshGeneration = bumpPopupRefreshGeneration()
 	await sendPopupMessageToOpenWindows({ method: 'popup_settingsUpdated', data: settings, popupRefreshGeneration })
 	await promoteRpcAsPrimary(rpcNetwork)
+	return signerStateToken === false
+		? { type: 'signerUnavailable' as const }
+		: { type: 'signerRequestSent' as const, signerStateToken }
 }
 
 function getProviderHandler(method: string) {
@@ -494,6 +506,14 @@ function parseWalletRevokePermissionsRequest(websiteTabConnections: WebsiteTabCo
 	return undefined
 }
 
+async function getActiveAddressForRequest(settings: Settings, websiteTabConnections: WebsiteTabConnections, tabId: number) {
+	if (settings.simulationMode && !settings.useSignersAddressAsActiveAddress) return await getActiveAddress(settings, tabId)
+	const signerStateToken = getConfirmedSignerStateToken(websiteTabConnections, tabId)
+	if (signerStateToken === undefined) return undefined
+	const activeAddress = await getActiveAddress(settings, tabId)
+	return isSignerStateTokenCurrent(websiteTabConnections, signerStateToken) ? activeAddress : undefined
+}
+
 async function discoverAccountRequestAddressContext(
 	websiteTabConnections: WebsiteTabConnections,
 	socket: WebsiteSocket,
@@ -501,14 +521,14 @@ async function discoverAccountRequestAddressContext(
 	websiteOrigin: string,
 ) {
 	const settings = await getSettings()
-	const activeAddress = await getActiveAddress(settings, socket.tabId)
+	const activeAddress = await getActiveAddressForRequest(settings, websiteTabConnections, socket.tabId)
 	if (activeAddress !== undefined) return { settings, activeAddress, requestedSignerAccountsForSiteAccess: false, signerAccountError: undefined }
 	if (!isAccountConnectionMethod(request.method)) return { settings, activeAddress, requestedSignerAccountsForSiteAccess: false, signerAccountError: undefined }
 	if (getWebsiteAccessApprovalState(settings.websiteAccess, websiteOrigin) !== 'hasAccess') return { settings, activeAddress, requestedSignerAccountsForSiteAccess: false, signerAccountError: undefined }
 
 	const signerAccountsResult = await askForSignerAccountsFromSignerIfNotAvailable(websiteTabConnections, socket, true)
 	const refreshedSettings = await getSettings()
-	const refreshedActiveAddress = await getActiveAddress(refreshedSettings, socket.tabId)
+	const refreshedActiveAddress = await getActiveAddressForRequest(refreshedSettings, websiteTabConnections, socket.tabId)
 	if (refreshedActiveAddress !== undefined) return { settings: refreshedSettings, activeAddress: refreshedActiveAddress, requestedSignerAccountsForSiteAccess: true, signerAccountError: signerAccountsResult.error }
 	const firstSignerAddress = signerAccountsResult.accounts[0] === undefined ? undefined : await getActiveAddressEntry(signerAccountsResult.accounts[0])
 	return { settings: refreshedSettings, activeAddress: firstSignerAddress, requestedSignerAccountsForSiteAccess: true, signerAccountError: signerAccountsResult.error }
@@ -541,7 +561,7 @@ export const handleInterceptedRequest = async (port: browser.runtime.Port | unde
 		const result = await revokeWebsitePermissions(ethereum, tokenPriceService, resetSimulationServices, websiteTabConnections, websiteOrigin)
 		return replyToInterceptedRequest(websiteTabConnections, { ...getRequestWithDefinedParams(request), ...result })
 	}
-	const initialActiveAddress = await getActiveAddress(initialSettings, socket.tabId)
+	const initialActiveAddress = await getActiveAddressForRequest(initialSettings, websiteTabConnections, socket.tabId)
 	if (request.interceptorInternalRequest !== true && isInternalProviderMethod(request.method)) return refusePublicInternalProviderMethod(websiteTabConnections, request)
 	const providerHandler = getProviderHandler(request.method)
 	const identifiedMethod = providerHandler.method
@@ -594,7 +614,14 @@ export const handleInterceptedRequest = async (port: browser.runtime.Port | unde
 		const firstSignerAccount = signerAccounts[0]
 		if (firstSignerAccount === undefined) return replyWithEmptyAccountIdentity(websiteTabConnections, request)
 		const refreshedSettings = await getSettings()
-		const refreshedActiveAddress = await getActiveAddress(refreshedSettings, socket.tabId) ?? await getActiveAddressEntry(firstSignerAccount)
+		let refreshedActiveAddress = await getActiveAddressForRequest(refreshedSettings, websiteTabConnections, socket.tabId)
+		if (refreshedActiveAddress === undefined) {
+			const signerStateToken = getConfirmedSignerStateToken(websiteTabConnections, socket.tabId)
+			if (signerStateToken !== undefined) {
+				const firstSignerAddress = await getActiveAddressEntry(firstSignerAccount)
+				if (isSignerStateTokenCurrent(websiteTabConnections, signerStateToken)) refreshedActiveAddress = firstSignerAddress
+			}
+		}
 		if (refreshedActiveAddress === undefined) return replyWithEmptyAccountIdentity(websiteTabConnections, request)
 		const refreshedAccess = verifyAccess(websiteTabConnections, socket, false, websiteOrigin, refreshedActiveAddress, refreshedSettings, true)
 		if (refreshedAccess !== 'hasAccess') return replyWithEmptyAccountIdentity(websiteTabConnections, request)

--- a/app/ts/background/background.ts
+++ b/app/ts/background/background.ts
@@ -7,7 +7,7 @@ import { changeActiveAddress, changePage, confirmDialog, removeTransactionOrSign
 import { PASSTHROUGH_STATE, type ResolvedExecutionSimulationState, type ResolvedSimulationInput, type ResolvedSimulationState, type WebsiteCreatedEthereumUnsignedTransactionOrFailed, toResolvedExecutionSimulationState, toResolvedSimulationInput, toResolvedSimulationState } from '../types/visualizer-types.js'
 import type { WebsiteTabConnections } from '../types/user-interface-types.js'
 import { askForSignerAccountsFromSignerIfNotAvailable, interceptorAccessMetadataRefresh, requestAccessFromUser } from './windows/interceptorAccess.js'
-import { METAMASK_ERROR_FAILED_TO_PARSE_REQUEST, METAMASK_ERROR_NOT_AUTHORIZED, METAMASK_ERROR_NOT_CONNECTED_TO_CHAIN, ERROR_INTERCEPTOR_DISABLED, NEW_BLOCK_ABORT } from '../utils/constants.js'
+import { METAMASK_ERROR_FAILED_TO_PARSE_REQUEST, METAMASK_ERROR_NOT_AUTHORIZED, METAMASK_ERROR_NOT_CONNECTED_TO_CHAIN, METAMASK_ERROR_PROVIDER_DISCONNECTED, ERROR_INTERCEPTOR_DISABLED, NEW_BLOCK_ABORT } from '../utils/constants.js'
 import { clearWebsiteConnectionIntent, hasAccess as getWebsiteAccessApprovalState, hasAddressAccess as getWebsiteAddressAccessApprovalState, persistWebsiteAccessChange, sendActiveAccountChangeToApprovedWebsitePorts, sendMessageToApprovedWebsitePorts, sendProviderConnectionEventsToPort, updateWebsiteApprovalAccesses, verifyAccess, withSuppressedUnscopedConnectionEventsForSocket } from './accessManagement.js'
 import { getActiveAddressEntry, identifyAddress } from './metadataUtils.js'
 import { getActiveAddress, sendPopupMessageToOpenWindows } from './backgroundUtils.js'
@@ -36,6 +36,7 @@ import { updatePopupVisualisationIfNeeded } from './popupVisualisationUpdater.js
 import type { TokenPriceService } from '../simulation/services/priceEstimator.js'
 import type { ResetSimulationServices } from '../simulation/serviceLifecycle.js'
 import { isAccountConnectionMethod, isAccountOnlyMethod } from './accountRequestMethods.js'
+import type { ErrorWithCodeAndOptionalData } from '../types/error.js'
 
 const simulationAbortController = new AbortController()
 const JSON_RPC_METHOD_NOT_FOUND = -32601
@@ -501,16 +502,26 @@ async function discoverAccountRequestAddressContext(
 ) {
 	const settings = await getSettings()
 	const activeAddress = await getActiveAddress(settings, socket.tabId)
-	if (activeAddress !== undefined) return { settings, activeAddress, requestedSignerAccountsForSiteAccess: false }
-	if (!isAccountConnectionMethod(request.method)) return { settings, activeAddress, requestedSignerAccountsForSiteAccess: false }
-	if (getWebsiteAccessApprovalState(settings.websiteAccess, websiteOrigin) !== 'hasAccess') return { settings, activeAddress, requestedSignerAccountsForSiteAccess: false }
+	if (activeAddress !== undefined) return { settings, activeAddress, requestedSignerAccountsForSiteAccess: false, signerAccountError: undefined }
+	if (!isAccountConnectionMethod(request.method)) return { settings, activeAddress, requestedSignerAccountsForSiteAccess: false, signerAccountError: undefined }
+	if (getWebsiteAccessApprovalState(settings.websiteAccess, websiteOrigin) !== 'hasAccess') return { settings, activeAddress, requestedSignerAccountsForSiteAccess: false, signerAccountError: undefined }
 
-	const accounts = await askForSignerAccountsFromSignerIfNotAvailable(websiteTabConnections, socket, true)
+	const signerAccountsResult = await askForSignerAccountsFromSignerIfNotAvailable(websiteTabConnections, socket, true)
 	const refreshedSettings = await getSettings()
 	const refreshedActiveAddress = await getActiveAddress(refreshedSettings, socket.tabId)
-	if (refreshedActiveAddress !== undefined) return { settings: refreshedSettings, activeAddress: refreshedActiveAddress, requestedSignerAccountsForSiteAccess: true }
-	const firstSignerAddress = accounts[0] === undefined ? undefined : await getActiveAddressEntry(accounts[0])
-	return { settings: refreshedSettings, activeAddress: firstSignerAddress, requestedSignerAccountsForSiteAccess: true }
+	if (refreshedActiveAddress !== undefined) return { settings: refreshedSettings, activeAddress: refreshedActiveAddress, requestedSignerAccountsForSiteAccess: true, signerAccountError: signerAccountsResult.error }
+	const firstSignerAddress = signerAccountsResult.accounts[0] === undefined ? undefined : await getActiveAddressEntry(signerAccountsResult.accounts[0])
+	return { settings: refreshedSettings, activeAddress: firstSignerAddress, requestedSignerAccountsForSiteAccess: true, signerAccountError: signerAccountsResult.error }
+}
+
+const isSignerProviderDisconnectedError = (error: ErrorWithCodeAndOptionalData | undefined): error is ErrorWithCodeAndOptionalData => error?.code === METAMASK_ERROR_PROVIDER_DISCONNECTED
+
+function replyWithSignerAccountError(websiteTabConnections: WebsiteTabConnections, request: InterceptedRequest, error: ErrorWithCodeAndOptionalData) {
+	return replyToInterceptedRequest(websiteTabConnections, {
+		type: 'result',
+		...getRequestWithDefinedParams(request),
+		error,
+	})
 }
 
 export const handleInterceptedRequest = async (port: browser.runtime.Port | undefined, websiteOrigin: string, websitePromise: Promise<Website> | Website, ethereum: EthereumClientService, tokenPriceService: TokenPriceService, resetSimulationServices: ResetSimulationServices, socket: WebsiteSocket, request: InterceptedRequest, websiteTabConnections: WebsiteTabConnections, publishRpcConnectionStatus: PublishRpcConnectionStatus): Promise<unknown> => {
@@ -538,7 +549,8 @@ export const handleInterceptedRequest = async (port: browser.runtime.Port | unde
 		const message: InpageScriptRequest = { uniqueRequestIdentifier: request.uniqueRequestIdentifier, ...providerHandlerReturn }
 		return replyToInterceptedRequest(websiteTabConnections, message)
 	}
-	const { settings, activeAddress, requestedSignerAccountsForSiteAccess } = await discoverAccountRequestAddressContext(websiteTabConnections, socket, request, websiteOrigin)
+	const { settings, activeAddress, requestedSignerAccountsForSiteAccess, signerAccountError } = await discoverAccountRequestAddressContext(websiteTabConnections, socket, request, websiteOrigin)
+	if (isSignerProviderDisconnectedError(signerAccountError)) return replyWithSignerAccountError(websiteTabConnections, request, signerAccountError)
 	if (requestedSignerAccountsForSiteAccess && activeAddress === undefined) {
 		if (getWebsiteAccessApprovalState(settings.websiteAccess, websiteOrigin) === 'interceptorDisabled') return replyToInterceptedRequest(websiteTabConnections, { type: 'result', ...getRequestWithDefinedParams(request), ...ERROR_INTERCEPTOR_DISABLED })
 		return refuseAccess(websiteTabConnections, request)
@@ -559,13 +571,16 @@ export const handleInterceptedRequest = async (port: browser.runtime.Port | unde
 	if (access === 'hasAccess' && activeAddress === undefined && accountConnectionRequest) {
 		// user has granted access to the site, but not to this account and the application is requesting accounts
 		if (requestedSignerAccountsForSiteAccess) return refuseAccess(websiteTabConnections, request)
-		const account = await askForSignerAccountsFromSignerIfNotAvailable(websiteTabConnections, socket, true)
-		if (account.length === 0) return refuseAccess(websiteTabConnections, request)
+		const signerAccountsResult = await askForSignerAccountsFromSignerIfNotAvailable(websiteTabConnections, socket, true)
+		if (isSignerProviderDisconnectedError(signerAccountsResult.error)) return replyWithSignerAccountError(websiteTabConnections, request, signerAccountsResult.error)
+		if (signerAccountsResult.accounts.length === 0) return refuseAccess(websiteTabConnections, request)
 		const result: unknown = await handleInterceptedRequest(port, websiteOrigin, websitePromise, ethereum, tokenPriceService, resetSimulationServices, socket, request, websiteTabConnections, publishRpcConnectionStatus)
 		return result
 	}
 	if (access === 'hasAccess' && activeAddress === undefined && (request.method === 'eth_accounts' || request.method === 'wallet_getPermissions') && (!settings.simulationMode || settings.useSignersAddressAsActiveAddress)) {
-		const signerAccounts = await askForSignerAccountsFromSignerIfNotAvailable(websiteTabConnections, socket, false)
+		const signerAccountsResult = await askForSignerAccountsFromSignerIfNotAvailable(websiteTabConnections, socket, false)
+		if (isSignerProviderDisconnectedError(signerAccountsResult.error)) return replyWithSignerAccountError(websiteTabConnections, request, signerAccountsResult.error)
+		const signerAccounts = signerAccountsResult.accounts
 		if (signerAccounts.length === 0) return replyWithEmptyAccountIdentity(websiteTabConnections, request)
 		const firstSignerAccount = signerAccounts[0]
 		if (firstSignerAccount === undefined) return replyWithEmptyAccountIdentity(websiteTabConnections, request)

--- a/app/ts/background/messageSending.ts
+++ b/app/ts/background/messageSending.ts
@@ -43,7 +43,7 @@ export async function replyToInterceptedRequestAfterManifestV2Reconnect(websiteT
 }
 
 export function sendSubscriptionReplyOrCallBackToPort(port: browser.runtime.Port, message: SubscriptionReplyOrCallBack) {
-	postMessageToPortIfConnected(port, {...message, interceptorApproved: true })
+	return postMessageToPortIfConnected(port, {...message, interceptorApproved: true })
 }
 
 export function sendSubscriptionReplyOrCallBack(websiteTabConnections: WebsiteTabConnections, socket: WebsiteSocket, message: SubscriptionReplyOrCallBack) {

--- a/app/ts/background/popupMessageHandlers.ts
+++ b/app/ts/background/popupMessageHandlers.ts
@@ -4,7 +4,7 @@ import { getPendingTransactionsAndMessages, getCurrentTabId, getTabState, saveCu
 import { parseEvents, parseInputData } from '../simulation/parsing.js'
 import { type ChangeActiveAddress, type ModifyMakeMeRich, type ChangePage, type RemoveTransaction, type RequestAccountsFromSigner, type TransactionConfirmation, type InterceptorAccess, type ChangeInterceptorAccess, type ChainChangeConfirmation, type EnableSimulationMode, type ChangeActiveChain, type AddOrEditAddressBookEntry, type GetAddressBookData, type RemoveAddressBookEntry, type InterceptorAccessRefresh, type InterceptorAccessChangeAddress, type Settings, type ChangeSettings, type ImportSettings, type ImportSettingsReply, type SetRpcList, type UpdateHomePage, type SimulateGovernanceContractExecution, type ChangeAddOrModifyAddressWindowState, type OpenWebPage, type DisableInterceptor, type SetEnsNameForHash, UpdateConfirmTransactionDialog, UpdateConfirmTransactionDialogPendingTransactions, type BlockOrAllowExternalRequests, type RemoveWebsiteAccess, type AllowOrPreventAddressAccessForWebsite, type RemoveWebsiteAddressAccess, type ForceSetGasLimitForTransaction, type RetrieveWebsiteAccess, type ChangePreSimulationBlockTimeManipulation, type SetTransactionOrMessageBlockTimeManipulator, type FetchSimulationStackRequestConfirmation, type ImportSimulationStack, type PopupReadyAndListeningPage } from '../types/interceptor-messages.js'
 import { formEthSendTransaction, formSendRawTransaction, resolvePendingTransactionOrMessage, updateConfirmTransactionView, setGasLimitForTransaction, toPopupPendingTransactionOrSignableMessage } from './windows/confirmTransaction.js'
-import { askForSignerAccountsFromSignerIfNotAvailable, getAddressMetadataForAccess, requestAddressChange, resolveInterceptorAccess } from './windows/interceptorAccess.js'
+import { askForSignerAccountsFromSignerIfNotAvailable, getAddressMetadataForAccess, refreshSignerAccountsFromApprovedWebsitePorts, requestAddressChange, resolveInterceptorAccess } from './windows/interceptorAccess.js'
 import { resolveChainChange } from './windows/changeChain.js'
 import { sendMessageToApprovedWebsitePorts, setInterceptorDisabledForWebsite, updateWebsiteApprovalAccesses } from './accessManagement.js'
 import { getActiveOrFirstSignerAddress, getHtmlFile, sendPopupMessageToOpenWindows } from './backgroundUtils.js'
@@ -180,15 +180,15 @@ async function getSignerAccount() {
 export async function changeActiveAddress(ethereum: EthereumClientService, tokenPriceService: TokenPriceService, resetSimulationServices: ResetSimulationServices, websiteTabConnections: WebsiteTabConnections, addressChange: ChangeActiveAddress) {
 	// if using signers address, set the active address to signers address if available, otherwise we don't know active address and set it to be undefined
 	if (addressChange.data.activeAddress === 'signer') {
-		const signerAccount = await getSignerAccount()
-		await setUseSignersAddressAsActiveAddress(addressChange.data.activeAddress === 'signer', signerAccount)
-		sendMessageToApprovedWebsitePorts(websiteTabConnections, { method: 'request_signer_to_eth_accounts', result: [] })
+		await setUseSignersAddressAsActiveAddress(true, await getSignerAccount())
+		await refreshSignerAccountsFromApprovedWebsitePorts(websiteTabConnections, false)
 		sendMessageToApprovedWebsitePorts(websiteTabConnections, { method: 'request_signer_chainId', result: [] })
+		const signerAccount = await getSignerAccount()
 
-			await changeActiveAddressAndChain(ethereum, tokenPriceService, resetSimulationServices, websiteTabConnections, {
-				simulationMode: addressChange.data.simulationMode,
-				activeAddress: signerAccount,
-			})
+		await changeActiveAddressAndChain(ethereum, tokenPriceService, resetSimulationServices, websiteTabConnections, {
+			simulationMode: addressChange.data.simulationMode,
+			activeAddress: signerAccount,
+		})
 		} else {
 			await setUseSignersAddressAsActiveAddress(false)
 			await changeActiveAddressAndChain(ethereum, tokenPriceService, resetSimulationServices, websiteTabConnections, {
@@ -261,7 +261,7 @@ export const changePage = async (page: ChangePage) => await setPage(page.data)
 
 export async function requestAccountsFromSigner(websiteTabConnections: WebsiteTabConnections, params: RequestAccountsFromSigner) {
 	if (params.data) {
-		sendMessageToApprovedWebsitePorts(websiteTabConnections, { method: 'request_signer_to_eth_requestAccounts', result: [] })
+		await refreshSignerAccountsFromApprovedWebsitePorts(websiteTabConnections, true)
 		sendMessageToApprovedWebsitePorts(websiteTabConnections, { method: 'request_signer_chainId', result: [] })
 	}
 }
@@ -455,7 +455,7 @@ export async function enableSimulationMode(ethereum: EthereumClientService, toke
 	const settings = await getSettings()
 	// if we are on unsupported chain, force change to a supported one
 	if (settings.useSignersAddressAsActiveAddress || params.data === false) {
-		sendMessageToApprovedWebsitePorts(websiteTabConnections, { method: 'request_signer_to_eth_accounts', result: [] })
+		await refreshSignerAccountsFromApprovedWebsitePorts(websiteTabConnections, false)
 		sendMessageToApprovedWebsitePorts(websiteTabConnections, { method: 'request_signer_chainId', result: [] })
 		const tabId = await getLastKnownCurrentTabId()
 		const chainToSwitch = tabId === undefined ? undefined : (await getTabState(tabId)).signerChain

--- a/app/ts/background/popupMessageHandlers.ts
+++ b/app/ts/background/popupMessageHandlers.ts
@@ -6,8 +6,9 @@ import { type ChangeActiveAddress, type ModifyMakeMeRich, type ChangePage, type 
 import { formEthSendTransaction, formSendRawTransaction, resolvePendingTransactionOrMessage, updateConfirmTransactionView, setGasLimitForTransaction, toPopupPendingTransactionOrSignableMessage } from './windows/confirmTransaction.js'
 import { askForSignerAccountsFromSignerIfNotAvailable, getAddressMetadataForAccess, refreshSignerAccountsFromApprovedWebsitePorts, requestAddressChange, resolveInterceptorAccess } from './windows/interceptorAccess.js'
 import { resolveChainChange } from './windows/changeChain.js'
-import { sendMessageToApprovedWebsitePorts, setInterceptorDisabledForWebsite, updateWebsiteApprovalAccesses } from './accessManagement.js'
+import { setInterceptorDisabledForWebsite, updateWebsiteApprovalAccesses } from './accessManagement.js'
 import { getActiveOrFirstSignerAddress, getHtmlFile, sendPopupMessageToOpenWindows } from './backgroundUtils.js'
+import { getConfirmedSignerStateToken, isSignerStateTokenCurrent, sendCallbackToAllConfirmedSignerOwners } from './signerStateOwnership.js'
 import { findEntryWithSymbolOrName, getMetadataForAddressBookData } from './medataSearch.js'
 import { getActiveAddressEntry, getActiveAddresses, identifyAddress } from './metadataUtils.js'
 import type { TabState, WebsiteTabConnections } from '../types/user-interface-types.js'
@@ -182,7 +183,7 @@ export async function changeActiveAddress(ethereum: EthereumClientService, token
 	if (addressChange.data.activeAddress === 'signer') {
 		await setUseSignersAddressAsActiveAddress(true, await getSignerAccount())
 		await refreshSignerAccountsFromApprovedWebsitePorts(websiteTabConnections, false)
-		sendMessageToApprovedWebsitePorts(websiteTabConnections, { method: 'request_signer_chainId', result: [] })
+		sendCallbackToAllConfirmedSignerOwners(websiteTabConnections, { method: 'request_signer_chainId', result: [] })
 		const signerAccount = await getSignerAccount()
 
 		await changeActiveAddressAndChain(ethereum, tokenPriceService, resetSimulationServices, websiteTabConnections, {
@@ -262,7 +263,7 @@ export const changePage = async (page: ChangePage) => await setPage(page.data)
 export async function requestAccountsFromSigner(websiteTabConnections: WebsiteTabConnections, params: RequestAccountsFromSigner) {
 	if (params.data) {
 		await refreshSignerAccountsFromApprovedWebsitePorts(websiteTabConnections, true)
-		sendMessageToApprovedWebsitePorts(websiteTabConnections, { method: 'request_signer_chainId', result: [] })
+		sendCallbackToAllConfirmedSignerOwners(websiteTabConnections, { method: 'request_signer_chainId', result: [] })
 	}
 }
 
@@ -444,7 +445,7 @@ export async function refreshPopupConfirmTransactionSimulation(ethereum: Ethereu
 }
 
 export async function popupChangeActiveRpc(ethereum: EthereumClientService, tokenPriceService: TokenPriceService, resetSimulationServices: ResetSimulationServices, websiteTabConnections: WebsiteTabConnections, params: ChangeActiveChain, settings: Settings) {
-	return await changeActiveRpc(ethereum, tokenPriceService, resetSimulationServices, websiteTabConnections, params.data, settings.simulationMode)
+	await changeActiveRpc(ethereum, tokenPriceService, resetSimulationServices, websiteTabConnections, params.data, settings.simulationMode, await getLastKnownCurrentTabId())
 }
 
 export async function changeChainDialog(ethereum: EthereumClientService, tokenPriceService: TokenPriceService, resetSimulationServices: ResetSimulationServices, websiteTabConnections: WebsiteTabConnections, chainChange: ChainChangeConfirmation) {
@@ -456,7 +457,7 @@ export async function enableSimulationMode(ethereum: EthereumClientService, toke
 	// if we are on unsupported chain, force change to a supported one
 	if (settings.useSignersAddressAsActiveAddress || params.data === false) {
 		await refreshSignerAccountsFromApprovedWebsitePorts(websiteTabConnections, false)
-		sendMessageToApprovedWebsitePorts(websiteTabConnections, { method: 'request_signer_chainId', result: [] })
+		sendCallbackToAllConfirmedSignerOwners(websiteTabConnections, { method: 'request_signer_chainId', result: [] })
 		const tabId = await getLastKnownCurrentTabId()
 		const chainToSwitch = tabId === undefined ? undefined : (await getTabState(tabId)).signerChain
 		const networkToSwitch = chainToSwitch === undefined ? (await getRpcList())[0] : await getPrimaryRpcForChain(chainToSwitch)
@@ -972,6 +973,14 @@ async function getCachedRichData() {
 	}
 }
 
+async function getActiveAddressForCurrentPopupSignerState(settings: Settings, websiteTabConnections: WebsiteTabConnections, tabId: number) {
+	if (settings.simulationMode && !settings.useSignersAddressAsActiveAddress) return await getActiveOrFirstSignerAddress(settings, tabId)
+	const signerStateToken = getConfirmedSignerStateToken(websiteTabConnections, tabId)
+	if (signerStateToken === undefined) return undefined
+	const activeAddress = await getActiveOrFirstSignerAddress(settings, tabId)
+	return isSignerStateTokenCurrent(websiteTabConnections, signerStateToken) ? activeAddress : undefined
+}
+
 async function buildHomePageUpdate(
 	ethereum: EthereumClientService,
 	websiteTabConnections: WebsiteTabConnections,
@@ -1006,7 +1015,7 @@ async function buildHomePageUpdate(
 	const settings = await settingsPromise
 	let tabState = await tabStatePromise
 	tabState = await refreshSignerAccountsForTabIfNeeded(websiteTabConnections, tabId, tabState, shouldRefreshSignerAccounts)
-	const activeSigningAddress = tabId === undefined ? undefined : (await getActiveOrFirstSignerAddress(settings, tabId))?.address
+	const activeSigningAddress = tabId === undefined ? undefined : (await getActiveAddressForCurrentPopupSignerState(settings, websiteTabConnections, tabId))?.address
 	const websiteOrigin = tabState.website?.websiteOrigin
 	const interceptorDisabled = websiteOrigin === undefined ? false : settings.websiteAccess.find((entry) => entry.website.websiteOrigin === websiteOrigin && entry.interceptorDisabled === true) !== undefined
 	const richData = await richDataPromise

--- a/app/ts/background/popupMessageHandlers.ts
+++ b/app/ts/background/popupMessageHandlers.ts
@@ -8,7 +8,7 @@ import { askForSignerAccountsFromSignerIfNotAvailable, getAddressMetadataForAcce
 import { resolveChainChange } from './windows/changeChain.js'
 import { setInterceptorDisabledForWebsite, updateWebsiteApprovalAccesses } from './accessManagement.js'
 import { getActiveOrFirstSignerAddress, getHtmlFile, sendPopupMessageToOpenWindows } from './backgroundUtils.js'
-import { getConfirmedSignerStateToken, isSignerStateTokenCurrent, sendCallbackToAllConfirmedSignerOwners } from './signerStateOwnership.js'
+import { getActiveAddressForCurrentSignerState, sendCallbackToAllConfirmedSignerOwners } from './signerStateOwnership.js'
 import { findEntryWithSymbolOrName, getMetadataForAddressBookData } from './medataSearch.js'
 import { getActiveAddressEntry, getActiveAddresses, identifyAddress } from './metadataUtils.js'
 import type { TabState, WebsiteTabConnections } from '../types/user-interface-types.js'
@@ -974,11 +974,7 @@ async function getCachedRichData() {
 }
 
 async function getActiveAddressForCurrentPopupSignerState(settings: Settings, websiteTabConnections: WebsiteTabConnections, tabId: number) {
-	if (settings.simulationMode && !settings.useSignersAddressAsActiveAddress) return await getActiveOrFirstSignerAddress(settings, tabId)
-	const signerStateToken = getConfirmedSignerStateToken(websiteTabConnections, tabId)
-	if (signerStateToken === undefined) return undefined
-	const activeAddress = await getActiveOrFirstSignerAddress(settings, tabId)
-	return isSignerStateTokenCurrent(websiteTabConnections, signerStateToken) ? activeAddress : undefined
+	return await getActiveAddressForCurrentSignerState(websiteTabConnections, settings, tabId, async () => await getActiveOrFirstSignerAddress(settings, tabId))
 }
 
 async function buildHomePageUpdate(

--- a/app/ts/background/providerMessageHandlers.ts
+++ b/app/ts/background/providerMessageHandlers.ts
@@ -28,15 +28,16 @@ export async function ethAccountsReply(ethereum: EthereumClientService, tokenPri
 	if (signerAccountsReply.type === 'error') {
 		const stringifiedData = signerAccountsReply.error.data ? JSON.stringify(signerAccountsReply.error.data) : undefined
 		const error = signerAccountsReply.error
+		const signerAccountError = {
+			code: error.code,
+			message: error.message,
+			...(stringifiedData !== undefined ? { data: stringifiedData } : {}),
+		}
 		await updateTabState(port.sender.tab.id, (previousState: TabState) => modifyObject(previousState, {
-			signerAccountError: {
-				code: error.code,
-				message: error.message,
-				...(stringifiedData !== undefined ? { data: stringifiedData } : {}),
-			}
+			signerAccountError,
 		}))
 		// Wake requesters waiting for a signer accounts round-trip even when the signer rejected or errored.
-		if (socket) sendInternalWindowMessage({ method: 'window_signer_accounts_changed', data: { socket } })
+		if (socket) sendInternalWindowMessage({ method: 'window_signer_accounts_changed', data: { socket, error: signerAccountError } })
 		await sendPopupMessageToOpenWindows({ method: 'popup_accounts_update' })
 		return returnValue
 	}

--- a/app/ts/background/providerMessageHandlers.ts
+++ b/app/ts/background/providerMessageHandlers.ts
@@ -3,9 +3,9 @@ import type { TabState, WebsiteTabConnections } from '../types/user-interface-ty
 import { EthereumAccountsReply, EthereumChainReply } from '../types/JsonRpc-types.js'
 import { changeActiveAddressAndChain } from './background.js'
 import { getSocketFromPort, sendInternalWindowMessage, sendPopupMessageToOpenWindows } from './backgroundUtils.js'
-import { getRpcNetworkForChain, getTabState, setDefaultSignerName, updatePendingTransactionOrMessage, updateTabState } from './storageVariables.js'
+import { getRpcNetworkForChain, setDefaultSignerName, updatePendingTransactionOrMessage, updateTabState } from './storageVariables.js'
 import { getMetamaskCompatibilityMode, getSettings } from './settings.js'
-import { resolveSignerChainChange } from './windows/changeChain.js'
+import { getPendingSignerChainChangeTokenForCallback, isPendingSignerChainChangeReply, resolveSignerChainChange } from './windows/changeChain.js'
 import { type ApprovalState, withSuppressedUnscopedConnectionEventsForSocketAsync } from './accessManagement.js'
 import type { ProviderMessage } from '../utils/requests.js'
 import { METAMASK_ERROR_USER_REJECTED_REQUEST } from '../utils/constants.js'
@@ -17,69 +17,115 @@ import type { EthereumClientService } from '../simulation/services/EthereumClien
 import type { TokenPriceService } from '../simulation/services/priceEstimator.js'
 import type { ResetSimulationServices } from '../simulation/serviceLifecycle.js'
 import { isSignerMissing } from '../utils/signerMetadata.js'
+import { beginSignerStateConfirmation, clearSignerDerivedTabState, confirmSignerState, getConfirmedSignerStateToken, isCurrentWebsiteConnection, isSignerStateTokenCurrent, runSignerStateOperation, signerConnectionReplacedError, tabHasApprovedWebsiteConnection, type SignerStateToken } from './signerStateOwnership.js'
+
+function getSignerCallbackToken(websiteTabConnections: WebsiteTabConnections, port: browser.runtime.Port, signerProviderGeneration: number) {
+	const socket = getSocketFromPort(port)
+	if (socket === undefined) return undefined
+	const token = getConfirmedSignerStateToken(websiteTabConnections, socket.tabId)
+	if (token === undefined) return undefined
+	if (token.socket.connectionName !== socket.connectionName || token.port !== port) return undefined
+	if (token.signerProviderGeneration !== signerProviderGeneration) return undefined
+	return token
+}
+
+async function getConnectedToSignerResult() {
+	return { type: 'result' as const, method: 'connected_to_signer' as const, result: { metamaskCompatibilityMode: await getMetamaskCompatibilityMode() } }
+}
+
+function hasSignerCallbackAccess(websiteTabConnections: WebsiteTabConnections, tabId: number, approval: ApprovalState) {
+	return approval === 'hasAccess' || tabHasApprovedWebsiteConnection(websiteTabConnections, tabId)
+}
 
 export async function ethAccountsReply(ethereum: EthereumClientService, tokenPriceService: TokenPriceService, resetSimulationServices: ResetSimulationServices, websiteTabConnections: WebsiteTabConnections, port: browser.runtime.Port, request: ProviderMessage, approval: ApprovalState, _activeAddress: bigint | undefined) {
 	const returnValue = { type: 'result' as const, method: 'eth_accounts_reply' as const, result: '0x' as const }
-	if (approval !== 'hasAccess') return returnValue
 	if (!('params' in request)) return returnValue
 	if (port.sender?.tab?.id === undefined) return returnValue
+	const tabId = port.sender.tab.id
+	if (!hasSignerCallbackAccess(websiteTabConnections, tabId, approval)) return returnValue
 
 	const [signerAccountsReply] = EthereumAccountsReply.parse(request.params)
-	const socket = getSocketFromPort(port)
-	if (signerAccountsReply.type === 'error') {
-		const stringifiedData = signerAccountsReply.error.data ? JSON.stringify(signerAccountsReply.error.data) : undefined
-		const error = signerAccountsReply.error
-		const signerAccountError = {
-			code: error.code,
-			message: error.message,
-			...(stringifiedData !== undefined ? { data: stringifiedData } : {}),
+	return await runSignerStateOperation(websiteTabConnections, tabId, async () => {
+		const signerStateToken = getSignerCallbackToken(websiteTabConnections, port, signerAccountsReply.signerProviderGeneration)
+		if (signerStateToken === undefined) return returnValue
+		if (signerAccountsReply.type === 'error') {
+			const stringifiedData = signerAccountsReply.error.data ? JSON.stringify(signerAccountsReply.error.data) : undefined
+			const error = signerAccountsReply.error
+			const signerAccountError = {
+				code: error.code,
+				message: error.message,
+				...(stringifiedData !== undefined ? { data: stringifiedData } : {}),
+			}
+			// Signer discovery reports local absence through this request-scoped error so account requests can settle.
+			// The connected_to_signer message owns the persistent NoSigner state; only actual wallet errors belong in the popup.
+			if (signerAccountsReply.signerUnavailable !== true) {
+				await updateTabState(tabId, (previousState: TabState) => modifyObject(previousState, { signerAccountError }))
+			}
+			if (!isSignerStateTokenCurrent(websiteTabConnections, signerStateToken)) return returnValue
+			// Wake requesters waiting for a signer accounts round-trip even when the signer rejected or errored.
+			sendInternalWindowMessage({
+				method: 'window_signer_accounts_changed',
+				data: {
+					socket: signerStateToken.socket,
+					signerStateOwnerGeneration: signerStateToken.ownerGeneration,
+					signerProviderGeneration: signerStateToken.signerProviderGeneration,
+					error: signerAccountError,
+				},
+			})
+			await sendPopupMessageToOpenWindows({ method: 'popup_accounts_update' })
+			return returnValue
 		}
-		// Signer discovery reports local absence through this request-scoped error so account requests can settle.
-		// The connected_to_signer message owns the persistent NoSigner state; only actual wallet errors belong in the popup.
-		if (signerAccountsReply.signerUnavailable !== true) {
-			await updateTabState(port.sender.tab.id, (previousState: TabState) => modifyObject(previousState, {
-				signerAccountError,
-			}))
-		}
-		// Wake requesters waiting for a signer accounts round-trip even when the signer rejected or errored.
-		if (socket) sendInternalWindowMessage({ method: 'window_signer_accounts_changed', data: { socket, error: signerAccountError } })
-		await sendPopupMessageToOpenWindows({ method: 'popup_accounts_update' })
-		return returnValue
-	}
-	const signerAccounts = signerAccountsReply.accounts
-	const activeSigningAddress = signerAccounts.length > 0 ? signerAccounts[0] : undefined
-	const tabStateChange = await updateTabState(port.sender.tab.id, (previousState: TabState) => modifyObject(previousState, { ...signerAccounts.length > 0 ? { signerAccountError: undefined } : {}, signerAccounts, activeSigningAddress }))
-	sendPopupMessageToOpenWindows({ method: 'popup_activeSigningAddressChanged', data: { tabId: port.sender.tab.id, activeSigningAddress } })
-	if (socket) sendInternalWindowMessage({ method: 'window_signer_accounts_changed', data: { socket } })
-	// update active address if we are using signers address
-	const settings = await getSettings()
-	if ((settings.useSignersAddressAsActiveAddress && settings.activeSimulationAddress !== signerAccounts[0])
-	|| (settings.simulationMode === false && tabStateChange.previousState.activeSigningAddress !== tabStateChange.newState.activeSigningAddress)) {
-		const changeActiveAddress = () => changeActiveAddressAndChain(ethereum, tokenPriceService, resetSimulationServices, websiteTabConnections, {
-			simulationMode: settings.simulationMode,
-			activeAddress: tabStateChange.newState.activeSigningAddress,
+		const signerAccounts = signerAccountsReply.accounts
+		const activeSigningAddress = signerAccounts.length > 0 ? signerAccounts[0] : undefined
+		const tabStateChange = await updateTabState(tabId, (previousState: TabState) => modifyObject(previousState, {
+			...signerAccounts.length > 0 ? { signerAccountError: undefined } : {},
+			signerAccounts,
+			activeSigningAddress,
+		}))
+		if (!isSignerStateTokenCurrent(websiteTabConnections, signerStateToken)) return returnValue
+		await sendPopupMessageToOpenWindows({ method: 'popup_activeSigningAddressChanged', data: { tabId, activeSigningAddress } })
+		sendInternalWindowMessage({
+			method: 'window_signer_accounts_changed',
+			data: {
+				socket: signerStateToken.socket,
+				signerStateOwnerGeneration: signerStateToken.ownerGeneration,
+				signerProviderGeneration: signerStateToken.signerProviderGeneration,
+			},
 		})
-		if (signerAccountsReply.requestAccounts && socket !== undefined) {
-			await withSuppressedUnscopedConnectionEventsForSocketAsync(socket, changeActiveAddress)
-		} else {
-			await changeActiveAddress()
+		// Update the active address if we are using the signer's address. This remains inside the signer-state
+		// operation so a reconnect cannot interleave with the downstream address and chain mutations.
+		const settings = await getSettings()
+		if ((settings.useSignersAddressAsActiveAddress && settings.activeSimulationAddress !== signerAccounts[0])
+		|| (settings.simulationMode === false && tabStateChange.previousState.activeSigningAddress !== tabStateChange.newState.activeSigningAddress)) {
+			const changeActiveAddress = async () => await changeActiveAddressAndChain(ethereum, tokenPriceService, resetSimulationServices, websiteTabConnections, {
+				simulationMode: settings.simulationMode,
+				activeAddress: tabStateChange.newState.activeSigningAddress,
+			})
+			if (signerAccountsReply.requestAccounts) {
+				await withSuppressedUnscopedConnectionEventsForSocketAsync(signerStateToken.socket, changeActiveAddress)
+			} else {
+				await changeActiveAddress()
+			}
+			await sendPopupMessageToOpenWindows({ method: 'popup_accounts_update' })
 		}
-		await sendPopupMessageToOpenWindows({ method: 'popup_accounts_update' })
-	}
-	return returnValue
+		return returnValue
+	})
 }
 
-async function changeSignerChain(ethereum: EthereumClientService, tokenPriceService: TokenPriceService, resetSimulationServices: ResetSimulationServices, websiteTabConnections: WebsiteTabConnections, port: browser.runtime.Port, signerChain: bigint, approval: ApprovalState, _activeAddress: bigint | undefined) {
+async function changeSignerChain(ethereum: EthereumClientService, tokenPriceService: TokenPriceService, resetSimulationServices: ResetSimulationServices, websiteTabConnections: WebsiteTabConnections, signerStateToken: SignerStateToken, signerChain: bigint, approval: ApprovalState, _activeAddress: bigint | undefined) {
 	if (approval !== 'hasAccess') return
-	if (port.sender?.tab?.id === undefined) return
-	const oldSignerChain = (await getTabState(port.sender.tab.id)).signerChain
-	if (oldSignerChain !== signerChain) await updateTabState(port.sender.tab.id, (previousState: TabState) => modifyObject(previousState, { signerChain }))
+	const tabStateChange = await updateTabState(signerStateToken.socket.tabId, (previousState: TabState) => {
+		return previousState.signerChain === signerChain ? previousState : modifyObject(previousState, { signerChain })
+	})
+	if (!isSignerStateTokenCurrent(websiteTabConnections, signerStateToken)) return
+	const oldSignerChain = tabStateChange.previousState.signerChain
 	// update active address if we are using signers address
 	const settings = await getSettings()
 	if ((settings.useSignersAddressAsActiveAddress || !settings.simulationMode) && settings.activeRpcNetwork.chainId !== signerChain) {
+		const rpcNetwork = await getRpcNetworkForChain(signerChain)
 		return changeActiveAddressAndChain(ethereum, tokenPriceService, resetSimulationServices, websiteTabConnections, {
 			simulationMode: settings.simulationMode,
-			rpcNetwork: await getRpcNetworkForChain(signerChain),
+			rpcNetwork,
 		})
 	}
 	if (oldSignerChain !== signerChain) sendPopupMessageToOpenWindows({ method: 'popup_chain_update' })
@@ -88,83 +134,144 @@ async function changeSignerChain(ethereum: EthereumClientService, tokenPriceServ
 export async function signerChainChanged(ethereum: EthereumClientService, tokenPriceService: TokenPriceService, resetSimulationServices: ResetSimulationServices, websiteTabConnections: WebsiteTabConnections, port: browser.runtime.Port, request: ProviderMessage, approval: ApprovalState, activeAddress: bigint | undefined) {
 	const returnValue = { type: 'result' as const, method: 'signer_chainChanged' as const, result: '0x' as const }
 	if (!('params' in request)) return returnValue
-	const signerChain = EthereumChainReply.parse(request.params)[0]
-	if (signerChain === undefined) throw new Error('signer chain were undefined')
-	await changeSignerChain(ethereum, tokenPriceService, resetSimulationServices, websiteTabConnections, port, signerChain, approval, activeAddress)
-	return returnValue
+	const [signerChain, signerProviderGeneration] = EthereumChainReply.parse(request.params)
+	const socket = getSocketFromPort(port)
+	if (socket === undefined) return returnValue
+	if (!hasSignerCallbackAccess(websiteTabConnections, socket.tabId, approval)) return returnValue
+	return await runSignerStateOperation(websiteTabConnections, socket.tabId, async () => {
+		const signerStateToken = getSignerCallbackToken(websiteTabConnections, port, signerProviderGeneration)
+		if (signerStateToken === undefined) return returnValue
+		await changeSignerChain(ethereum, tokenPriceService, resetSimulationServices, websiteTabConnections, signerStateToken, signerChain, 'hasAccess', activeAddress)
+		return returnValue
+	})
 }
 
 export async function walletSwitchEthereumChainReply(ethereum: EthereumClientService, tokenPriceService: TokenPriceService, resetSimulationServices: ResetSimulationServices, websiteTabConnections: WebsiteTabConnections, port: browser.runtime.Port, request: ProviderMessage, approval: ApprovalState, activeAddress: bigint | undefined) {
 	const returnValue = { type: 'result' as const, method: 'wallet_switchEthereumChain_reply' as const, result: '0x' as const }
-	if (approval !== 'hasAccess') return returnValue
 	const params = WalletSwitchEthereumChainReply.parse(request).params[0]
-	if (params.accept) await changeSignerChain(ethereum, tokenPriceService, resetSimulationServices, websiteTabConnections, port, params.chainId, approval, activeAddress)
-	await resolveSignerChainChange({
-		method: 'popup_signerChangeChainDialog',
-		data: [params]
+	const socket = getSocketFromPort(port)
+	if (socket === undefined) return returnValue
+	return await runSignerStateOperation(websiteTabConnections, socket.tabId, async () => {
+		const currentSignerStateToken = getConfirmedSignerStateToken(websiteTabConnections, socket.tabId)
+		if (currentSignerStateToken?.socket.connectionName !== socket.connectionName || currentSignerStateToken.port !== port) return returnValue
+		const pendingSignerStateToken = getPendingSignerChainChangeTokenForCallback(port, params.signerProviderGeneration, params.chainId)
+		const callbackSignerStateToken = pendingSignerStateToken
+			?? (currentSignerStateToken.signerProviderGeneration === params.signerProviderGeneration ? currentSignerStateToken : undefined)
+		if (callbackSignerStateToken === undefined) return returnValue
+		const solicitedReply = isPendingSignerChainChangeReply(callbackSignerStateToken, params.chainId)
+		// A solicited wallet reply retains the tab authorization captured when its command was dispatched.
+		// Unsolicited chainChanged-style updates still require a currently approved frame.
+		if (!solicitedReply && !hasSignerCallbackAccess(websiteTabConnections, socket.tabId, approval)) return returnValue
+		if (currentSignerStateToken.signerProviderGeneration !== params.signerProviderGeneration) {
+			resolveSignerChainChange(callbackSignerStateToken, {
+				method: 'popup_signerChangeChainDialog',
+				data: [{ accept: false, chainId: params.chainId, error: signerConnectionReplacedError, signerProviderGeneration: params.signerProviderGeneration }],
+			})
+			return returnValue
+		}
+		if (params.accept) await changeSignerChain(ethereum, tokenPriceService, resetSimulationServices, websiteTabConnections, currentSignerStateToken, params.chainId, 'hasAccess', activeAddress)
+		resolveSignerChainChange(callbackSignerStateToken, {
+			method: 'popup_signerChangeChainDialog',
+			data: [params],
+		})
+		return returnValue
 	})
-	return returnValue
 }
 
-export async function connectedToSigner(_ethereum: EthereumClientService, _tokenPriceService: TokenPriceService, _resetSimulationServices: ResetSimulationServices, _websiteTabConnections: WebsiteTabConnections, port: browser.runtime.Port, request: ProviderMessage, approval: ApprovalState, _activeAddress: bigint | undefined) {
-	const [signerConnected, signerName] = ConnectedToSigner.parse(request).params
+export async function connectedToSigner(_ethereum: EthereumClientService, _tokenPriceService: TokenPriceService, _resetSimulationServices: ResetSimulationServices, websiteTabConnections: WebsiteTabConnections, port: browser.runtime.Port, request: ProviderMessage, approval: ApprovalState, _activeAddress: bigint | undefined) {
+	const [signerConnected, signerName, signerProviderGeneration] = ConnectedToSigner.parse(request).params
 	// MV2 and test ports may omit frameId. Treat those as the top frame, while preventing an
 	// unapproved MV3 child frame from taking ownership of tab-wide signer state.
 	const isTopFrame = port.sender?.frameId === undefined || port.sender.frameId === 0
 	if (approval !== 'hasAccess' && !isTopFrame) {
-		return { type: 'result' as const, method: 'connected_to_signer' as const, result: { metamaskCompatibilityMode: await getMetamaskCompatibilityMode() } }
+		return await getConnectedToSignerResult()
 	}
-	await setDefaultSignerName(signerName)
-	await updateTabState(request.uniqueRequestIdentifier.requestSocket.tabId, (previousState: TabState) => {
-		if (!isSignerMissing(signerName)) return modifyObject(previousState, { signerName, signerConnected })
-		return modifyObject(previousState, {
-			signerName,
-			signerConnected: false,
-			signerAccounts: [],
-			signerChain: undefined,
-			signerAccountError: undefined,
-			activeSigningAddress: undefined,
+	const socket = getSocketFromPort(port)
+	const requestSocket = request.uniqueRequestIdentifier.requestSocket
+	if (socket === undefined || socket.tabId !== requestSocket.tabId || socket.connectionName !== requestSocket.connectionName) return await getConnectedToSignerResult()
+	return await runSignerStateOperation(websiteTabConnections, socket.tabId, async () => {
+		const tabConnection = websiteTabConnections.get(socket.tabId)
+		if (!isCurrentWebsiteConnection(tabConnection, socket, port) || tabConnection?.signerStateOwnerConnectionName !== socket.connectionName) {
+			return await getConnectedToSignerResult()
+		}
+		const previousSignerProviderGeneration = tabConnection.signerProviderGeneration
+		if (tabConnection.signerStateOwnerConfirmed === true
+			&& previousSignerProviderGeneration !== undefined
+			&& signerProviderGeneration < previousSignerProviderGeneration) {
+			return await getConnectedToSignerResult()
+		}
+		const signerStateWasConfirmed = tabConnection.signerStateOwnerConfirmed === true
+		beginSignerStateConfirmation(tabConnection)
+		const signerMissing = isSignerMissing(signerName)
+		await updateTabState(socket.tabId, (previousState: TabState) => {
+			const signerIdentityChanged = previousState.signerName !== signerName
+			const clearSignerState = !signerStateWasConfirmed
+				|| previousSignerProviderGeneration !== signerProviderGeneration
+				|| signerIdentityChanged
+				|| signerMissing
+				|| !signerConnected
+			const baseState = clearSignerState ? clearSignerDerivedTabState(previousState) : previousState
+			return modifyObject(baseState, { signerName, signerConnected: signerMissing ? false : signerConnected })
 		})
+		if (!isCurrentWebsiteConnection(tabConnection, socket, port) || tabConnection.signerStateOwnerConnectionName !== socket.connectionName) {
+			return await getConnectedToSignerResult()
+		}
+		confirmSignerState(tabConnection, signerProviderGeneration)
+		await setDefaultSignerName(signerName)
+		await sendPopupMessageToOpenWindows({ method: 'popup_signer_name_changed' })
+		if (hasSignerCallbackAccess(websiteTabConnections, socket.tabId, approval)) {
+			const settings = await getSettings()
+			if (!signerMissing && (!settings.simulationMode || settings.useSignersAddressAsActiveAddress)) {
+				sendSubscriptionReplyOrCallBackToPort(port, { type: 'result', method: 'request_signer_chainId', result: [] })
+			}
+		}
+		return await getConnectedToSignerResult()
 	})
-	await sendPopupMessageToOpenWindows({ method: 'popup_signer_name_changed' })
-	if (approval !== 'hasAccess') {
-		return { type: 'result' as const, method: 'connected_to_signer' as const, result: { metamaskCompatibilityMode: await getMetamaskCompatibilityMode() } }
-	}
-	const settings = await getSettings()
-	if (!isSignerMissing(signerName) && (!settings.simulationMode || settings.useSignersAddressAsActiveAddress)) {
-		sendSubscriptionReplyOrCallBackToPort(port, { type: 'result', method: 'request_signer_chainId', result: [] })
-	}
-	return { type: 'result' as const, method: 'connected_to_signer' as const, result: { metamaskCompatibilityMode: await getMetamaskCompatibilityMode() } }
 }
 
-export async function signerReply(ethereum: EthereumClientService, tokenPriceService: TokenPriceService, _resetSimulationServices: ResetSimulationServices, websiteTabConnections: WebsiteTabConnections, _port: browser.runtime.Port, request: ProviderMessage, _approval: ApprovalState, _activeAddress: bigint | undefined) {
+export async function signerReply(ethereum: EthereumClientService, tokenPriceService: TokenPriceService, _resetSimulationServices: ResetSimulationServices, websiteTabConnections: WebsiteTabConnections, port: browser.runtime.Port, request: ProviderMessage, _approval: ApprovalState, _activeAddress: bigint | undefined) {
 	const signerReply = SignerReply.parse(request)
 	const params = signerReply.params[0]
 	const doNotReply = { type: 'doNotReply' as const }
-	switch(params.forwardRequest.method) {
-		case 'personal_sign':
-		case 'eth_signTypedData':
-		case 'eth_signTypedData_v1':
-		case 'eth_signTypedData_v2':
-		case 'eth_signTypedData_v3':
-		case 'eth_signTypedData_v4':
-		case 'eth_sendRawTransaction':
-		case 'eth_sendTransaction': {
-			const uniqueRequestIdentifier = { requestId: params.forwardRequest.requestId, requestSocket: request.uniqueRequestIdentifier.requestSocket }
-			if (params.success) {
-				try {
-					await resolvePendingTransactionOrMessage(ethereum, tokenPriceService, websiteTabConnections, {
-						method: 'popup_confirmDialog',
-						data: {
-							uniqueRequestIdentifier,
-							action: 'signerIncluded',
-							signerReply: params.reply,
-						}
-					})
-				} catch(e) {
-					await reportUnexpectedError(e)
-				}
-				return doNotReply
+	const socket = getSocketFromPort(port)
+	if (socket === undefined) return doNotReply
+	return await runSignerStateOperation(websiteTabConnections, socket.tabId, async () => {
+		const requestSocket = request.uniqueRequestIdentifier.requestSocket
+		const uniqueRequestIdentifier = { requestId: params.forwardRequest.requestId, requestSocket }
+		const tabConnection = websiteTabConnections.get(socket.tabId)
+		// Signing is routed back through the frame that originated the request, which may be a child frame.
+		// Unlike tab-wide account and chain cache updates, this reply is scoped by its request id and exact port;
+		// the inpage bridge converts a provider-generation change into a terminal disconnected error.
+		if (!isCurrentWebsiteConnection(tabConnection, socket, port)
+			|| requestSocket.tabId !== socket.tabId
+			|| requestSocket.connectionName !== socket.connectionName) {
+			await updatePendingTransactionOrMessage(uniqueRequestIdentifier, async (transaction) => modifyObject(transaction, { approvalStatus: { status: 'SignerError', ...signerConnectionReplacedError } }))
+			await updateConfirmTransactionView(ethereum, tokenPriceService)
+			return doNotReply
+		}
+		switch(params.forwardRequest.method) {
+			case 'personal_sign':
+			case 'eth_signTypedData':
+			case 'eth_signTypedData_v1':
+			case 'eth_signTypedData_v2':
+			case 'eth_signTypedData_v3':
+			case 'eth_signTypedData_v4':
+			case 'eth_sendRawTransaction':
+			case 'eth_sendTransaction': {
+				if (params.success) {
+					try {
+						await resolvePendingTransactionOrMessage(ethereum, tokenPriceService, websiteTabConnections, {
+							method: 'popup_confirmDialog',
+							data: {
+								uniqueRequestIdentifier,
+								action: 'signerIncluded',
+								signerReply: params.reply,
+							}
+						})
+					} catch(e) {
+						await reportUnexpectedError(e)
+					}
+					return doNotReply
 				}
 				if (params.error.code === METAMASK_ERROR_USER_REJECTED_REQUEST) {
 					await updatePendingTransactionOrMessage(uniqueRequestIdentifier, async (transaction) => modifyObject(transaction, { approvalStatus: { status: 'WaitingForUser' } }))
@@ -176,6 +283,7 @@ export async function signerReply(ethereum: EthereumClientService, tokenPriceSer
 				return doNotReply
 			}
 		}
-	if (params.success) return { type: 'result' as const, method: 'signer_reply' as const, result: params.reply }
-	return { type: 'result' as const, method: 'signer_reply' as const, error: params.error }
+		if (params.success) return { type: 'result' as const, method: 'signer_reply' as const, result: params.reply }
+		return { type: 'result' as const, method: 'signer_reply' as const, error: params.error }
+	})
 }

--- a/app/ts/background/providerMessageHandlers.ts
+++ b/app/ts/background/providerMessageHandlers.ts
@@ -191,16 +191,16 @@ export async function connectedToSigner(_ethereum: EthereumClientService, _token
 	if (socket === undefined || socket.tabId !== requestSocket.tabId || socket.connectionName !== requestSocket.connectionName) return await getConnectedToSignerResult()
 	return await runSignerStateOperation(websiteTabConnections, socket.tabId, async () => {
 		const tabConnection = websiteTabConnections.get(socket.tabId)
-		if (!isCurrentWebsiteConnection(tabConnection, socket, port) || tabConnection?.signerStateOwnerConnectionName !== socket.connectionName) {
+		if (!isCurrentWebsiteConnection(tabConnection, socket, port) || tabConnection?.signerStateOwner?.connectionName !== socket.connectionName) {
 			return await getConnectedToSignerResult()
 		}
-		const previousSignerProviderGeneration = tabConnection.signerProviderGeneration
-		if (tabConnection.signerStateOwnerConfirmed === true
+		const previousSignerProviderGeneration = tabConnection.signerStateOwner.providerGeneration
+		if (tabConnection.signerStateOwner.confirmed
 			&& previousSignerProviderGeneration !== undefined
 			&& signerProviderGeneration < previousSignerProviderGeneration) {
 			return await getConnectedToSignerResult()
 		}
-		const signerStateWasConfirmed = tabConnection.signerStateOwnerConfirmed === true
+		const signerStateWasConfirmed = tabConnection.signerStateOwner.confirmed
 		beginSignerStateConfirmation(tabConnection)
 		const signerMissing = isSignerMissing(signerName)
 		await updateTabState(socket.tabId, (previousState: TabState) => {
@@ -213,7 +213,7 @@ export async function connectedToSigner(_ethereum: EthereumClientService, _token
 			const baseState = clearSignerState ? clearSignerDerivedTabState(previousState) : previousState
 			return modifyObject(baseState, { signerName, signerConnected: signerMissing ? false : signerConnected })
 		})
-		if (!isCurrentWebsiteConnection(tabConnection, socket, port) || tabConnection.signerStateOwnerConnectionName !== socket.connectionName) {
+		if (!isCurrentWebsiteConnection(tabConnection, socket, port) || tabConnection.signerStateOwner.connectionName !== socket.connectionName) {
 			return await getConnectedToSignerResult()
 		}
 		confirmSignerState(tabConnection, signerProviderGeneration)

--- a/app/ts/background/providerMessageHandlers.ts
+++ b/app/ts/background/providerMessageHandlers.ts
@@ -16,6 +16,7 @@ import { sendSubscriptionReplyOrCallBackToPort } from './messageSending.js'
 import type { EthereumClientService } from '../simulation/services/EthereumClientService.js'
 import type { TokenPriceService } from '../simulation/services/priceEstimator.js'
 import type { ResetSimulationServices } from '../simulation/serviceLifecycle.js'
+import { isSignerMissing } from '../utils/signerMetadata.js'
 
 export async function ethAccountsReply(ethereum: EthereumClientService, tokenPriceService: TokenPriceService, resetSimulationServices: ResetSimulationServices, websiteTabConnections: WebsiteTabConnections, port: browser.runtime.Port, request: ProviderMessage, approval: ApprovalState, _activeAddress: bigint | undefined) {
 	const returnValue = { type: 'result' as const, method: 'eth_accounts_reply' as const, result: '0x' as const }
@@ -33,9 +34,13 @@ export async function ethAccountsReply(ethereum: EthereumClientService, tokenPri
 			message: error.message,
 			...(stringifiedData !== undefined ? { data: stringifiedData } : {}),
 		}
-		await updateTabState(port.sender.tab.id, (previousState: TabState) => modifyObject(previousState, {
-			signerAccountError,
-		}))
+		// Signer discovery reports local absence through this request-scoped error so account requests can settle.
+		// The connected_to_signer message owns the persistent NoSigner state; only actual wallet errors belong in the popup.
+		if (signerAccountsReply.signerUnavailable !== true) {
+			await updateTabState(port.sender.tab.id, (previousState: TabState) => modifyObject(previousState, {
+				signerAccountError,
+			}))
+		}
 		// Wake requesters waiting for a signer accounts round-trip even when the signer rejected or errored.
 		if (socket) sendInternalWindowMessage({ method: 'window_signer_accounts_changed', data: { socket, error: signerAccountError } })
 		await sendPopupMessageToOpenWindows({ method: 'popup_accounts_update' })
@@ -103,14 +108,30 @@ export async function walletSwitchEthereumChainReply(ethereum: EthereumClientSer
 
 export async function connectedToSigner(_ethereum: EthereumClientService, _tokenPriceService: TokenPriceService, _resetSimulationServices: ResetSimulationServices, _websiteTabConnections: WebsiteTabConnections, port: browser.runtime.Port, request: ProviderMessage, approval: ApprovalState, _activeAddress: bigint | undefined) {
 	const [signerConnected, signerName] = ConnectedToSigner.parse(request).params
-	if (approval !== 'hasAccess') {
+	// MV2 and test ports may omit frameId. Treat those as the top frame, while preventing an
+	// unapproved MV3 child frame from taking ownership of tab-wide signer state.
+	const isTopFrame = port.sender?.frameId === undefined || port.sender.frameId === 0
+	if (approval !== 'hasAccess' && !isTopFrame) {
 		return { type: 'result' as const, method: 'connected_to_signer' as const, result: { metamaskCompatibilityMode: await getMetamaskCompatibilityMode() } }
 	}
 	await setDefaultSignerName(signerName)
-	await updateTabState(request.uniqueRequestIdentifier.requestSocket.tabId, (previousState: TabState) => modifyObject(previousState, { signerName, signerConnected }))
+	await updateTabState(request.uniqueRequestIdentifier.requestSocket.tabId, (previousState: TabState) => {
+		if (!isSignerMissing(signerName)) return modifyObject(previousState, { signerName, signerConnected })
+		return modifyObject(previousState, {
+			signerName,
+			signerConnected: false,
+			signerAccounts: [],
+			signerChain: undefined,
+			signerAccountError: undefined,
+			activeSigningAddress: undefined,
+		})
+	})
 	await sendPopupMessageToOpenWindows({ method: 'popup_signer_name_changed' })
+	if (approval !== 'hasAccess') {
+		return { type: 'result' as const, method: 'connected_to_signer' as const, result: { metamaskCompatibilityMode: await getMetamaskCompatibilityMode() } }
+	}
 	const settings = await getSettings()
-	if (!settings.simulationMode || settings.useSignersAddressAsActiveAddress) {
+	if (!isSignerMissing(signerName) && (!settings.simulationMode || settings.useSignersAddressAsActiveAddress)) {
 		sendSubscriptionReplyOrCallBackToPort(port, { type: 'result', method: 'request_signer_chainId', result: [] })
 	}
 	return { type: 'result' as const, method: 'connected_to_signer' as const, result: { metamaskCompatibilityMode: await getMetamaskCompatibilityMode() } }

--- a/app/ts/background/signerStateOwnership.ts
+++ b/app/ts/background/signerStateOwnership.ts
@@ -1,7 +1,7 @@
 import type { TabConnection, TabState, WebsiteTabConnections } from '../types/user-interface-types.js'
-import type { InpageScriptCallBack } from '../types/interceptor-messages.js'
+import type { InpageScriptCallBack, Settings } from '../types/interceptor-messages.js'
 import type { WebsiteSocket } from '../utils/requests.js'
-import { Semaphore } from '../utils/semaphore.js'
+import { createScopedKeyedSerialExecutor } from '../utils/semaphore.js'
 import { modifyObject } from '../utils/typescript.js'
 import { sendInternalWindowMessage, websiteSocketToString } from './backgroundUtils.js'
 import { updateTabState } from './storageVariables.js'
@@ -9,7 +9,7 @@ import { METAMASK_ERROR_PROVIDER_DISCONNECTED } from '../utils/constants.js'
 import { sendSubscriptionReplyOrCallBackToPort } from './messageSending.js'
 
 const SIGNER_STATE_CONFIRMATION_TIMEOUT_MS = 3_000
-const signerStateOperationLocks = new WeakMap<WebsiteTabConnections, Map<number, { readonly semaphore: Semaphore, operations: number }>>()
+const serializeSignerStateOperation = createScopedKeyedSerialExecutor<WebsiteTabConnections, number>()
 const signerStateReplacementListeners = new Set<(signerStateToken: SignerStateToken, error: typeof signerConnectionReplacedError) => void>()
 
 export const signerConnectionReplacedError = {
@@ -77,23 +77,7 @@ export function clearSignerDerivedTabState(previousState: TabState) {
 }
 
 export async function runSignerStateOperation<T>(websiteTabConnections: WebsiteTabConnections, tabId: number, operation: () => Promise<T>) {
-	let tabLocks = signerStateOperationLocks.get(websiteTabConnections)
-	if (tabLocks === undefined) {
-		tabLocks = new Map()
-		signerStateOperationLocks.set(websiteTabConnections, tabLocks)
-	}
-	let lock = tabLocks.get(tabId)
-	if (lock === undefined) {
-		lock = { semaphore: new Semaphore(1), operations: 0 }
-		tabLocks.set(tabId, lock)
-	}
-	lock.operations += 1
-	try {
-		return await lock.semaphore.execute(operation)
-	} finally {
-		lock.operations -= 1
-		if (lock.operations === 0 && tabLocks.get(tabId) === lock) tabLocks.delete(tabId)
-	}
+	return await serializeSignerStateOperation(websiteTabConnections, tabId, operation)
 }
 
 export function isCurrentWebsiteConnection(tabConnection: TabConnection | undefined, socket: WebsiteSocket, port: browser.runtime.Port) {
@@ -101,32 +85,37 @@ export function isCurrentWebsiteConnection(tabConnection: TabConnection | undefi
 }
 
 export function advanceSignerStateGeneration(tabConnection: TabConnection) {
-	tabConnection.signerStateOwnerGeneration = (tabConnection.signerStateOwnerGeneration ?? 0) + 1
-	return tabConnection.signerStateOwnerGeneration
+	const signerStateOwner = tabConnection.signerStateOwner ?? { confirmed: false, generation: 0 }
+	tabConnection.signerStateOwner = signerStateOwner
+	signerStateOwner.generation += 1
+	return signerStateOwner.generation
 }
 
 export function resolveSignerStateConfirmation(tabConnection: TabConnection) {
-	tabConnection.signerStateConfirmation?.resolve()
-	tabConnection.signerStateConfirmation = undefined
+	tabConnection.signerStateOwner?.confirmation?.resolve()
+	if (tabConnection.signerStateOwner !== undefined) tabConnection.signerStateOwner.confirmation = undefined
 }
 
 export function beginSignerStateConfirmation(tabConnection: TabConnection) {
 	resolveSignerStateConfirmation(tabConnection)
 	advanceSignerStateGeneration(tabConnection)
-	tabConnection.signerStateOwnerConfirmed = false
-	tabConnection.signerStateConfirmation = createSignerStateConfirmation()
+	if (tabConnection.signerStateOwner === undefined) throw new Error('Signer state owner lifecycle missing')
+	tabConnection.signerStateOwner.confirmed = false
+	tabConnection.signerStateOwner.confirmation = createSignerStateConfirmation()
 }
 
 export function confirmSignerState(tabConnection: TabConnection, signerProviderGeneration: number) {
-	tabConnection.signerProviderGeneration = signerProviderGeneration
-	tabConnection.signerStateOwnerConfirmed = true
+	if (tabConnection.signerStateOwner === undefined) throw new Error('Signer state owner lifecycle missing')
+	tabConnection.signerStateOwner.providerGeneration = signerProviderGeneration
+	tabConnection.signerStateOwner.confirmed = true
 	resolveSignerStateConfirmation(tabConnection)
 }
 
 function provisionallyClaimSignerStateOwnerWithinOperation(tabConnection: TabConnection, socket: WebsiteSocket) {
 	beginSignerStateConfirmation(tabConnection)
-	tabConnection.signerStateOwnerConnectionName = socket.connectionName
-	tabConnection.signerProviderGeneration = undefined
+	if (tabConnection.signerStateOwner === undefined) throw new Error('Signer state owner lifecycle missing')
+	tabConnection.signerStateOwner.connectionName = socket.connectionName
+	tabConnection.signerStateOwner.providerGeneration = undefined
 }
 
 export async function registerWebsiteConnectionAndProvisionallyClaimSignerState(
@@ -155,10 +144,12 @@ export async function registerWebsiteConnectionAndProvisionallyClaimSignerState(
 
 export function getConfirmedSignerStateToken(websiteTabConnections: WebsiteTabConnections, tabId: number): SignerStateToken | undefined {
 	const tabConnection = websiteTabConnections.get(tabId)
-	if (tabConnection?.signerStateOwnerConfirmed !== true) return undefined
-	const connectionName = tabConnection.signerStateOwnerConnectionName
-	const ownerGeneration = tabConnection.signerStateOwnerGeneration
-	const signerProviderGeneration = tabConnection.signerProviderGeneration
+	if (tabConnection === undefined) return undefined
+	const signerStateOwner = tabConnection.signerStateOwner
+	if (signerStateOwner?.confirmed !== true) return undefined
+	const connectionName = signerStateOwner.connectionName
+	const ownerGeneration = signerStateOwner.generation
+	const signerProviderGeneration = signerStateOwner.providerGeneration
 	if (connectionName === undefined || ownerGeneration === undefined || signerProviderGeneration === undefined) return undefined
 	const socket = { tabId, connectionName }
 	const port = tabConnection.connections[websiteSocketToString(socket)]?.port
@@ -169,6 +160,19 @@ export function getConfirmedSignerStateToken(websiteTabConnections: WebsiteTabCo
 export function isSignerStateTokenCurrent(websiteTabConnections: WebsiteTabConnections, token: SignerStateToken) {
 	const currentToken = getConfirmedSignerStateToken(websiteTabConnections, token.socket.tabId)
 	return currentToken !== undefined && doSignerStateTokensMatch(currentToken, token)
+}
+
+export async function getActiveAddressForCurrentSignerState<T>(
+	websiteTabConnections: WebsiteTabConnections,
+	settings: Pick<Settings, 'simulationMode' | 'useSignersAddressAsActiveAddress'>,
+	tabId: number,
+	getAddress: () => Promise<T | undefined>,
+): Promise<T | undefined> {
+	if (settings.simulationMode && !settings.useSignersAddressAsActiveAddress) return await getAddress()
+	const signerStateToken = getConfirmedSignerStateToken(websiteTabConnections, tabId)
+	if (signerStateToken === undefined) return undefined
+	const activeAddress = await getAddress()
+	return isSignerStateTokenCurrent(websiteTabConnections, signerStateToken) ? activeAddress : undefined
 }
 
 export function tabHasApprovedWebsiteConnection(websiteTabConnections: WebsiteTabConnections, tabId: number) {
@@ -197,7 +201,7 @@ export async function waitForConfirmedSignerStateToken(websiteTabConnections: We
 	for (;;) {
 		const token = getConfirmedSignerStateToken(websiteTabConnections, tabId)
 		if (token !== undefined) return token
-		const confirmation = websiteTabConnections.get(tabId)?.signerStateConfirmation
+		const confirmation = websiteTabConnections.get(tabId)?.signerStateOwner?.confirmation
 		if (confirmation === undefined) return undefined
 		const remainingTime = deadline - Date.now()
 		if (remainingTime <= 0) return undefined

--- a/app/ts/background/signerStateOwnership.ts
+++ b/app/ts/background/signerStateOwnership.ts
@@ -1,0 +1,221 @@
+import type { TabConnection, TabState, WebsiteTabConnections } from '../types/user-interface-types.js'
+import type { InpageScriptCallBack } from '../types/interceptor-messages.js'
+import type { WebsiteSocket } from '../utils/requests.js'
+import { Semaphore } from '../utils/semaphore.js'
+import { modifyObject } from '../utils/typescript.js'
+import { sendInternalWindowMessage, websiteSocketToString } from './backgroundUtils.js'
+import { updateTabState } from './storageVariables.js'
+import { METAMASK_ERROR_PROVIDER_DISCONNECTED } from '../utils/constants.js'
+import { sendSubscriptionReplyOrCallBackToPort } from './messageSending.js'
+
+const SIGNER_STATE_CONFIRMATION_TIMEOUT_MS = 3_000
+const signerStateOperationLocks = new WeakMap<WebsiteTabConnections, Map<number, { readonly semaphore: Semaphore, operations: number }>>()
+const signerStateReplacementListeners = new Set<(signerStateToken: SignerStateToken, error: typeof signerConnectionReplacedError) => void>()
+
+export const signerConnectionReplacedError = {
+	code: METAMASK_ERROR_PROVIDER_DISCONNECTED,
+	message: 'Signer connection changed before the previous wallet replied.',
+}
+
+export const signerUnavailableError = {
+	code: METAMASK_ERROR_PROVIDER_DISCONNECTED,
+	message: 'No signer wallet is available to this page. Enable your wallet extension for this site, then try again.',
+}
+
+export type SignerStateToken = {
+	readonly socket: WebsiteSocket
+	readonly port: browser.runtime.Port
+	readonly ownerGeneration: number
+	readonly signerProviderGeneration: number
+}
+
+export function doSignerStateTokensMatch(first: SignerStateToken, second: SignerStateToken) {
+	return first.socket.tabId === second.socket.tabId
+		&& first.socket.connectionName === second.socket.connectionName
+		&& first.port === second.port
+		&& first.ownerGeneration === second.ownerGeneration
+		&& first.signerProviderGeneration === second.signerProviderGeneration
+}
+
+function createSignerStateConfirmation() {
+	let resolveConfirmation: (() => void) | undefined
+	const promise = new Promise<void>((resolve) => { resolveConfirmation = resolve })
+	return {
+		promise,
+		resolve: () => resolveConfirmation?.(),
+	}
+}
+
+export function settleSignerRequestsForReplacedState(signerStateToken: SignerStateToken | undefined, error = signerConnectionReplacedError) {
+	if (signerStateToken === undefined) return
+	sendInternalWindowMessage({
+		method: 'window_signer_accounts_changed',
+		data: {
+			socket: signerStateToken.socket,
+			signerStateOwnerGeneration: signerStateToken.ownerGeneration,
+			signerProviderGeneration: signerStateToken.signerProviderGeneration,
+			error,
+		},
+	})
+	for (const listener of signerStateReplacementListeners) listener(signerStateToken, error)
+}
+
+export function addSignerStateReplacementListener(listener: (signerStateToken: SignerStateToken, error: typeof signerConnectionReplacedError) => void) {
+	signerStateReplacementListeners.add(listener)
+	return () => signerStateReplacementListeners.delete(listener)
+}
+
+export function clearSignerDerivedTabState(previousState: TabState) {
+	return modifyObject(previousState, {
+		signerConnected: false,
+		signerName: 'NoSigner',
+		signerAccounts: [],
+		signerChain: undefined,
+		signerAccountError: undefined,
+		activeSigningAddress: undefined,
+	})
+}
+
+export async function runSignerStateOperation<T>(websiteTabConnections: WebsiteTabConnections, tabId: number, operation: () => Promise<T>) {
+	let tabLocks = signerStateOperationLocks.get(websiteTabConnections)
+	if (tabLocks === undefined) {
+		tabLocks = new Map()
+		signerStateOperationLocks.set(websiteTabConnections, tabLocks)
+	}
+	let lock = tabLocks.get(tabId)
+	if (lock === undefined) {
+		lock = { semaphore: new Semaphore(1), operations: 0 }
+		tabLocks.set(tabId, lock)
+	}
+	lock.operations += 1
+	try {
+		return await lock.semaphore.execute(operation)
+	} finally {
+		lock.operations -= 1
+		if (lock.operations === 0 && tabLocks.get(tabId) === lock) tabLocks.delete(tabId)
+	}
+}
+
+export function isCurrentWebsiteConnection(tabConnection: TabConnection | undefined, socket: WebsiteSocket, port: browser.runtime.Port) {
+	return tabConnection?.connections[websiteSocketToString(socket)]?.port === port
+}
+
+export function advanceSignerStateGeneration(tabConnection: TabConnection) {
+	tabConnection.signerStateOwnerGeneration = (tabConnection.signerStateOwnerGeneration ?? 0) + 1
+	return tabConnection.signerStateOwnerGeneration
+}
+
+export function resolveSignerStateConfirmation(tabConnection: TabConnection) {
+	tabConnection.signerStateConfirmation?.resolve()
+	tabConnection.signerStateConfirmation = undefined
+}
+
+export function beginSignerStateConfirmation(tabConnection: TabConnection) {
+	resolveSignerStateConfirmation(tabConnection)
+	advanceSignerStateGeneration(tabConnection)
+	tabConnection.signerStateOwnerConfirmed = false
+	tabConnection.signerStateConfirmation = createSignerStateConfirmation()
+}
+
+export function confirmSignerState(tabConnection: TabConnection, signerProviderGeneration: number) {
+	tabConnection.signerProviderGeneration = signerProviderGeneration
+	tabConnection.signerStateOwnerConfirmed = true
+	resolveSignerStateConfirmation(tabConnection)
+}
+
+function provisionallyClaimSignerStateOwnerWithinOperation(tabConnection: TabConnection, socket: WebsiteSocket) {
+	beginSignerStateConfirmation(tabConnection)
+	tabConnection.signerStateOwnerConnectionName = socket.connectionName
+	tabConnection.signerProviderGeneration = undefined
+}
+
+export async function registerWebsiteConnectionAndProvisionallyClaimSignerState(
+	websiteTabConnections: WebsiteTabConnections,
+	socket: WebsiteSocket,
+	connection: TabConnection['connections'][string],
+	isTopFrame: boolean,
+) {
+	return await runSignerStateOperation(websiteTabConnections, socket.tabId, async () => {
+		let tabConnection = websiteTabConnections.get(socket.tabId)
+		const createdTabConnection = tabConnection === undefined
+		if (tabConnection === undefined) {
+			tabConnection = { connections: {} }
+			websiteTabConnections.set(socket.tabId, tabConnection)
+		}
+		const previousSignerStateToken = isTopFrame ? getConfirmedSignerStateToken(websiteTabConnections, socket.tabId) : undefined
+		tabConnection.connections[websiteSocketToString(socket)] = connection
+		if (isTopFrame) {
+			provisionallyClaimSignerStateOwnerWithinOperation(tabConnection, socket)
+			settleSignerRequestsForReplacedState(previousSignerStateToken)
+			await updateTabState(socket.tabId, clearSignerDerivedTabState)
+		}
+		return { createdTabConnection, provisionallyClaimedSignerState: isTopFrame }
+	})
+}
+
+export function getConfirmedSignerStateToken(websiteTabConnections: WebsiteTabConnections, tabId: number): SignerStateToken | undefined {
+	const tabConnection = websiteTabConnections.get(tabId)
+	if (tabConnection?.signerStateOwnerConfirmed !== true) return undefined
+	const connectionName = tabConnection.signerStateOwnerConnectionName
+	const ownerGeneration = tabConnection.signerStateOwnerGeneration
+	const signerProviderGeneration = tabConnection.signerProviderGeneration
+	if (connectionName === undefined || ownerGeneration === undefined || signerProviderGeneration === undefined) return undefined
+	const socket = { tabId, connectionName }
+	const port = tabConnection.connections[websiteSocketToString(socket)]?.port
+	if (port === undefined) return undefined
+	return { socket, port, ownerGeneration, signerProviderGeneration }
+}
+
+export function isSignerStateTokenCurrent(websiteTabConnections: WebsiteTabConnections, token: SignerStateToken) {
+	const currentToken = getConfirmedSignerStateToken(websiteTabConnections, token.socket.tabId)
+	return currentToken !== undefined && doSignerStateTokensMatch(currentToken, token)
+}
+
+export function tabHasApprovedWebsiteConnection(websiteTabConnections: WebsiteTabConnections, tabId: number) {
+	return Object.values(websiteTabConnections.get(tabId)?.connections ?? {}).some((connection) => connection.approved)
+}
+
+export function sendCallbackToConfirmedSignerOwner(websiteTabConnections: WebsiteTabConnections, tabId: number, message: InpageScriptCallBack) {
+	const signerStateToken = getConfirmedSignerStateToken(websiteTabConnections, tabId)
+	if (signerStateToken === undefined) return false
+	const tabConnection = websiteTabConnections.get(tabId)
+	const ownerConnection = tabConnection?.connections[websiteSocketToString(signerStateToken.socket)]
+	if (!tabHasApprovedWebsiteConnection(websiteTabConnections, tabId) || ownerConnection?.port !== signerStateToken.port) return false
+	return sendSubscriptionReplyOrCallBackToPort(signerStateToken.port, { type: 'result', ...message }) ? signerStateToken : false
+}
+
+export function sendCallbackToAllConfirmedSignerOwners(websiteTabConnections: WebsiteTabConnections, message: InpageScriptCallBack) {
+	let sentCount = 0
+	for (const tabId of websiteTabConnections.keys()) {
+		if (sendCallbackToConfirmedSignerOwner(websiteTabConnections, tabId, message)) sentCount += 1
+	}
+	return sentCount
+}
+
+export async function waitForConfirmedSignerStateToken(websiteTabConnections: WebsiteTabConnections, tabId: number): Promise<SignerStateToken | undefined> {
+	const deadline = Date.now() + SIGNER_STATE_CONFIRMATION_TIMEOUT_MS
+	for (;;) {
+		const token = getConfirmedSignerStateToken(websiteTabConnections, tabId)
+		if (token !== undefined) return token
+		const confirmation = websiteTabConnections.get(tabId)?.signerStateConfirmation
+		if (confirmation === undefined) return undefined
+		const remainingTime = deadline - Date.now()
+		if (remainingTime <= 0) return undefined
+		let timedOut = false
+		let timeout: ReturnType<typeof setTimeout> | undefined
+		try {
+			await Promise.race([
+				confirmation.promise,
+				new Promise<void>((resolve) => {
+					timeout = setTimeout(() => {
+						timedOut = true
+						resolve()
+					}, remainingTime)
+				}),
+			])
+		} finally {
+			if (timeout !== undefined) clearTimeout(timeout)
+		}
+		if (timedOut) return undefined
+	}
+}

--- a/app/ts/background/websiteTabConnections.ts
+++ b/app/ts/background/websiteTabConnections.ts
@@ -1,15 +1,28 @@
 import type { WebsiteTabConnections } from '../types/user-interface-types.js'
 import type { WebsiteSocket } from '../utils/requests.js'
 import { websiteSocketToString } from './backgroundUtils.js'
+import { advanceSignerStateGeneration, clearSignerDerivedTabState, getConfirmedSignerStateToken, resolveSignerStateConfirmation, runSignerStateOperation, settleSignerRequestsForReplacedState } from './signerStateOwnership.js'
+import { updateTabState } from './storageVariables.js'
 
-export function removeWebsiteTabConnection(websiteTabConnections: WebsiteTabConnections, socket: WebsiteSocket, disconnectedPort: browser.runtime.Port) {
-	const tabConnection = websiteTabConnections.get(socket.tabId)
-	if (tabConnection === undefined) return
-	const connectionIdentifier = websiteSocketToString(socket)
-	const currentConnection = tabConnection.connections[connectionIdentifier]
-	if (currentConnection?.port !== disconnectedPort) return
-	delete tabConnection.connections[connectionIdentifier]
-	if (Object.keys(tabConnection.connections).length === 0) {
-		websiteTabConnections.delete(socket.tabId)
-	}
+export async function removeWebsiteTabConnection(websiteTabConnections: WebsiteTabConnections, socket: WebsiteSocket, disconnectedPort: browser.runtime.Port) {
+	return await runSignerStateOperation(websiteTabConnections, socket.tabId, async () => {
+		const tabConnection = websiteTabConnections.get(socket.tabId)
+		if (tabConnection === undefined) return false
+		const connectionIdentifier = websiteSocketToString(socket)
+		const currentConnection = tabConnection.connections[connectionIdentifier]
+		if (currentConnection?.port !== disconnectedPort) return false
+		const signerStateToken = getConfirmedSignerStateToken(websiteTabConnections, socket.tabId)
+		delete tabConnection.connections[connectionIdentifier]
+		if (tabConnection.signerStateOwnerConnectionName === socket.connectionName) {
+			resolveSignerStateConfirmation(tabConnection)
+			advanceSignerStateGeneration(tabConnection)
+			tabConnection.signerStateOwnerConnectionName = undefined
+			tabConnection.signerStateOwnerConfirmed = false
+			tabConnection.signerProviderGeneration = undefined
+			await updateTabState(socket.tabId, clearSignerDerivedTabState)
+			settleSignerRequestsForReplacedState(signerStateToken)
+		}
+		if (Object.keys(tabConnection.connections).length === 0) websiteTabConnections.delete(socket.tabId)
+		return true
+	})
 }

--- a/app/ts/background/websiteTabConnections.ts
+++ b/app/ts/background/websiteTabConnections.ts
@@ -13,12 +13,13 @@ export async function removeWebsiteTabConnection(websiteTabConnections: WebsiteT
 		if (currentConnection?.port !== disconnectedPort) return false
 		const signerStateToken = getConfirmedSignerStateToken(websiteTabConnections, socket.tabId)
 		delete tabConnection.connections[connectionIdentifier]
-		if (tabConnection.signerStateOwnerConnectionName === socket.connectionName) {
+		if (tabConnection.signerStateOwner?.connectionName === socket.connectionName) {
 			resolveSignerStateConfirmation(tabConnection)
 			advanceSignerStateGeneration(tabConnection)
-			tabConnection.signerStateOwnerConnectionName = undefined
-			tabConnection.signerStateOwnerConfirmed = false
-			tabConnection.signerProviderGeneration = undefined
+			if (tabConnection.signerStateOwner === undefined) throw new Error('Signer state owner lifecycle missing')
+			tabConnection.signerStateOwner.connectionName = undefined
+			tabConnection.signerStateOwner.confirmed = false
+			tabConnection.signerStateOwner.providerGeneration = undefined
 			await updateTabState(socket.tabId, clearSignerDerivedTabState)
 			settleSignerRequestsForReplacedState(signerStateToken)
 		}

--- a/app/ts/background/windows/changeChain.ts
+++ b/app/ts/background/windows/changeChain.ts
@@ -14,9 +14,24 @@ import type { EthereumClientService } from '../../simulation/services/EthereumCl
 import type { TokenPriceService } from '../../simulation/services/priceEstimator.js'
 import type { ResetSimulationServices } from '../../simulation/serviceLifecycle.js'
 import { type PopupOrTab, addWindowTabListeners, closePopupOrTabById, getPopupOrTabById, openPopupOrTab, removeWindowTabListeners } from '../../utils/popupOrTab.js'
+import { addSignerStateReplacementListener, doSignerStateTokensMatch, signerUnavailableError, type SignerStateToken } from '../signerStateOwnership.js'
 
 let pendForUserReply: Future<ChainChangeConfirmation> | undefined 
-let pendForSignerReply: Future<SignerChainChangeConfirmation> | undefined 
+
+type PendingSignerChainChange = {
+	readonly future: Future<
+		| { readonly type: 'reply', readonly confirmation: SignerChainChangeConfirmation }
+		| { readonly type: 'replacement', readonly error: typeof signerUnavailableError }
+	>
+	readonly requestTabId: number
+	readonly requestedChainId: bigint
+	signerStateToken: SignerStateToken | undefined
+	readonly repliesBeforeToken: Array<{ readonly signerStateToken: SignerStateToken, readonly confirmation: SignerChainChangeConfirmation }>
+	readonly replacementsBeforeToken: Array<{ readonly signerStateToken: SignerStateToken, readonly error: typeof signerUnavailableError }>
+}
+
+let pendingSignerChainChange: PendingSignerChainChange | undefined
+let chainChangeResolutionInProgress = false
 
 let openedDialog: PopupOrTab | undefined 
 
@@ -31,21 +46,57 @@ export async function resolveChainChange(ethereum: EthereumClientService, tokenP
 		pendForUserReply.resolve(confirmation)
 		return
 	}
-	const data = await getChainChangeConfirmationPromise()
-	if (data === undefined || !doesUniqueRequestIdentifiersMatch(confirmation.data.uniqueRequestIdentifier, data.request.uniqueRequestIdentifier)) throw new Error('Unique request identifier mismatch in change chain')
-	const resolved = await resolve(ethereum, tokenPriceService, resetSimulationServices, websiteTabConnections, confirmation, data.simulationMode)
-	if (resolved.error !== undefined) {
-		replyToInterceptedRequest(websiteTabConnections, { type: 'result', method: 'wallet_switchEthereumChain' as const, error: resolved.error, uniqueRequestIdentifier: data.request.uniqueRequestIdentifier })
-	} else {
-		replyToInterceptedRequest(websiteTabConnections, { type: 'result', method: 'wallet_switchEthereumChain' as const, result: resolved.result, uniqueRequestIdentifier: data.request.uniqueRequestIdentifier })
-	}
-	if (openedDialog) await closePopupOrTabById(openedDialog)
-	openedDialog = undefined
+	await runExclusiveChainChangeResolution(async () => {
+		const data = await getChainChangeConfirmationPromise()
+		if (data === undefined || !doesUniqueRequestIdentifiersMatch(confirmation.data.uniqueRequestIdentifier, data.request.uniqueRequestIdentifier)) throw new Error('Unique request identifier mismatch in change chain')
+		const resolved = await resolve(ethereum, tokenPriceService, resetSimulationServices, websiteTabConnections, confirmation, data.simulationMode)
+		if (resolved.error !== undefined) {
+			replyToInterceptedRequest(websiteTabConnections, { type: 'result', method: 'wallet_switchEthereumChain' as const, error: resolved.error, uniqueRequestIdentifier: data.request.uniqueRequestIdentifier })
+		} else {
+			replyToInterceptedRequest(websiteTabConnections, { type: 'result', method: 'wallet_switchEthereumChain' as const, result: resolved.result, uniqueRequestIdentifier: data.request.uniqueRequestIdentifier })
+		}
+		if (openedDialog) await closePopupOrTabById(openedDialog)
+		openedDialog = undefined
+	})
 }
 
-export async function resolveSignerChainChange(confirmation: SignerChainChangeConfirmation) {
-	if (pendForSignerReply !== undefined) pendForSignerReply.resolve(confirmation)
-	pendForSignerReply = undefined
+async function runExclusiveChainChangeResolution<T>(resolution: () => Promise<T>) {
+	if (chainChangeResolutionInProgress) return undefined
+	chainChangeResolutionInProgress = true
+	try {
+		return await resolution()
+	} finally {
+		chainChangeResolutionInProgress = false
+	}
+}
+
+function doesPendingSignerChainChangeMatch(pending: PendingSignerChainChange, signerStateToken: SignerStateToken, chainId: bigint) {
+	if (pending.requestedChainId !== chainId) return false
+	return pending.signerStateToken === undefined
+		? pending.requestTabId === signerStateToken.socket.tabId
+		: doSignerStateTokensMatch(pending.signerStateToken, signerStateToken)
+}
+
+export function getPendingSignerChainChangeTokenForCallback(port: browser.runtime.Port, signerProviderGeneration: number, chainId: bigint) {
+	const signerStateToken = pendingSignerChainChange?.signerStateToken
+	if (signerStateToken === undefined || pendingSignerChainChange?.requestedChainId !== chainId) return undefined
+	if (signerStateToken.port !== port || signerStateToken.signerProviderGeneration !== signerProviderGeneration) return undefined
+	return signerStateToken
+}
+
+export function isPendingSignerChainChangeReply(signerStateToken: SignerStateToken, chainId: bigint) {
+	return pendingSignerChainChange !== undefined && doesPendingSignerChainChangeMatch(pendingSignerChainChange, signerStateToken, chainId)
+}
+
+export function resolveSignerChainChange(signerStateToken: SignerStateToken, confirmation: SignerChainChangeConfirmation) {
+	const pending = pendingSignerChainChange
+	if (pending === undefined || !doesPendingSignerChainChangeMatch(pending, signerStateToken, confirmation.data[0].chainId)) return false
+	if (pending.signerStateToken === undefined) {
+		pending.repliesBeforeToken.push({ signerStateToken, confirmation })
+		return true
+	}
+	pending.future.resolve({ type: 'reply', confirmation })
+	return true
 }
 
 function rejectMessage(rpcNetwork: RpcNetwork, uniqueRequestIdentifier: UniqueRequestIdentifier) {
@@ -76,7 +127,7 @@ export const openChangeChainDialog = async (
 	website: Website,
 	params: SwitchEthereumChainParams,
 ) => {
-	if (openedDialog !== undefined || pendForUserReply || pendForSignerReply) return userDeniedChange
+	if (openedDialog !== undefined || pendForUserReply || pendingSignerChainChange || chainChangeResolutionInProgress) return userDeniedChange
 
 	pendForUserReply = new Future<ChainChangeConfirmation>()
 
@@ -121,12 +172,11 @@ export const openChangeChainDialog = async (
 				rejectMessage(await getRpcNetworkForChain(params.params[0].chainId), request.uniqueRequestIdentifier),
 			)
 		}
-		pendForSignerReply = undefined
-
 		const reply = await pendForUserReply
 
 		// forward message to content script
-		return resolve(ethereum, tokenPriceService, resetSimulationServices, websiteTabConnections, reply, simulationMode)
+		const resolution = runExclusiveChainChangeResolution(async () => await resolve(ethereum, tokenPriceService, resetSimulationServices, websiteTabConnections, reply, simulationMode))
+		return resolution.then((result) => result ?? userDeniedChange)
 	} finally {
 		removeWindowTabListeners(onCloseWindow, onCloseTab)
 		pendForUserReply = undefined
@@ -139,14 +189,51 @@ async function resolve(ethereum: EthereumClientService, tokenPriceService: Token
 	await setChainChangeConfirmationPromise(undefined)
 	if (reply.data.accept) {
 		if (simulationMode) {
-			await changeActiveRpc(ethereum, tokenPriceService, resetSimulationServices, websiteTabConnections, reply.data.rpcNetwork, simulationMode)
+			await changeActiveRpc(ethereum, tokenPriceService, resetSimulationServices, websiteTabConnections, reply.data.rpcNetwork, simulationMode, reply.data.uniqueRequestIdentifier.requestSocket.tabId)
 			return { result: null }
 		}
-		pendForSignerReply = new Future<SignerChainChangeConfirmation>() // when not in simulation mode, we need to get reply from the signer too
-		await changeActiveRpc(ethereum, tokenPriceService, resetSimulationServices, websiteTabConnections, reply.data.rpcNetwork, simulationMode)
-		const signerReply = await pendForSignerReply
-		if (signerReply.data[0].accept === false) return { error: signerReply.data[0].error } as const // forward signers error to the application
-		if (signerReply.data[0].chainId === reply.data.rpcNetwork.chainId) return { result: null }
+		const pending: PendingSignerChainChange = {
+			future: new Future<
+				| { readonly type: 'reply', readonly confirmation: SignerChainChangeConfirmation }
+				| { readonly type: 'replacement', readonly error: typeof signerUnavailableError }
+			>(),
+			requestTabId: reply.data.uniqueRequestIdentifier.requestSocket.tabId,
+			requestedChainId: reply.data.rpcNetwork.chainId,
+			signerStateToken: undefined,
+			repliesBeforeToken: [],
+			replacementsBeforeToken: [],
+		}
+		const removeReplacementListener = addSignerStateReplacementListener((signerStateToken, error) => {
+			if (pending.signerStateToken === undefined) {
+				pending.replacementsBeforeToken.push({ signerStateToken, error })
+				return
+			}
+			if (doSignerStateTokensMatch(pending.signerStateToken, signerStateToken)) pending.future.resolve({ type: 'replacement', error })
+		})
+		pendingSignerChainChange = pending
+		try {
+			const changeActiveRpcResult = await changeActiveRpc(ethereum, tokenPriceService, resetSimulationServices, websiteTabConnections, reply.data.rpcNetwork, simulationMode, reply.data.uniqueRequestIdentifier.requestSocket.tabId)
+			if (changeActiveRpcResult.type !== 'signerRequestSent') {
+				return changeActiveRpcResult.type === 'signerRequestNotNeeded'
+					? { result: null } as const
+					: { error: signerUnavailableError } as const
+			}
+			pending.signerStateToken = changeActiveRpcResult.signerStateToken
+			const precedingReply = pending.repliesBeforeToken.find(({ signerStateToken, confirmation }) => {
+				return doSignerStateTokensMatch(changeActiveRpcResult.signerStateToken, signerStateToken)
+					&& confirmation.data[0].chainId === pending.requestedChainId
+			})
+			if (precedingReply !== undefined) pending.future.resolve({ type: 'reply', confirmation: precedingReply.confirmation })
+			const precedingReplacement = pending.replacementsBeforeToken.find(({ signerStateToken }) => doSignerStateTokensMatch(changeActiveRpcResult.signerStateToken, signerStateToken))
+			if (precedingReplacement !== undefined) pending.future.resolve({ type: 'replacement', error: precedingReplacement.error })
+			const signerResult = await pending.future
+			if (signerResult.type === 'replacement') return { error: signerResult.error } as const
+			if (signerResult.confirmation.data[0].accept === false) return { error: signerResult.confirmation.data[0].error } as const // forward signers error to the application
+			if (signerResult.confirmation.data[0].chainId === reply.data.rpcNetwork.chainId) return { result: null }
+		} finally {
+			removeReplacementListener()
+			if (pendingSignerChainChange === pending) pendingSignerChainChange = undefined
+		}
 	}
 	return userDeniedChange
 }

--- a/app/ts/background/windows/interceptorAccess.ts
+++ b/app/ts/background/windows/interceptorAccess.ts
@@ -10,7 +10,7 @@ import { getActiveAddressEntry, getActiveAddresses } from '../metadataUtils.js'
 import { getSettings } from '../settings.js'
 import { getTabState, updatePendingAccessRequests, getPendingAccessRequests, clearPendingAccessRequests } from '../storageVariables.js'
 import { doesUniqueRequestIdentifiersMatch, type InterceptedRequest, type WebsiteSocket } from '../../utils/requests.js'
-import { replyToInterceptedRequest, sendSubscriptionReplyOrCallBackAfterManifestV2Reconnect } from '../messageSending.js'
+import { replyToInterceptedRequest, sendSubscriptionReplyOrCallBackToPort } from '../messageSending.js'
 import type { PopupOrTabId, Website, WebsiteAccessArray } from '../../types/websiteAccessTypes.js'
 import type { PendingAccessRequest } from '../../types/accessRequest.js'
 import type { AddressBookEntries, AddressBookEntry } from '../../types/addressBookTypes.js'
@@ -21,6 +21,7 @@ import type { PublishRpcConnectionStatus } from '../rpcSlowRequestTracking.js'
 import { type PopupOrTab, addWindowTabListeners, closePopupOrTabById, getPopupOrTabById, openPopupOrTab, removeWindowTabListeners, tryFocusingTabOrWindow } from '../../utils/popupOrTab.js'
 import { isAccountConnectionMethod } from '../accountRequestMethods.js'
 import type { ErrorWithCodeAndOptionalData } from '../../types/error.js'
+import { getConfirmedSignerStateToken, isSignerStateTokenCurrent, signerConnectionReplacedError, signerUnavailableError, tabHasApprovedWebsiteConnection, waitForConfirmedSignerStateToken } from '../signerStateOwnership.js'
 
 type OpenedDialogWithListeners = {
 	popupOrTab: PopupOrTab
@@ -31,22 +32,22 @@ type OpenedDialogWithListeners = {
 let openedDialog: OpenedDialogWithListeners 
 
 const pendingInterceptorAccessSemaphore = new Semaphore(1)
-// Signer account replies identify their socket but not the request. Keep one round trip active per socket so an empty passive reply cannot settle an interactive request.
-const signerAccountRequestLocks = new Map<string, { readonly semaphore: Semaphore, pendingRequests: number }>()
+// Signer account replies identify the tab-wide signer owner but not the originating request. Keep one round trip
+// active per tab so requests from sibling frames cannot settle each other.
+const signerAccountRequestLocks = new Map<number, { readonly semaphore: Semaphore, pendingRequests: number }>()
 
-async function serializeSignerAccountRequest<T>(socket: WebsiteSocket, request: () => Promise<T>): Promise<T> {
-	const socketIdentifier = websiteSocketToString(socket)
-	let lock = signerAccountRequestLocks.get(socketIdentifier)
+async function serializeSignerAccountRequest<T>(tabId: number, request: () => Promise<T>): Promise<T> {
+	let lock = signerAccountRequestLocks.get(tabId)
 	if (lock === undefined) {
 		lock = { semaphore: new Semaphore(1), pendingRequests: 0 }
-		signerAccountRequestLocks.set(socketIdentifier, lock)
+		signerAccountRequestLocks.set(tabId, lock)
 	}
 	lock.pendingRequests += 1
 	try {
 		return await lock.semaphore.execute(request)
 	} finally {
 		lock.pendingRequests -= 1
-		if (lock.pendingRequests === 0 && signerAccountRequestLocks.get(socketIdentifier) === lock) signerAccountRequestLocks.delete(socketIdentifier)
+		if (lock.pendingRequests === 0 && signerAccountRequestLocks.get(tabId) === lock) signerAccountRequestLocks.delete(tabId)
 	}
 }
 
@@ -155,13 +156,27 @@ export async function updateInterceptorAccessViewWithPendingRequests() {
 }
 
 async function requestSignerAccountsFromSigner(websiteTabConnections: WebsiteTabConnections, socket: WebsiteSocket, requestAccounts: boolean, onlyIfUnavailable: boolean) {
-	return await serializeSignerAccountRequest(socket, async () => {
+	return await serializeSignerAccountRequest(socket.tabId, async () => {
+		const signerStateToken = await waitForConfirmedSignerStateToken(websiteTabConnections, socket.tabId)
+		if (signerStateToken === undefined) return { accounts: [], error: signerUnavailableError }
 		const tabState = await getTabState(socket.tabId)
+		if (!isSignerStateTokenCurrent(websiteTabConnections, signerStateToken)) return { accounts: [], error: signerConnectionReplacedError }
 		if (onlyIfUnavailable && tabState.signerAccounts.length !== 0) return { accounts: tabState.signerAccounts, error: undefined }
 
 		const future = new Future<ErrorWithCodeAndOptionalData | undefined>
 		const listener = createInternalMessageListener( (message: WindowMessage) => {
-			if (message.method === 'window_signer_accounts_changed' && websiteSocketToString(message.data.socket) === websiteSocketToString(socket)) return future.resolve(message.data.error)
+			if (message.method !== 'window_signer_accounts_changed') return
+			if (websiteSocketToString(message.data.socket) !== websiteSocketToString(signerStateToken.socket)) return
+			const currentSignerStateToken = getConfirmedSignerStateToken(websiteTabConnections, socket.tabId)
+			const messageMatchesCurrentSignerState = currentSignerStateToken !== undefined
+				&& currentSignerStateToken.port === signerStateToken.port
+				&& message.data.signerStateOwnerGeneration === currentSignerStateToken.ownerGeneration
+				&& message.data.signerProviderGeneration === currentSignerStateToken.signerProviderGeneration
+			const messageSettlesInitialSignerState = message.data.signerStateOwnerGeneration === signerStateToken.ownerGeneration
+				&& message.data.signerProviderGeneration === signerStateToken.signerProviderGeneration
+				&& currentSignerStateToken?.port !== signerStateToken.port
+			if (messageMatchesCurrentSignerState) return future.resolve(message.data.error)
+			if (messageSettlesInitialSignerState) return future.resolve(message.data.error ?? signerConnectionReplacedError)
 		})
 		const channel = new BroadcastChannel(INTERNAL_CHANNEL_NAME)
 		let error: ErrorWithCodeAndOptionalData | undefined
@@ -170,12 +185,16 @@ async function requestSignerAccountsFromSigner(websiteTabConnections: WebsiteTab
 			const requestSignerAccountsMessage = requestAccounts
 				? { type: 'result' as const, method: 'request_signer_to_eth_requestAccounts' as const, result: [] as const }
 				: { type: 'result' as const, method: 'request_signer_to_eth_accounts' as const, result: [] as const }
-			const messageSent = await sendSubscriptionReplyOrCallBackAfterManifestV2Reconnect(websiteTabConnections, socket, requestSignerAccountsMessage)
+			const messageSent = isSignerStateTokenCurrent(websiteTabConnections, signerStateToken)
+				&& sendSubscriptionReplyOrCallBackToPort(signerStateToken.port, requestSignerAccountsMessage)
 			if (messageSent) error = await future
+			else error = signerConnectionReplacedError
 		} finally {
 			channel.removeEventListener('message', listener)
 			channel.close()
 		}
+		const completedSignerStateToken = getConfirmedSignerStateToken(websiteTabConnections, socket.tabId)
+		if (completedSignerStateToken?.port !== signerStateToken.port) return { accounts: [], error: error ?? signerConnectionReplacedError }
 		return { accounts: (await getTabState(socket.tabId)).signerAccounts, error }
 	})
 }
@@ -186,11 +205,10 @@ export async function askForSignerAccountsFromSignerIfNotAvailable(websiteTabCon
 
 export async function refreshSignerAccountsFromApprovedWebsitePorts(websiteTabConnections: WebsiteTabConnections, requestAccounts: boolean) {
 	const accountRequests: Promise<SignerAccountsRequestResult>[] = []
-	for (const tabConnection of websiteTabConnections.values()) {
-		for (const connection of Object.values(tabConnection.connections)) {
-			if (!connection.approved) continue
-			accountRequests.push(requestSignerAccountsFromSigner(websiteTabConnections, connection.socket, requestAccounts, false))
-		}
+	for (const tabId of websiteTabConnections.keys()) {
+		const signerStateToken = getConfirmedSignerStateToken(websiteTabConnections, tabId)
+		if (signerStateToken === undefined || !tabHasApprovedWebsiteConnection(websiteTabConnections, tabId)) continue
+		accountRequests.push(requestSignerAccountsFromSigner(websiteTabConnections, signerStateToken.socket, requestAccounts, false))
 	}
 	await Promise.all(accountRequests)
 }

--- a/app/ts/background/windows/interceptorAccess.ts
+++ b/app/ts/background/windows/interceptorAccess.ts
@@ -1,7 +1,7 @@
 import { METAMASK_ERROR_ALREADY_PENDING } from '../../utils/constants.js'
 import { Future } from '../../utils/future.js'
 import type { InterceptorAccessChangeAddress, InterceptorAccessRefresh, InterceptorAccessReply, Settings, WindowMessage } from '../../types/interceptor-messages.js'
-import { Semaphore } from '../../utils/semaphore.js'
+import { createScopedKeyedSerialExecutor, Semaphore } from '../../utils/semaphore.js'
 import type { WebsiteTabConnections } from '../../types/user-interface-types.js'
 import { getAssociatedAddresses, persistWebsiteAccessChange, verifyAccess, withSuppressedUnscopedConnectionEventsForSocket, withSuppressedUnscopedConnectionEventsForSocketAsync } from '../accessManagement.js'
 import { changeActiveAddressAndChain, handleInterceptedRequest, refuseAccess } from '../background.js'
@@ -34,22 +34,8 @@ let openedDialog: OpenedDialogWithListeners
 const pendingInterceptorAccessSemaphore = new Semaphore(1)
 // Signer account replies identify the tab-wide signer owner but not the originating request. Keep one round trip
 // active per tab so requests from sibling frames cannot settle each other.
-const signerAccountRequestLocks = new Map<number, { readonly semaphore: Semaphore, pendingRequests: number }>()
+const serializeSignerAccountRequest = createScopedKeyedSerialExecutor<WebsiteTabConnections, number>()
 
-async function serializeSignerAccountRequest<T>(tabId: number, request: () => Promise<T>): Promise<T> {
-	let lock = signerAccountRequestLocks.get(tabId)
-	if (lock === undefined) {
-		lock = { semaphore: new Semaphore(1), pendingRequests: 0 }
-		signerAccountRequestLocks.set(tabId, lock)
-	}
-	lock.pendingRequests += 1
-	try {
-		return await lock.semaphore.execute(request)
-	} finally {
-		lock.pendingRequests -= 1
-		if (lock.pendingRequests === 0 && signerAccountRequestLocks.get(tabId) === lock) signerAccountRequestLocks.delete(tabId)
-	}
-}
 
 type SignerAccountsRequestResult = {
 	readonly accounts: readonly bigint[]
@@ -156,7 +142,7 @@ export async function updateInterceptorAccessViewWithPendingRequests() {
 }
 
 async function requestSignerAccountsFromSigner(websiteTabConnections: WebsiteTabConnections, socket: WebsiteSocket, requestAccounts: boolean, onlyIfUnavailable: boolean) {
-	return await serializeSignerAccountRequest(socket.tabId, async () => {
+	return await serializeSignerAccountRequest(websiteTabConnections, socket.tabId, async () => {
 		const signerStateToken = await waitForConfirmedSignerStateToken(websiteTabConnections, socket.tabId)
 		if (signerStateToken === undefined) return { accounts: [], error: signerUnavailableError }
 		const tabState = await getTabState(socket.tabId)

--- a/app/ts/background/windows/interceptorAccess.ts
+++ b/app/ts/background/windows/interceptorAccess.ts
@@ -30,6 +30,24 @@ type OpenedDialogWithListeners = {
 let openedDialog: OpenedDialogWithListeners 
 
 const pendingInterceptorAccessSemaphore = new Semaphore(1)
+// Signer account replies identify their socket but not the request. Keep one round trip active per socket so an empty passive reply cannot settle an interactive request.
+const signerAccountRequestLocks = new Map<string, { readonly semaphore: Semaphore, pendingRequests: number }>()
+
+async function serializeSignerAccountRequest<T>(socket: WebsiteSocket, request: () => Promise<T>): Promise<T> {
+	const socketIdentifier = websiteSocketToString(socket)
+	let lock = signerAccountRequestLocks.get(socketIdentifier)
+	if (lock === undefined) {
+		lock = { semaphore: new Semaphore(1), pendingRequests: 0 }
+		signerAccountRequestLocks.set(socketIdentifier, lock)
+	}
+	lock.pendingRequests += 1
+	try {
+		return await lock.semaphore.execute(request)
+	} finally {
+		lock.pendingRequests -= 1
+		if (lock.pendingRequests === 0 && signerAccountRequestLocks.get(socketIdentifier) === lock) signerAccountRequestLocks.delete(socketIdentifier)
+	}
+}
 
 const onCloseWindowOrTab = async (ethereum: EthereumClientService, tokenPriceService: TokenPriceService, resetSimulationServices: ResetSimulationServices, popupOrTabs: PopupOrTabId, websiteTabConnections: WebsiteTabConnections) => await pendingInterceptorAccessSemaphore.execute(async () => { // check if user has closed the window on their own, if so, reject signature
 	if (openedDialog === undefined || openedDialog.popupOrTab.id !== popupOrTabs.id || openedDialog.popupOrTab.type !== popupOrTabs.type) return
@@ -130,27 +148,44 @@ export async function updateInterceptorAccessViewWithPendingRequests() {
 	} })
 }
 
-export async function askForSignerAccountsFromSignerIfNotAvailable(websiteTabConnections: WebsiteTabConnections, socket: WebsiteSocket, requestAccounts = true) {
-	const tabState = await getTabState(socket.tabId)
-	if (tabState.signerAccounts.length !== 0) return tabState.signerAccounts
+async function requestSignerAccountsFromSigner(websiteTabConnections: WebsiteTabConnections, socket: WebsiteSocket, requestAccounts: boolean, onlyIfUnavailable: boolean) {
+	return await serializeSignerAccountRequest(socket, async () => {
+		const tabState = await getTabState(socket.tabId)
+		if (onlyIfUnavailable && tabState.signerAccounts.length !== 0) return tabState.signerAccounts
 
-	const future = new Future<void>
-	const listener = createInternalMessageListener( (message: WindowMessage) => {
-		if (message.method === 'window_signer_accounts_changed' && websiteSocketToString(message.data.socket) === websiteSocketToString(socket)) return future.resolve()
+		const future = new Future<void>
+		const listener = createInternalMessageListener( (message: WindowMessage) => {
+			if (message.method === 'window_signer_accounts_changed' && websiteSocketToString(message.data.socket) === websiteSocketToString(socket)) return future.resolve()
+		})
+		const channel = new BroadcastChannel(INTERNAL_CHANNEL_NAME)
+		try {
+			channel.addEventListener('message', listener)
+			const requestSignerAccountsMessage = requestAccounts
+				? { type: 'result' as const, method: 'request_signer_to_eth_requestAccounts' as const, result: [] as const }
+				: { type: 'result' as const, method: 'request_signer_to_eth_accounts' as const, result: [] as const }
+			const messageSent = await sendSubscriptionReplyOrCallBackAfterManifestV2Reconnect(websiteTabConnections, socket, requestSignerAccountsMessage)
+			if (messageSent) await future
+		} finally {
+			channel.removeEventListener('message', listener)
+			channel.close()
+		}
+		return (await getTabState(socket.tabId)).signerAccounts
 	})
-	const channel = new BroadcastChannel(INTERNAL_CHANNEL_NAME)
-	try {
-		channel.addEventListener('message', listener)
-		const requestSignerAccountsMessage = requestAccounts
-			? { type: 'result' as const, method: 'request_signer_to_eth_requestAccounts' as const, result: [] as const }
-			: { type: 'result' as const, method: 'request_signer_to_eth_accounts' as const, result: [] as const }
-		const messageSent = await sendSubscriptionReplyOrCallBackAfterManifestV2Reconnect(websiteTabConnections, socket, requestSignerAccountsMessage)
-		if (messageSent) await future
-	} finally {
-		channel.removeEventListener('message', listener)
-		channel.close()
+}
+
+export async function askForSignerAccountsFromSignerIfNotAvailable(websiteTabConnections: WebsiteTabConnections, socket: WebsiteSocket, requestAccounts = true) {
+	return await requestSignerAccountsFromSigner(websiteTabConnections, socket, requestAccounts, true)
+}
+
+export async function refreshSignerAccountsFromApprovedWebsitePorts(websiteTabConnections: WebsiteTabConnections, requestAccounts: boolean) {
+	const accountRequests: Promise<readonly bigint[]>[] = []
+	for (const tabConnection of websiteTabConnections.values()) {
+		for (const connection of Object.values(tabConnection.connections)) {
+			if (!connection.approved) continue
+			accountRequests.push(requestSignerAccountsFromSigner(websiteTabConnections, connection.socket, requestAccounts, false))
+		}
 	}
-	return (await getTabState(socket.tabId)).signerAccounts
+	await Promise.all(accountRequests)
 }
 
 export async function requestAccessFromUser(

--- a/app/ts/background/windows/interceptorAccess.ts
+++ b/app/ts/background/windows/interceptorAccess.ts
@@ -20,6 +20,7 @@ import type { ResetSimulationServices } from '../../simulation/serviceLifecycle.
 import type { PublishRpcConnectionStatus } from '../rpcSlowRequestTracking.js'
 import { type PopupOrTab, addWindowTabListeners, closePopupOrTabById, getPopupOrTabById, openPopupOrTab, removeWindowTabListeners, tryFocusingTabOrWindow } from '../../utils/popupOrTab.js'
 import { isAccountConnectionMethod } from '../accountRequestMethods.js'
+import type { ErrorWithCodeAndOptionalData } from '../../types/error.js'
 
 type OpenedDialogWithListeners = {
 	popupOrTab: PopupOrTab
@@ -47,6 +48,11 @@ async function serializeSignerAccountRequest<T>(socket: WebsiteSocket, request: 
 		lock.pendingRequests -= 1
 		if (lock.pendingRequests === 0 && signerAccountRequestLocks.get(socketIdentifier) === lock) signerAccountRequestLocks.delete(socketIdentifier)
 	}
+}
+
+type SignerAccountsRequestResult = {
+	readonly accounts: readonly bigint[]
+	readonly error: ErrorWithCodeAndOptionalData | undefined
 }
 
 const onCloseWindowOrTab = async (ethereum: EthereumClientService, tokenPriceService: TokenPriceService, resetSimulationServices: ResetSimulationServices, popupOrTabs: PopupOrTabId, websiteTabConnections: WebsiteTabConnections) => await pendingInterceptorAccessSemaphore.execute(async () => { // check if user has closed the window on their own, if so, reject signature
@@ -151,34 +157,35 @@ export async function updateInterceptorAccessViewWithPendingRequests() {
 async function requestSignerAccountsFromSigner(websiteTabConnections: WebsiteTabConnections, socket: WebsiteSocket, requestAccounts: boolean, onlyIfUnavailable: boolean) {
 	return await serializeSignerAccountRequest(socket, async () => {
 		const tabState = await getTabState(socket.tabId)
-		if (onlyIfUnavailable && tabState.signerAccounts.length !== 0) return tabState.signerAccounts
+		if (onlyIfUnavailable && tabState.signerAccounts.length !== 0) return { accounts: tabState.signerAccounts, error: undefined }
 
-		const future = new Future<void>
+		const future = new Future<ErrorWithCodeAndOptionalData | undefined>
 		const listener = createInternalMessageListener( (message: WindowMessage) => {
-			if (message.method === 'window_signer_accounts_changed' && websiteSocketToString(message.data.socket) === websiteSocketToString(socket)) return future.resolve()
+			if (message.method === 'window_signer_accounts_changed' && websiteSocketToString(message.data.socket) === websiteSocketToString(socket)) return future.resolve(message.data.error)
 		})
 		const channel = new BroadcastChannel(INTERNAL_CHANNEL_NAME)
+		let error: ErrorWithCodeAndOptionalData | undefined
 		try {
 			channel.addEventListener('message', listener)
 			const requestSignerAccountsMessage = requestAccounts
 				? { type: 'result' as const, method: 'request_signer_to_eth_requestAccounts' as const, result: [] as const }
 				: { type: 'result' as const, method: 'request_signer_to_eth_accounts' as const, result: [] as const }
 			const messageSent = await sendSubscriptionReplyOrCallBackAfterManifestV2Reconnect(websiteTabConnections, socket, requestSignerAccountsMessage)
-			if (messageSent) await future
+			if (messageSent) error = await future
 		} finally {
 			channel.removeEventListener('message', listener)
 			channel.close()
 		}
-		return (await getTabState(socket.tabId)).signerAccounts
+		return { accounts: (await getTabState(socket.tabId)).signerAccounts, error }
 	})
 }
 
-export async function askForSignerAccountsFromSignerIfNotAvailable(websiteTabConnections: WebsiteTabConnections, socket: WebsiteSocket, requestAccounts = true) {
+export async function askForSignerAccountsFromSignerIfNotAvailable(websiteTabConnections: WebsiteTabConnections, socket: WebsiteSocket, requestAccounts = true): Promise<SignerAccountsRequestResult> {
 	return await requestSignerAccountsFromSigner(websiteTabConnections, socket, requestAccounts, true)
 }
 
 export async function refreshSignerAccountsFromApprovedWebsitePorts(websiteTabConnections: WebsiteTabConnections, requestAccounts: boolean) {
-	const accountRequests: Promise<readonly bigint[]>[] = []
+	const accountRequests: Promise<SignerAccountsRequestResult>[] = []
 	for (const tabConnection of websiteTabConnections.values()) {
 		for (const connection of Object.values(tabConnection.connections)) {
 			if (!connection.approved) continue
@@ -436,8 +443,8 @@ export async function requestAddressChange(websiteTabConnections: WebsiteTabConn
 				return tabState.signerAccounts[0]
 			}
 			if (message.data.newActiveAddress === 'signer') {
-				const signerAccounts = await askForSignerAccountsFromSignerIfNotAvailable(websiteTabConnections, message.data.socket)
-				return signerAccounts[0]
+				const signerAccountsResult = await askForSignerAccountsFromSignerIfNotAvailable(websiteTabConnections, message.data.socket)
+				return signerAccountsResult.accounts[0]
 			}
 			return message.data.newActiveAddress
 		}

--- a/app/ts/components/App.tsx
+++ b/app/ts/components/App.tsx
@@ -2,12 +2,10 @@ import { useEffect } from 'preact/hooks'
 import type { JSX } from 'preact'
 import type { ModifyAddressWindowState, EditEnsNamedHashWindowState } from '../types/visualizer-types.js'
 import { Home } from './pages/Home.js'
-import type { TabState } from '../types/user-interface-types.js'
 import Hint from './subcomponents/Hint.js'
 import { getAddress, isAddress } from '../utils/viem.js'
 import { PasteCatcher } from './subcomponents/PasteCatcher.js'
 import { truncateAddr } from '../utils/ethereum.js'
-import { METAMASK_ERROR_ALREADY_PENDING, METAMASK_ERROR_USER_REJECTED_REQUEST } from '../utils/constants.js'
 import type { Settings } from '../types/interceptor-messages.js'
 import { version, gitCommitSha } from '../version.js'
 import { sendPopupMessageToBackgroundPage } from '../background/backgroundUtils.js'
@@ -15,8 +13,7 @@ import type { EthereumBytes32 } from '../types/wire-types.js'
 import { checksummedAddress } from '../utils/bigint.js'
 import type { AddressBookEntry } from '../types/addressBookTypes.js'
 import type { RpcEntry } from '../types/rpc.js'
-import { ErrorBoundary, ErrorComponent, UnexpectedError } from './subcomponents/Error.js'
-import { SignersLogoName } from './subcomponents/signers.js'
+import { ErrorBoundary, UnexpectedError } from './subcomponents/Error.js'
 import { addressEditEntry } from './ui-utils.js'
 import { Signal, useComputed, useSignal } from '@preact/signals'
 import { CenterToPageTextSpinner } from './subcomponents/Spinner.js'
@@ -25,18 +22,8 @@ import type { AddAddressParam, ChangeActiveAddressParam, InterceptorAccessListPa
 import { createUnexpectedErrorPopupMessage } from '../utils/unexpectedErrorPopupMessage.js'
 import { useLiveSimulationHomeData } from './hooks/useLiveSimulationHomeData.js'
 import { NetworkErrors } from './subcomponents/NetworkErrors.js'
+import { ProviderErrors } from './subcomponents/ProviderErrors.js'
 export { NetworkErrors } from './subcomponents/NetworkErrors.js'
-
-type ProviderErrorsParam = {
-	tabState: Signal<TabState | undefined>
-}
-
-function ProviderErrors({ tabState } : ProviderErrorsParam) {
-	if (tabState.value === undefined || tabState.value.signerAccountError === undefined) return <></>
-	if (tabState.value.signerAccountError.code === METAMASK_ERROR_USER_REJECTED_REQUEST) return <ErrorComponent warning = { true } text = { <>Could not get an account from <SignersLogoName signerName = { tabState.value.signerName } /> as user denied the request.</> }/>
-	if (tabState.value.signerAccountError.code === METAMASK_ERROR_ALREADY_PENDING.error.code) return <ErrorComponent warning = { true } text = { <>There's a connection request pending on <SignersLogoName signerName = { tabState.value.signerName } />. Please review the request.</> }/>
-	return <ErrorComponent warning = { true } text = { <><SignersLogoName signerName = { tabState.value.signerName } /> returned error: "{ tabState.value.signerAccountError.message }".</> }/>
-}
 
 type Page = { page: 'Home' | 'ChangeActiveAddress' | 'AccessList' | 'Settings' | 'Unknown' }
 	| { page: 'EditEnsNamedHash', state: EditEnsNamedHashWindowState }

--- a/app/ts/components/subcomponents/ProviderErrors.tsx
+++ b/app/ts/components/subcomponents/ProviderErrors.tsx
@@ -1,0 +1,17 @@
+import type { Signal } from '@preact/signals'
+import type { TabState } from '../../types/user-interface-types.js'
+import { METAMASK_ERROR_ALREADY_PENDING, METAMASK_ERROR_USER_REJECTED_REQUEST } from '../../utils/constants.js'
+import { isSignerMissing } from '../../utils/signerMetadata.js'
+import { ErrorComponent } from './Error.js'
+import { SignersLogoName } from './signers.js'
+
+type ProviderErrorsParam = {
+	tabState: Signal<TabState | undefined>
+}
+
+export function ProviderErrors({ tabState }: ProviderErrorsParam) {
+	if (tabState.value === undefined || tabState.value.signerAccountError === undefined || isSignerMissing(tabState.value.signerName)) return <></>
+	if (tabState.value.signerAccountError.code === METAMASK_ERROR_USER_REJECTED_REQUEST) return <ErrorComponent warning = { true } text = { <>Could not get an account from <SignersLogoName signerName = { tabState.value.signerName } /> as user denied the request.</> }/>
+	if (tabState.value.signerAccountError.code === METAMASK_ERROR_ALREADY_PENDING.error.code) return <ErrorComponent warning = { true } text = { <>There's a connection request pending on <SignersLogoName signerName = { tabState.value.signerName } />. Please review the request.</> }/>
+	return <ErrorComponent warning = { true } text = { <><SignersLogoName signerName = { tabState.value.signerName } /> returned error: "{ tabState.value.signerAccountError.message }".</> }/>
+}

--- a/app/ts/types/JsonRpc-types.ts
+++ b/app/ts/types/JsonRpc-types.ts
@@ -177,19 +177,24 @@ export const EthereumAccountsReply = funtypes.ReadonlyTuple(
 			accounts: funtypes.ReadonlyArray(EthereumAddress),
 			requestAccounts: funtypes.Boolean,
 		}),
-		funtypes.ReadonlyObject({
-			type: funtypes.Literal('error'),
-			requestAccounts: funtypes.Boolean,
-			error: funtypes.Intersect(
-				funtypes.ReadonlyObject({
-					code: funtypes.Number,
-					message: funtypes.String,
-				}),
-				funtypes.Partial({
-					data: funtypes.Unknown
-				})
-			)
-		})
+		funtypes.Intersect(
+			funtypes.ReadonlyObject({
+				type: funtypes.Literal('error'),
+				requestAccounts: funtypes.Boolean,
+				error: funtypes.Intersect(
+					funtypes.ReadonlyObject({
+						code: funtypes.Number,
+						message: funtypes.String,
+					}),
+					funtypes.Partial({
+						data: funtypes.Unknown
+					})
+				)
+			}),
+			funtypes.ReadonlyPartial({
+				signerUnavailable: funtypes.Literal(true),
+			}),
+		)
 	)
 )
 

--- a/app/ts/types/JsonRpc-types.ts
+++ b/app/ts/types/JsonRpc-types.ts
@@ -171,35 +171,40 @@ export const SendRawTransactionParams = funtypes.ReadonlyObject({
 
 export type EthereumAccountsReply = funtypes.Static<typeof EthereumAccountsReply>
 export const EthereumAccountsReply = funtypes.ReadonlyTuple(
-	funtypes.Union(
+	funtypes.Intersect(
 		funtypes.ReadonlyObject({
-			type: funtypes.Literal('success'),
-			accounts: funtypes.ReadonlyArray(EthereumAddress),
-			requestAccounts: funtypes.Boolean,
+			signerProviderGeneration: funtypes.Number,
 		}),
-		funtypes.Intersect(
+		funtypes.Union(
 			funtypes.ReadonlyObject({
-				type: funtypes.Literal('error'),
+				type: funtypes.Literal('success'),
+				accounts: funtypes.ReadonlyArray(EthereumAddress),
 				requestAccounts: funtypes.Boolean,
-				error: funtypes.Intersect(
-					funtypes.ReadonlyObject({
-						code: funtypes.Number,
-						message: funtypes.String,
-					}),
-					funtypes.Partial({
-						data: funtypes.Unknown
-					})
-				)
 			}),
-			funtypes.ReadonlyPartial({
-				signerUnavailable: funtypes.Literal(true),
-			}),
+			funtypes.Intersect(
+				funtypes.ReadonlyObject({
+					type: funtypes.Literal('error'),
+					requestAccounts: funtypes.Boolean,
+					error: funtypes.Intersect(
+						funtypes.ReadonlyObject({
+							code: funtypes.Number,
+							message: funtypes.String,
+						}),
+						funtypes.Partial({
+							data: funtypes.Unknown
+						})
+					)
+				}),
+				funtypes.ReadonlyPartial({
+					signerUnavailable: funtypes.Literal(true),
+				}),
+			)
 		)
 	)
 )
 
 export type EthereumChainReply = funtypes.Static<typeof EthereumChainReply>
-export const EthereumChainReply = funtypes.ReadonlyArray(EthereumQuantity)
+export const EthereumChainReply = funtypes.ReadonlyTuple(EthereumQuantity, funtypes.Number)
 
 export type TransactionReceiptParams = funtypes.Static<typeof TransactionReceiptParams>
 export const TransactionReceiptParams = funtypes.ReadonlyObject({

--- a/app/ts/types/interceptor-messages.ts
+++ b/app/ts/types/interceptor-messages.ts
@@ -23,11 +23,13 @@ const WalletSwitchEthereumChainReplyParams = funtypes.Tuple(funtypes.Union(
 	funtypes.ReadonlyObject({
 		accept: funtypes.Literal(true),
 		chainId: EthereumQuantity,
+		signerProviderGeneration: funtypes.Number,
 	}),
 	funtypes.ReadonlyObject({
 		accept: funtypes.Literal(false),
 		chainId: EthereumQuantity,
-		error: ErrorWithCodeAndOptionalData
+		error: ErrorWithCodeAndOptionalData,
+		signerProviderGeneration: funtypes.Number,
 	})
 ))
 
@@ -63,6 +65,7 @@ const ErrorReturn = funtypes.ReadonlyObject({
 export type InpageScriptCallBack = funtypes.Static<typeof InpageScriptCallBack>
 export const InpageScriptCallBack = funtypes.Union(
 	ErrorReturn,
+	funtypes.ReadonlyObject({ method: funtypes.Literal('request_signer_connection_status'), result: funtypes.ReadonlyTuple() }),
 	funtypes.ReadonlyObject({ method: funtypes.Literal('request_signer_chainId'), result: funtypes.ReadonlyTuple() }),
 	funtypes.ReadonlyObject({ method: funtypes.Literal('request_signer_to_wallet_switchEthereumChain'), result: EthereumQuantity }),
 	funtypes.ReadonlyObject({ method: funtypes.Literal('request_signer_to_eth_requestAccounts'), result: funtypes.ReadonlyTuple() }),
@@ -397,7 +400,7 @@ export const SignerChainChangeConfirmation = funtypes.ReadonlyObject({
 export type ConnectedToSigner = funtypes.Static<typeof ConnectedToSigner>
 export const ConnectedToSigner = funtypes.ReadonlyObject({
 	method: funtypes.Literal('connected_to_signer'),
-	params: funtypes.Tuple(funtypes.Boolean, SignerName),
+	params: funtypes.Tuple(funtypes.Boolean, SignerName, funtypes.Number),
 }).asReadonly()
 
 
@@ -410,18 +413,20 @@ const SignerReplyForwardRequest = funtypes.Intersect(
 export type SignerReply = funtypes.Static<typeof SignerReply>
 export const SignerReply = funtypes.ReadonlyObject({
 	method: funtypes.Literal('signer_reply'),
-	params: funtypes.Tuple(funtypes.Union(
-		funtypes.ReadonlyObject({
-			success: funtypes.Literal(true),
-			forwardRequest: SignerReplyForwardRequest,
-			reply: funtypes.Unknown,
-		}),
-		funtypes.ReadonlyObject({
-			success: funtypes.Literal(false),
-			forwardRequest: SignerReplyForwardRequest,
-			error: ErrorWithCodeAndOptionalData
-		})
-
+	params: funtypes.Tuple(funtypes.Intersect(
+		funtypes.ReadonlyObject({ signerProviderGeneration: funtypes.Number }),
+		funtypes.Union(
+			funtypes.ReadonlyObject({
+				success: funtypes.Literal(true),
+				forwardRequest: SignerReplyForwardRequest,
+				reply: funtypes.Unknown,
+			}),
+			funtypes.ReadonlyObject({
+				success: funtypes.Literal(false),
+				forwardRequest: SignerReplyForwardRequest,
+				error: ErrorWithCodeAndOptionalData
+			})
+		)
 	)),
 }).asReadonly()
 
@@ -622,6 +627,8 @@ const WindowMessageSignerAccountsChanged = funtypes.ReadonlyObject({
 	data: funtypes.Intersect(
 		funtypes.ReadonlyObject({
 			socket: WebsiteSocket,
+			signerStateOwnerGeneration: funtypes.Number,
+			signerProviderGeneration: funtypes.Number,
 		}),
 		funtypes.ReadonlyPartial({
 			error: ErrorWithCodeAndOptionalData,

--- a/app/ts/types/interceptor-messages.ts
+++ b/app/ts/types/interceptor-messages.ts
@@ -619,9 +619,14 @@ const ActiveSigningAddressChanged = funtypes.ReadonlyObject({
 type WindowMessageSignerAccountsChanged = funtypes.Static<typeof WindowMessageSignerAccountsChanged>
 const WindowMessageSignerAccountsChanged = funtypes.ReadonlyObject({
 	method: funtypes.Literal('window_signer_accounts_changed'),
-	data: funtypes.ReadonlyObject({
-		socket: WebsiteSocket,
-	})
+	data: funtypes.Intersect(
+		funtypes.ReadonlyObject({
+			socket: WebsiteSocket,
+		}),
+		funtypes.ReadonlyPartial({
+			error: ErrorWithCodeAndOptionalData,
+		}),
+	)
 })
 
 export type WindowMessage = funtypes.Static<typeof WindowMessage>

--- a/app/ts/types/user-interface-types.ts
+++ b/app/ts/types/user-interface-types.ts
@@ -150,18 +150,22 @@ export const TabIconDetails = funtypes.ReadonlyObject({
 	iconReason: funtypes.String,
 })
 
-export type TabConnection = {
-	connections: Record<string, SocketConnection> // socket as string
-	// Cached signer fields belong to the page connection that last identified its signer.
-	signerStateOwnerConnectionName?: bigint
-	// A top-frame port provisionally owns signer state until its explicit signer-status handshake completes.
-	signerStateOwnerConfirmed?: boolean
-	signerStateOwnerGeneration?: number
-	signerProviderGeneration?: number
-	signerStateConfirmation?: {
+export type SignerStateOwner = {
+	// The owner lifecycle remains allocated after disconnect so its generation stays monotonic.
+	connectionName?: bigint
+	confirmed: boolean
+	generation: number
+	providerGeneration?: number
+	confirmation?: {
 		readonly promise: Promise<void>
 		readonly resolve: () => void
 	}
+}
+
+export type TabConnection = {
+	connections: Record<string, SocketConnection> // socket as string
+	// Signer ownership is a separate lifecycle from the passive page connection registry.
+	signerStateOwner?: SignerStateOwner
 }
 
 export type WebsiteTabConnections = Map<number, TabConnection>

--- a/app/ts/types/user-interface-types.ts
+++ b/app/ts/types/user-interface-types.ts
@@ -152,6 +152,16 @@ export const TabIconDetails = funtypes.ReadonlyObject({
 
 export type TabConnection = {
 	connections: Record<string, SocketConnection> // socket as string
+	// Cached signer fields belong to the page connection that last identified its signer.
+	signerStateOwnerConnectionName?: bigint
+	// A top-frame port provisionally owns signer state until its explicit signer-status handshake completes.
+	signerStateOwnerConfirmed?: boolean
+	signerStateOwnerGeneration?: number
+	signerProviderGeneration?: number
+	signerStateConfirmation?: {
+		readonly promise: Promise<void>
+		readonly resolve: () => void
+	}
 }
 
 export type WebsiteTabConnections = Map<number, TabConnection>

--- a/app/ts/utils/constants.ts
+++ b/app/ts/utils/constants.ts
@@ -110,6 +110,7 @@ export const CAN_DO_EVERYTHING = 0n
 // https://blog.logrocket.com/understanding-resolving-metamask-error-codes/#4001
 export const METAMASK_ERROR_USER_REJECTED_REQUEST = 4001
 export const METAMASK_ERROR_NOT_AUTHORIZED = 4100
+export const METAMASK_ERROR_PROVIDER_DISCONNECTED = 4900
 export const METAMASK_ERROR_FAILED_TO_PARSE_REQUEST = -32700
 export const METAMASK_ERROR_BLANKET_ERROR = -32603
 export const HTTP_STATUS_REQUEST_TIMEOUT = 408
@@ -133,7 +134,7 @@ export const JSON_RPC_ERROR_CODE_LIMIT_EXCEEDED = -32005
 export const ERROR_INTERCEPTOR_DISABLED = { error: { code: METAMASK_ERROR_USER_REJECTED_REQUEST, message: 'The Interceptor is disabled' } }
 export const METAMASK_ERROR_ALREADY_PENDING = { error: { code: -32002, message: 'Access request pending already.' } }
 export const ERROR_INTERCEPTOR_NO_ACTIVE_ADDRESS = { error: { code: 2, message: 'Interceptor: No active address' } }
-export const METAMASK_ERROR_NOT_CONNECTED_TO_CHAIN = { error: { code: 4900, message: 'Interceptor: Not connected to chain' } }
+export const METAMASK_ERROR_NOT_CONNECTED_TO_CHAIN = { error: { code: METAMASK_ERROR_PROVIDER_DISCONNECTED, message: 'Interceptor: Not connected to chain' } }
 export const ERROR_INTERCEPTOR_GET_CODE_FAILED = { error: { code: -40001, message: 'Interceptor: Get code failed' } } // I wonder how we should come up with these numbers?
 export const ERROR_INTERCEPTOR_GAS_ESTIMATION_FAILED = -40002
 // const ERROR_INTERCEPTOR_NOT_READY = { error: { code: 1, message: 'Interceptor: Not ready' } }

--- a/app/ts/utils/semaphore.ts
+++ b/app/ts/utils/semaphore.ts
@@ -157,3 +157,31 @@ export class Semaphore {
 		}
 	}
 }
+
+type SerialExecutionLock = {
+	readonly semaphore: Semaphore
+	operations: number
+}
+
+export function createScopedKeyedSerialExecutor<Scope extends object, Key>() {
+	const scopedLocks = new WeakMap<Scope, Map<Key, SerialExecutionLock>>()
+	return async <T>(scope: Scope, key: Key, operation: () => Promise<T>): Promise<T> => {
+		let locks = scopedLocks.get(scope)
+		if (locks === undefined) {
+			locks = new Map()
+			scopedLocks.set(scope, locks)
+		}
+		let lock = locks.get(key)
+		if (lock === undefined) {
+			lock = { semaphore: new Semaphore(1), operations: 0 }
+			locks.set(key, lock)
+		}
+		lock.operations += 1
+		try {
+			return await lock.semaphore.execute(operation)
+		} finally {
+			lock.operations -= 1
+			if (lock.operations === 0 && locks.get(key) === lock) locks.delete(key)
+		}
+	}
+}

--- a/app/ts/utils/signerMetadata.ts
+++ b/app/ts/utils/signerMetadata.ts
@@ -7,6 +7,10 @@ const signerLogos = {
 	CoinbaseWallet: COINBASEWALLET_LOGO,
 } as const
 
+export function isSignerMissing(signerName: SignerName) {
+	return signerName === 'NoSigner' || signerName === 'NoSignerDetected'
+}
+
 export function getPrettySignerName(signerName: SignerName) {
 	if (signerName === 'NoSigner' || signerName === 'NotRecognizedSigner' || signerName === 'NoSignerDetected') return 'Unknown signer'
 	return signerName

--- a/test/benchmarks/chromeCommunication.ts
+++ b/test/benchmarks/chromeCommunication.ts
@@ -6,10 +6,12 @@ type CommunicationPageState = {
 	phase: 'loading' | 'provider-ready' | 'requesting-access' | 'access-granted' | 'error'
 	accounts?: readonly string[]
 	error?: string
+	errorCode?: number
 }
 
 const COMMUNICATION_PAGE_STATE_GLOBAL = '__interceptorChromeCommunicationState' as const
 const ACCESS_APPROVE_BUTTON_SELECTOR = 'nav.popup-button-row button.is-primary:not(.is-danger)'
+const UNAVAILABLE_SIGNER_ERROR_MESSAGE = 'No signer wallet is available to this page. Enable your wallet extension for this site, then try again.'
 
 function sleep(ms: number) {
 	return new Promise<void>((resolve) => {
@@ -42,6 +44,14 @@ async function waitForCommunicationPagePhase(connection: CdpConnection, phase: C
 		if (state?.phase === 'error') throw new Error(`Communication page failed: ${ state.error ?? 'unknown error' }`)
 		return state?.phase === phase
 	}, timeoutMs, `communication page phase ${ phase }`)
+}
+
+async function waitForCommunicationPageError(connection: CdpConnection, timeoutMs: number) {
+	await waitForCondition(async () => (await getCommunicationPageState(connection))?.phase === 'error', timeoutMs, 'communication page error')
+	const state = await getCommunicationPageState(connection)
+	if (state?.errorCode !== 4001) throw new Error(`Unexpected unavailable-signer error code: ${ state?.errorCode ?? 'missing' }`)
+	if (state.error !== UNAVAILABLE_SIGNER_ERROR_MESSAGE) throw new Error(`Unexpected unavailable-signer error message: ${ state.error ?? 'missing' }`)
+	return state
 }
 
 async function waitForButtonEnabled(connection: CdpConnection, selector: string, timeoutMs: number) {
@@ -93,12 +103,23 @@ async function main() {
 			}
 
 			await waitForCommunicationPagePhase(pageConnection, 'access-granted', 30_000)
-			const finalState = await getCommunicationPageState(pageConnection)
+			const accessGrantedState = await getCommunicationPageState(pageConnection)
+
+			const signingModeWorkerConnection = await connectTarget(chrome.browserDebugPort, workerTarget.id)
+			try {
+				await signingModeWorkerConnection.evaluate('browser.storage.local.set({ simulationMode: false, useSignersAddressAsActiveAddress: false })')
+			} finally {
+				signingModeWorkerConnection.close()
+			}
+			await pageConnection.send('Page.navigate', { url: `${ server.baseUrl }?signer=unavailable` })
+			const unavailableSignerState = await waitForCommunicationPageError(pageConnection, 30_000)
+
 			console.warn(`Interceptor Chrome communication smoke test passed for extension ${ extensionId }.`)
 			console.warn(JSON.stringify({
 				ok: true,
 				extensionId,
-				finalState,
+				accessGrantedState,
+				unavailableSignerState,
 			}, null, 2))
 		} finally {
 			pageConnection.close()

--- a/test/benchmarks/chromeCommunicationPage.html
+++ b/test/benchmarks/chromeCommunicationPage.html
@@ -71,6 +71,7 @@
 					phase: 'loading',
 					accounts: undefined,
 					error: undefined,
+					errorCode: undefined,
 				}
 				const statusElement = document.getElementById('status')
 
@@ -78,6 +79,7 @@
 					state.phase = phase
 					state.accounts = Array.isArray(extra.accounts) ? extra.accounts : undefined
 					state.error = extra.error
+					state.errorCode = typeof extra.errorCode === 'number' ? extra.errorCode : undefined
 					if (statusElement !== null) {
 						statusElement.textContent = phase === 'error'
 							? `error: ${ extra.error ?? 'unknown error' }`
@@ -105,7 +107,8 @@
 						updateState('access-granted', { accounts: Array.isArray(accounts) ? accounts : [] })
 					} catch (error) {
 						const message = error instanceof Error ? error.message : String(error)
-						updateState('error', { error: message })
+						const errorCode = typeof error === 'object' && error !== null && typeof error.code === 'number' ? error.code : undefined
+						updateState('error', { error: message, errorCode })
 					}
 				})()
 			})()

--- a/test/tests/backgroundEthAccounts.test.ts
+++ b/test/tests/backgroundEthAccounts.test.ts
@@ -90,11 +90,11 @@ async function loadModules() {
 	}
 }
 
-function createPort(tabId: number, onPostMessage?: (message: PortMessage) => void) {
+function createPort(tabId: number, onPostMessage?: (message: PortMessage) => void, frameId?: number) {
 	const messages: PortMessage[] = []
 	const port = {
 		name: '0x0',
-		sender: { tab: { id: tabId } },
+		sender: { tab: { id: tabId }, ...(frameId === undefined ? {} : { frameId }) },
 		postMessage(message: unknown) {
 			const typedMessage = message as PortMessage
 			messages.push(typedMessage)
@@ -243,6 +243,121 @@ describe('background eth_accounts', () => {
 		const tabState = await getTabState(socket.tabId)
 		assert.deepEqual(tabState.signerAccounts, [account])
 		assert.equal(tabState.activeSigningAddress, account)
+	})
+
+	test('normalizes signer state before access and keeps unavailable discovery out of provider warnings', async () => {
+		installBrowserMock()
+		const {
+			handleInterceptedRequest,
+			websiteSocketToString,
+			updateWebsiteAccess,
+			updateTabState,
+			getTabState,
+			changeSimulationMode,
+			setUseSignersAddressAsActiveAddress,
+		} = await loadModules()
+		const websiteOrigin = 'https://example.test'
+		const website = { websiteOrigin, icon: undefined, title: undefined }
+		const staleAccount = 0x4444444444444444444444444444444444444444n
+		await changeSimulationMode({ simulationMode: false, activeSimulationAddress: undefined, activeSigningAddress: staleAccount })
+		await setUseSignersAddressAsActiveAddress(false)
+
+		const socket = { tabId: 1, connectionName: 0n }
+		const childSocket = { tabId: 1, connectionName: 1n }
+		await updateTabState(socket.tabId, (previousState) => ({
+			...previousState,
+			signerName: 'MetaMask',
+			signerConnected: true,
+			signerAccounts: [staleAccount],
+			signerChain: 1n,
+			signerAccountError: { code: 4001, message: 'Stale signer error' },
+			activeSigningAddress: staleAccount,
+		}))
+		const { port, messages } = createPort(socket.tabId, undefined, 0)
+		const { port: childPort, messages: childMessages } = createPort(childSocket.tabId, undefined, 1)
+		const connectionKey = websiteSocketToString(socket)
+		const childConnectionKey = websiteSocketToString(childSocket)
+		const connection = { port, socket, websiteOrigin, approved: false, wantsToConnect: true }
+		const websiteTabConnections = new Map([[socket.tabId, { connections: {
+			[connectionKey]: connection,
+			[childConnectionKey]: { port: childPort, socket: childSocket, websiteOrigin, approved: false, wantsToConnect: false },
+		} }]])
+		const { ethereum, tokenPriceService, resetSimulationServices } = createEthereumWithGetBlockCounter({ count: 0 })
+
+		await handleInterceptedRequest(port, websiteOrigin, website, ethereum, tokenPriceService, resetSimulationServices, socket, {
+			interceptorRequest: true,
+			interceptorInternalRequest: true,
+			usingInterceptorWithoutSigner: true,
+			uniqueRequestIdentifier: { requestId: 90, requestSocket: socket },
+			method: 'connected_to_signer',
+			params: [false, 'NoSigner'],
+		}, websiteTabConnections, noopPublishRpcConnectionStatus)
+
+		const noSignerState = await getTabState(socket.tabId)
+		assert.equal(noSignerState.signerName, 'NoSigner')
+		assert.equal(noSignerState.signerConnected, false)
+		assert.deepEqual(noSignerState.signerAccounts, [])
+		assert.equal(noSignerState.signerChain, undefined)
+		assert.equal(noSignerState.signerAccountError, undefined)
+		assert.equal(noSignerState.activeSigningAddress, undefined)
+		assert.equal(messages.some((message) => message.method === 'request_signer_chainId'), false)
+
+		await handleInterceptedRequest(port, websiteOrigin, website, ethereum, tokenPriceService, resetSimulationServices, socket, {
+			interceptorRequest: true,
+			interceptorInternalRequest: true,
+			usingInterceptorWithoutSigner: true,
+			uniqueRequestIdentifier: { requestId: 91, requestSocket: socket },
+			method: 'eth_accounts_reply',
+			params: [{
+				type: 'error',
+				requestAccounts: false,
+				signerUnavailable: true,
+				error: { code: 4900, message: 'No signer wallet is available to this page. Enable your wallet extension for this site, then try again.' },
+			}],
+		}, websiteTabConnections, noopPublishRpcConnectionStatus)
+		assert.equal((await getTabState(socket.tabId)).signerAccountError, undefined)
+
+		// Signer identity is trusted extension state and must be current before the website receives access.
+		await handleInterceptedRequest(port, websiteOrigin, website, ethereum, tokenPriceService, resetSimulationServices, socket, {
+			interceptorRequest: true,
+			interceptorInternalRequest: true,
+			usingInterceptorWithoutSigner: false,
+			uniqueRequestIdentifier: { requestId: 92, requestSocket: socket },
+			method: 'connected_to_signer',
+			params: [true, 'MetaMask'],
+		}, websiteTabConnections, noopPublishRpcConnectionStatus)
+		const identifiedSignerState = await getTabState(socket.tabId)
+		assert.equal(identifiedSignerState.signerName, 'MetaMask')
+		assert.equal(identifiedSignerState.signerConnected, true)
+		assert.equal(messages.some((message) => message.method === 'request_signer_chainId'), false)
+
+		await handleInterceptedRequest(childPort, websiteOrigin, website, ethereum, tokenPriceService, resetSimulationServices, childSocket, {
+			interceptorRequest: true,
+			interceptorInternalRequest: true,
+			usingInterceptorWithoutSigner: true,
+			uniqueRequestIdentifier: { requestId: 94, requestSocket: childSocket },
+			method: 'connected_to_signer',
+			params: [false, 'NoSigner'],
+		}, websiteTabConnections, noopPublishRpcConnectionStatus)
+		const stateAfterChildFrame = await getTabState(socket.tabId)
+		assert.equal(stateAfterChildFrame.signerName, 'MetaMask')
+		assert.equal(stateAfterChildFrame.signerConnected, true)
+		assert.equal(childMessages.some((message) => message.method === 'request_signer_chainId'), false)
+
+		await updateWebsiteAccess(() => [{ website, access: true, addressAccess: undefined }])
+		connection.approved = true
+		await handleInterceptedRequest(port, websiteOrigin, website, ethereum, tokenPriceService, resetSimulationServices, socket, {
+			interceptorRequest: true,
+			interceptorInternalRequest: true,
+			usingInterceptorWithoutSigner: false,
+			uniqueRequestIdentifier: { requestId: 93, requestSocket: socket },
+			method: 'eth_accounts_reply',
+			params: [{ type: 'error', requestAccounts: false, error: { code: 4900, message: 'MetaMask disconnected' } }],
+		}, websiteTabConnections, noopPublishRpcConnectionStatus)
+		const signerErrorState = await getTabState(socket.tabId)
+		assert.equal(signerErrorState.signerName, 'MetaMask')
+		assert.equal(signerErrorState.signerConnected, true)
+		assert.deepEqual(signerErrorState.signerAccountError, { code: 4900, message: 'MetaMask disconnected' })
 	})
 
 	test('skip simulation state refresh for eth_accounts in simulation mode', async () => {
@@ -1381,6 +1496,7 @@ describe('background eth_accounts', () => {
 			changeSimulationMode,
 			setUseSignersAddressAsActiveAddress,
 			updateWebsiteAccess,
+			getTabState,
 		} = await loadModules()
 		const websiteOrigin = 'https://example.test'
 		const website = { websiteOrigin, icon: undefined, title: undefined }
@@ -1411,7 +1527,7 @@ describe('background eth_accounts', () => {
 				usingInterceptorWithoutSigner: true,
 				uniqueRequestIdentifier: { requestId: internalRequestId, requestSocket: socket },
 				method: 'eth_accounts_reply',
-				params: [{ type: 'error', requestAccounts: accountRequest.requestAccounts, error: unavailableSignerError }],
+				params: [{ type: 'error', requestAccounts: accountRequest.requestAccounts, signerUnavailable: true, error: unavailableSignerError }],
 			}, websiteTabConnections, noopPublishRpcConnectionStatus)
 		})
 		port = createdPort
@@ -1439,6 +1555,7 @@ describe('background eth_accounts', () => {
 			assert.equal(messages.some((message) => (message.method === 'connect' || message.method === 'accountsChanged') && message.requestId === requestId), false)
 		}
 		assert.equal(messages.some((message) => message.method === 'connect' || message.method === 'accountsChanged'), false)
+		assert.equal((await getTabState(socket.tabId)).signerAccountError, undefined)
 	})
 
 	test('ignores a provider-disconnected completion from a sibling socket', async () => {

--- a/test/tests/backgroundEthAccounts.test.ts
+++ b/test/tests/backgroundEthAccounts.test.ts
@@ -6,14 +6,24 @@ import { EthereumClientService } from '../../app/ts/simulation/services/Ethereum
 import { TokenPriceService } from '../../app/ts/simulation/services/priceEstimator.js'
 import type { RpcEntry } from '../../app/ts/types/rpc.js'
 import type { PublishRpcConnectionStatus } from '../../app/ts/background/rpcSlowRequestTracking.js'
+import type { WebsiteTabConnections } from '../../app/ts/types/user-interface-types.js'
 
 type Listener = () => void
 type PortMessage = { type?: unknown, method?: unknown, result?: unknown, requestId?: unknown, error?: { code?: unknown, message?: unknown } }
 const noopPublishRpcConnectionStatus: PublishRpcConnectionStatus = async () => undefined
 const ADDRESS_PROMPT_TIMEOUT_MS = 100
 
-function installBrowserMock() {
+function createDeferredSignal() {
+	let resolveSignal = () => undefined
+	const promise = new Promise<void>((resolve) => { resolveSignal = resolve })
+	return { promise, resolve: () => resolveSignal() }
+}
+
+function installBrowserMock({ deferFirstChainChangeRemoval = false } = {}) {
 	const storageState: Record<string, unknown> = {}
+	const chainChangeRemovalStarted = createDeferredSignal()
+	const chainChangeRemovalRelease = createDeferredSignal()
+	let chainChangeRemovalDeferred = false
 	;(globalThis as typeof globalThis & { browser: typeof globalThis.browser }).browser = {
 		runtime: {
 			lastError: null,
@@ -36,7 +46,13 @@ function installBrowserMock() {
 					Object.assign(storageState, items)
 				},
 				async remove(keys: string | string[]) {
-					for (const key of Array.isArray(keys) ? keys : [keys]) delete storageState[key]
+					const keysToRemove = Array.isArray(keys) ? keys : [keys]
+					if (deferFirstChainChangeRemoval && !chainChangeRemovalDeferred && keysToRemove.includes('chainChangeConfirmationPromise')) {
+						chainChangeRemovalDeferred = true
+						chainChangeRemovalStarted.resolve()
+						await chainChangeRemovalRelease.promise
+					}
+					for (const key of keysToRemove) delete storageState[key]
 				},
 			},
 		},
@@ -77,6 +93,10 @@ function installBrowserMock() {
 	} as unknown as typeof globalThis.browser
 	;(globalThis as typeof globalThis & { chrome: { runtime: { id: string } } }).chrome = { runtime: { id: 'test-extension' } }
 	;(globalThis as typeof globalThis & { location: Location }).location = { origin: '' } as unknown as Location
+	return {
+		waitForDeferredChainChangeRemoval: async () => await chainChangeRemovalStarted.promise,
+		releaseDeferredChainChangeRemoval: chainChangeRemovalRelease.resolve,
+	}
 }
 
 async function loadModules() {
@@ -84,16 +104,20 @@ async function loadModules() {
 		...await import('../../app/ts/background/accessManagement.js'),
 		...await import('../../app/ts/background/background.js'),
 		...await import('../../app/ts/background/backgroundUtils.js'),
+		...await import('../../app/ts/background/popupMessageHandlers.js'),
 		...await import('../../app/ts/background/settings.js'),
 		...await import('../../app/ts/background/storageVariables.js'),
+		...await import('../../app/ts/background/websiteTabConnections.js'),
+		...await import('../../app/ts/background/windows/changeChain.js'),
 		...await import('../../app/ts/background/windows/interceptorAccess.js'),
+		...await import('../../app/ts/background/signerStateOwnership.js'),
 	}
 }
 
-function createPort(tabId: number, onPostMessage?: (message: PortMessage) => void, frameId?: number) {
+function createPort(tabId: number, onPostMessage?: (message: PortMessage) => void, frameId?: number, connectionName = 0n) {
 	const messages: PortMessage[] = []
 	const port = {
-		name: '0x0',
+		name: `0x${ connectionName.toString(16) }`,
 		sender: { tab: { id: tabId }, ...(frameId === undefined ? {} : { frameId }) },
 		postMessage(message: unknown) {
 			const typedMessage = message as PortMessage
@@ -102,6 +126,15 @@ function createPort(tabId: number, onPostMessage?: (message: PortMessage) => voi
 		},
 	} as unknown as browser.runtime.Port
 	return { port, messages }
+}
+
+function confirmedSignerOwnership(socket: { readonly connectionName: bigint }) {
+	return {
+		signerStateOwnerConnectionName: socket.connectionName,
+		signerStateOwnerConfirmed: true,
+		signerStateOwnerGeneration: 1,
+		signerProviderGeneration: 1,
+	}
 }
 
 async function waitForPortMessageCount(messages: readonly PortMessage[], method: string, count: number, timeoutMs = 100) {
@@ -180,7 +213,7 @@ describe('background eth_accounts', () => {
 		const socket = { tabId: 1, connectionName: 0n }
 		const { port, messages } = createPort(socket.tabId)
 		const connectionKey = websiteSocketToString(socket)
-		const websiteTabConnections = new Map([[socket.tabId, { connections: {
+		const websiteTabConnections = new Map([[socket.tabId, { ...confirmedSignerOwnership(socket), connections: {
 			[connectionKey]: { port, socket, websiteOrigin, approved: true, wantsToConnect: true },
 		} }]])
 		const { ethereum, tokenPriceService, resetSimulationServices } = createEthereumWithGetBlockCounter({ count: 0 })
@@ -222,7 +255,7 @@ describe('background eth_accounts', () => {
 		const socket = { tabId: 1, connectionName: 0n }
 		const { port, messages } = createPort(socket.tabId)
 		const connectionKey = websiteSocketToString(socket)
-		const websiteTabConnections = new Map([[socket.tabId, { connections: {
+		const websiteTabConnections = new Map([[socket.tabId, { ...confirmedSignerOwnership(socket), connections: {
 			[connectionKey]: { port, socket, websiteOrigin, approved: true, wantsToConnect: true },
 		} }]])
 		const { ethereum, tokenPriceService, resetSimulationServices } = createEthereumWithGetBlockCounter({ count: 0 })
@@ -233,7 +266,7 @@ describe('background eth_accounts', () => {
 			usingInterceptorWithoutSigner: false,
 			uniqueRequestIdentifier: { requestId: 9, requestSocket: socket },
 			method: 'eth_accounts_reply',
-			params: [{ type: 'success', accounts: ['0x3333333333333333333333333333333333333333'], requestAccounts: false }],
+params: [{ signerProviderGeneration: 1, type: 'success', accounts: ['0x3333333333333333333333333333333333333333'], requestAccounts: false }],
 		}, websiteTabConnections, noopPublishRpcConnectionStatus)
 
 		const reply = messages.at(-1)
@@ -278,7 +311,7 @@ describe('background eth_accounts', () => {
 		const connectionKey = websiteSocketToString(socket)
 		const childConnectionKey = websiteSocketToString(childSocket)
 		const connection = { port, socket, websiteOrigin, approved: false, wantsToConnect: true }
-		const websiteTabConnections = new Map([[socket.tabId, { connections: {
+		const websiteTabConnections = new Map([[socket.tabId, { ...confirmedSignerOwnership(socket), connections: {
 			[connectionKey]: connection,
 			[childConnectionKey]: { port: childPort, socket: childSocket, websiteOrigin, approved: false, wantsToConnect: false },
 		} }]])
@@ -290,7 +323,7 @@ describe('background eth_accounts', () => {
 			usingInterceptorWithoutSigner: true,
 			uniqueRequestIdentifier: { requestId: 90, requestSocket: socket },
 			method: 'connected_to_signer',
-			params: [false, 'NoSigner'],
+			params: [false, 'NoSigner', 2],
 		}, websiteTabConnections, noopPublishRpcConnectionStatus)
 
 		const noSignerState = await getTabState(socket.tabId)
@@ -309,6 +342,7 @@ describe('background eth_accounts', () => {
 			uniqueRequestIdentifier: { requestId: 91, requestSocket: socket },
 			method: 'eth_accounts_reply',
 			params: [{
+				signerProviderGeneration: 2,
 				type: 'error',
 				requestAccounts: false,
 				signerUnavailable: true,
@@ -324,7 +358,7 @@ describe('background eth_accounts', () => {
 			usingInterceptorWithoutSigner: false,
 			uniqueRequestIdentifier: { requestId: 92, requestSocket: socket },
 			method: 'connected_to_signer',
-			params: [true, 'MetaMask'],
+			params: [true, 'MetaMask', 3],
 		}, websiteTabConnections, noopPublishRpcConnectionStatus)
 		const identifiedSignerState = await getTabState(socket.tabId)
 		assert.equal(identifiedSignerState.signerName, 'MetaMask')
@@ -337,7 +371,7 @@ describe('background eth_accounts', () => {
 			usingInterceptorWithoutSigner: true,
 			uniqueRequestIdentifier: { requestId: 94, requestSocket: childSocket },
 			method: 'connected_to_signer',
-			params: [false, 'NoSigner'],
+			params: [false, 'NoSigner', 4],
 		}, websiteTabConnections, noopPublishRpcConnectionStatus)
 		const stateAfterChildFrame = await getTabState(socket.tabId)
 		assert.equal(stateAfterChildFrame.signerName, 'MetaMask')
@@ -352,12 +386,412 @@ describe('background eth_accounts', () => {
 			usingInterceptorWithoutSigner: false,
 			uniqueRequestIdentifier: { requestId: 93, requestSocket: socket },
 			method: 'eth_accounts_reply',
-			params: [{ type: 'error', requestAccounts: false, error: { code: 4900, message: 'MetaMask disconnected' } }],
+			params: [{ signerProviderGeneration: 3, type: 'error', requestAccounts: false, error: { code: 4900, message: 'MetaMask disconnected' } }],
 		}, websiteTabConnections, noopPublishRpcConnectionStatus)
 		const signerErrorState = await getTabState(socket.tabId)
 		assert.equal(signerErrorState.signerName, 'MetaMask')
 		assert.equal(signerErrorState.signerConnected, true)
 		assert.deepEqual(signerErrorState.signerAccountError, { code: 4900, message: 'MetaMask disconnected' })
+	})
+
+	test('refreshes accounts after signer identity or page ownership changes', async () => {
+		installBrowserMock()
+		const {
+			handleInterceptedRequest,
+			websiteSocketToString,
+			updateWebsiteAccess,
+			updateTabState,
+			getTabState,
+			changeSimulationMode,
+			setUseSignersAddressAsActiveAddress,
+			createInternalMessageListener,
+			INTERNAL_CHANNEL_NAME,
+			registerWebsiteConnectionAndProvisionallyClaimSignerState,
+		} = await loadModules()
+		const websiteOrigin = 'https://example.test'
+		const website = { websiteOrigin, icon: undefined, title: undefined }
+		const braveAccount = 0x4141414141414141414141414141414141414141n
+		const metaMaskAccount = 0x4242424242424242424242424242424242424242n
+		const metaMaskAccountString = '0x4242424242424242424242424242424242424242'
+		await changeSimulationMode({ simulationMode: false, activeSimulationAddress: undefined, activeSigningAddress: braveAccount })
+		await setUseSignersAddressAsActiveAddress(false)
+		await updateWebsiteAccess(() => [{ website, access: true, addressAccess: [{ address: metaMaskAccount, access: true }] }])
+
+		const socket = { tabId: 1, connectionName: 0n }
+		const signerAccountSnapshots: bigint[][] = []
+		const { port: createdPort, messages } = createPort(socket.tabId, (message) => {
+			if (message.method !== 'request_signer_to_eth_requestAccounts') return
+			void (async () => {
+				signerAccountSnapshots.push([...(await getTabState(socket.tabId)).signerAccounts])
+				await handleInterceptedRequest(port, websiteOrigin, website, ethereum, tokenPriceService, resetSimulationServices, socket, {
+					interceptorRequest: true,
+					interceptorInternalRequest: true,
+					usingInterceptorWithoutSigner: false,
+					uniqueRequestIdentifier: { requestId: 202, requestSocket: socket },
+					method: 'eth_accounts_reply',
+					params: [{ signerProviderGeneration: 2, type: 'success', accounts: [metaMaskAccountString], requestAccounts: true }],
+				}, websiteTabConnections, noopPublishRpcConnectionStatus)
+			})()
+		}, 0)
+		const port = createdPort
+		const connectionKey = websiteSocketToString(socket)
+		const websiteTabConnections = new Map([[socket.tabId, { ...confirmedSignerOwnership(socket), connections: {
+			[connectionKey]: { port, socket, websiteOrigin, approved: true, wantsToConnect: true },
+		} }]])
+		const { ethereum, tokenPriceService, resetSimulationServices } = createEthereumWithGetBlockCounter({ count: 0 })
+		await updateTabState(socket.tabId, (previousState) => ({
+			...previousState,
+			signerName: 'Brave',
+			signerConnected: true,
+			signerAccounts: [braveAccount],
+			signerChain: 1n,
+			signerAccountError: { code: 4001, message: 'Stale Brave error' },
+			activeSigningAddress: braveAccount,
+		}))
+
+		await handleInterceptedRequest(port, websiteOrigin, website, ethereum, tokenPriceService, resetSimulationServices, socket, {
+			interceptorRequest: true,
+			interceptorInternalRequest: true,
+			usingInterceptorWithoutSigner: false,
+			uniqueRequestIdentifier: { requestId: 200, requestSocket: socket },
+			method: 'connected_to_signer',
+			params: [true, 'MetaMask', 2],
+		}, websiteTabConnections, noopPublishRpcConnectionStatus)
+
+		const stateAfterMetaMaskSelection = await getTabState(socket.tabId)
+		assert.equal(stateAfterMetaMaskSelection.signerName, 'MetaMask')
+		assert.equal(stateAfterMetaMaskSelection.signerConnected, true)
+		assert.deepEqual(stateAfterMetaMaskSelection.signerAccounts, [])
+		assert.equal(stateAfterMetaMaskSelection.signerChain, undefined)
+		assert.equal(stateAfterMetaMaskSelection.signerAccountError, undefined)
+		assert.equal(stateAfterMetaMaskSelection.activeSigningAddress, undefined)
+
+		await handleInterceptedRequest(port, websiteOrigin, website, ethereum, tokenPriceService, resetSimulationServices, socket, {
+			interceptorRequest: true,
+			usingInterceptorWithoutSigner: false,
+			uniqueRequestIdentifier: { requestId: 201, requestSocket: socket },
+			method: 'eth_requestAccounts',
+		}, websiteTabConnections, noopPublishRpcConnectionStatus)
+
+		assert.deepEqual(signerAccountSnapshots, [[]])
+		assert.equal(messages.filter((message) => message.method === 'request_signer_to_eth_requestAccounts').length, 1)
+		assert.deepEqual(messages.filter((message) => message.method === 'eth_accounts' && message.requestId === 201).at(-1)?.result, [metaMaskAccountString])
+		assert.deepEqual((await getTabState(socket.tabId)).signerAccounts, [metaMaskAccount])
+
+		const nextSocket = { tabId: socket.tabId, connectionName: 1n }
+		const { port: nextPort } = createPort(nextSocket.tabId, undefined, 0, nextSocket.connectionName)
+		const tabConnection = websiteTabConnections.get(nextSocket.tabId)
+		if (tabConnection === undefined) throw new Error('Missing tab connection')
+		await registerWebsiteConnectionAndProvisionallyClaimSignerState(
+			websiteTabConnections,
+			nextSocket,
+			{ port: nextPort, socket: nextSocket, websiteOrigin, approved: true, wantsToConnect: true },
+			true,
+		)
+		await handleInterceptedRequest(nextPort, websiteOrigin, website, ethereum, tokenPriceService, resetSimulationServices, nextSocket, {
+			interceptorRequest: true,
+			interceptorInternalRequest: true,
+			usingInterceptorWithoutSigner: false,
+			uniqueRequestIdentifier: { requestId: 203, requestSocket: nextSocket },
+			method: 'connected_to_signer',
+			params: [true, 'MetaMask', 1],
+		}, websiteTabConnections, noopPublishRpcConnectionStatus)
+
+		const stateAfterNewPageConnection = await getTabState(nextSocket.tabId)
+		assert.equal(stateAfterNewPageConnection.signerName, 'MetaMask')
+		assert.equal(stateAfterNewPageConnection.signerConnected, true)
+		assert.deepEqual(stateAfterNewPageConnection.signerAccounts, [])
+		assert.equal(stateAfterNewPageConnection.signerChain, undefined)
+		assert.equal(stateAfterNewPageConnection.signerAccountError, undefined)
+		assert.equal(stateAfterNewPageConnection.activeSigningAddress, undefined)
+
+		const currentSignerError = { code: 4001, message: 'Current MetaMask error' }
+		await updateTabState(nextSocket.tabId, (previousState) => ({
+			...previousState,
+			signerAccounts: [metaMaskAccount],
+			signerChain: 5n,
+			signerAccountError: currentSignerError,
+			activeSigningAddress: metaMaskAccount,
+		}))
+		const staleAccountCompletionErrors: Array<{ code: number, message: string } | undefined> = []
+		const completionChannel = new BroadcastChannel(INTERNAL_CHANNEL_NAME)
+		const completionListener = createInternalMessageListener((message) => {
+			if (message.method !== 'window_signer_accounts_changed') return
+			if (message.data.socket.connectionName !== socket.connectionName) return
+			staleAccountCompletionErrors.push(message.data.error)
+		})
+		completionChannel.addEventListener('message', completionListener)
+		try {
+			await handleInterceptedRequest(port, websiteOrigin, website, ethereum, tokenPriceService, resetSimulationServices, socket, {
+				interceptorRequest: true,
+				interceptorInternalRequest: true,
+				usingInterceptorWithoutSigner: false,
+				uniqueRequestIdentifier: { requestId: 204, requestSocket: socket },
+				method: 'eth_accounts_reply',
+				params: [{ signerProviderGeneration: 1, type: 'success', accounts: ['0x4141414141414141414141414141414141414141'], requestAccounts: true }],
+			}, websiteTabConnections, noopPublishRpcConnectionStatus)
+			await handleInterceptedRequest(port, websiteOrigin, website, ethereum, tokenPriceService, resetSimulationServices, socket, {
+				interceptorRequest: true,
+				interceptorInternalRequest: true,
+				usingInterceptorWithoutSigner: false,
+				uniqueRequestIdentifier: { requestId: 205, requestSocket: socket },
+				method: 'eth_accounts_reply',
+				params: [{ signerProviderGeneration: 1, type: 'error', requestAccounts: true, error: { code: 4001, message: 'Late Brave error' } }],
+			}, websiteTabConnections, noopPublishRpcConnectionStatus)
+			await handleInterceptedRequest(port, websiteOrigin, website, ethereum, tokenPriceService, resetSimulationServices, socket, {
+				interceptorRequest: true,
+				interceptorInternalRequest: true,
+				usingInterceptorWithoutSigner: false,
+				uniqueRequestIdentifier: { requestId: 206, requestSocket: socket },
+				method: 'signer_chainChanged',
+				params: ['0x2', 2],
+			}, websiteTabConnections, noopPublishRpcConnectionStatus)
+			const completionDeadline = Date.now() + 100
+			while (staleAccountCompletionErrors.length < 2 && Date.now() < completionDeadline) await new Promise((resolve) => setTimeout(resolve, 0))
+		} finally {
+			completionChannel.removeEventListener('message', completionListener)
+			completionChannel.close()
+		}
+
+		assert.deepEqual(staleAccountCompletionErrors, [])
+		assert.equal(tabConnection.signerStateOwnerConnectionName, nextSocket.connectionName)
+		const stateAfterStaleReplies = await getTabState(nextSocket.tabId)
+		assert.deepEqual(stateAfterStaleReplies.signerAccounts, [metaMaskAccount])
+		assert.equal(stateAfterStaleReplies.activeSigningAddress, metaMaskAccount)
+		assert.equal(stateAfterStaleReplies.signerChain, 5n)
+		assert.deepEqual(stateAfterStaleReplies.signerAccountError, currentSignerError)
+	})
+
+	test('waits for provisional page ownership before reading or requesting signer accounts', async () => {
+		installBrowserMock()
+		const {
+			changeSimulationMode,
+			getTabState,
+			handleInterceptedRequest,
+			registerWebsiteConnectionAndProvisionallyClaimSignerState,
+			setUseSignersAddressAsActiveAddress,
+			updateTabState,
+			updateWebsiteAccess,
+			websiteSocketToString,
+		} = await loadModules()
+		const websiteOrigin = 'https://example.test'
+		const website = { websiteOrigin, icon: undefined, title: undefined }
+		const staleAccount = 0x5151515151515151515151515151515151515151n
+		const currentAccount = 0x5252525252525252525252525252525252525252n
+		const currentAccountString = '0x5252525252525252525252525252525252525252'
+		await changeSimulationMode({ simulationMode: false, activeSimulationAddress: undefined, activeSigningAddress: staleAccount })
+		await setUseSignersAddressAsActiveAddress(false)
+		await updateWebsiteAccess(() => [{ website, access: true, addressAccess: [{ address: currentAccount, access: true }] }])
+
+		const previousSocket = { tabId: 1, connectionName: 50n }
+		const restoredSocket = { tabId: 1, connectionName: 51n }
+		const { port: previousPort } = createPort(previousSocket.tabId, undefined, 0, previousSocket.connectionName)
+		let restoredPort: browser.runtime.Port
+		const { port: createdRestoredPort, messages } = createPort(restoredSocket.tabId, (message) => {
+			if (message.method !== 'request_signer_to_eth_accounts') return
+			void handleInterceptedRequest(restoredPort, websiteOrigin, website, ethereum, tokenPriceService, resetSimulationServices, restoredSocket, {
+				interceptorRequest: true,
+				interceptorInternalRequest: true,
+				usingInterceptorWithoutSigner: false,
+				uniqueRequestIdentifier: { requestId: 302, requestSocket: restoredSocket },
+				method: 'eth_accounts_reply',
+				params: [{ signerProviderGeneration: 1, type: 'success', accounts: [currentAccountString], requestAccounts: false }],
+			}, websiteTabConnections, noopPublishRpcConnectionStatus)
+		}, 0, restoredSocket.connectionName)
+		restoredPort = createdRestoredPort
+		const websiteTabConnections = new Map([[restoredSocket.tabId, {
+			signerStateOwnerConnectionName: previousSocket.connectionName,
+			signerStateOwnerConfirmed: true,
+			signerStateOwnerGeneration: 1,
+			signerProviderGeneration: 7,
+			connections: {
+				[websiteSocketToString(previousSocket)]: { port: previousPort, socket: previousSocket, websiteOrigin, approved: true, wantsToConnect: true },
+			},
+		}]])
+		const { ethereum, tokenPriceService, resetSimulationServices } = createEthereumWithGetBlockCounter({ count: 0 })
+		await updateTabState(restoredSocket.tabId, (previousState) => ({
+			...previousState,
+			signerName: 'MetaMask',
+			signerConnected: true,
+			signerAccounts: [staleAccount],
+			signerChain: 1n,
+			activeSigningAddress: staleAccount,
+		}))
+		await registerWebsiteConnectionAndProvisionallyClaimSignerState(
+			websiteTabConnections,
+			restoredSocket,
+			{ port: restoredPort, socket: restoredSocket, websiteOrigin, approved: true, wantsToConnect: true },
+			true,
+		)
+
+		const accountRequest = handleInterceptedRequest(restoredPort, websiteOrigin, website, ethereum, tokenPriceService, resetSimulationServices, restoredSocket, {
+			interceptorRequest: true,
+			usingInterceptorWithoutSigner: false,
+			uniqueRequestIdentifier: { requestId: 300, requestSocket: restoredSocket },
+			method: 'eth_accounts',
+		}, websiteTabConnections, noopPublishRpcConnectionStatus)
+		await new Promise((resolve) => setTimeout(resolve, 0))
+		assert.equal(messages.some((message) => message.method === 'request_signer_to_eth_accounts'), false)
+		assert.equal(messages.some((message) => message.method === 'eth_accounts' && message.requestId === 300), false)
+
+		await handleInterceptedRequest(restoredPort, websiteOrigin, website, ethereum, tokenPriceService, resetSimulationServices, restoredSocket, {
+			interceptorRequest: true,
+			interceptorInternalRequest: true,
+			usingInterceptorWithoutSigner: false,
+			uniqueRequestIdentifier: { requestId: 301, requestSocket: restoredSocket },
+			method: 'connected_to_signer',
+			params: [true, 'MetaMask', 1],
+		}, websiteTabConnections, noopPublishRpcConnectionStatus)
+		await accountRequest
+
+		assert.deepEqual(messages.filter((message) => message.method === 'eth_accounts' && message.requestId === 300).at(-1)?.result, [currentAccountString])
+		assert.deepEqual((await getTabState(restoredSocket.tabId)).signerAccounts, [currentAccount])
+	})
+
+	test('finishes the first account request when the signer changes on the same page port', async () => {
+		installBrowserMock()
+		const {
+			changeSimulationMode,
+			handleInterceptedRequest,
+			setUseSignersAddressAsActiveAddress,
+			updateWebsiteAccess,
+			websiteSocketToString,
+		} = await loadModules()
+		const websiteOrigin = 'https://example.test'
+		const website = { websiteOrigin, icon: undefined, title: undefined }
+		const account = 0x6060606060606060606060606060606060606060n
+		const accountString = '0x6060606060606060606060606060606060606060'
+		await changeSimulationMode({ simulationMode: false, activeSimulationAddress: undefined, activeSigningAddress: undefined })
+		await setUseSignersAddressAsActiveAddress(false)
+		await updateWebsiteAccess(() => [{ website, access: true, addressAccess: [{ address: account, access: true }] }])
+
+		const socket = { tabId: 1, connectionName: 59n }
+		let port: browser.runtime.Port
+		let websiteTabConnections: WebsiteTabConnections
+		const createdPort = createPort(socket.tabId, (message) => {
+			if (message.method !== 'request_signer_to_eth_requestAccounts') return
+			void (async () => {
+				await handleInterceptedRequest(port, websiteOrigin, website, ethereum, tokenPriceService, resetSimulationServices, socket, {
+					interceptorRequest: true,
+					interceptorInternalRequest: true,
+					usingInterceptorWithoutSigner: false,
+					uniqueRequestIdentifier: { requestId: 308, requestSocket: socket },
+					method: 'connected_to_signer',
+					params: [true, 'MetaMask', 2],
+				}, websiteTabConnections, noopPublishRpcConnectionStatus)
+				await handleInterceptedRequest(port, websiteOrigin, website, ethereum, tokenPriceService, resetSimulationServices, socket, {
+					interceptorRequest: true,
+					interceptorInternalRequest: true,
+					usingInterceptorWithoutSigner: false,
+					uniqueRequestIdentifier: { requestId: 309, requestSocket: socket },
+					method: 'eth_accounts_reply',
+					params: [{ signerProviderGeneration: 2, type: 'success', accounts: [accountString], requestAccounts: true }],
+				}, websiteTabConnections, noopPublishRpcConnectionStatus)
+			})()
+		}, 0, socket.connectionName)
+		port = createdPort.port
+		websiteTabConnections = new Map([[socket.tabId, {
+			...confirmedSignerOwnership(socket),
+			connections: {
+				[websiteSocketToString(socket)]: { port, socket, websiteOrigin, approved: true, wantsToConnect: true },
+			},
+		}]])
+		const { ethereum, tokenPriceService, resetSimulationServices } = createEthereumWithGetBlockCounter({ count: 0 })
+
+		await handleInterceptedRequest(port, websiteOrigin, website, ethereum, tokenPriceService, resetSimulationServices, socket, {
+			interceptorRequest: true,
+			usingInterceptorWithoutSigner: true,
+			uniqueRequestIdentifier: { requestId: 307, requestSocket: socket },
+			method: 'eth_requestAccounts',
+		}, websiteTabConnections, noopPublishRpcConnectionStatus)
+
+		assert.equal(createdPort.messages.filter((message) => message.method === 'request_signer_to_eth_requestAccounts').length, 1)
+		assert.deepEqual(createdPort.messages.filter((message) => message.method === 'eth_accounts' && message.requestId === 307).at(-1)?.result, [accountString])
+	})
+
+	test('rejects stale account and chain callbacks from an older signer epoch on the current port', async () => {
+		installBrowserMock()
+		const {
+			changeSimulationMode,
+			createInternalMessageListener,
+			getTabState,
+			handleInterceptedRequest,
+			INTERNAL_CHANNEL_NAME,
+			setUseSignersAddressAsActiveAddress,
+			updateTabState,
+			updateWebsiteAccess,
+			websiteSocketToString,
+		} = await loadModules()
+		const websiteOrigin = 'https://example.test'
+		const website = { websiteOrigin, icon: undefined, title: undefined }
+		const currentAccount = 0x6161616161616161616161616161616161616161n
+		await changeSimulationMode({ simulationMode: true, activeSimulationAddress: undefined, activeSigningAddress: undefined })
+		await setUseSignersAddressAsActiveAddress(false)
+		await updateWebsiteAccess(() => [{ website, access: true, addressAccess: undefined }])
+
+		const socket = { tabId: 1, connectionName: 60n }
+		const { port } = createPort(socket.tabId, undefined, 0, socket.connectionName)
+		const websiteTabConnections = new Map([[socket.tabId, {
+			signerStateOwnerConnectionName: socket.connectionName,
+			signerStateOwnerConfirmed: true,
+			signerStateOwnerGeneration: 4,
+			signerProviderGeneration: 2,
+			connections: {
+				[websiteSocketToString(socket)]: { port, socket, websiteOrigin, approved: true, wantsToConnect: true },
+			},
+		}]])
+		const { ethereum, tokenPriceService, resetSimulationServices } = createEthereumWithGetBlockCounter({ count: 0 })
+		const currentError = { code: 4001, message: 'Current signer error' }
+		await updateTabState(socket.tabId, (previousState) => ({
+			...previousState,
+			signerName: 'MetaMask',
+			signerConnected: true,
+			signerAccounts: [currentAccount],
+			signerChain: 5n,
+			signerAccountError: currentError,
+			activeSigningAddress: currentAccount,
+		}))
+		const completionErrors: Array<{ code: number, message: string } | undefined> = []
+		const completionChannel = new BroadcastChannel(INTERNAL_CHANNEL_NAME)
+		const completionListener = createInternalMessageListener((message) => {
+			if (message.method === 'window_signer_accounts_changed' && message.data.socket.connectionName === socket.connectionName) completionErrors.push(message.data.error)
+		})
+		completionChannel.addEventListener('message', completionListener)
+		try {
+			for (const [requestId, params] of [
+				[310, { signerProviderGeneration: 1, type: 'success', accounts: ['0x6262626262626262626262626262626262626262'], requestAccounts: true }],
+				[311, { signerProviderGeneration: 1, type: 'error', requestAccounts: true, error: { code: 4900, message: 'Stale error' } }],
+			] as const) {
+				await handleInterceptedRequest(port, websiteOrigin, website, ethereum, tokenPriceService, resetSimulationServices, socket, {
+					interceptorRequest: true,
+					interceptorInternalRequest: true,
+					usingInterceptorWithoutSigner: false,
+					uniqueRequestIdentifier: { requestId, requestSocket: socket },
+					method: 'eth_accounts_reply',
+					params: [params],
+				}, websiteTabConnections, noopPublishRpcConnectionStatus)
+			}
+			await handleInterceptedRequest(port, websiteOrigin, website, ethereum, tokenPriceService, resetSimulationServices, socket, {
+				interceptorRequest: true,
+				interceptorInternalRequest: true,
+				usingInterceptorWithoutSigner: false,
+				uniqueRequestIdentifier: { requestId: 312, requestSocket: socket },
+				method: 'signer_chainChanged',
+				params: ['0x2', 1],
+			}, websiteTabConnections, noopPublishRpcConnectionStatus)
+			const completionDeadline = Date.now() + 100
+			while (completionErrors.length < 2 && Date.now() < completionDeadline) await new Promise((resolve) => setTimeout(resolve, 0))
+		} finally {
+			completionChannel.removeEventListener('message', completionListener)
+			completionChannel.close()
+		}
+
+		assert.deepEqual(completionErrors, [])
+		const tabState = await getTabState(socket.tabId)
+		assert.deepEqual(tabState.signerAccounts, [currentAccount])
+		assert.equal(tabState.signerChain, 5n)
+		assert.deepEqual(tabState.signerAccountError, currentError)
+		assert.equal(tabState.activeSigningAddress, currentAccount)
 	})
 
 	test('skip simulation state refresh for eth_accounts in simulation mode', async () => {
@@ -373,7 +807,7 @@ describe('background eth_accounts', () => {
 		const socket = { tabId: 1, connectionName: 0n }
 		const { port, messages } = createPort(socket.tabId)
 		const connectionKey = websiteSocketToString(socket)
-		const websiteTabConnections = new Map([[socket.tabId, { connections: {
+		const websiteTabConnections = new Map([[socket.tabId, { ...confirmedSignerOwnership(socket), connections: {
 			[connectionKey]: { port, socket, websiteOrigin, approved: true, wantsToConnect: true },
 		} }]])
 		const getBlockCalls = { count: 0 }
@@ -406,7 +840,7 @@ describe('background eth_accounts', () => {
 		const socket = { tabId: 1, connectionName: 0n }
 		const { port, messages } = createPort(socket.tabId)
 		const connectionKey = websiteSocketToString(socket)
-		const websiteTabConnections = new Map([[socket.tabId, { connections: {
+		const websiteTabConnections = new Map([[socket.tabId, { ...confirmedSignerOwnership(socket), connections: {
 			[connectionKey]: { port, socket, websiteOrigin, approved: true, wantsToConnect: true },
 		} }]])
 		const { ethereum, tokenPriceService, resetSimulationServices } = createEthereumWithGetBlockCounter({ count: 0 })
@@ -436,7 +870,7 @@ describe('background eth_accounts', () => {
 		const socket = { tabId: 1, connectionName: 0n }
 		const { port, messages } = createPort(socket.tabId)
 		const connectionKey = websiteSocketToString(socket)
-		const websiteTabConnections = new Map([[socket.tabId, { connections: {
+		const websiteTabConnections = new Map([[socket.tabId, { ...confirmedSignerOwnership(socket), connections: {
 			[connectionKey]: { port, socket, websiteOrigin, approved: true, wantsToConnect: true },
 		} }]])
 		const { ethereum, tokenPriceService, resetSimulationServices } = createEthereumWithGetBlockCounter({ count: 0 })
@@ -466,7 +900,7 @@ describe('background eth_accounts', () => {
 		const socket = { tabId: 1, connectionName: 0n }
 		const { port, messages } = createPort(socket.tabId)
 		const connectionKey = websiteSocketToString(socket)
-		const websiteTabConnections = new Map([[socket.tabId, { connections: {
+		const websiteTabConnections = new Map([[socket.tabId, { ...confirmedSignerOwnership(socket), connections: {
 			[connectionKey]: { port, socket, websiteOrigin, approved: true, wantsToConnect: true },
 		} }]])
 		await updateTabState(socket.tabId, (previousState) => ({ ...previousState, signerAccounts: [account], activeSigningAddress: undefined }))
@@ -501,7 +935,7 @@ describe('background eth_accounts', () => {
 		const socket = { tabId: 1, connectionName: 0n }
 		const { port, messages } = createPort(socket.tabId)
 		const connectionKey = websiteSocketToString(socket)
-		const websiteTabConnections = new Map([[socket.tabId, { connections: {
+		const websiteTabConnections = new Map([[socket.tabId, { ...confirmedSignerOwnership(socket), connections: {
 			[connectionKey]: { port, socket, websiteOrigin, approved: true, wantsToConnect: true },
 		} }]])
 		await updateTabState(socket.tabId, (previousState) => ({ ...previousState, signerAccounts: [account], activeSigningAddress: undefined }))
@@ -542,7 +976,7 @@ describe('background eth_accounts', () => {
 		const socket = { tabId: 1, connectionName: 0n }
 		const { port, messages } = createPort(socket.tabId)
 		const connectionKey = websiteSocketToString(socket)
-		const websiteTabConnections = new Map([[socket.tabId, { connections: {
+		const websiteTabConnections = new Map([[socket.tabId, { ...confirmedSignerOwnership(socket), connections: {
 			[connectionKey]: { port, socket, websiteOrigin, approved: true, wantsToConnect: true },
 		} }]])
 		const { ethereum, tokenPriceService, resetSimulationServices } = createEthereumWithGetBlockCounter({ count: 0 }, false)
@@ -588,7 +1022,7 @@ describe('background eth_accounts', () => {
 		const socket = { tabId: 1, connectionName: 0n }
 		const { port, messages } = createPort(socket.tabId)
 		const connectionKey = websiteSocketToString(socket)
-		const websiteTabConnections = new Map([[socket.tabId, { connections: {
+		const websiteTabConnections = new Map([[socket.tabId, { ...confirmedSignerOwnership(socket), connections: {
 			[connectionKey]: { port, socket, websiteOrigin, approved: true, wantsToConnect: true },
 		} }]])
 		const { ethereum, tokenPriceService, resetSimulationServices } = createEthereumWithGetBlockCounter({ count: 0 }, false)
@@ -641,11 +1075,14 @@ describe('background eth_accounts', () => {
 			if (message.method !== 'request_signer_to_eth_accounts') return
 			void (async () => {
 				await updateTabState(socket.tabId, (previousState) => ({ ...previousState, signerAccounts: [account], activeSigningAddress: account }))
-				sendInternalWindowMessage({ method: 'window_signer_accounts_changed', data: { socket } })
+				sendInternalWindowMessage({
+					method: 'window_signer_accounts_changed',
+					data: { socket, signerStateOwnerGeneration: 1, signerProviderGeneration: 1 },
+				})
 			})()
 		})
 		const connectionKey = websiteSocketToString(socket)
-		const websiteTabConnections = new Map([[socket.tabId, { connections: {
+		const websiteTabConnections = new Map([[socket.tabId, { ...confirmedSignerOwnership(socket), connections: {
 			[connectionKey]: { port, socket, websiteOrigin, approved: true, wantsToConnect: true },
 		} }]])
 		const { ethereum, tokenPriceService, resetSimulationServices } = createEthereumWithGetBlockCounter({ count: 0 })
@@ -664,11 +1101,12 @@ describe('background eth_accounts', () => {
 		assert.deepEqual(ethAccountsReplies.at(-1)?.result, ['0x2222222222222222222222222222222222222222'])
 	})
 
-	test('serializes a popup refresh and interactive signer account discovery for one connection', async () => {
+	test('routes one tab-wide signer refresh while serializing passive and interactive discovery', async () => {
 		installBrowserMock()
 		const {
 			handleInterceptedRequest,
 			refreshSignerAccountsFromApprovedWebsitePorts,
+			sendCallbackToConfirmedSignerOwner,
 			websiteSocketToString,
 			changeSimulationMode,
 			setUseSignersAddressAsActiveAddress,
@@ -683,10 +1121,14 @@ describe('background eth_accounts', () => {
 		await updateWebsiteAccess(() => [{ website, access: true, addressAccess: [{ address: account, access: true }] }])
 
 		const socket = { tabId: 1, connectionName: 0n }
+		const childSocket = { tabId: 1, connectionName: 1n }
 		const { port, messages } = createPort(socket.tabId)
+		const { port: childPort, messages: childMessages } = createPort(childSocket.tabId, undefined, 2, childSocket.connectionName)
 		const connectionKey = websiteSocketToString(socket)
-		const websiteTabConnections = new Map([[socket.tabId, { connections: {
+		const childConnectionKey = websiteSocketToString(childSocket)
+		const websiteTabConnections = new Map([[socket.tabId, { ...confirmedSignerOwnership(socket), connections: {
 			[connectionKey]: { port, socket, websiteOrigin, approved: true, wantsToConnect: true },
+			[childConnectionKey]: { port: childPort, socket: childSocket, websiteOrigin, approved: true, wantsToConnect: true },
 		} }]])
 		const { ethereum, tokenPriceService, resetSimulationServices } = createEthereumWithGetBlockCounter({ count: 0 })
 		const replyWithSignerAccounts = async (requestId: number, requestAccounts: boolean, accounts: readonly string[]) => {
@@ -696,7 +1138,7 @@ describe('background eth_accounts', () => {
 				usingInterceptorWithoutSigner: false,
 				uniqueRequestIdentifier: { requestId, requestSocket: socket },
 				method: 'eth_accounts_reply',
-				params: [{ type: 'success', accounts, requestAccounts }],
+				params: [{ signerProviderGeneration: 1, type: 'success', accounts, requestAccounts }],
 			}, websiteTabConnections, noopPublishRpcConnectionStatus)
 		}
 
@@ -718,7 +1160,451 @@ describe('background eth_accounts', () => {
 		await Promise.all([passiveRequest, interactiveRequest])
 
 		assert.equal(interactiveRequestsBeforePassiveReply, 0)
+		assert.equal(childMessages.some((message) => message.method === 'request_signer_to_eth_accounts' || message.method === 'request_signer_to_eth_requestAccounts'), false)
 		assert.deepEqual(messages.filter((message) => message.method === 'eth_accounts' && message.requestId === 71).at(-1)?.result, [accountString])
+		const signerStateToken = sendCallbackToConfirmedSignerOwner(websiteTabConnections, socket.tabId, { method: 'request_signer_to_wallet_switchEthereumChain', result: 2n })
+		assert.notEqual(signerStateToken, false)
+		if (signerStateToken === false) throw new Error('Expected a confirmed signer owner')
+		assert.equal(signerStateToken.port, port)
+		assert.equal(messages.filter((message) => message.method === 'request_signer_to_wallet_switchEthereumChain').length, 1)
+		assert.equal(childMessages.some((message) => message.method === 'request_signer_to_wallet_switchEthereumChain'), false)
+	})
+
+	test('uses an unapproved signer owner for tab-wide refresh when a sibling frame is approved', async () => {
+		installBrowserMock()
+		const {
+			changeSimulationMode,
+			handleInterceptedRequest,
+			refreshSignerAccountsFromApprovedWebsitePorts,
+			sendCallbackToConfirmedSignerOwner,
+			setUseSignersAddressAsActiveAddress,
+			websiteSocketToString,
+			getTabState,
+		} = await loadModules()
+		const websiteOrigin = 'https://example.test'
+		const website = { websiteOrigin, icon: undefined, title: undefined }
+		const socket = { tabId: 1, connectionName: 0n }
+		const childSocket = { tabId: 1, connectionName: 1n }
+		const { port, messages } = createPort(socket.tabId)
+		const { port: childPort, messages: childMessages } = createPort(childSocket.tabId, undefined, 2, childSocket.connectionName)
+		const websiteTabConnections = new Map([[socket.tabId, { ...confirmedSignerOwnership(socket), connections: {
+			[websiteSocketToString(socket)]: { port, socket, websiteOrigin, approved: false, wantsToConnect: false },
+			[websiteSocketToString(childSocket)]: { port: childPort, socket: childSocket, websiteOrigin, approved: true, wantsToConnect: true },
+		} }]])
+		const { ethereum, tokenPriceService, resetSimulationServices } = createEthereumWithGetBlockCounter({ count: 0 })
+		const account = '0x2424242424242424242424242424242424242424'
+		await changeSimulationMode({ simulationMode: true, activeSimulationAddress: undefined, activeSigningAddress: undefined })
+		await setUseSignersAddressAsActiveAddress(false)
+
+		const refresh = refreshSignerAccountsFromApprovedWebsitePorts(websiteTabConnections, false)
+		await waitForPortMessageCount(messages, 'request_signer_to_eth_accounts', 1)
+		await handleInterceptedRequest(port, websiteOrigin, website, ethereum, tokenPriceService, resetSimulationServices, socket, {
+			interceptorRequest: true,
+			interceptorInternalRequest: true,
+			usingInterceptorWithoutSigner: false,
+			uniqueRequestIdentifier: { requestId: 92, requestSocket: socket },
+			method: 'eth_accounts_reply',
+			params: [{ signerProviderGeneration: 1, type: 'success', accounts: [account], requestAccounts: false }],
+		}, websiteTabConnections, noopPublishRpcConnectionStatus)
+		await refresh
+
+		assert.deepEqual((await getTabState(socket.tabId)).signerAccounts, [0x2424242424242424242424242424242424242424n])
+		assert.equal(childMessages.some((message) => message.method === 'request_signer_to_eth_accounts'), false)
+		const signerStateToken = sendCallbackToConfirmedSignerOwner(websiteTabConnections, socket.tabId, { method: 'request_signer_to_wallet_switchEthereumChain', result: 2n })
+		assert.notEqual(signerStateToken, false)
+		assert.equal(messages.filter((message) => message.method === 'request_signer_to_wallet_switchEthereumChain').length, 1)
+		assert.equal(childMessages.some((message) => message.method === 'request_signer_to_wallet_switchEthereumChain'), false)
+		await handleInterceptedRequest(port, websiteOrigin, website, ethereum, tokenPriceService, resetSimulationServices, socket, {
+			interceptorRequest: true,
+			interceptorInternalRequest: true,
+			usingInterceptorWithoutSigner: false,
+			uniqueRequestIdentifier: { requestId: 94, requestSocket: socket },
+			method: 'signer_chainChanged',
+			params: ['0x2', 1],
+		}, websiteTabConnections, noopPublishRpcConnectionStatus)
+		assert.equal((await getTabState(socket.tabId)).signerChain, 2n)
+	})
+
+	test('settles a pending chain switch when its exact signer owner disconnects', async () => {
+		installBrowserMock()
+		const {
+			changeSimulationMode,
+			removeWebsiteTabConnection,
+			resolveChainChange,
+			setChainChangeConfirmationPromise,
+			websiteSocketToString,
+		} = await loadModules()
+		const websiteOrigin = 'https://example.test'
+		const website = { websiteOrigin, icon: undefined, title: undefined }
+		const ownerSocket = { tabId: 1, connectionName: 0n }
+		const requestSocket = { tabId: 1, connectionName: 1n }
+		const { port: ownerPort, messages: ownerMessages } = createPort(ownerSocket.tabId)
+		const { port: requestPort, messages: requestMessages } = createPort(requestSocket.tabId, undefined, 2, requestSocket.connectionName)
+		const websiteTabConnections = new Map([[ownerSocket.tabId, { ...confirmedSignerOwnership(ownerSocket), connections: {
+			[websiteSocketToString(ownerSocket)]: { port: ownerPort, socket: ownerSocket, websiteOrigin, approved: false, wantsToConnect: false },
+			[websiteSocketToString(requestSocket)]: { port: requestPort, socket: requestSocket, websiteOrigin, approved: true, wantsToConnect: true },
+		} }]])
+		const currentRpcNetwork = {
+			name: 'Current RPC',
+			chainId: 1n,
+			httpsRpc: 'https://current.example',
+			currencyName: 'Ether',
+			currencyTicker: 'ETH',
+			primary: true,
+			minimized: false,
+		}
+		const requestedRpcNetwork = {
+			name: 'Requested RPC',
+			chainId: 2n,
+			httpsRpc: 'https://requested.example',
+			currencyName: 'Ether',
+			currencyTicker: 'ETH',
+			primary: true,
+			minimized: false,
+		}
+		const uniqueRequestIdentifier = { requestId: 93, requestSocket }
+		const request = {
+			interceptorRequest: true,
+			usingInterceptorWithoutSigner: false,
+			uniqueRequestIdentifier,
+			method: 'wallet_switchEthereumChain' as const,
+			params: [{ chainId: requestedRpcNetwork.chainId }],
+		}
+		await changeSimulationMode({ simulationMode: false, rpcNetwork: currentRpcNetwork, activeSimulationAddress: undefined, activeSigningAddress: undefined })
+		await setChainChangeConfirmationPromise({
+			website,
+			popupOrTabId: { type: 'popup', id: 9 },
+			request,
+			rpcNetwork: requestedRpcNetwork,
+			simulationMode: false,
+		})
+		const { ethereum, tokenPriceService, resetSimulationServices } = createEthereumWithGetBlockCounter({ count: 0 })
+		const resolution = resolveChainChange(ethereum, tokenPriceService, resetSimulationServices, websiteTabConnections, {
+			method: 'popup_changeChainDialog',
+			data: { rpcNetwork: requestedRpcNetwork, uniqueRequestIdentifier, accept: true },
+		})
+		await waitForPortMessageCount(ownerMessages, 'request_signer_to_wallet_switchEthereumChain', 1)
+
+		await removeWebsiteTabConnection(websiteTabConnections, ownerSocket, ownerPort)
+		await resolution
+
+		const reply = requestMessages.find((message) => message.method === 'wallet_switchEthereumChain' && message.requestId === uniqueRequestIdentifier.requestId)
+		assert.equal(reply?.error?.code, 4900)
+		assert.equal(reply?.error?.message, 'Signer connection changed before the previous wallet replied.')
+	})
+
+	test('accepts the exact solicited chain reply after the approving sibling disconnects', async () => {
+		installBrowserMock()
+		const {
+			changeSimulationMode,
+			handleInterceptedRequest,
+			removeWebsiteTabConnection,
+			resolveChainChange,
+			setChainChangeConfirmationPromise,
+			websiteSocketToString,
+		} = await loadModules()
+		const websiteOrigin = 'https://example.test'
+		const website = { websiteOrigin, icon: undefined, title: undefined }
+		const ownerSocket = { tabId: 1, connectionName: 0n }
+		const approvingSocket = { tabId: 1, connectionName: 1n }
+		const requestSocket = { tabId: 1, connectionName: 2n }
+		const { port: ownerPort, messages: ownerMessages } = createPort(ownerSocket.tabId)
+		const { port: approvingPort } = createPort(approvingSocket.tabId, undefined, 2, approvingSocket.connectionName)
+		const { port: requestPort, messages: requestMessages } = createPort(requestSocket.tabId, undefined, 3, requestSocket.connectionName)
+		const websiteTabConnections = new Map([[ownerSocket.tabId, { ...confirmedSignerOwnership(ownerSocket), connections: {
+			[websiteSocketToString(ownerSocket)]: { port: ownerPort, socket: ownerSocket, websiteOrigin, approved: false, wantsToConnect: false },
+			[websiteSocketToString(approvingSocket)]: { port: approvingPort, socket: approvingSocket, websiteOrigin, approved: true, wantsToConnect: true },
+			[websiteSocketToString(requestSocket)]: { port: requestPort, socket: requestSocket, websiteOrigin, approved: false, wantsToConnect: false },
+		} }]])
+		const currentRpcNetwork = {
+			name: 'Current RPC',
+			chainId: 1n,
+			httpsRpc: 'https://current.example',
+			currencyName: 'Ether',
+			currencyTicker: 'ETH',
+			primary: true,
+			minimized: false,
+		}
+		const requestedRpcNetwork = {
+			name: 'Sepolia',
+			chainId: 11155111n,
+			httpsRpc: 'https://sepolia.example',
+			currencyName: 'Sepolia Testnet ETH',
+			currencyTicker: 'SEETH',
+			primary: true,
+			minimized: false,
+		}
+		const uniqueRequestIdentifier = { requestId: 95, requestSocket }
+		const request = {
+			interceptorRequest: true,
+			usingInterceptorWithoutSigner: false,
+			uniqueRequestIdentifier,
+			method: 'wallet_switchEthereumChain' as const,
+			params: [{ chainId: requestedRpcNetwork.chainId }],
+		}
+		await changeSimulationMode({ simulationMode: false, rpcNetwork: currentRpcNetwork, activeSimulationAddress: undefined, activeSigningAddress: undefined })
+		await setChainChangeConfirmationPromise({
+			website,
+			popupOrTabId: { type: 'popup', id: 10 },
+			request,
+			rpcNetwork: requestedRpcNetwork,
+			simulationMode: false,
+		})
+		const { ethereum, tokenPriceService, resetSimulationServices } = createEthereumWithGetBlockCounter({ count: 0 })
+		const resolution = resolveChainChange(ethereum, tokenPriceService, resetSimulationServices, websiteTabConnections, {
+			method: 'popup_changeChainDialog',
+			data: { rpcNetwork: requestedRpcNetwork, uniqueRequestIdentifier, accept: true },
+		})
+		await waitForPortMessageCount(ownerMessages, 'request_signer_to_wallet_switchEthereumChain', 1)
+		await new Promise((resolve) => setTimeout(resolve, 0))
+
+		await removeWebsiteTabConnection(websiteTabConnections, approvingSocket, approvingPort)
+		await handleInterceptedRequest(ownerPort, websiteOrigin, website, ethereum, tokenPriceService, resetSimulationServices, ownerSocket, {
+			interceptorRequest: true,
+			interceptorInternalRequest: true,
+			usingInterceptorWithoutSigner: false,
+			uniqueRequestIdentifier: { requestId: 96, requestSocket: ownerSocket },
+			method: 'wallet_switchEthereumChain_reply',
+			params: [{ accept: true, chainId: '0xaa36a7', signerProviderGeneration: 1 }],
+		}, websiteTabConnections, noopPublishRpcConnectionStatus)
+		await Promise.race([
+			resolution,
+			new Promise<never>((_resolve, reject) => setTimeout(() => reject(new Error('Solicited chain reply did not settle')), 100)),
+		])
+
+		const reply = requestMessages.find((message) => message.method === 'wallet_switchEthereumChain' && message.requestId === uniqueRequestIdentifier.requestId)
+		assert.equal(reply?.result, null)
+	})
+
+	test('does not let another tab chain reply settle the pending dapp switch', async () => {
+		installBrowserMock()
+		const {
+			changeSimulationMode,
+			getSettings,
+			handleInterceptedRequest,
+			popupChangeActiveRpc,
+			resolveChainChange,
+			saveCurrentTabId,
+			setChainChangeConfirmationPromise,
+			websiteSocketToString,
+		} = await loadModules()
+		const websiteOrigin = 'https://example.test'
+		const website = { websiteOrigin, icon: undefined, title: undefined }
+		const requestSocket = { tabId: 1, connectionName: 0n }
+		const popupSocket = { tabId: 2, connectionName: 0n }
+		const { port: requestPort, messages: requestMessages } = createPort(requestSocket.tabId)
+		const { port: popupPort, messages: popupMessages } = createPort(popupSocket.tabId)
+		const websiteTabConnections = new Map([
+			[requestSocket.tabId, { ...confirmedSignerOwnership(requestSocket), connections: {
+				[websiteSocketToString(requestSocket)]: { port: requestPort, socket: requestSocket, websiteOrigin, approved: true, wantsToConnect: true },
+			} }],
+			[popupSocket.tabId, { ...confirmedSignerOwnership(popupSocket), connections: {
+				[websiteSocketToString(popupSocket)]: { port: popupPort, socket: popupSocket, websiteOrigin, approved: true, wantsToConnect: true },
+			} }],
+		])
+		const currentRpcNetwork = {
+			name: 'Current RPC',
+			chainId: 1n,
+			httpsRpc: 'https://current.example',
+			currencyName: 'Ether',
+			currencyTicker: 'ETH',
+			primary: true,
+			minimized: false,
+		}
+		const requestedRpcNetwork = {
+			name: 'Sepolia',
+			chainId: 11155111n,
+			httpsRpc: 'https://sepolia.example',
+			currencyName: 'Sepolia Testnet ETH',
+			currencyTicker: 'SEETH',
+			primary: true,
+			minimized: false,
+		}
+		const popupRpcNetwork = {
+			name: 'Holesky',
+			chainId: 17000n,
+			httpsRpc: 'https://holesky.example',
+			currencyName: 'Holesky Testnet ETH',
+			currencyTicker: 'HOETH',
+			primary: true,
+			minimized: false,
+		}
+		const uniqueRequestIdentifier = { requestId: 97, requestSocket }
+		const request = {
+			interceptorRequest: true,
+			usingInterceptorWithoutSigner: false,
+			uniqueRequestIdentifier,
+			method: 'wallet_switchEthereumChain' as const,
+			params: [{ chainId: requestedRpcNetwork.chainId }],
+		}
+		await changeSimulationMode({ simulationMode: false, rpcNetwork: currentRpcNetwork, activeSimulationAddress: undefined, activeSigningAddress: undefined })
+		await setChainChangeConfirmationPromise({
+			website,
+			popupOrTabId: { type: 'popup', id: 11 },
+			request,
+			rpcNetwork: requestedRpcNetwork,
+			simulationMode: false,
+		})
+		const { ethereum, tokenPriceService, resetSimulationServices } = createEthereumWithGetBlockCounter({ count: 0 })
+		let requestSettled = false
+		const resolution = resolveChainChange(ethereum, tokenPriceService, resetSimulationServices, websiteTabConnections, {
+			method: 'popup_changeChainDialog',
+			data: { rpcNetwork: requestedRpcNetwork, uniqueRequestIdentifier, accept: true },
+		}).then(() => { requestSettled = true })
+		await waitForPortMessageCount(requestMessages, 'request_signer_to_wallet_switchEthereumChain', 1)
+		await new Promise((resolve) => setTimeout(resolve, 0))
+
+		await saveCurrentTabId(popupSocket.tabId)
+		await popupChangeActiveRpc(ethereum, tokenPriceService, resetSimulationServices, websiteTabConnections, {
+			method: 'popup_changeActiveRpc',
+			data: popupRpcNetwork,
+		}, await getSettings())
+		await waitForPortMessageCount(popupMessages, 'request_signer_to_wallet_switchEthereumChain', 1)
+		await handleInterceptedRequest(popupPort, websiteOrigin, website, ethereum, tokenPriceService, resetSimulationServices, popupSocket, {
+			interceptorRequest: true,
+			interceptorInternalRequest: true,
+			usingInterceptorWithoutSigner: false,
+			uniqueRequestIdentifier: { requestId: 98, requestSocket: popupSocket },
+			method: 'wallet_switchEthereumChain_reply',
+			params: [{ accept: false, chainId: '0x4268', error: { code: 4001, message: 'Popup tab rejected' }, signerProviderGeneration: 1 }],
+		}, websiteTabConnections, noopPublishRpcConnectionStatus)
+		await new Promise((resolve) => setTimeout(resolve, 0))
+		assert.equal(requestSettled, false)
+
+		await handleInterceptedRequest(requestPort, websiteOrigin, website, ethereum, tokenPriceService, resetSimulationServices, requestSocket, {
+			interceptorRequest: true,
+			interceptorInternalRequest: true,
+			usingInterceptorWithoutSigner: false,
+			uniqueRequestIdentifier: { requestId: 99, requestSocket },
+			method: 'wallet_switchEthereumChain_reply',
+			params: [{ accept: false, chainId: '0xaa36a7', error: { code: 4001, message: 'Dapp tab rejected' }, signerProviderGeneration: 1 }],
+		}, websiteTabConnections, noopPublishRpcConnectionStatus)
+		await resolution
+
+		const reply = requestMessages.find((message) => message.method === 'wallet_switchEthereumChain' && message.requestId === uniqueRequestIdentifier.requestId)
+		assert.equal(reply?.error?.code, 4001)
+		assert.equal(reply?.error?.message, 'Dapp tab rejected')
+	})
+
+	test('keeps the production chain dialog guarded while signer resolution starts', async () => {
+		const { waitForDeferredChainChangeRemoval, releaseDeferredChainChangeRemoval } = installBrowserMock({ deferFirstChainChangeRemoval: true })
+		const {
+			changeSimulationMode,
+			getChainChangeConfirmationPromise,
+			handleInterceptedRequest,
+			openChangeChainDialog,
+			resolveChainChange,
+			websiteSocketToString,
+		} = await loadModules()
+		const websiteOrigin = 'https://example.test'
+		const website = { websiteOrigin, icon: undefined, title: undefined }
+		const socket = { tabId: 1, connectionName: 0n }
+		const { port, messages } = createPort(socket.tabId)
+		const websiteTabConnections = new Map([[socket.tabId, { ...confirmedSignerOwnership(socket), connections: {
+			[websiteSocketToString(socket)]: { port, socket, websiteOrigin, approved: true, wantsToConnect: true },
+		} }]])
+		const currentRpcNetwork = {
+			name: 'Current RPC',
+			chainId: 1n,
+			httpsRpc: 'https://current.example',
+			currencyName: 'Ether',
+			currencyTicker: 'ETH',
+			primary: true,
+			minimized: false,
+		}
+		const requestedRpcNetwork = {
+			name: 'Sepolia',
+			chainId: 11155111n,
+			httpsRpc: 'https://sepolia.example',
+			currencyName: 'Sepolia Testnet ETH',
+			currencyTicker: 'SEETH',
+			primary: true,
+			minimized: false,
+		}
+		const secondRpcNetwork = {
+			name: 'Holesky',
+			chainId: 17000n,
+			httpsRpc: 'https://holesky.example',
+			currencyName: 'Holesky Testnet ETH',
+			currencyTicker: 'HOETH',
+			primary: true,
+			minimized: false,
+		}
+		const firstUniqueRequestIdentifier = { requestId: 100, requestSocket: socket }
+		const firstRequest = {
+			interceptorRequest: true,
+			usingInterceptorWithoutSigner: false,
+			uniqueRequestIdentifier: firstUniqueRequestIdentifier,
+			method: 'wallet_switchEthereumChain' as const,
+			params: [{ chainId: requestedRpcNetwork.chainId }],
+		}
+		const secondUniqueRequestIdentifier = { requestId: 101, requestSocket: socket }
+		const secondRequest = {
+			interceptorRequest: true,
+			usingInterceptorWithoutSigner: false,
+			uniqueRequestIdentifier: secondUniqueRequestIdentifier,
+			method: 'wallet_switchEthereumChain' as const,
+			params: [{ chainId: secondRpcNetwork.chainId }],
+		}
+		await changeSimulationMode({ simulationMode: false, rpcNetwork: currentRpcNetwork, activeSimulationAddress: undefined, activeSigningAddress: undefined })
+		const { ethereum, tokenPriceService, resetSimulationServices } = createEthereumWithGetBlockCounter({ count: 0 })
+		const firstResolution = openChangeChainDialog(
+			ethereum,
+			tokenPriceService,
+			resetSimulationServices,
+			websiteTabConnections,
+			firstRequest,
+			false,
+			website,
+			{ method: 'wallet_switchEthereumChain', params: [{ chainId: requestedRpcNetwork.chainId }] },
+		)
+		const pendingDeadline = Date.now() + 100
+		let pendingChainChange = await getChainChangeConfirmationPromise()
+		while (pendingChainChange === undefined && Date.now() < pendingDeadline) {
+			await new Promise((resolve) => setTimeout(resolve, 0))
+			pendingChainChange = await getChainChangeConfirmationPromise()
+		}
+		if (pendingChainChange === undefined) throw new Error('Missing production chain-change dialog state')
+		await resolveChainChange(ethereum, tokenPriceService, resetSimulationServices, websiteTabConnections, {
+			method: 'popup_changeChainDialog',
+			data: { rpcNetwork: requestedRpcNetwork, uniqueRequestIdentifier: firstUniqueRequestIdentifier, accept: true },
+		})
+		await Promise.race([
+			waitForDeferredChainChangeRemoval(),
+			new Promise<never>((_resolve, reject) => setTimeout(() => reject(new Error('Chain resolution did not start')), 100)),
+		])
+		await new Promise((resolve) => setTimeout(resolve, 0))
+
+		const secondResolution = await Promise.race([
+			openChangeChainDialog(
+				ethereum,
+				tokenPriceService,
+				resetSimulationServices,
+				websiteTabConnections,
+				secondRequest,
+				false,
+				website,
+				{ method: 'wallet_switchEthereumChain', params: [{ chainId: secondRpcNetwork.chainId }] },
+			),
+			new Promise<never>((_resolve, reject) => setTimeout(() => reject(new Error('Second chain dialog was not rejected')), 100)),
+		])
+		assert.equal(secondResolution.error?.code, 4001)
+
+		releaseDeferredChainChangeRemoval()
+		await waitForPortMessageCount(messages, 'request_signer_to_wallet_switchEthereumChain', 1)
+		await handleInterceptedRequest(port, websiteOrigin, website, ethereum, tokenPriceService, resetSimulationServices, socket, {
+			interceptorRequest: true,
+			interceptorInternalRequest: true,
+			usingInterceptorWithoutSigner: false,
+			uniqueRequestIdentifier: { requestId: 102, requestSocket: socket },
+			method: 'wallet_switchEthereumChain_reply',
+			params: [{ accept: false, chainId: '0xaa36a7', error: { code: 4001, message: 'First signer rejected' }, signerProviderGeneration: 1 }],
+		}, websiteTabConnections, noopPublishRpcConnectionStatus)
+		const firstResult = await Promise.race([
+			firstResolution,
+			new Promise<never>((_resolve, reject) => setTimeout(() => reject(new Error('First production chain dialog did not settle')), 100)),
+		])
+		assert.equal(firstResult.error?.message, 'First signer rejected')
 	})
 
 	test('resolves approved eth_requestAccounts after signer account state is refreshed', async () => {
@@ -750,7 +1636,7 @@ describe('background eth_accounts', () => {
 					usingInterceptorWithoutSigner: false,
 					uniqueRequestIdentifier: { requestId: 99, requestSocket: socket },
 					method: 'eth_accounts_reply',
-					params: [{ type: 'success', accounts: [accountString], requestAccounts: true }],
+					params: [{ signerProviderGeneration: 1, type: 'success', accounts: [accountString], requestAccounts: true }],
 				}, websiteTabConnections, noopPublishRpcConnectionStatus)
 			}
 			if (message.method === 'eth_accounts' && message.requestId === 9) {
@@ -760,10 +1646,10 @@ describe('background eth_accounts', () => {
 			}
 		})
 		const port = createdPort
-		const { port: siblingPort, messages: siblingMessages } = createPort(siblingSocket.tabId)
+		const { port: siblingPort, messages: siblingMessages } = createPort(siblingSocket.tabId, undefined, undefined, siblingSocket.connectionName)
 		const connectionKey = websiteSocketToString(socket)
 		const siblingConnectionKey = websiteSocketToString(siblingSocket)
-		const websiteTabConnections = new Map([[socket.tabId, { connections: {
+		const websiteTabConnections = new Map([[socket.tabId, { ...confirmedSignerOwnership(socket), connections: {
 			[connectionKey]: { port, socket, websiteOrigin, approved: true, wantsToConnect: true },
 			[siblingConnectionKey]: { port: siblingPort, socket: siblingSocket, websiteOrigin, approved: true, wantsToConnect: true },
 		} }]])
@@ -838,14 +1724,14 @@ describe('background eth_accounts', () => {
 				usingInterceptorWithoutSigner: false,
 				uniqueRequestIdentifier: { requestId: 100, requestSocket: socket },
 				method: 'eth_accounts_reply',
-				params: [{ type: 'success', accounts: [accountString], requestAccounts: true }],
+				params: [{ signerProviderGeneration: 1, type: 'success', accounts: [accountString], requestAccounts: true }],
 			}, websiteTabConnections, noopPublishRpcConnectionStatus)
 		})
 		const port = createdPort
-		const { port: siblingPort, messages: siblingMessages } = createPort(siblingSocket.tabId)
+		const { port: siblingPort, messages: siblingMessages } = createPort(siblingSocket.tabId, undefined, undefined, siblingSocket.connectionName)
 		const connectionKey = websiteSocketToString(socket)
 		const siblingConnectionKey = websiteSocketToString(siblingSocket)
-		const websiteTabConnections = new Map([[socket.tabId, { connections: {
+		const websiteTabConnections = new Map([[socket.tabId, { ...confirmedSignerOwnership(socket), connections: {
 			[connectionKey]: { port, socket, websiteOrigin, approved: false, wantsToConnect: true },
 			[siblingConnectionKey]: { port: siblingPort, socket: siblingSocket, websiteOrigin, approved: true, wantsToConnect: true },
 		} }]])
@@ -893,12 +1779,12 @@ describe('background eth_accounts', () => {
 				usingInterceptorWithoutSigner: false,
 				uniqueRequestIdentifier: { requestId: 104, requestSocket: socket },
 				method: 'eth_accounts_reply',
-				params: [{ type: 'success', accounts: [accountString], requestAccounts: true }],
+				params: [{ signerProviderGeneration: 1, type: 'success', accounts: [accountString], requestAccounts: true }],
 			}, websiteTabConnections, noopPublishRpcConnectionStatus)
 		})
 		const port = createdPort
 		const connectionKey = websiteSocketToString(socket)
-		const websiteTabConnections = new Map([[socket.tabId, { connections: {
+		const websiteTabConnections = new Map([[socket.tabId, { ...confirmedSignerOwnership(socket), connections: {
 			[connectionKey]: { port, socket, websiteOrigin, approved: true, wantsToConnect: true },
 		} }]])
 		const { ethereum, tokenPriceService, resetSimulationServices } = createEthereumWithGetBlockCounter({ count: 0 })
@@ -948,7 +1834,7 @@ describe('background eth_accounts', () => {
 		await updateTabState(socket.tabId, (previousState) => ({ ...previousState, signerAccounts: [account], activeSigningAddress: account }))
 		const { port, messages } = createPort(socket.tabId)
 		const connectionKey = websiteSocketToString(socket)
-		const websiteTabConnections = new Map([[socket.tabId, { connections: {
+		const websiteTabConnections = new Map([[socket.tabId, { ...confirmedSignerOwnership(socket), connections: {
 			[connectionKey]: { port, socket, websiteOrigin, approved: true, wantsToConnect: true },
 		} }]])
 		const { ethereum, tokenPriceService, resetSimulationServices } = createEthereumWithGetBlockCounter({ count: 0 })
@@ -1006,7 +1892,7 @@ describe('background eth_accounts', () => {
 		await updateTabState(socket.tabId, (previousState) => ({ ...previousState, signerAccounts: [account], activeSigningAddress: account }))
 		const { port, messages } = createPort(socket.tabId)
 		const connectionKey = websiteSocketToString(socket)
-		const websiteTabConnections = new Map([[socket.tabId, { connections: {
+		const websiteTabConnections = new Map([[socket.tabId, { ...confirmedSignerOwnership(socket), connections: {
 			[connectionKey]: { port, socket, websiteOrigin, approved: true, wantsToConnect: true },
 		} }]])
 		const { ethereum, tokenPriceService, resetSimulationServices } = createEthereumWithGetBlockCounter({ count: 0 })
@@ -1051,7 +1937,7 @@ describe('background eth_accounts', () => {
 		await updateTabState(socket.tabId, (previousState) => ({ ...previousState, signerAccounts: [account], activeSigningAddress: account }))
 		const { port, messages } = createPort(socket.tabId)
 		const connectionKey = websiteSocketToString(socket)
-		const websiteTabConnections = new Map([[socket.tabId, { connections: {
+		const websiteTabConnections = new Map([[socket.tabId, { ...confirmedSignerOwnership(socket), connections: {
 			[connectionKey]: { port, socket, websiteOrigin, approved: true, wantsToConnect: true },
 		} }]])
 		const { ethereum, tokenPriceService, resetSimulationServices } = createEthereumWithGetBlockCounter({ count: 0 })
@@ -1061,7 +1947,7 @@ describe('background eth_accounts', () => {
 			usingInterceptorWithoutSigner: false,
 			uniqueRequestIdentifier: { requestId: 12, requestSocket: socket },
 			method: 'connected_to_signer',
-			params: [true, 'MetaMask'],
+			params: [true, 'MetaMask', 2],
 		}
 
 		await handleInterceptedRequest(port, websiteOrigin, website, ethereum, tokenPriceService, resetSimulationServices, socket, request, websiteTabConnections, noopPublishRpcConnectionStatus)
@@ -1097,11 +1983,11 @@ describe('background eth_accounts', () => {
 				usingInterceptorWithoutSigner: false,
 				uniqueRequestIdentifier: { requestId: 100, requestSocket: socket },
 				method: 'eth_accounts_reply',
-				params: [{ type: 'success', accounts: [accountString], requestAccounts: true }],
+				params: [{ signerProviderGeneration: 1, type: 'success', accounts: [accountString], requestAccounts: true }],
 			}, websiteTabConnections, noopPublishRpcConnectionStatus)
 		})
 		const connectionKey = websiteSocketToString(socket)
-		const websiteTabConnections = new Map([[socket.tabId, { connections: {
+		const websiteTabConnections = new Map([[socket.tabId, { ...confirmedSignerOwnership(socket), connections: {
 			[connectionKey]: { port, socket, websiteOrigin, approved: false, wantsToConnect: true },
 		} }]])
 		const { ethereum, tokenPriceService, resetSimulationServices } = createEthereumWithGetBlockCounter({ count: 0 })
@@ -1153,7 +2039,7 @@ describe('background eth_accounts', () => {
 		const socket = { tabId: 1, connectionName: 0n }
 		const { port, messages } = createPort(socket.tabId)
 		const connectionKey = websiteSocketToString(socket)
-		const websiteTabConnections = new Map([[socket.tabId, { connections: {
+		const websiteTabConnections = new Map([[socket.tabId, { ...confirmedSignerOwnership(socket), connections: {
 			[connectionKey]: { port, socket, websiteOrigin, approved: false, wantsToConnect: true },
 		} }]])
 		const { ethereum, tokenPriceService, resetSimulationServices } = createEthereumWithGetBlockCounter({ count: 0 })
@@ -1220,7 +2106,7 @@ describe('background eth_accounts', () => {
 		const socket = { tabId: 1, connectionName: 0n }
 		const { port, messages } = createPort(socket.tabId)
 		const connectionKey = websiteSocketToString(socket)
-		const websiteTabConnections = new Map([[socket.tabId, { connections: {
+		const websiteTabConnections = new Map([[socket.tabId, { ...confirmedSignerOwnership(socket), connections: {
 			[connectionKey]: { port, socket, websiteOrigin, approved: false, wantsToConnect: true },
 		} }]])
 		const { ethereum, tokenPriceService, resetSimulationServices } = createEthereumWithGetBlockCounter({ count: 0 })
@@ -1310,12 +2196,12 @@ describe('background eth_accounts', () => {
 					usingInterceptorWithoutSigner: false,
 					uniqueRequestIdentifier: { requestId: 101, requestSocket: socket },
 					method: 'eth_accounts_reply',
-					params: [{ type: 'success', accounts: [accountString], requestAccounts: true }],
+					params: [{ signerProviderGeneration: 1, type: 'success', accounts: [accountString], requestAccounts: true }],
 				}, websiteTabConnections, noopPublishRpcConnectionStatus)
 			})()
 		})
 		const connectionKey = websiteSocketToString(socket)
-		const websiteTabConnections = new Map([[socket.tabId, { connections: {
+		const websiteTabConnections = new Map([[socket.tabId, { ...confirmedSignerOwnership(socket), connections: {
 			[connectionKey]: { port, socket, websiteOrigin, approved: false, wantsToConnect: true },
 		} }]])
 		const { ethereum, tokenPriceService, resetSimulationServices } = createEthereumWithGetBlockCounter({ count: 0 })
@@ -1361,11 +2247,11 @@ describe('background eth_accounts', () => {
 				usingInterceptorWithoutSigner: false,
 				uniqueRequestIdentifier: { requestId: 102, requestSocket: socket },
 				method: 'eth_accounts_reply',
-				params: [{ type: 'error', requestAccounts: true, error: { code: 4001, message: 'User rejected the request.' } }],
+				params: [{ signerProviderGeneration: 1, type: 'error', requestAccounts: true, error: { code: 4001, message: 'User rejected the request.' } }],
 			}, websiteTabConnections, noopPublishRpcConnectionStatus)
 		})
 		const connectionKey = websiteSocketToString(socket)
-		const websiteTabConnections = new Map([[socket.tabId, { connections: {
+		const websiteTabConnections = new Map([[socket.tabId, { ...confirmedSignerOwnership(socket), connections: {
 			[connectionKey]: { port, socket, websiteOrigin, approved: false, wantsToConnect: true },
 		} }]])
 		const { ethereum, tokenPriceService, resetSimulationServices } = createEthereumWithGetBlockCounter({ count: 0 })
@@ -1410,11 +2296,11 @@ describe('background eth_accounts', () => {
 				usingInterceptorWithoutSigner: false,
 				uniqueRequestIdentifier: { requestId: 103, requestSocket: socket },
 				method: 'eth_accounts_reply',
-				params: [{ type: 'success', accounts: [], requestAccounts: true }],
+				params: [{ signerProviderGeneration: 1, type: 'success', accounts: [], requestAccounts: true }],
 			}, websiteTabConnections, noopPublishRpcConnectionStatus)
 		})
 		const connectionKey = websiteSocketToString(socket)
-		const websiteTabConnections = new Map([[socket.tabId, { connections: {
+		const websiteTabConnections = new Map([[socket.tabId, { ...confirmedSignerOwnership(socket), connections: {
 			[connectionKey]: { port, socket, websiteOrigin, approved: false, wantsToConnect: true },
 		} }]])
 		const { ethereum, tokenPriceService, resetSimulationServices } = createEthereumWithGetBlockCounter({ count: 0 })
@@ -1462,13 +2348,13 @@ describe('background eth_accounts', () => {
 					usingInterceptorWithoutSigner: false,
 					uniqueRequestIdentifier: { requestId: 99, requestSocket: socket },
 					method: 'eth_accounts_reply',
-					params: [{ type: 'error', requestAccounts: true, error: { code: 4001, message: 'User rejected the request.' } }],
+					params: [{ signerProviderGeneration: 1, type: 'error', requestAccounts: true, error: { code: 4001, message: 'User rejected the request.' } }],
 				}, websiteTabConnections, noopPublishRpcConnectionStatus)
 			})()
 		})
 		port = createdPort
 		const connectionKey = websiteSocketToString(socket)
-		const websiteTabConnections = new Map([[socket.tabId, { connections: {
+		const websiteTabConnections = new Map([[socket.tabId, { ...confirmedSignerOwnership(socket), connections: {
 			[connectionKey]: { port, socket, websiteOrigin, approved: true, wantsToConnect: true },
 		} }]])
 		const { ethereum, tokenPriceService, resetSimulationServices } = createEthereumWithGetBlockCounter({ count: 0 })
@@ -1527,12 +2413,12 @@ describe('background eth_accounts', () => {
 				usingInterceptorWithoutSigner: true,
 				uniqueRequestIdentifier: { requestId: internalRequestId, requestSocket: socket },
 				method: 'eth_accounts_reply',
-				params: [{ type: 'error', requestAccounts: accountRequest.requestAccounts, signerUnavailable: true, error: unavailableSignerError }],
+				params: [{ signerProviderGeneration: 1, type: 'error', requestAccounts: accountRequest.requestAccounts, signerUnavailable: true, error: unavailableSignerError }],
 			}, websiteTabConnections, noopPublishRpcConnectionStatus)
 		})
 		port = createdPort
 		const connectionKey = websiteSocketToString(socket)
-		const websiteTabConnections = new Map([[socket.tabId, { connections: {
+		const websiteTabConnections = new Map([[socket.tabId, { ...confirmedSignerOwnership(socket), connections: {
 			[connectionKey]: { port, socket, websiteOrigin, approved: true, wantsToConnect: true },
 		} }]])
 		const { ethereum, tokenPriceService, resetSimulationServices } = createEthereumWithGetBlockCounter({ count: 0 })
@@ -1554,7 +2440,6 @@ describe('background eth_accounts', () => {
 			})
 			assert.equal(messages.some((message) => (message.method === 'connect' || message.method === 'accountsChanged') && message.requestId === requestId), false)
 		}
-		assert.equal(messages.some((message) => message.method === 'connect' || message.method === 'accountsChanged'), false)
 		assert.equal((await getTabState(socket.tabId)).signerAccountError, undefined)
 	})
 
@@ -1579,10 +2464,10 @@ describe('background eth_accounts', () => {
 		const socket = { tabId: 1, connectionName: 0n }
 		const siblingSocket = { tabId: 1, connectionName: 1n }
 		const { port, messages } = createPort(socket.tabId)
-		const { port: siblingPort } = createPort(siblingSocket.tabId)
+		const { port: siblingPort } = createPort(siblingSocket.tabId, undefined, undefined, siblingSocket.connectionName)
 		const connectionKey = websiteSocketToString(socket)
 		const siblingConnectionKey = websiteSocketToString(siblingSocket)
-		const websiteTabConnections = new Map([[socket.tabId, { connections: {
+		const websiteTabConnections = new Map([[socket.tabId, { ...confirmedSignerOwnership(socket), connections: {
 			[connectionKey]: { port, socket, websiteOrigin, approved: true, wantsToConnect: true },
 			[siblingConnectionKey]: { port: siblingPort, socket: siblingSocket, websiteOrigin, approved: true, wantsToConnect: true },
 		} }]])
@@ -1600,6 +2485,8 @@ describe('background eth_accounts', () => {
 			method: 'window_signer_accounts_changed',
 			data: {
 				socket: siblingSocket,
+				signerStateOwnerGeneration: 1,
+				signerProviderGeneration: 1,
 				error: { code: 4900, message: 'Sibling signer is unavailable' },
 			},
 		})
@@ -1612,7 +2499,7 @@ describe('background eth_accounts', () => {
 			usingInterceptorWithoutSigner: false,
 			uniqueRequestIdentifier: { requestId: 105, requestSocket: socket },
 			method: 'eth_accounts_reply',
-			params: [{ type: 'success', accounts: [accountString], requestAccounts: true }],
+			params: [{ signerProviderGeneration: 1, type: 'success', accounts: [accountString], requestAccounts: true }],
 		}, websiteTabConnections, noopPublishRpcConnectionStatus)
 		await requestPromise
 
@@ -1646,10 +2533,10 @@ describe('background eth_accounts', () => {
 		const socket = { tabId: 1, connectionName: 0n }
 		const siblingSocket = { tabId: 1, connectionName: 1n }
 		const { port, messages } = createPort(socket.tabId)
-		const { port: siblingPort, messages: siblingMessages } = createPort(siblingSocket.tabId)
+		const { port: siblingPort, messages: siblingMessages } = createPort(siblingSocket.tabId, undefined, undefined, siblingSocket.connectionName)
 		const connectionKey = websiteSocketToString(socket)
 		const siblingConnectionKey = websiteSocketToString(siblingSocket)
-		const websiteTabConnections = new Map([[socket.tabId, { connections: {
+		const websiteTabConnections = new Map([[socket.tabId, { ...confirmedSignerOwnership(socket), connections: {
 			[connectionKey]: { port, socket, websiteOrigin, approved: false, wantsToConnect: true },
 			[siblingConnectionKey]: { port: siblingPort, socket: siblingSocket, websiteOrigin, approved: false, wantsToConnect: true },
 		} }]])
@@ -1723,7 +2610,7 @@ describe('background eth_accounts', () => {
 		const socket = { tabId: 1, connectionName: 0n }
 		const { port } = createPort(socket.tabId)
 		const connectionKey = websiteSocketToString(socket)
-		const websiteTabConnections = new Map([[socket.tabId, { connections: {
+		const websiteTabConnections = new Map([[socket.tabId, { ...confirmedSignerOwnership(socket), connections: {
 			[connectionKey]: { port, socket, websiteOrigin, approved: false, wantsToConnect: true },
 		} }]])
 		const { ethereum, tokenPriceService, resetSimulationServices } = createEthereumWithGetBlockCounter({ count: 0 })
@@ -1783,7 +2670,7 @@ describe('background eth_accounts', () => {
 		const socket = { tabId: 1, connectionName: 0n }
 		const { port, messages } = createPort(socket.tabId)
 		const connectionKey = websiteSocketToString(socket)
-		const websiteTabConnections = new Map([[socket.tabId, { connections: {
+		const websiteTabConnections = new Map([[socket.tabId, { ...confirmedSignerOwnership(socket), connections: {
 			[connectionKey]: { port, socket, websiteOrigin, approved: false, wantsToConnect: true },
 		} }]])
 		const { ethereum, tokenPriceService, resetSimulationServices } = createEthereumWithGetBlockCounter({ count: 0 })
@@ -1848,7 +2735,7 @@ describe('background eth_accounts', () => {
 		const socket = { tabId: 1, connectionName: 0n }
 		const { port, messages } = createPort(socket.tabId)
 		const connectionKey = websiteSocketToString(socket)
-		const websiteTabConnections = new Map([[socket.tabId, { connections: {
+		const websiteTabConnections = new Map([[socket.tabId, { ...confirmedSignerOwnership(socket), connections: {
 			[connectionKey]: { port, socket, websiteOrigin, approved: true, wantsToConnect: true },
 		} }]])
 		const { ethereum, tokenPriceService, resetSimulationServices } = createEthereumWithGetBlockCounter({ count: 0 })
@@ -1897,12 +2784,12 @@ describe('background eth_accounts', () => {
 				usingInterceptorWithoutSigner: false,
 				uniqueRequestIdentifier: { requestId: 230, requestSocket: socket },
 				method: 'eth_accounts_reply',
-				params: [{ type: 'success', accounts: [accountString], requestAccounts: true }],
+				params: [{ signerProviderGeneration: 1, type: 'success', accounts: [accountString], requestAccounts: true }],
 			}, websiteTabConnections, noopPublishRpcConnectionStatus)
 		})
 		port = createdPort
 		const connectionKey = websiteSocketToString(socket)
-		const websiteTabConnections = new Map([[socket.tabId, { connections: {
+		const websiteTabConnections = new Map([[socket.tabId, { ...confirmedSignerOwnership(socket), connections: {
 			[connectionKey]: { port, socket, websiteOrigin, approved: false, wantsToConnect: true },
 		} }]])
 		const { ethereum, tokenPriceService, resetSimulationServices } = createEthereumWithGetBlockCounter({ count: 0 })
@@ -1994,12 +2881,12 @@ describe('background eth_accounts', () => {
 				usingInterceptorWithoutSigner: false,
 				uniqueRequestIdentifier: { requestId: 731, requestSocket: socket },
 				method: 'eth_accounts_reply',
-				params: [{ type: 'success', accounts: [accountString], requestAccounts: true }],
+				params: [{ signerProviderGeneration: 1, type: 'success', accounts: [accountString], requestAccounts: true }],
 			}, websiteTabConnections, noopPublishRpcConnectionStatus)
 		})
 		port = createdPort
 		const connectionKey = websiteSocketToString(socket)
-		const websiteTabConnections = new Map([[socket.tabId, { connections: {
+		const websiteTabConnections = new Map([[socket.tabId, { ...confirmedSignerOwnership(socket), connections: {
 			[connectionKey]: { port, socket, websiteOrigin, approved: false, wantsToConnect: true },
 		} }]])
 		const { ethereum, tokenPriceService, resetSimulationServices } = createEthereumWithGetBlockCounter({ count: 0 })
@@ -2056,7 +2943,7 @@ describe('background eth_accounts', () => {
 		const socket = { tabId: 1, connectionName: 0n }
 		const { port, messages } = createPort(socket.tabId)
 		const connectionKey = websiteSocketToString(socket)
-		const websiteTabConnections = new Map([[socket.tabId, { connections: {
+		const websiteTabConnections = new Map([[socket.tabId, { ...confirmedSignerOwnership(socket), connections: {
 			[connectionKey]: { port, socket, websiteOrigin, approved: false, wantsToConnect: true },
 		} }]])
 		const { ethereum, tokenPriceService, resetSimulationServices } = createEthereumWithGetBlockCounter({ count: 0 })
@@ -2135,7 +3022,7 @@ describe('background eth_accounts', () => {
 		const socket = { tabId: 171, connectionName: 171n }
 		const { port, messages } = createPort(socket.tabId)
 		const connectionKey = websiteSocketToString(socket)
-		const websiteTabConnections = new Map([[socket.tabId, { connections: {
+		const websiteTabConnections = new Map([[socket.tabId, { ...confirmedSignerOwnership(socket), connections: {
 			[connectionKey]: { port, socket, websiteOrigin, approved: true, wantsToConnect: true },
 		} }]])
 		const { ethereum, tokenPriceService, resetSimulationServices } = createEthereumWithGetBlockCounter({ count: 0 })
@@ -2176,7 +3063,7 @@ describe('background eth_accounts', () => {
 		const socket = { tabId: 172, connectionName: 172n }
 		const { port, messages } = createPort(socket.tabId)
 		const connectionKey = websiteSocketToString(socket)
-		const websiteTabConnections = new Map([[socket.tabId, { connections: {
+		const websiteTabConnections = new Map([[socket.tabId, { ...confirmedSignerOwnership(socket), connections: {
 			[connectionKey]: { port, socket, websiteOrigin, approved: true, wantsToConnect: true },
 		} }]])
 		const { ethereum, tokenPriceService, resetSimulationServices } = createEthereumWithGetBlockCounter({ count: 0 })
@@ -2221,7 +3108,7 @@ describe('background eth_accounts', () => {
 		const socket = { tabId: 1, connectionName: 0n }
 		const { port, messages } = createPort(socket.tabId)
 		const connectionKey = websiteSocketToString(socket)
-		const websiteTabConnections = new Map([[socket.tabId, { connections: {
+		const websiteTabConnections = new Map([[socket.tabId, { ...confirmedSignerOwnership(socket), connections: {
 			[connectionKey]: { port, socket, websiteOrigin, approved: true, wantsToConnect: true },
 		} }]])
 		const { ethereum, tokenPriceService, resetSimulationServices } = createEthereumWithGetBlockCounter({ count: 0 })
@@ -2260,7 +3147,7 @@ describe('background eth_accounts', () => {
 		const socket = { tabId: 1, connectionName: 0n }
 		const { port, messages } = createPort(socket.tabId)
 		const connectionKey = websiteSocketToString(socket)
-		const websiteTabConnections = new Map([[socket.tabId, { connections: {
+		const websiteTabConnections = new Map([[socket.tabId, { ...confirmedSignerOwnership(socket), connections: {
 			[connectionKey]: { port, socket, websiteOrigin, approved: false, wantsToConnect: true },
 		} }]])
 		const { ethereum, tokenPriceService, resetSimulationServices } = createEthereumWithGetBlockCounter({ count: 0 })
@@ -2305,7 +3192,7 @@ describe('background eth_accounts', () => {
 		const socket = { tabId: 1, connectionName: 0n }
 		const { port, messages } = createPort(socket.tabId)
 		const connectionKey = websiteSocketToString(socket)
-		const websiteTabConnections = new Map([[socket.tabId, { connections: {
+		const websiteTabConnections = new Map([[socket.tabId, { ...confirmedSignerOwnership(socket), connections: {
 			[connectionKey]: { port, socket, websiteOrigin, approved: false, wantsToConnect: true },
 		} }]])
 		const { ethereum, tokenPriceService, resetSimulationServices } = createEthereumWithGetBlockCounter({ count: 0 })
@@ -2341,7 +3228,7 @@ describe('background eth_accounts', () => {
 		const socket = { tabId: 1, connectionName: 0n }
 		const { port } = createPort(socket.tabId)
 		const connectionKey = websiteSocketToString(socket)
-		const websiteTabConnections = new Map([[socket.tabId, { connections: {
+		const websiteTabConnections = new Map([[socket.tabId, { ...confirmedSignerOwnership(socket), connections: {
 			[connectionKey]: { port, socket, websiteOrigin, approved: true, wantsToConnect: true },
 		} }]])
 		const { ethereum, tokenPriceService, resetSimulationServices } = createEthereumWithGetBlockCounter({ count: 0 })
@@ -2384,7 +3271,7 @@ describe('background eth_accounts', () => {
 		const socket = { tabId: 1, connectionName: 0n }
 		const { port, messages } = createPort(socket.tabId)
 		const connectionKey = websiteSocketToString(socket)
-		const websiteTabConnections = new Map([[socket.tabId, { connections: {
+		const websiteTabConnections = new Map([[socket.tabId, { ...confirmedSignerOwnership(socket), connections: {
 			[connectionKey]: { port, socket, websiteOrigin, approved: true, wantsToConnect: true },
 		} }]])
 		const { ethereum, tokenPriceService, resetSimulationServices } = createEthereumWithGetBlockCounter({ count: 0 })

--- a/test/tests/backgroundEthAccounts.test.ts
+++ b/test/tests/backgroundEthAccounts.test.ts
@@ -1010,7 +1010,7 @@ describe('background eth_accounts', () => {
 		assert.equal(pendingRequests[0]?.originalRequestAccessToAddress?.address, account)
 	})
 
-	test('uses cached signer account for address access when active signing address is missing', async () => {
+	test('uses cached signer account instead of a stale provider-disconnected error when active signing address is missing', async () => {
 		installBrowserMock()
 		const {
 			handleInterceptedRequest,
@@ -1028,7 +1028,12 @@ describe('background eth_accounts', () => {
 		await changeSimulationMode({ simulationMode: false, activeSimulationAddress: undefined, activeSigningAddress: undefined })
 		await setUseSignersAddressAsActiveAddress(false)
 		await updateWebsiteAccess(() => [{ website, access: true, addressAccess: undefined }])
-		await updateTabState(1, (previousState) => ({ ...previousState, signerAccounts: [account], activeSigningAddress: undefined }))
+		await updateTabState(1, (previousState) => ({
+			...previousState,
+			signerAccounts: [account],
+			activeSigningAddress: undefined,
+			signerAccountError: { code: 4900, message: 'Stale signer error' },
+		}))
 
 		const socket = { tabId: 1, connectionName: 0n }
 		const { port, messages } = createPort(socket.tabId)
@@ -1366,6 +1371,121 @@ describe('background eth_accounts', () => {
 		assert.equal(requestAccountsReplies.at(-1)?.error?.code, 4100)
 		assert.equal(requestAccountsReplies.at(-1)?.error?.message, 'The requested method and/or account has not been authorized by the user.')
 		assert.deepEqual((await getTabState(socket.tabId)).signerAccounts, [])
+	})
+
+	test('returns an actionable provider-disconnected error when no signer is available to the page', async () => {
+		installBrowserMock()
+		const {
+			handleInterceptedRequest,
+			websiteSocketToString,
+			changeSimulationMode,
+			setUseSignersAddressAsActiveAddress,
+			updateWebsiteAccess,
+		} = await loadModules()
+		const websiteOrigin = 'https://example.test'
+		const website = { websiteOrigin, icon: undefined, title: undefined }
+		const unavailableSignerError = {
+			code: 4900,
+			message: 'No signer wallet is available to this page. Enable your wallet extension for this site, then try again.',
+		}
+		await changeSimulationMode({ simulationMode: false, activeSimulationAddress: undefined, activeSigningAddress: undefined })
+		await setUseSignersAddressAsActiveAddress(false)
+		await updateWebsiteAccess(() => [{ website, access: true, addressAccess: undefined }])
+
+		const socket = { tabId: 1, connectionName: 0n }
+		let port: browser.runtime.Port
+		const { port: createdPort, messages } = createPort(socket.tabId, (message) => {
+			if (message.method !== 'request_signer_to_eth_requestAccounts') return
+			void handleInterceptedRequest(port, websiteOrigin, website, ethereum, tokenPriceService, resetSimulationServices, socket, {
+				interceptorRequest: true,
+				interceptorInternalRequest: true,
+				usingInterceptorWithoutSigner: true,
+				uniqueRequestIdentifier: { requestId: 104, requestSocket: socket },
+				method: 'eth_accounts_reply',
+				params: [{ type: 'error', requestAccounts: true, error: unavailableSignerError }],
+			}, websiteTabConnections, noopPublishRpcConnectionStatus)
+		})
+		port = createdPort
+		const connectionKey = websiteSocketToString(socket)
+		const websiteTabConnections = new Map([[socket.tabId, { connections: {
+			[connectionKey]: { port, socket, websiteOrigin, approved: true, wantsToConnect: true },
+		} }]])
+		const { ethereum, tokenPriceService, resetSimulationServices } = createEthereumWithGetBlockCounter({ count: 0 })
+		const request = {
+			interceptorRequest: true,
+			usingInterceptorWithoutSigner: true,
+			uniqueRequestIdentifier: { requestId: 15, requestSocket: socket },
+			method: 'eth_requestAccounts',
+		}
+
+		await handleInterceptedRequest(port, websiteOrigin, website, ethereum, tokenPriceService, resetSimulationServices, socket, request, websiteTabConnections, noopPublishRpcConnectionStatus)
+
+		const requestAccountsReplies = messages.filter((message) => message.method === 'eth_requestAccounts' && message.requestId === 15)
+		assert.equal(requestAccountsReplies.length, 1)
+		assert.deepEqual(requestAccountsReplies[0]?.error, unavailableSignerError)
+	})
+
+	test('ignores a provider-disconnected completion from a sibling socket', async () => {
+		installBrowserMock()
+		const {
+			handleInterceptedRequest,
+			sendInternalWindowMessage,
+			websiteSocketToString,
+			changeSimulationMode,
+			setUseSignersAddressAsActiveAddress,
+			updateWebsiteAccess,
+		} = await loadModules()
+		const websiteOrigin = 'https://example.test'
+		const website = { websiteOrigin, icon: undefined, title: undefined }
+		const account = 0x2424242424242424242424242424242424242424n
+		const accountString = '0x2424242424242424242424242424242424242424'
+		await changeSimulationMode({ simulationMode: false, activeSimulationAddress: undefined, activeSigningAddress: undefined })
+		await setUseSignersAddressAsActiveAddress(false)
+		await updateWebsiteAccess(() => [{ website, access: true, addressAccess: [{ address: account, access: true }] }])
+
+		const socket = { tabId: 1, connectionName: 0n }
+		const siblingSocket = { tabId: 1, connectionName: 1n }
+		const { port, messages } = createPort(socket.tabId)
+		const { port: siblingPort } = createPort(siblingSocket.tabId)
+		const connectionKey = websiteSocketToString(socket)
+		const siblingConnectionKey = websiteSocketToString(siblingSocket)
+		const websiteTabConnections = new Map([[socket.tabId, { connections: {
+			[connectionKey]: { port, socket, websiteOrigin, approved: true, wantsToConnect: true },
+			[siblingConnectionKey]: { port: siblingPort, socket: siblingSocket, websiteOrigin, approved: true, wantsToConnect: true },
+		} }]])
+		const { ethereum, tokenPriceService, resetSimulationServices } = createEthereumWithGetBlockCounter({ count: 0 })
+		const request = {
+			interceptorRequest: true,
+			usingInterceptorWithoutSigner: true,
+			uniqueRequestIdentifier: { requestId: 18, requestSocket: socket },
+			method: 'eth_requestAccounts',
+		}
+
+		const requestPromise = handleInterceptedRequest(port, websiteOrigin, website, ethereum, tokenPriceService, resetSimulationServices, socket, request, websiteTabConnections, noopPublishRpcConnectionStatus)
+		await waitForPortMessageCount(messages, 'request_signer_to_eth_requestAccounts', 1)
+		sendInternalWindowMessage({
+			method: 'window_signer_accounts_changed',
+			data: {
+				socket: siblingSocket,
+				error: { code: 4900, message: 'Sibling signer is unavailable' },
+			},
+		})
+		await new Promise((resolve) => setTimeout(resolve, 0))
+		assert.equal(messages.some((message) => message.requestId === 18), false)
+
+		await handleInterceptedRequest(port, websiteOrigin, website, ethereum, tokenPriceService, resetSimulationServices, socket, {
+			interceptorRequest: true,
+			interceptorInternalRequest: true,
+			usingInterceptorWithoutSigner: false,
+			uniqueRequestIdentifier: { requestId: 105, requestSocket: socket },
+			method: 'eth_accounts_reply',
+			params: [{ type: 'success', accounts: [accountString], requestAccounts: true }],
+		}, websiteTabConnections, noopPublishRpcConnectionStatus)
+		await requestPromise
+
+		const requestAccountsReplies = messages.filter((message) => message.method === 'eth_accounts' && message.requestId === 18)
+		assert.equal(requestAccountsReplies.length, 1)
+		assert.deepEqual(requestAccountsReplies[0]?.result, [accountString])
 	})
 
 	test('keeps sibling connection events when popup approval resolves eth_requestAccounts', async () => {

--- a/test/tests/backgroundEthAccounts.test.ts
+++ b/test/tests/backgroundEthAccounts.test.ts
@@ -104,6 +104,14 @@ function createPort(tabId: number, onPostMessage?: (message: PortMessage) => voi
 	return { port, messages }
 }
 
+async function waitForPortMessageCount(messages: readonly PortMessage[], method: string, count: number, timeoutMs = 100) {
+	const deadline = Date.now() + timeoutMs
+	while (messages.filter((message) => message.method === method).length < count) {
+		if (Date.now() >= deadline) throw new Error(`Missing ${ method } port message`)
+		await new Promise((resolve) => setTimeout(resolve, 0))
+	}
+}
+
 async function waitForPendingAddressRequest<T extends { requestAccessToAddress?: { address?: bigint } }>(
 	getPendingAccessRequests: () => Promise<readonly T[]>,
 	account: bigint,
@@ -539,6 +547,63 @@ describe('background eth_accounts', () => {
 		assert.equal(messages.some((message) => message.method === 'request_signer_to_eth_requestAccounts'), false)
 		const ethAccountsReplies = messages.filter((message) => message.method === 'eth_accounts' && message.requestId === 7)
 		assert.deepEqual(ethAccountsReplies.at(-1)?.result, ['0x2222222222222222222222222222222222222222'])
+	})
+
+	test('serializes a popup refresh and interactive signer account discovery for one connection', async () => {
+		installBrowserMock()
+		const {
+			handleInterceptedRequest,
+			refreshSignerAccountsFromApprovedWebsitePorts,
+			websiteSocketToString,
+			changeSimulationMode,
+			setUseSignersAddressAsActiveAddress,
+			updateWebsiteAccess,
+		} = await loadModules()
+		const websiteOrigin = 'https://example.test'
+		const website = { websiteOrigin, icon: undefined, title: undefined }
+		const account = 0x2323232323232323232323232323232323232323n
+		const accountString = '0x2323232323232323232323232323232323232323'
+		await changeSimulationMode({ simulationMode: false, activeSimulationAddress: undefined, activeSigningAddress: undefined })
+		await setUseSignersAddressAsActiveAddress(false)
+		await updateWebsiteAccess(() => [{ website, access: true, addressAccess: [{ address: account, access: true }] }])
+
+		const socket = { tabId: 1, connectionName: 0n }
+		const { port, messages } = createPort(socket.tabId)
+		const connectionKey = websiteSocketToString(socket)
+		const websiteTabConnections = new Map([[socket.tabId, { connections: {
+			[connectionKey]: { port, socket, websiteOrigin, approved: true, wantsToConnect: true },
+		} }]])
+		const { ethereum, tokenPriceService, resetSimulationServices } = createEthereumWithGetBlockCounter({ count: 0 })
+		const replyWithSignerAccounts = async (requestId: number, requestAccounts: boolean, accounts: readonly string[]) => {
+			await handleInterceptedRequest(port, websiteOrigin, website, ethereum, tokenPriceService, resetSimulationServices, socket, {
+				interceptorRequest: true,
+				interceptorInternalRequest: true,
+				usingInterceptorWithoutSigner: false,
+				uniqueRequestIdentifier: { requestId, requestSocket: socket },
+				method: 'eth_accounts_reply',
+				params: [{ type: 'success', accounts, requestAccounts }],
+			}, websiteTabConnections, noopPublishRpcConnectionStatus)
+		}
+
+		const passiveRequest = refreshSignerAccountsFromApprovedWebsitePorts(websiteTabConnections, false)
+		await waitForPortMessageCount(messages, 'request_signer_to_eth_accounts', 1)
+
+		const interactiveRequest = handleInterceptedRequest(port, websiteOrigin, website, ethereum, tokenPriceService, resetSimulationServices, socket, {
+			interceptorRequest: true,
+			usingInterceptorWithoutSigner: false,
+			uniqueRequestIdentifier: { requestId: 71, requestSocket: socket },
+			method: 'eth_requestAccounts',
+		}, websiteTabConnections, noopPublishRpcConnectionStatus)
+		await new Promise((resolve) => setTimeout(resolve, 0))
+		const interactiveRequestsBeforePassiveReply = messages.filter((message) => message.method === 'request_signer_to_eth_requestAccounts').length
+
+		await replyWithSignerAccounts(90, false, [])
+		await waitForPortMessageCount(messages, 'request_signer_to_eth_requestAccounts', 1)
+		await replyWithSignerAccounts(91, true, [accountString])
+		await Promise.all([passiveRequest, interactiveRequest])
+
+		assert.equal(interactiveRequestsBeforePassiveReply, 0)
+		assert.deepEqual(messages.filter((message) => message.method === 'eth_accounts' && message.requestId === 71).at(-1)?.result, [accountString])
 	})
 
 	test('resolves approved eth_requestAccounts after signer account state is refreshed', async () => {

--- a/test/tests/backgroundEthAccounts.test.ts
+++ b/test/tests/backgroundEthAccounts.test.ts
@@ -1267,8 +1267,8 @@ describe('background eth_accounts', () => {
 		assert.equal(messages.some((message) => message.method === 'connect'), false)
 		assert.equal(messages.some((message) => message.method === 'accountsChanged'), false)
 		const requestAccountsReplies = messages.filter((message) => message.method === 'eth_requestAccounts' && message.requestId === 13)
-		assert.equal(requestAccountsReplies.at(-1)?.error?.code, 4100)
-		assert.equal(requestAccountsReplies.at(-1)?.error?.message, 'The requested method and/or account has not been authorized by the user.')
+		assert.equal(requestAccountsReplies.at(-1)?.error?.code, 4001)
+		assert.equal(requestAccountsReplies.at(-1)?.error?.message, 'User rejected the request.')
 	})
 
 	test('does not connect an unapproved port when signer returns empty accounts for site-approved eth_requestAccounts', async () => {
@@ -1320,7 +1320,7 @@ describe('background eth_accounts', () => {
 		assert.equal(requestAccountsReplies.at(-1)?.error?.message, 'The requested method and/or account has not been authorized by the user.')
 	})
 
-	test('resolves approved eth_requestAccounts when signer rejects the account request', async () => {
+	test('preserves the signer account-access rejection for approved eth_requestAccounts', async () => {
 		installBrowserMock()
 		const {
 			handleInterceptedRequest,
@@ -1368,12 +1368,12 @@ describe('background eth_accounts', () => {
 
 		assert.equal(messages.filter((message) => message.method === 'request_signer_to_eth_requestAccounts').length, 1)
 		const requestAccountsReplies = messages.filter((message) => message.method === 'eth_requestAccounts' && message.requestId === 8)
-		assert.equal(requestAccountsReplies.at(-1)?.error?.code, 4100)
-		assert.equal(requestAccountsReplies.at(-1)?.error?.message, 'The requested method and/or account has not been authorized by the user.')
+		assert.equal(requestAccountsReplies.at(-1)?.error?.code, 4001)
+		assert.equal(requestAccountsReplies.at(-1)?.error?.message, 'User rejected the request.')
 		assert.deepEqual((await getTabState(socket.tabId)).signerAccounts, [])
 	})
 
-	test('returns an actionable provider-disconnected error when no signer is available to the page', async () => {
+	test('maps unavailable signer errors only for interactive account connection methods', async () => {
 		installBrowserMock()
 		const {
 			handleInterceptedRequest,
@@ -1388,21 +1388,30 @@ describe('background eth_accounts', () => {
 			code: 4900,
 			message: 'No signer wallet is available to this page. Enable your wallet extension for this site, then try again.',
 		}
+		const accountRequests = [
+			{ method: 'eth_requestAccounts', signerRequestMethod: 'request_signer_to_eth_requestAccounts', expectedPublicErrorCode: 4001, requestAccounts: true },
+			{ method: 'wallet_requestPermissions', signerRequestMethod: 'request_signer_to_eth_requestAccounts', expectedPublicErrorCode: 4001, requestAccounts: true },
+			{ method: 'eth_accounts', signerRequestMethod: 'request_signer_to_eth_accounts', expectedPublicErrorCode: 4900, requestAccounts: false },
+			{ method: 'wallet_getPermissions', signerRequestMethod: 'request_signer_to_eth_accounts', expectedPublicErrorCode: 4900, requestAccounts: false },
+		] as const
 		await changeSimulationMode({ simulationMode: false, activeSimulationAddress: undefined, activeSigningAddress: undefined })
 		await setUseSignersAddressAsActiveAddress(false)
 		await updateWebsiteAccess(() => [{ website, access: true, addressAccess: undefined }])
 
 		const socket = { tabId: 1, connectionName: 0n }
 		let port: browser.runtime.Port
+		let internalRequestId = 104
 		const { port: createdPort, messages } = createPort(socket.tabId, (message) => {
-			if (message.method !== 'request_signer_to_eth_requestAccounts') return
+			const accountRequest = accountRequests.find((candidate) => candidate.signerRequestMethod === message.method)
+			if (accountRequest === undefined) return
+			internalRequestId += 1
 			void handleInterceptedRequest(port, websiteOrigin, website, ethereum, tokenPriceService, resetSimulationServices, socket, {
 				interceptorRequest: true,
 				interceptorInternalRequest: true,
 				usingInterceptorWithoutSigner: true,
-				uniqueRequestIdentifier: { requestId: 104, requestSocket: socket },
+				uniqueRequestIdentifier: { requestId: internalRequestId, requestSocket: socket },
 				method: 'eth_accounts_reply',
-				params: [{ type: 'error', requestAccounts: true, error: unavailableSignerError }],
+				params: [{ type: 'error', requestAccounts: accountRequest.requestAccounts, error: unavailableSignerError }],
 			}, websiteTabConnections, noopPublishRpcConnectionStatus)
 		})
 		port = createdPort
@@ -1411,18 +1420,25 @@ describe('background eth_accounts', () => {
 			[connectionKey]: { port, socket, websiteOrigin, approved: true, wantsToConnect: true },
 		} }]])
 		const { ethereum, tokenPriceService, resetSimulationServices } = createEthereumWithGetBlockCounter({ count: 0 })
-		const request = {
-			interceptorRequest: true,
-			usingInterceptorWithoutSigner: true,
-			uniqueRequestIdentifier: { requestId: 15, requestSocket: socket },
-			method: 'eth_requestAccounts',
+
+		for (const [requestIndex, accountRequest] of accountRequests.entries()) {
+			const requestId = 15 + requestIndex
+			await handleInterceptedRequest(port, websiteOrigin, website, ethereum, tokenPriceService, resetSimulationServices, socket, {
+				interceptorRequest: true,
+				usingInterceptorWithoutSigner: true,
+				uniqueRequestIdentifier: { requestId, requestSocket: socket },
+				method: accountRequest.method,
+			}, websiteTabConnections, noopPublishRpcConnectionStatus)
+
+			const replies = messages.filter((message) => message.method === accountRequest.method && message.requestId === requestId)
+			assert.equal(replies.length, 1)
+			assert.deepEqual(replies[0]?.error, {
+				...unavailableSignerError,
+				code: accountRequest.expectedPublicErrorCode,
+			})
+			assert.equal(messages.some((message) => (message.method === 'connect' || message.method === 'accountsChanged') && message.requestId === requestId), false)
 		}
-
-		await handleInterceptedRequest(port, websiteOrigin, website, ethereum, tokenPriceService, resetSimulationServices, socket, request, websiteTabConnections, noopPublishRpcConnectionStatus)
-
-		const requestAccountsReplies = messages.filter((message) => message.method === 'eth_requestAccounts' && message.requestId === 15)
-		assert.equal(requestAccountsReplies.length, 1)
-		assert.deepEqual(requestAccountsReplies[0]?.error, unavailableSignerError)
+		assert.equal(messages.some((message) => message.method === 'connect' || message.method === 'accountsChanged'), false)
 	})
 
 	test('ignores a provider-disconnected completion from a sibling socket', async () => {

--- a/test/tests/backgroundEthAccounts.test.ts
+++ b/test/tests/backgroundEthAccounts.test.ts
@@ -130,10 +130,12 @@ function createPort(tabId: number, onPostMessage?: (message: PortMessage) => voi
 
 function confirmedSignerOwnership(socket: { readonly connectionName: bigint }) {
 	return {
-		signerStateOwnerConnectionName: socket.connectionName,
-		signerStateOwnerConfirmed: true,
-		signerStateOwnerGeneration: 1,
-		signerProviderGeneration: 1,
+		signerStateOwner: {
+			connectionName: socket.connectionName,
+			confirmed: true,
+			generation: 1,
+			providerGeneration: 1,
+		},
 	}
 }
 
@@ -554,7 +556,7 @@ params: [{ signerProviderGeneration: 1, type: 'success', accounts: ['0x333333333
 		}
 
 		assert.deepEqual(staleAccountCompletionErrors, [])
-		assert.equal(tabConnection.signerStateOwnerConnectionName, nextSocket.connectionName)
+		assert.equal(tabConnection.signerStateOwner?.connectionName, nextSocket.connectionName)
 		const stateAfterStaleReplies = await getTabState(nextSocket.tabId)
 		assert.deepEqual(stateAfterStaleReplies.signerAccounts, [metaMaskAccount])
 		assert.equal(stateAfterStaleReplies.activeSigningAddress, metaMaskAccount)
@@ -600,10 +602,12 @@ params: [{ signerProviderGeneration: 1, type: 'success', accounts: ['0x333333333
 		}, 0, restoredSocket.connectionName)
 		restoredPort = createdRestoredPort
 		const websiteTabConnections = new Map([[restoredSocket.tabId, {
-			signerStateOwnerConnectionName: previousSocket.connectionName,
-			signerStateOwnerConfirmed: true,
-			signerStateOwnerGeneration: 1,
-			signerProviderGeneration: 7,
+			signerStateOwner: {
+				connectionName: previousSocket.connectionName,
+				confirmed: true,
+				generation: 1,
+				providerGeneration: 7,
+			},
 			connections: {
 				[websiteSocketToString(previousSocket)]: { port: previousPort, socket: previousSocket, websiteOrigin, approved: true, wantsToConnect: true },
 			},
@@ -732,10 +736,12 @@ params: [{ signerProviderGeneration: 1, type: 'success', accounts: ['0x333333333
 		const socket = { tabId: 1, connectionName: 60n }
 		const { port } = createPort(socket.tabId, undefined, 0, socket.connectionName)
 		const websiteTabConnections = new Map([[socket.tabId, {
-			signerStateOwnerConnectionName: socket.connectionName,
-			signerStateOwnerConfirmed: true,
-			signerStateOwnerGeneration: 4,
-			signerProviderGeneration: 2,
+			signerStateOwner: {
+				connectionName: socket.connectionName,
+				confirmed: true,
+				generation: 4,
+				providerGeneration: 2,
+			},
 			connections: {
 				[websiteSocketToString(socket)]: { port, socket, websiteOrigin, approved: true, wantsToConnect: true },
 			},

--- a/test/tests/confirmTransactionRefreshTimestamp.test.ts
+++ b/test/tests/confirmTransactionRefreshTimestamp.test.ts
@@ -149,6 +149,7 @@ async function loadModules() {
 		messageSending,
 		pendingTerminalReplies,
 		terminalReplyDelivery,
+		providerMessageHandlers,
 	] = await Promise.all([
 		import('../../app/ts/simulation/services/EthereumClientService.js'),
 		import('../../app/ts/simulation/services/priceEstimator.js'),
@@ -165,6 +166,7 @@ async function loadModules() {
 		import('../../app/ts/background/messageSending.js'),
 		import('../../app/ts/background/pendingTerminalReplies.js'),
 		import('../../app/ts/background/terminalReplyDelivery.js'),
+		import('../../app/ts/background/providerMessageHandlers.js'),
 	])
 
 	return {
@@ -187,6 +189,7 @@ async function loadModules() {
 		queueTerminalReply: terminalReplyDelivery.queueTerminalReply,
 		attemptQueuedTerminalReplyDelivery: terminalReplyDelivery.attemptQueuedTerminalReplyDelivery,
 		queueTerminalReplyAndAttemptDelivery: terminalReplyDelivery.queueTerminalReplyAndAttemptDelivery,
+		signerReply: providerMessageHandlers.signerReply,
 		browserStorageLocalSet2: storageUtils.browserStorageLocalSet2,
 		websiteSocketToString: backgroundUtils.websiteSocketToString,
 		serialize: wireTypes.serialize,
@@ -428,6 +431,14 @@ function createRecordingPort(postedMessages: unknown[]): browser.runtime.Port {
 	}
 }
 
+function createWebsitePort(socket: { readonly tabId: number, readonly connectionName: bigint }, frameId: number, postedMessages: unknown[]): browser.runtime.Port {
+	return {
+		...createRecordingPort(postedMessages),
+		name: `0x${ socket.connectionName.toString(16) }`,
+		sender: { tab: { id: socket.tabId }, frameId },
+	}
+}
+
 async function waitForPendingTransactionsToClear() {
 	const deadline = Date.now() + 2_000
 	while ((await modules.getPendingTransactionsAndMessages()).length > 0) {
@@ -435,6 +446,61 @@ async function waitForPendingTransactionsToClear() {
 		await new Promise((resolve) => setTimeout(resolve, 10))
 	}
 }
+
+test('accepts a signer reply from the current approved child-frame port', async () => {
+	const topSocket = { tabId: 1, connectionName: 40n }
+	const childSocket = { tabId: 1, connectionName: 41n }
+	const childRequestIdentifier = { requestId: 77, requestSocket: childSocket }
+	const topMessages: unknown[] = []
+	const childMessages: unknown[] = []
+	const topPort = createWebsitePort(topSocket, 0, topMessages)
+	const childPort = createWebsitePort(childSocket, 2, childMessages)
+	const websiteOrigin = 'https://example.com'
+	const websiteTabConnections = new Map([[topSocket.tabId, {
+		signerStateOwnerConnectionName: topSocket.connectionName,
+		signerStateOwnerConfirmed: true,
+		signerStateOwnerGeneration: 3,
+		signerProviderGeneration: 8,
+		connections: {
+			[modules.websiteSocketToString(topSocket)]: { port: topPort, socket: topSocket, websiteOrigin, approved: true, wantsToConnect: true },
+			[modules.websiteSocketToString(childSocket)]: { port: childPort, socket: childSocket, websiteOrigin, approved: true, wantsToConnect: true },
+		},
+	}]])
+	await modules.browserStorageLocalSet2({
+		pendingTransactionsAndMessages: [{
+			...pendingTransaction,
+			uniqueRequestIdentifier: childRequestIdentifier,
+			simulationMode: false,
+			approvalStatus: { status: 'WaitingForSigner' },
+		}],
+	})
+
+	await modules.signerReply(simulator.ethereum, simulator.tokenPriceService, () => undefined, websiteTabConnections, childPort, {
+		method: 'signer_reply',
+		params: [{
+			success: true,
+			signerProviderGeneration: 12,
+			forwardRequest: {
+				type: 'forwardToSigner',
+				replyWithSignersReply: true,
+				method: pendingTransaction.originalRequestParameters.method,
+				params: pendingTransaction.originalRequestParameters.params,
+				requestId: childRequestIdentifier.requestId,
+			},
+			reply: modules.EthereumBytes32.serialize(signedTransaction.hash),
+		}],
+		interceptorRequest: true,
+		interceptorInternalRequest: true,
+		usingInterceptorWithoutSigner: false,
+		uniqueRequestIdentifier: { requestId: 78, requestSocket: childSocket },
+	}, 'hasAccess', activeAddress)
+
+	assert.deepEqual(await modules.getPendingTransactionsAndMessages(), [])
+	assert.equal(topMessages.length, 0)
+	const childReply = childMessages.find((message) => isRecord(message) && message.method === 'eth_sendTransaction' && message.requestId === childRequestIdentifier.requestId)
+	if (!isRecord(childReply)) throw new Error('Missing child-frame signer reply')
+	assert.equal(childReply.result, modules.EthereumBytes32.serialize(signedTransaction.hash))
+})
 
 test('failed signer delivery keeps the request and replaces the waiting spinner with a wallet-neutral error', async () => {
 	await browser.storage.local.set({ simulationMode: false })

--- a/test/tests/confirmTransactionRefreshTimestamp.test.ts
+++ b/test/tests/confirmTransactionRefreshTimestamp.test.ts
@@ -457,10 +457,12 @@ test('accepts a signer reply from the current approved child-frame port', async 
 	const childPort = createWebsitePort(childSocket, 2, childMessages)
 	const websiteOrigin = 'https://example.com'
 	const websiteTabConnections = new Map([[topSocket.tabId, {
-		signerStateOwnerConnectionName: topSocket.connectionName,
-		signerStateOwnerConfirmed: true,
-		signerStateOwnerGeneration: 3,
-		signerProviderGeneration: 8,
+		signerStateOwner: {
+			connectionName: topSocket.connectionName,
+			confirmed: true,
+			generation: 3,
+			providerGeneration: 8,
+		},
 		connections: {
 			[modules.websiteSocketToString(topSocket)]: { port: topPort, socket: topSocket, websiteOrigin, approved: true, wantsToConnect: true },
 			[modules.websiteSocketToString(childSocket)]: { port: childPort, socket: childSocket, websiteOrigin, approved: true, wantsToConnect: true },

--- a/test/tests/contentScriptsUpdating.test.ts
+++ b/test/tests/contentScriptsUpdating.test.ts
@@ -1,4 +1,5 @@
 import * as assert from 'assert'
+import * as fs from 'node:fs'
 import { describe, test } from 'bun:test'
 import { withSilencedConsole } from './consoleSilence.js'
 
@@ -18,6 +19,7 @@ type BrowserMockOptions = {
 function installBrowserMock({ registerError, executeScriptError, tabUrl = 'https://example.com/', hasVisibleTabUrl = true, tabUrlAfterStorageRead }: BrowserMockOptions = {}) {
 	const storageState: Record<string, unknown> = {}
 	const sentMessages: RuntimeMessage[] = []
+	const executedScriptFiles: string[] = []
 	let executeScriptCalls = 0
 	let currentTabUrl = tabUrl
 	let committedListener: ((details: browser.webNavigation._OnCommittedDetails) => unknown) | undefined
@@ -66,8 +68,9 @@ function installBrowserMock({ registerError, executeScriptError, tabUrl = 'https
 				async query() { return [{ id: 42, url: currentTabUrl }] },
 				async get() { return hasVisibleTabUrl ? { id: 42, url: currentTabUrl } : { id: 42 } },
 				async update() { return undefined },
-				async executeScript() {
+				async executeScript(_tabId: number, injection: { readonly file?: string }) {
 					executeScriptCalls++
+					if (injection.file !== undefined) executedScriptFiles.push(injection.file)
 					if (executeScriptError !== undefined) throw executeScriptError
 					return undefined
 				},
@@ -105,6 +108,7 @@ function installBrowserMock({ registerError, executeScriptError, tabUrl = 'https
 	return {
 		sentMessages,
 		getExecuteScriptCalls() { return executeScriptCalls },
+		getExecutedScriptFiles() { return [...executedScriptFiles] },
 		getCommittedListener() {
 			if (committedListener === undefined) throw new Error('webNavigation listener was not registered')
 			return committedListener
@@ -130,7 +134,34 @@ async function loadModules() {
 	}
 }
 
-describe('content script injection strategy errors', () => {
+function getManifestV2WebAccessibleResources() {
+	const manifest: unknown = JSON.parse(fs.readFileSync('app/manifestV2.json', 'utf8'))
+	if (typeof manifest !== 'object' || manifest === null || !('web_accessible_resources' in manifest)) throw new Error('Manifest V2 must declare web-accessible resources')
+	const resources = manifest.web_accessible_resources
+	if (!Array.isArray(resources) || !resources.every((resource) => typeof resource === 'string')) throw new Error('Manifest V2 web-accessible resources must be strings')
+	return resources
+}
+
+describe('content script injection strategy', () => {
+	test('exposes every manifest v2 injected file to Firefox', async () => {
+		const { getCommittedListener, getExecutedScriptFiles } = installBrowserMock()
+		const { updateContentScriptInjectionStrategyManifestV2 } = await loadModules()
+
+		await updateContentScriptInjectionStrategyManifestV2()
+		await getCommittedListener()(committedDetails)
+
+		const injectedFiles = [
+			'/vendor/webextension-polyfill/dist/browser-polyfill.js',
+			'/inpage/js/listenContentScript.js',
+			'/inpage/js/document_start.js',
+		]
+		assert.deepEqual(getExecutedScriptFiles(), injectedFiles)
+		assert.deepEqual(getManifestV2WebAccessibleResources(), [
+			...injectedFiles.map((file) => file.slice(1)),
+			'inpage/js/inpage.js',
+		])
+	})
+
 	test('records manifest v3 registration failures as unexpected errors', async () => {
 		const { sentMessages } = installBrowserMock({ registerError: new Error('registration failed') })
 		const { updateContentScriptInjectionStrategyManifestV3, getLatestUnexpectedError } = await loadModules()

--- a/test/tests/extensionIconDeduping.test.ts
+++ b/test/tests/extensionIconDeduping.test.ts
@@ -103,6 +103,7 @@ async function loadModules() {
 		...await import('../../app/ts/background/popupMessageHandlers.js'),
 		...await import('../../app/ts/background/storageVariables.js'),
 		...await import('../../app/ts/background/websiteTabConnections.js'),
+		...await import('../../app/ts/background/signerStateOwnership.js'),
 	}
 }
 
@@ -323,7 +324,7 @@ describe('extension icon deduping', () => {
 			}],
 		])
 
-		removeWebsiteTabConnection(websiteTabConnections, socket, port)
+		await removeWebsiteTabConnection(websiteTabConnections, socket, port)
 
 		assert.equal(websiteTabConnections.has(1), false)
 	})
@@ -344,10 +345,93 @@ describe('extension icon deduping', () => {
 			}],
 		])
 
-		removeWebsiteTabConnection(websiteTabConnections, socket, disconnectedPort)
+		await removeWebsiteTabConnection(websiteTabConnections, socket, disconnectedPort)
 
 		assert.strictEqual(websiteTabConnections.get(1)?.connections[connectionIdentifier]?.port, replacementPort)
-		removeWebsiteTabConnection(websiteTabConnections, socket, replacementPort)
+		await removeWebsiteTabConnection(websiteTabConnections, socket, replacementPort)
 		assert.equal(websiteTabConnections.has(1), false)
+	})
+
+	test('signer owner disconnect releases ownership while sibling connections remain', async () => {
+		installBrowserMock([{ id: 1, url: 'https://example.test', status: 'complete' }])
+		const { removeWebsiteTabConnection, websiteSocketToString } = await loadModules()
+
+		const ownerSocket = { tabId: 1, connectionName: 0n }
+		const siblingSocket = { tabId: 1, connectionName: 1n }
+		const ownerPort = createPort(1)
+		const siblingPort = createPort(1)
+		const websiteTabConnections = new Map([
+			[1, {
+				connections: {
+					[websiteSocketToString(ownerSocket)]: { port: ownerPort, socket: ownerSocket, websiteOrigin: 'example.test', approved: false, wantsToConnect: false },
+					[websiteSocketToString(siblingSocket)]: { port: siblingPort, socket: siblingSocket, websiteOrigin: 'example.test', approved: false, wantsToConnect: false },
+				},
+				signerStateOwnerConnectionName: ownerSocket.connectionName,
+				signerStateOwnerConfirmed: true,
+			}],
+		])
+
+		await removeWebsiteTabConnection(websiteTabConnections, ownerSocket, ownerPort)
+
+		const remainingTabConnection = websiteTabConnections.get(1)
+		assert.equal(remainingTabConnection?.signerStateOwnerConnectionName, undefined)
+		assert.equal(remainingTabConnection?.signerStateOwnerConfirmed, false)
+		assert.strictEqual(remainingTabConnection?.connections[websiteSocketToString(siblingSocket)]?.port, siblingPort)
+	})
+
+	test('BFCache restoration provisionally reclaims signer ownership before the previous page disconnects', async () => {
+		installBrowserMock([{ id: 1, url: 'https://example.test', status: 'complete' }])
+		const {
+			getTabState,
+			registerWebsiteConnectionAndProvisionallyClaimSignerState,
+			removeWebsiteTabConnection,
+			updateTabState,
+			websiteSocketToString,
+		} = await loadModules()
+
+		const restoredSocket = { tabId: 1, connectionName: 10n }
+		const previousPageSocket = { tabId: 1, connectionName: 11n }
+		const staleRestoredPort = createPort(1)
+		const restoredPort = createPort(1)
+		const previousPagePort = createPort(1)
+		const staleAccount = 0x1111111111111111111111111111111111111111n
+		const websiteTabConnections = new Map([
+			[1, {
+				connections: {
+					[websiteSocketToString(restoredSocket)]: { port: staleRestoredPort, socket: restoredSocket, websiteOrigin: 'example.test', approved: true, wantsToConnect: true },
+					[websiteSocketToString(previousPageSocket)]: { port: previousPagePort, socket: previousPageSocket, websiteOrigin: 'example.test', approved: true, wantsToConnect: true },
+				},
+				signerStateOwnerConnectionName: previousPageSocket.connectionName,
+				signerStateOwnerConfirmed: true,
+				signerStateOwnerGeneration: 1,
+				signerProviderGeneration: 5,
+			}],
+		])
+		await updateTabState(1, (previousState) => ({
+			...previousState,
+			signerName: 'MetaMask',
+			signerConnected: true,
+			signerAccounts: [staleAccount],
+			signerChain: 1n,
+			activeSigningAddress: staleAccount,
+		}))
+
+		await registerWebsiteConnectionAndProvisionallyClaimSignerState(
+			websiteTabConnections,
+			restoredSocket,
+			{ port: restoredPort, socket: restoredSocket, websiteOrigin: 'example.test', approved: true, wantsToConnect: true },
+			true,
+		)
+		await removeWebsiteTabConnection(websiteTabConnections, previousPageSocket, previousPagePort)
+
+		const tabConnection = websiteTabConnections.get(1)
+		assert.equal(tabConnection?.signerStateOwnerConnectionName, restoredSocket.connectionName)
+		assert.equal(tabConnection?.signerStateOwnerConfirmed, false)
+		assert.equal((await getTabState(restoredSocket.tabId)).signerName, 'NoSigner')
+		assert.strictEqual(tabConnection?.connections[websiteSocketToString(restoredSocket)]?.port, restoredPort)
+		const tabState = await getTabState(1)
+		assert.deepEqual(tabState.signerAccounts, [])
+		assert.equal(tabState.signerChain, undefined)
+		assert.equal(tabState.activeSigningAddress, undefined)
 	})
 })

--- a/test/tests/extensionIconDeduping.test.ts
+++ b/test/tests/extensionIconDeduping.test.ts
@@ -366,16 +366,20 @@ describe('extension icon deduping', () => {
 					[websiteSocketToString(ownerSocket)]: { port: ownerPort, socket: ownerSocket, websiteOrigin: 'example.test', approved: false, wantsToConnect: false },
 					[websiteSocketToString(siblingSocket)]: { port: siblingPort, socket: siblingSocket, websiteOrigin: 'example.test', approved: false, wantsToConnect: false },
 				},
-				signerStateOwnerConnectionName: ownerSocket.connectionName,
-				signerStateOwnerConfirmed: true,
+				signerStateOwner: {
+					connectionName: ownerSocket.connectionName,
+					confirmed: true,
+					generation: 1,
+					providerGeneration: 1,
+				},
 			}],
 		])
 
 		await removeWebsiteTabConnection(websiteTabConnections, ownerSocket, ownerPort)
 
 		const remainingTabConnection = websiteTabConnections.get(1)
-		assert.equal(remainingTabConnection?.signerStateOwnerConnectionName, undefined)
-		assert.equal(remainingTabConnection?.signerStateOwnerConfirmed, false)
+		assert.equal(remainingTabConnection?.signerStateOwner?.connectionName, undefined)
+		assert.equal(remainingTabConnection?.signerStateOwner?.confirmed, false)
 		assert.strictEqual(remainingTabConnection?.connections[websiteSocketToString(siblingSocket)]?.port, siblingPort)
 	})
 
@@ -401,10 +405,12 @@ describe('extension icon deduping', () => {
 					[websiteSocketToString(restoredSocket)]: { port: staleRestoredPort, socket: restoredSocket, websiteOrigin: 'example.test', approved: true, wantsToConnect: true },
 					[websiteSocketToString(previousPageSocket)]: { port: previousPagePort, socket: previousPageSocket, websiteOrigin: 'example.test', approved: true, wantsToConnect: true },
 				},
-				signerStateOwnerConnectionName: previousPageSocket.connectionName,
-				signerStateOwnerConfirmed: true,
-				signerStateOwnerGeneration: 1,
-				signerProviderGeneration: 5,
+				signerStateOwner: {
+					connectionName: previousPageSocket.connectionName,
+					confirmed: true,
+					generation: 1,
+					providerGeneration: 5,
+				},
 			}],
 		])
 		await updateTabState(1, (previousState) => ({
@@ -425,8 +431,8 @@ describe('extension icon deduping', () => {
 		await removeWebsiteTabConnection(websiteTabConnections, previousPageSocket, previousPagePort)
 
 		const tabConnection = websiteTabConnections.get(1)
-		assert.equal(tabConnection?.signerStateOwnerConnectionName, restoredSocket.connectionName)
-		assert.equal(tabConnection?.signerStateOwnerConfirmed, false)
+		assert.equal(tabConnection?.signerStateOwner?.connectionName, restoredSocket.connectionName)
+		assert.equal(tabConnection?.signerStateOwner?.confirmed, false)
 		assert.equal((await getTabState(restoredSocket.tabId)).signerName, 'NoSigner')
 		assert.strictEqual(tabConnection?.connections[websiteSocketToString(restoredSocket)]?.port, restoredPort)
 		const tabState = await getTabState(1)

--- a/test/tests/inpageSignerBridge.test.ts
+++ b/test/tests/inpageSignerBridge.test.ts
@@ -469,7 +469,7 @@ describe('inpage signer bridge', () => {
 		assert.deepEqual(backgroundEthAccountsReplies, [{
 			type: 'error',
 			requestAccounts: true,
-			error: { code: 4900, message: 'No signer wallet became available for this page.' },
+			error: { code: 4900, message: 'No signer wallet is available to this page. Enable your wallet extension for this site, then try again.' },
 		}])
 	})
 

--- a/test/tests/inpageSignerBridge.test.ts
+++ b/test/tests/inpageSignerBridge.test.ts
@@ -453,7 +453,21 @@ describe('inpage signer bridge', () => {
 	})
 
 	test('settles signer account discovery when no signer initializes', async () => {
-		const { fakeWindow, backgroundEthAccountsReplies, sendBackgroundMessage } = createFakeWindow()
+		const connectedToSignerParams: unknown[][] = []
+		const { fakeWindow, backgroundEthAccountsReplies, sendBackgroundMessage } = createFakeWindow({
+			handleRequest: (request, sendBackgroundReply) => {
+				if (request.method !== 'connected_to_signer') return false
+				connectedToSignerParams.push(request.params ?? [])
+				sendBackgroundReply({
+					interceptorApproved: true,
+					requestId: request.requestId,
+					type: 'result',
+					method: 'connected_to_signer',
+					result: { metamaskCompatibilityMode: true },
+				})
+				return true
+			},
+		})
 		Reflect.deleteProperty(fakeWindow, 'ethereum')
 
 		await withFakeInpageWindow(fakeWindow, '../../app/inpage/ts/inpage.js?unavailable-signer-account-reply', async () => {
@@ -469,8 +483,10 @@ describe('inpage signer bridge', () => {
 		assert.deepEqual(backgroundEthAccountsReplies, [{
 			type: 'error',
 			requestAccounts: true,
+			signerUnavailable: true,
 			error: { code: 4900, message: 'No signer wallet is available to this page. Enable your wallet extension for this site, then try again.' },
 		}])
+		assert.deepEqual(connectedToSignerParams, [[false, 'NoSigner']])
 	})
 
 	test('ignores replayed terminal replies after the original request settles', async () => {

--- a/test/tests/inpageSignerBridge.test.ts
+++ b/test/tests/inpageSignerBridge.test.ts
@@ -329,6 +329,136 @@ describe('inpage signer bridge', () => {
 		assert.equal(bridgeRequests.filter((request) => request.internal === true).every((request) => request.replayOnDisconnect === undefined), true)
 	})
 
+	test('settles the first account request and keeps signing when MetaMask initializes after Interceptor', async () => {
+		const signerAccountReplies: unknown[] = []
+		const connectedSignerNames: unknown[] = []
+		const signerRequestMethods: string[] = []
+		const signedTransactionHash = '0x2222222222222222222222222222222222222222222222222222222222222222'
+		let pendingAccountRequest: InpageRequest | undefined
+		const { fakeWindow, signerAccounts, sendBackgroundMessage } = createFakeWindow({
+			handleRequest: (request, sendBackgroundMessageForRequest) => {
+				if (request.method === 'connected_to_signer') {
+					connectedSignerNames.push(request.params?.[1])
+					return false
+				}
+				if (request.method === 'eth_requestAccounts' && request.internal !== true) {
+					pendingAccountRequest = request
+					return true
+				}
+				if (request.method === 'eth_accounts_reply') {
+					const signerAccountsReply = request.params?.[0]
+					if (!isRecord(signerAccountsReply)) throw new Error('Malformed signer accounts reply')
+					signerAccountReplies.push(signerAccountsReply)
+					sendBackgroundMessageForRequest({
+						interceptorApproved: true,
+						requestId: request.requestId,
+						type: 'result',
+						method: 'eth_accounts_reply',
+						result: undefined,
+					})
+					const accountRequest = pendingAccountRequest
+					if (signerAccountsReply.type !== 'success' || !Array.isArray(signerAccountsReply.accounts) || accountRequest === undefined) return true
+					pendingAccountRequest = undefined
+					sendBackgroundMessageForRequest({
+						interceptorApproved: true,
+						requestId: accountRequest.requestId,
+						type: 'result',
+						method: 'eth_accounts',
+						result: signerAccountsReply.accounts,
+					})
+					return true
+				}
+				if (request.method === 'eth_sendTransaction') {
+					sendBackgroundMessageForRequest({
+						interceptorApproved: true,
+						requestId: request.requestId,
+						type: 'forwardToSigner',
+						method: request.method,
+						params: request.params,
+					})
+					return true
+				}
+				if (request.method !== 'signer_reply') return false
+				const signerReply = request.params?.[0]
+				if (!isRecord(signerReply) || !isRecord(signerReply.forwardRequest) || typeof signerReply.forwardRequest.requestId !== 'number') throw new Error('Malformed signer reply')
+				sendBackgroundMessageForRequest({
+					interceptorApproved: true,
+					requestId: signerReply.forwardRequest.requestId,
+					type: 'result',
+					method: 'eth_sendTransaction',
+					result: signerReply.reply,
+				})
+				sendBackgroundMessageForRequest({
+					interceptorApproved: true,
+					requestId: request.requestId,
+					type: 'result',
+					method: 'signer_reply',
+					result: '0x',
+				})
+				return true
+			},
+			handleSignerRequest: ({ method }) => {
+				signerRequestMethods.push(method)
+				if (method === 'eth_sendTransaction') return signedTransactionHash
+				return undefined
+			},
+		})
+		const lateMetaMaskProvider = fakeWindow.ethereum
+		Reflect.deleteProperty(fakeWindow, 'ethereum')
+
+		await withFakeInpageWindow(fakeWindow, '../../app/inpage/ts/inpage.js?late-metamask-first-connect-and-signing', async () => {
+			const interceptorProvider = fakeWindow.ethereum
+			const accountRequest = interceptorProvider.request({ method: 'eth_requestAccounts' })
+			await waitFor(() => pendingAccountRequest !== undefined)
+			sendBackgroundMessage({
+				interceptorApproved: true,
+				type: 'result',
+				method: 'request_signer_to_eth_requestAccounts',
+				result: [],
+			})
+			await new Promise((resolve) => setTimeout(resolve, 0))
+
+			fakeWindow.addEventListener('eip6963:requestProvider', () => fakeWindow.dispatchEvent({
+				type: 'eip6963:announceProvider',
+				detail: {
+					info: { uuid: '55555555-5555-4555-8555-555555555555', name: 'MetaMask', icon: 'data:image/svg+xml,<svg/>', rdns: 'io.metamask' },
+					provider: lateMetaMaskProvider,
+				},
+			}))
+			fakeWindow.dispatchEvent({ type: 'ethereum#initialized' })
+
+			await waitFor(() => signerAccountReplies.length === 1, 500)
+			assert.deepEqual(signerAccountReplies, [{ type: 'success', accounts: signerAccounts, requestAccounts: true }])
+			assert.deepEqual(await accountRequest, signerAccounts)
+			assert.equal(await interceptorProvider.request({ method: 'eth_sendTransaction', params: [{ from: signerAccounts[0] }] }), signedTransactionHash)
+		})
+
+		assert.deepEqual(connectedSignerNames, ['NoSigner', 'MetaMask'])
+		assert.equal(signerRequestMethods.includes('eth_requestAccounts'), true)
+		assert.equal(signerRequestMethods.includes('eth_sendTransaction'), true)
+	})
+
+	test('settles signer account discovery when no signer initializes', async () => {
+		const { fakeWindow, backgroundEthAccountsReplies, sendBackgroundMessage } = createFakeWindow()
+		Reflect.deleteProperty(fakeWindow, 'ethereum')
+
+		await withFakeInpageWindow(fakeWindow, '../../app/inpage/ts/inpage.js?unavailable-signer-account-reply', async () => {
+			sendBackgroundMessage({
+				interceptorApproved: true,
+				type: 'result',
+				method: 'request_signer_to_eth_requestAccounts',
+				result: [],
+			})
+			await waitFor(() => backgroundEthAccountsReplies.length === 1, 3500)
+		})
+
+		assert.deepEqual(backgroundEthAccountsReplies, [{
+			type: 'error',
+			requestAccounts: true,
+			error: { code: 4900, message: 'No signer wallet became available for this page.' },
+		}])
+	})
+
 	test('ignores replayed terminal replies after the original request settles', async () => {
 		let capturedRequest: InpageRequest | undefined
 		const { fakeWindow, interceptorErrorPayloads, sendBackgroundMessage } = createFakeWindow({

--- a/test/tests/inpageSignerBridge.test.ts
+++ b/test/tests/inpageSignerBridge.test.ts
@@ -329,10 +329,11 @@ describe('inpage signer bridge', () => {
 		assert.equal(bridgeRequests.filter((request) => request.internal === true).every((request) => request.replayOnDisconnect === undefined), true)
 	})
 
-	test('settles the first account request and keeps signing when MetaMask initializes after Interceptor', async () => {
+	test('waits for late MetaMask instead of using Brave for the first account request and signing', async () => {
 		const signerAccountReplies: unknown[] = []
 		const connectedSignerNames: unknown[] = []
 		const signerRequestMethods: string[] = []
+		const braveSignerRequestMethods: string[] = []
 		const signedTransactionHash = '0x2222222222222222222222222222222222222222222222222222222222222222'
 		let pendingAccountRequest: InpageRequest | undefined
 		const { fakeWindow, signerAccounts, sendBackgroundMessage } = createFakeWindow({
@@ -404,7 +405,19 @@ describe('inpage signer bridge', () => {
 			},
 		})
 		const lateMetaMaskProvider = fakeWindow.ethereum
-		Reflect.deleteProperty(fakeWindow, 'ethereum')
+		const braveSigner = {
+			isBraveWallet: true,
+			isConnected: () => true,
+			request: async ({ method }: { method: string }) => {
+				braveSignerRequestMethods.push(method)
+				if (method === 'eth_chainId') return '0x1'
+				if (method === 'eth_accounts' || method === 'eth_requestAccounts') return []
+				throw new Error(`Unexpected Brave signer request: ${ method }`)
+			},
+			on: () => braveSigner,
+			removeListener: () => braveSigner,
+		}
+		Object.defineProperty(fakeWindow, 'ethereum', { configurable: true, writable: true, value: braveSigner })
 
 		await withFakeInpageWindow(fakeWindow, '../../app/inpage/ts/inpage.js?late-metamask-first-connect-and-signing', async () => {
 			const interceptorProvider = fakeWindow.ethereum
@@ -417,6 +430,7 @@ describe('inpage signer bridge', () => {
 				result: [],
 			})
 			await new Promise((resolve) => setTimeout(resolve, 0))
+			assert.equal(braveSignerRequestMethods.includes('eth_requestAccounts'), false)
 
 			fakeWindow.addEventListener('eip6963:requestProvider', () => fakeWindow.dispatchEvent({
 				type: 'eip6963:announceProvider',
@@ -425,7 +439,6 @@ describe('inpage signer bridge', () => {
 					provider: lateMetaMaskProvider,
 				},
 			}))
-			fakeWindow.dispatchEvent({ type: 'ethereum#initialized' })
 
 			await waitFor(() => signerAccountReplies.length === 1, 500)
 			assert.deepEqual(signerAccountReplies, [{ type: 'success', accounts: signerAccounts, requestAccounts: true }])
@@ -433,7 +446,8 @@ describe('inpage signer bridge', () => {
 			assert.equal(await interceptorProvider.request({ method: 'eth_sendTransaction', params: [{ from: signerAccounts[0] }] }), signedTransactionHash)
 		})
 
-		assert.deepEqual(connectedSignerNames, ['NoSigner', 'MetaMask'])
+		assert.deepEqual(connectedSignerNames, ['Brave', 'MetaMask'])
+		assert.equal(braveSignerRequestMethods.includes('eth_requestAccounts'), false)
 		assert.equal(signerRequestMethods.includes('eth_requestAccounts'), true)
 		assert.equal(signerRequestMethods.includes('eth_sendTransaction'), true)
 	})
@@ -1122,10 +1136,10 @@ describe('inpage signer bridge', () => {
 		}
 	})
 
-	test('does not let a late page announcement replace the selected Brave signer', async () => {
+	test('only replaces a selected Brave signer during requested provider discovery', async () => {
 		const connectedSignerNames: unknown[] = []
 		let announcedProviderSubscriptionCount = 0
-		const { fakeWindow } = createFakeWindow({
+		const { fakeWindow, sendBackgroundMessage } = createFakeWindow({
 			handleRequest: (request) => {
 				if (request.method === 'connected_to_signer') connectedSignerNames.push(request.params?.[1])
 				return false
@@ -1160,10 +1174,27 @@ describe('inpage signer bridge', () => {
 				},
 			})
 			await new Promise((resolve) => setTimeout(resolve, 0))
+			assert.equal(announcedProviderSubscriptionCount, 0)
+			assert.deepEqual(connectedSignerNames, ['Brave'])
+
+			fakeWindow.addEventListener('eip6963:requestProvider', () => fakeWindow.dispatchEvent({
+				type: 'eip6963:announceProvider',
+				detail: {
+					info: { uuid: '44444444-4444-4444-8444-444444444444', name: 'MetaMask', icon: 'data:image/svg+xml,<svg/>', rdns: 'io.metamask' },
+					provider: announcedProvider,
+				},
+			}))
+			sendBackgroundMessage({
+				interceptorApproved: true,
+				type: 'result',
+				method: 'request_signer_to_eth_requestAccounts',
+				result: [],
+			})
+			await waitFor(() => connectedSignerNames.includes('MetaMask'))
 		})
 
-		assert.equal(announcedProviderSubscriptionCount, 0)
-		assert.deepEqual(connectedSignerNames, ['Brave'])
+		assert.equal(announcedProviderSubscriptionCount > 0, true)
+		assert.deepEqual(connectedSignerNames, ['Brave', 'MetaMask'])
 	})
 
 	test('keeps signer selectedAddress mutations hidden until Interceptor account replay', async () => {

--- a/test/tests/inpageSignerBridge.test.ts
+++ b/test/tests/inpageSignerBridge.test.ts
@@ -441,7 +441,7 @@ describe('inpage signer bridge', () => {
 			}))
 
 			await waitFor(() => signerAccountReplies.length === 1, 500)
-			assert.deepEqual(signerAccountReplies, [{ type: 'success', accounts: signerAccounts, requestAccounts: true }])
+			assert.deepEqual(signerAccountReplies, [{ type: 'success', accounts: signerAccounts, requestAccounts: true, signerProviderGeneration: 4 }])
 			assert.deepEqual(await accountRequest, signerAccounts)
 			assert.equal(await interceptorProvider.request({ method: 'eth_sendTransaction', params: [{ from: signerAccounts[0] }] }), signedTransactionHash)
 		})
@@ -451,6 +451,67 @@ describe('inpage signer bridge', () => {
 		assert.equal(signerRequestMethods.includes('eth_requestAccounts'), true)
 		assert.equal(signerRequestMethods.includes('eth_sendTransaction'), true)
 	})
+
+	test('retries an in-flight Brave account request when MetaMask becomes available', async () => {
+		const connectedSignerNames: unknown[] = []
+		const braveSignerRequestMethods: string[] = []
+		const braveAccounts = ['0x3333333333333333333333333333333333333333']
+		let resolveBraveAccounts: ((accounts: string[]) => void) | undefined
+		const { fakeWindow, signerAccounts, backgroundEthAccountsReplies, sendBackgroundMessage } = createFakeWindow({
+			handleRequest: (request) => {
+				if (request.method === 'connected_to_signer') connectedSignerNames.push(request.params?.[1])
+				return false
+			},
+		})
+		const lateMetaMaskProvider = fakeWindow.ethereum
+		const braveSigner = {
+			isBraveWallet: true,
+			isConnected: () => true,
+			request: async ({ method }: { method: string }) => {
+				braveSignerRequestMethods.push(method)
+				if (method === 'eth_chainId') return '0x1'
+				if (method === 'eth_requestAccounts') {
+					return await new Promise<string[]>((resolve) => { resolveBraveAccounts = resolve })
+				}
+				if (method === 'eth_accounts') return braveAccounts
+				throw new Error(`Unexpected Brave signer request: ${ method }`)
+			},
+			on: () => braveSigner,
+			removeListener: () => braveSigner,
+		}
+		Object.defineProperty(fakeWindow, 'ethereum', { configurable: true, writable: true, value: braveSigner })
+
+		await withFakeInpageWindow(fakeWindow, '../../app/inpage/ts/inpage.js?replace-in-flight-brave-accounts', async () => {
+			await waitFor(() => connectedSignerNames.includes('Brave'))
+			sendBackgroundMessage({
+				interceptorApproved: true,
+				type: 'result',
+				method: 'request_signer_to_eth_requestAccounts',
+				result: [],
+			})
+			await waitFor(() => resolveBraveAccounts !== undefined, 3500)
+
+			fakeWindow.addEventListener('eip6963:requestProvider', () => fakeWindow.dispatchEvent({
+				type: 'eip6963:announceProvider',
+				detail: {
+					info: { uuid: '66666666-6666-4666-8666-666666666666', name: 'MetaMask', icon: 'data:image/svg+xml,<svg/>', rdns: 'io.metamask' },
+					provider: lateMetaMaskProvider,
+				},
+			}))
+			fakeWindow.dispatchEvent({ type: 'ethereum#initialized' })
+
+			await waitFor(() => connectedSignerNames.includes('MetaMask'))
+			await waitFor(() => backgroundEthAccountsReplies.length === 1)
+			assert.deepEqual(backgroundEthAccountsReplies, [{ type: 'success', accounts: signerAccounts, requestAccounts: true, signerProviderGeneration: 4 }])
+
+			resolveBraveAccounts?.(braveAccounts)
+			await new Promise((resolve) => setTimeout(resolve, 0))
+			assert.equal(backgroundEthAccountsReplies.length, 1)
+		})
+
+		assert.deepEqual(connectedSignerNames, ['Brave', 'MetaMask'])
+		assert.equal(braveSignerRequestMethods.filter((method) => method === 'eth_requestAccounts').length, 1)
+	}, 7000)
 
 	test('settles signer account discovery when no signer initializes', async () => {
 		const connectedToSignerParams: unknown[][] = []
@@ -483,10 +544,210 @@ describe('inpage signer bridge', () => {
 		assert.deepEqual(backgroundEthAccountsReplies, [{
 			type: 'error',
 			requestAccounts: true,
+			signerProviderGeneration: 1,
 			signerUnavailable: true,
 			error: { code: 4900, message: 'No signer wallet is available to this page. Enable your wallet extension for this site, then try again.' },
 		}])
-		assert.deepEqual(connectedToSignerParams, [[false, 'NoSigner']])
+		assert.deepEqual(connectedToSignerParams, [[false, 'NoSigner', 1]])
+	})
+
+	test('reports a fresh signer epoch when the background requests reconnect status', async () => {
+		const connectedToSignerParams: unknown[][] = []
+		const { fakeWindow, sendBackgroundMessage } = createFakeWindow({
+			handleRequest: (request, sendBackgroundReply) => {
+				if (request.method !== 'connected_to_signer') return false
+				connectedToSignerParams.push(request.params ?? [])
+				sendBackgroundReply({
+					interceptorApproved: true,
+					requestId: request.requestId,
+					type: 'result',
+					method: 'connected_to_signer',
+					result: { metamaskCompatibilityMode: true },
+				})
+				return true
+			},
+		})
+
+		await withFakeInpageWindow(fakeWindow, '../../app/inpage/ts/inpage.js?explicit-signer-status-handshake', async () => {
+			await waitFor(() => connectedToSignerParams.length === 1)
+			sendBackgroundMessage({
+				interceptorApproved: true,
+				type: 'result',
+				method: 'request_signer_connection_status',
+				result: [],
+			})
+			await waitFor(() => connectedToSignerParams.length === 2)
+		})
+
+		const firstGeneration = connectedToSignerParams[0]?.[2]
+		const secondGeneration = connectedToSignerParams[1]?.[2]
+		assert.equal(connectedToSignerParams[1]?.[1], 'MetaMask')
+		assert.equal(typeof firstGeneration, 'number')
+		assert.equal(typeof secondGeneration, 'number')
+		if (typeof firstGeneration !== 'number' || typeof secondGeneration !== 'number') throw new Error('Missing signer provider generation')
+		assert.equal(secondGeneration > firstGeneration, true)
+	})
+
+	test('reports reconnect status without waiting for a lost previous status reply', async () => {
+		const connectedToSignerParams: unknown[][] = []
+		const { backgroundEthAccountsReplies, fakeWindow, sendBackgroundMessage, signerRequests } = createFakeWindow({
+			handleRequest: (request, sendBackgroundReply) => {
+				if (request.method !== 'connected_to_signer') return false
+				connectedToSignerParams.push(request.params ?? [])
+				if (connectedToSignerParams.length === 1) return true
+				sendBackgroundReply({
+					interceptorApproved: true,
+					requestId: request.requestId,
+					type: 'result',
+					method: 'connected_to_signer',
+					result: { metamaskCompatibilityMode: true },
+				})
+				return true
+			},
+		})
+
+		await withFakeInpageWindow(fakeWindow, '../../app/inpage/ts/inpage.js?lost-signer-status-reply', async () => {
+			await waitFor(() => connectedToSignerParams.length === 1)
+			sendBackgroundMessage({
+				interceptorApproved: true,
+				type: 'result',
+				method: 'request_signer_to_eth_accounts',
+				result: [],
+			})
+			await new Promise((resolve) => setTimeout(resolve, 0))
+			assert.equal(backgroundEthAccountsReplies.length, 0)
+			sendBackgroundMessage({
+				interceptorApproved: true,
+				type: 'result',
+				method: 'request_signer_connection_status',
+				result: [],
+			})
+			await waitFor(() => connectedToSignerParams.length === 2)
+			await waitFor(() => signerRequests.includes('eth_chainId'))
+			await waitFor(() => backgroundEthAccountsReplies.length === 1)
+		})
+
+		const firstGeneration = connectedToSignerParams[0]?.[2]
+		const secondGeneration = connectedToSignerParams[1]?.[2]
+		assert.equal(typeof firstGeneration, 'number')
+		assert.equal(typeof secondGeneration, 'number')
+		if (typeof firstGeneration !== 'number' || typeof secondGeneration !== 'number') throw new Error('Missing signer provider generation')
+		assert.equal(secondGeneration > firstGeneration, true)
+	})
+
+	test('settles a pending chain switch when the signer provider changes', async () => {
+		const chainSwitchReplies: unknown[] = []
+		let chainSwitchRequestCount = 0
+		const { fakeWindow, emitSignerEvent, sendBackgroundMessage } = createFakeWindow({
+			handleRequest: (request, sendBackgroundReply) => {
+				if (request.method !== 'wallet_switchEthereumChain_reply') return false
+				chainSwitchReplies.push(request.params?.[0])
+				sendBackgroundReply({
+					interceptorApproved: true,
+					requestId: request.requestId,
+					type: 'result',
+					method: 'wallet_switchEthereumChain_reply',
+					result: '0x',
+				})
+				return true
+			},
+			handleSignerRequest: ({ method }) => {
+				if (method !== 'wallet_switchEthereumChain') return undefined
+				chainSwitchRequestCount += 1
+				return new Promise<never>(() => undefined)
+			},
+		})
+
+		await withFakeInpageWindow(fakeWindow, '../../app/inpage/ts/inpage.js?chain-switch-provider-change', async () => {
+			sendBackgroundMessage({
+				interceptorApproved: true,
+				type: 'result',
+				method: 'request_signer_to_wallet_switchEthereumChain',
+				result: '0x2',
+			})
+			await waitFor(() => chainSwitchRequestCount === 1)
+			emitSignerEvent('connect', { chainId: '0x1' })
+			await waitFor(() => chainSwitchReplies.length === 1)
+		})
+
+		const reply = chainSwitchReplies[0]
+		if (!isRecord(reply) || !isRecord(reply.error)) throw new Error('Malformed chain switch reply')
+		assert.equal(reply.accept, false)
+		assert.equal(reply.chainId, '0x2')
+		assert.equal(reply.error.code, 4900)
+		assert.equal(reply.error.message, 'Signer connection changed before the previous wallet replied.')
+	})
+
+	test('settles a chain switch for an unexpected signer error', async () => {
+		const chainSwitchReplies: unknown[] = []
+		const { fakeWindow, sendBackgroundMessage } = createFakeWindow({
+			handleRequest: (request, sendBackgroundReply) => {
+				if (request.method !== 'wallet_switchEthereumChain_reply') return false
+				chainSwitchReplies.push(request.params?.[0])
+				sendBackgroundReply({
+					interceptorApproved: true,
+					requestId: request.requestId,
+					type: 'result',
+					method: 'wallet_switchEthereumChain_reply',
+					result: '0x',
+				})
+				return true
+			},
+			handleSignerRequest: ({ method }) => method === 'wallet_switchEthereumChain'
+				? Promise.reject({ code: -32000, message: 'Unexpected signer failure' })
+				: undefined,
+		})
+
+		await withFakeInpageWindow(fakeWindow, '../../app/inpage/ts/inpage.js?chain-switch-unexpected-error', async () => {
+			sendBackgroundMessage({
+				interceptorApproved: true,
+				type: 'result',
+				method: 'request_signer_to_wallet_switchEthereumChain',
+				result: '0x2',
+			})
+			await waitFor(() => chainSwitchReplies.length === 1)
+		})
+
+		const reply = chainSwitchReplies[0]
+		if (!isRecord(reply) || !isRecord(reply.error)) throw new Error('Malformed chain switch reply')
+		assert.equal(reply.accept, false)
+		assert.equal(reply.error.code, -32000)
+		assert.equal(reply.error.message, 'Unexpected signer failure')
+	})
+
+	test('settles a chain switch when no signer is injected', async () => {
+		const chainSwitchReplies: unknown[] = []
+		const { fakeWindow, sendBackgroundMessage } = createFakeWindow({
+			handleRequest: (request, sendBackgroundReply) => {
+				if (request.method !== 'wallet_switchEthereumChain_reply') return false
+				chainSwitchReplies.push(request.params?.[0])
+				sendBackgroundReply({
+					interceptorApproved: true,
+					requestId: request.requestId,
+					type: 'result',
+					method: 'wallet_switchEthereumChain_reply',
+					result: '0x',
+				})
+				return true
+			},
+		})
+		Reflect.deleteProperty(fakeWindow, 'ethereum')
+
+		await withFakeInpageWindow(fakeWindow, '../../app/inpage/ts/inpage.js?chain-switch-no-signer', async () => {
+			sendBackgroundMessage({
+				interceptorApproved: true,
+				type: 'result',
+				method: 'request_signer_to_wallet_switchEthereumChain',
+				result: '0x2',
+			})
+			await waitFor(() => chainSwitchReplies.length === 1)
+		})
+
+		const reply = chainSwitchReplies[0]
+		if (!isRecord(reply) || !isRecord(reply.error)) throw new Error('Malformed chain switch reply')
+		assert.equal(reply.accept, false)
+		assert.equal(reply.error.code, 4900)
+		assert.match(String(reply.error.message), /No signer wallet is available/)
 	})
 
 	test('ignores replayed terminal replies after the original request settles', async () => {
@@ -640,8 +901,8 @@ describe('inpage signer bridge', () => {
 			rejectPendingRequestAccounts({ code: 4001, message: 'User rejected the request.' })
 			await waitFor(() => backgroundEthAccountsReplies.length === 4)
 			assert.deepEqual(backgroundEthAccountsReplies.slice(2), [
-				{ type: 'error', requestAccounts: true, error: { code: 4001, message: 'User rejected the request.' } },
-				{ type: 'error', requestAccounts: true, error: { code: 4001, message: 'User rejected the request.' } },
+				{ type: 'error', requestAccounts: true, signerProviderGeneration: 2, error: { code: 4001, message: 'User rejected the request.' } },
+				{ type: 'error', requestAccounts: true, signerProviderGeneration: 2, error: { code: 4001, message: 'User rejected the request.' } },
 			])
 
 			const signerRequestCountBeforeSpoof = signerRequests.length
@@ -1059,6 +1320,7 @@ describe('inpage signer bridge', () => {
 		const signerReply = signerReplies[0]
 		if (!isRecord(signerReply) || !isRecord(signerReply.error)) throw new Error('Malformed signer reply')
 		assert.equal(signerReply.success, false)
+		assert.equal(typeof signerReply.signerProviderGeneration, 'number')
 		assert.deepEqual(signerReply.error, {
 			code: 4001,
 			message: 'MetaMask Tx Signature: User denied transaction signature.',
@@ -1067,7 +1329,7 @@ describe('inpage signer bridge', () => {
 		assert.doesNotThrow(() => SignerReply.parse({ method: 'signer_reply', params: [signerReply] }))
 	})
 
-	test('serializes unusable-root NoSigner recovery before EIP-6963 MetaMask connection', async () => {
+	test('reports unusable-root NoSigner before EIP-6963 MetaMask recovery', async () => {
 		const connectedSignerNames: unknown[] = []
 		const { fakeWindow, signerRequests } = createFakeWindow({
 			handleRequest: (request, sendBackgroundMessage) => {
@@ -1439,7 +1701,7 @@ describe('inpage signer bridge', () => {
 			resolvePendingRequestAccounts([signerAccount])
 			await waitFor(() => backgroundEthAccountsReplies.length === 1)
 			assert.deepEqual(backgroundEthAccountsReplies, [
-				{ type: 'success', accounts: [signerAccount], requestAccounts: true },
+				{ type: 'success', accounts: [signerAccount], requestAccounts: true, signerProviderGeneration: 2 },
 			])
 		})
 	})

--- a/test/tests/listenContentScriptArtifact.test.ts
+++ b/test/tests/listenContentScriptArtifact.test.ts
@@ -1,0 +1,23 @@
+import * as assert from 'assert'
+import * as path from 'node:path'
+import * as vm from 'node:vm'
+import { test } from 'bun:test'
+
+test('bundled content script listener has an undefined completion value', async () => {
+	const buildResult = await Bun.build({
+		entrypoints: [path.resolve('app/inpage/ts/listenContentScript.ts')],
+		target: 'browser',
+		format: 'esm',
+		splitting: false,
+		write: false,
+	})
+	if (!buildResult.success) throw new Error(buildResult.logs.map((log) => log.message).join('\n'))
+	const output = buildResult.outputs[0]
+	if (output === undefined) throw new Error('Bundling the content script listener produced no output')
+
+	const context = {}
+	const completionValue = vm.runInNewContext(await output.text(), context)
+
+	assert.equal(completionValue, undefined)
+	assert.equal(vm.runInNewContext('typeof globalThis[Symbol.for("TheInterceptor.listenContentScript")]', context), 'function')
+})

--- a/test/tests/popupClearReset.test.ts
+++ b/test/tests/popupClearReset.test.ts
@@ -468,7 +468,7 @@ describe('popup clear reset', () => {
 			interceptorTransactionStack,
 		})
 
-		await changeActiveRpc(fakeEthereum, fakeTokenPriceService, resetSimulationServices, new Map(), sameChainRpcNetwork, true)
+		await changeActiveRpc(fakeEthereum, fakeTokenPriceService, resetSimulationServices, new Map(), sameChainRpcNetwork, true, undefined)
 
 		const modules = await modulesPromise
 		const updatedSettings = await modules.getSettings()
@@ -495,7 +495,7 @@ describe('popup clear reset', () => {
 			interceptorTransactionStack: { operations: [{ type: 'TimeManipulation', blockTimeManipulation: DEFAULT_BLOCK_MANIPULATION }] },
 		})
 
-		await changeActiveRpc(fakeEthereum, fakeTokenPriceService, resetSimulationServices, new Map(), otherChainRpcNetwork, true)
+		await changeActiveRpc(fakeEthereum, fakeTokenPriceService, resetSimulationServices, new Map(), otherChainRpcNetwork, true, undefined)
 
 		const modules = await modulesPromise
 		const updatedSettings = await modules.getSettings()

--- a/test/tests/providerErrors.test.tsx
+++ b/test/tests/providerErrors.test.tsx
@@ -1,0 +1,52 @@
+import * as assert from 'assert'
+import { describe, test } from 'bun:test'
+import { signal } from '@preact/signals'
+import { h, render } from 'preact'
+import { ProviderErrors } from '../../app/ts/components/subcomponents/ProviderErrors.js'
+import type { SignerName } from '../../app/ts/types/signerTypes.js'
+import type { TabState } from '../../app/ts/types/user-interface-types.js'
+import { DEFAULT_TAB_CONNECTION } from '../../app/ts/utils/constants.js'
+import { installDomMock } from './domMock.js'
+
+function createTabState(signerName: SignerName): TabState {
+	return {
+		tabId: 1,
+		website: undefined,
+		signerConnected: false,
+		signerName,
+		signerAccounts: [],
+		signerChain: undefined,
+		signerAccountError: { code: 4900, message: 'Signer unavailable' },
+		tabIconDetails: DEFAULT_TAB_CONNECTION,
+		activeSigningAddress: undefined,
+	}
+}
+
+describe('provider account errors', () => {
+	test('does not render a warning when no signer is available', () => {
+		const dom = installDomMock()
+		try {
+			const tabState = signal<TabState | undefined>(createTabState('NoSigner'))
+			render(h(ProviderErrors, { tabState }), dom.document.body)
+			assert.equal(dom.document.body.textContent, '')
+
+			tabState.value = createTabState('NoSignerDetected')
+			assert.equal(dom.document.body.textContent, '')
+		} finally {
+			render(null, dom.document.body)
+			dom.restore()
+		}
+	})
+
+	test('keeps warnings from an identified signer visible', () => {
+		const dom = installDomMock()
+		try {
+			const tabState = signal<TabState | undefined>(createTabState('MetaMask'))
+			render(h(ProviderErrors, { tabState }), dom.document.body)
+			assert.match(dom.document.body.textContent, /MetaMask returned error: "Signer unavailable"/)
+		} finally {
+			render(null, dom.document.body)
+			dom.restore()
+		}
+	})
+})

--- a/test/tests/refreshHomeDataRpcStatus.test.ts
+++ b/test/tests/refreshHomeDataRpcStatus.test.ts
@@ -237,10 +237,12 @@ describe('refreshHomeData', () => {
 			})
 		})
 		const websiteTabConnections = new Map([[socket.tabId, {
-			signerStateOwnerConnectionName: socket.connectionName,
-			signerStateOwnerConfirmed: true,
-			signerStateOwnerGeneration: 1,
-			signerProviderGeneration: 1,
+			signerStateOwner: {
+				connectionName: socket.connectionName,
+				confirmed: true,
+				generation: 1,
+				providerGeneration: 1,
+			},
 			connections: {
 				[websiteSocketToString(socket)]: { port, socket, websiteOrigin: 'https://example.com', approved: true, wantsToConnect: true },
 			},
@@ -315,10 +317,12 @@ describe('refreshHomeData', () => {
 		const socket = { tabId: 1, connectionName: 0n }
 		const { port } = createPort(socket.tabId)
 		const websiteTabConnections = new Map([[socket.tabId, {
-			signerStateOwnerConnectionName: socket.connectionName,
-			signerStateOwnerConfirmed: true,
-			signerStateOwnerGeneration: 1,
-			signerProviderGeneration: 1,
+			signerStateOwner: {
+				connectionName: socket.connectionName,
+				confirmed: true,
+				generation: 1,
+				providerGeneration: 1,
+			},
 			connections: {
 				[websiteSocketToString(socket)]: { port, socket, websiteOrigin: 'https://example.com', approved: true, wantsToConnect: true },
 			},
@@ -397,10 +401,12 @@ describe('refreshHomeData', () => {
 			})
 		})
 		const websiteTabConnections = new Map([[socket.tabId, {
-			signerStateOwnerConnectionName: socket.connectionName,
-			signerStateOwnerConfirmed: true,
-			signerStateOwnerGeneration: 1,
-			signerProviderGeneration: 1,
+			signerStateOwner: {
+				connectionName: socket.connectionName,
+				confirmed: true,
+				generation: 1,
+				providerGeneration: 1,
+			},
 			connections: {
 				[websiteSocketToString(socket)]: { port, socket, websiteOrigin: 'https://example.com', approved: true, wantsToConnect: true },
 			},

--- a/test/tests/refreshHomeDataRpcStatus.test.ts
+++ b/test/tests/refreshHomeDataRpcStatus.test.ts
@@ -230,10 +230,17 @@ describe('refreshHomeData', () => {
 				signerAccounts: [signerAccount],
 				activeSigningAddress: signerAccount,
 			})).then(() => {
-				sendInternalWindowMessage({ method: 'window_signer_accounts_changed', data: { socket } })
+				sendInternalWindowMessage({
+					method: 'window_signer_accounts_changed',
+					data: { socket, signerStateOwnerGeneration: 1, signerProviderGeneration: 1 },
+				})
 			})
 		})
 		const websiteTabConnections = new Map([[socket.tabId, {
+			signerStateOwnerConnectionName: socket.connectionName,
+			signerStateOwnerConfirmed: true,
+			signerStateOwnerGeneration: 1,
+			signerProviderGeneration: 1,
 			connections: {
 				[websiteSocketToString(socket)]: { port, socket, websiteOrigin: 'https://example.com', approved: true, wantsToConnect: true },
 			},
@@ -265,7 +272,7 @@ describe('refreshHomeData', () => {
 	test('home data falls back to signer accounts for active address when activeSigningAddress is unset', async () => {
 		const browserMock = installBrowserMock()
 		const modules: TestModules = await loadModules()
-		const { browserStorageLocalSet, saveCurrentTabId, updateTabState, setRpcConnectionStatus, requestNewHomeData, defaultActiveAddresses, defaultRpcs, EthereumClientService } = modules
+		const { browserStorageLocalSet, saveCurrentTabId, updateTabState, setRpcConnectionStatus, requestNewHomeData, defaultActiveAddresses, defaultRpcs, websiteSocketToString, EthereumClientService } = modules
 
 		const [defaultAddress] = defaultActiveAddresses
 		if (defaultAddress === undefined) throw new Error('missing default address')
@@ -305,9 +312,20 @@ describe('refreshHomeData', () => {
 				return await new Promise<never>(() => undefined)
 			},
 		}, async () => undefined, async () => undefined, rpcNetwork)
+		const socket = { tabId: 1, connectionName: 0n }
+		const { port } = createPort(socket.tabId)
+		const websiteTabConnections = new Map([[socket.tabId, {
+			signerStateOwnerConnectionName: socket.connectionName,
+			signerStateOwnerConfirmed: true,
+			signerStateOwnerGeneration: 1,
+			signerProviderGeneration: 1,
+			connections: {
+				[websiteSocketToString(socket)]: { port, socket, websiteOrigin: 'https://example.com', approved: true, wantsToConnect: true },
+			},
+		}]])
 
 		try {
-			await requestNewHomeData(ethereum, new Map(), false, false, undefined, 1)
+			await requestNewHomeData(ethereum, websiteTabConnections, false, false, undefined, 1)
 		} finally {
 			ethereum.cleanup()
 		}
@@ -372,10 +390,17 @@ describe('refreshHomeData', () => {
 				signerAccounts: [signerAccount],
 				activeSigningAddress: signerAccount,
 			})).then(() => {
-				sendInternalWindowMessage({ method: 'window_signer_accounts_changed', data: { socket } })
+				sendInternalWindowMessage({
+					method: 'window_signer_accounts_changed',
+					data: { socket, signerStateOwnerGeneration: 1, signerProviderGeneration: 1 },
+				})
 			})
 		})
 		const websiteTabConnections = new Map([[socket.tabId, {
+			signerStateOwnerConnectionName: socket.connectionName,
+			signerStateOwnerConfirmed: true,
+			signerStateOwnerGeneration: 1,
+			signerProviderGeneration: 1,
 			connections: {
 				[websiteSocketToString(socket)]: { port, socket, websiteOrigin: 'https://example.com', approved: true, wantsToConnect: true },
 			},


### PR DESCRIPTION
## Why

When MetaMask site access is set to **On Click** and MetaMask has not yet injected its provider, connecting Interceptor from apps such as SAFE can spin forever, require a second Connect click, or later fail to open the signing popup. The same state races can surface stale signer metadata as an `Unknown signer` warning even though no signer is available.

Signer discovery and connection state are asynchronous and can span provider announcements, extension ports, frames, reconnects, and tab lifecycle events. Late or stale replies could therefore overwrite newer state or resolve a request through the wrong signer instance.

Firefox MV2 also stopped exposing `window.ethereum` when no external wallet was present because the inpage listener artifacts were no longer all available and injected in the required order.

## What changed

- Keep signer discovery active for late `ethereum#initialized` and EIP-6963 announcements while giving account requests a bounded failure path instead of leaving dapps on an infinite spinner.
- Refresh signer status through an explicit reconnect handshake so a lost initial reply does not force users to click Connect twice.
- Return a wallet-neutral no-signer error and clear stale signer metadata, avoiding misleading `Unknown signer` and yellow warning states when MetaMask is disabled for the site.
- Track the exact top-frame signer owner by port, socket, and provider epoch; serialize state updates and reject stale callbacks, replies, replacements, and disconnects.
- Continue accepting approved child-frame request origins while routing tab-wide account and chain commands exactly once through the confirmed signer owner.
- Bind pending chain changes to the exact signer instance and serialize their terminal resolution so popup cleanup cannot race a signer response.
- Restore the Firefox MV2 inpage polyfill/listener/document-start artifacts and loading order so Interceptor injects `window.ethereum` without requiring an external wallet.
- Add regression coverage for late initialization, unavailable signers, reconnects, frame ownership, stale signer messages, chain-change races, and MV2 listener artifacts.

## Expected behavior

With MetaMask set to **On Click**, Interceptor now either discovers MetaMask when it becomes available or finishes the connection request with a clear no-signer error. SAFE should no longer remain on `Connecting...` indefinitely, report a phantom signer, or require a second click because of stale connection state. Once MetaMask is enabled for the site, account access and signing can proceed normally.

## Validation

- `bun test` — 649 passed, 0 failed
- `bun run setup-chrome`
- `bun run typecheck`
- `bun run lint`
- `bun run test:chrome-communication` — normal access and finite unavailable-signer paths passed
- Firefox MV2 bundle and unpacked-extension injection check passed