### PR TITLE
Add management tabs for diagnostics and related pages

### DIFF
--- a/app/css/interceptor.css
+++ b/app/css/interceptor.css
@@ -589,6 +589,268 @@ html, body {
 	padding: 0;
 }
 
+.management-page {
+	display: flex;
+	flex-direction: column;
+	min-width: 0;
+	min-height: 100vh;
+}
+
+.management-header {
+	position: sticky;
+	top: 0;
+	z-index: 20;
+	display: flex;
+	flex-wrap: wrap;
+	align-items: center;
+	justify-content: space-between;
+	gap: 0.5rem 1.5rem;
+	min-width: 0;
+	padding: 0.5rem max(1rem, calc((100% - 64rem) / 2));
+	border-bottom: 1px solid var(--layout-line-color);
+}
+
+.management-brand {
+	display: flex;
+	align-items: center;
+	gap: 0.5rem;
+	min-width: max-content;
+	color: var(--text-color);
+}
+
+.management-brand h1 {
+	font-size: 1rem;
+	font-weight: 600;
+	text-transform: uppercase;
+}
+
+.management-tabs {
+	display: flex;
+	align-self: stretch;
+	gap: 0.25rem;
+	min-width: 0;
+	overflow-x: auto;
+}
+
+.management-tab {
+	display: flex;
+	align-items: center;
+	gap: 0.5rem;
+	min-height: 2.75rem;
+	padding: 0.25rem 0.75rem;
+	color: var(--unimportant-text-color);
+	background: transparent;
+	border: 0;
+	border-bottom: 2px solid transparent;
+	cursor: pointer;
+	font: inherit;
+	white-space: nowrap;
+}
+
+.management-tab:hover,
+.management-tab:focus-visible {
+	color: var(--text-color);
+	background: var(--white-alpha-08);
+	outline: none;
+}
+
+.management-tab.is-active {
+	color: var(--text-color);
+	border-bottom-color: var(--primary-color);
+}
+
+.management-tab img {
+	opacity: 0.7;
+}
+
+.management-tab.is-active img {
+	opacity: 1;
+}
+
+.management-panel {
+	flex: 1;
+	min-width: 0;
+}
+
+.management-panel[hidden] {
+	display: none;
+}
+
+.management-panel > main {
+	min-height: 100%;
+}
+
+.management-panel .address-book-content {
+	height: calc(100vh - 3.75rem);
+}
+
+.diagnostics-page {
+	width: min(100%, 64rem);
+	min-width: 0;
+	margin: 0 auto;
+	padding: 1.25rem;
+}
+
+.diagnostics-header {
+	display: flex;
+	flex-wrap: wrap;
+	align-items: center;
+	justify-content: space-between;
+	gap: 1rem;
+	margin-bottom: 1rem;
+}
+
+.diagnostics-header > div:first-child {
+	flex: 1 1 24rem;
+	min-width: 0;
+}
+
+.diagnostics-header h1 {
+	color: var(--text-color);
+	font-size: 1.5rem;
+}
+
+.diagnostics-header p {
+	color: var(--disabled-text-color);
+	font-size: 0.875rem;
+}
+
+.diagnostics-actions {
+	display: flex;
+	flex-wrap: wrap;
+	gap: 0.5rem;
+}
+
+.diagnostics-summary {
+	display: grid;
+	grid-template-columns: repeat(4, minmax(0, 1fr));
+	gap: 0.75rem;
+	margin-block: 1rem;
+}
+
+.diagnostics-summary > div {
+	display: flex;
+	flex-direction: column;
+	align-items: center;
+	padding: 0.75rem;
+	background: var(--card-bg-color);
+	border: 1px solid var(--layout-line-color);
+	border-radius: 4px;
+}
+
+.diagnostics-summary strong {
+	color: var(--text-color);
+	font-size: 1.5rem;
+}
+
+.diagnostics-summary span {
+	color: var(--disabled-text-color);
+	font-size: 0.75rem;
+	text-transform: uppercase;
+}
+
+.diagnostics-list {
+	display: grid;
+	gap: 0.75rem;
+	margin: 0;
+	padding: 0;
+	list-style: none;
+}
+
+.diagnostics-card {
+	margin: 0;
+	padding: 1rem;
+	background: var(--card-bg-color);
+	border: 1px solid var(--layout-line-color);
+	border-left: 4px solid var(--primary-color);
+	border-radius: 4px;
+}
+
+.diagnostics-card--warning {
+	border-left-color: var(--warning-color);
+}
+
+.diagnostics-card--error {
+	border-left-color: var(--negative-color);
+}
+
+.diagnostics-card-header {
+	display: flex;
+	flex-wrap: wrap;
+	justify-content: space-between;
+	gap: 0.75rem;
+}
+
+.diagnostics-card-header > div:first-child {
+	flex: 1 1 24rem;
+	min-width: 0;
+}
+
+.diagnostics-card-header strong,
+.diagnostics-card-header p,
+.diagnostics-details pre {
+	overflow-wrap: anywhere;
+}
+
+.diagnostics-card-header p,
+.diagnostics-card-time,
+.diagnostics-details {
+	color: var(--disabled-text-color);
+	font-size: 0.8rem;
+}
+
+.diagnostics-card-time {
+	display: flex;
+	flex-direction: column;
+	align-items: flex-end;
+	gap: 0.25rem;
+}
+
+.diagnostics-severity {
+	padding: 0.125rem 0.375rem;
+	border: 1px solid currentColor;
+	border-radius: 999px;
+	color: var(--primary-color);
+	font-size: 0.7rem;
+	text-transform: uppercase;
+}
+
+.diagnostics-severity--warning {
+	color: var(--warning-color);
+}
+
+.diagnostics-severity--error {
+	color: var(--negative-color);
+}
+
+.diagnostics-details {
+	margin-top: 0.75rem;
+	border-top: 1px solid var(--layout-line-color);
+	padding-top: 0.75rem;
+}
+
+.diagnostics-details summary {
+	cursor: pointer;
+}
+
+.diagnostics-details div,
+.diagnostics-details p {
+	margin-top: 0.75rem;
+}
+
+.diagnostics-details pre {
+	margin-top: 0.25rem;
+	padding: 0.5rem;
+	background: var(--surface-dark-color);
+	white-space: pre-wrap;
+}
+
+.diagnostics-empty {
+	padding: 3rem 1rem;
+	color: var(--disabled-text-color);
+	text-align: center;
+}
+
 .input:not([type='checkbox']):disabled, input:not([type='checkbox'])[disabled] {
 	border-bottom: unset
 }
@@ -1300,6 +1562,45 @@ svg.spinner > circle {
 }
 
 @media screen and (max-width: 520px) {
+	.management-header {
+		align-items: stretch;
+		padding: 0.5rem;
+	}
+
+	.management-brand {
+		padding-inline: 0.25rem;
+	}
+
+	.management-tabs {
+		flex: 1 1 100%;
+	}
+
+	.management-tab {
+		flex: 1;
+		justify-content: center;
+		padding-inline: 0.5rem;
+	}
+
+	.management-panel .address-book-content {
+		height: auto;
+	}
+
+	.diagnostics-page {
+		padding: 0.75rem;
+	}
+
+	.diagnostics-actions > button {
+		flex: 1 1 auto;
+	}
+
+	.diagnostics-summary {
+		grid-template-columns: repeat(2, minmax(0, 1fr));
+	}
+
+	.diagnostics-card-time {
+		align-items: flex-start;
+	}
+
 	.address-book-layout {
 		grid-template-columns: minmax(0, 1fr);
 		width: 100%;
@@ -2240,6 +2541,10 @@ header:has(form[role='search']) h1 {
 	z-index: 10;
 }
 
+.management-panel .simulation-stack-page > .simulation-stack-page-header {
+	position: static;
+}
+
 .simulation-stack-page-body {
 	min-width: 0;
 	min-height: 0;
@@ -2321,7 +2626,7 @@ header:has(form[role='search']) h1 {
 	background: var(--bg-color);
 	overflow-y: scroll;
 	overscroll-behavior: contain;
-	z-index: 10;
+	z-index: 30;
 }
 
 .input::-webkit-outer-spin-button {

--- a/app/html/settingsView.html
+++ b/app/html/settingsView.html
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <html style = 'background-color: var(--bg-color); overflow-y: inherit;'>
 	<head>
-		<title>Import settings - The Interceptor</title>
+		<title>Manage The Interceptor</title>
 		<meta charset = 'utf-8'>
 		<link rel = 'icon' type = 'image/x-icon' href = 'favicon.ico'>
 	</head>

--- a/app/html3/settingsViewV3.html
+++ b/app/html3/settingsViewV3.html
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <html style = 'background-color: var(--bg-color); overflow-y: inherit;'>
 	<head>
-		<title>Access Request - The Interceptor</title>
+		<title>Manage The Interceptor</title>
 		<meta charset = 'utf-8'>
 		<link rel = 'icon' type = 'image/x-icon' href = 'favicon.ico'>
 	</head>

--- a/app/ts/background/background.ts
+++ b/app/ts/background/background.ts
@@ -3,7 +3,8 @@ import 'webextension-polyfill'
 import { getTabState, promoteRpcAsPrimary, setLatestUnexpectedError, updateInterceptorTransactionStack } from './storageVariables.js'
 import { changeSimulationMode, getSettings, trackPreviousActiveAddressForMakeMeRichList, updateWebsiteAccess } from './settings.js'
 import { blockNumber, call, chainId, estimateGas, gasPrice, getAccounts, getBalance, getBlockByNumber, getBlockByHash, getCode, getFilterChanges, getFilterLogs, getLogs, getPermissions, getTransactionByHash, getTransactionCount, getTransactionReceipt, handleIterceptorError, installNewFilter, netVersion, personalSign, requestInterceptorSimulatorStack, requestPermissions, sendTransaction, subscribe, switchEthereumChain, ethSimulateV1, feeHistory, uninstallNewFilter, unsubscribe, web3ClientVersion } from './simulationModeHanders.js'
-import { changeActiveAddress, changePage, confirmDialog, removeTransactionOrSignedMessage, requestAccountsFromSigner, refreshPopupConfirmTransactionSimulation, confirmRequestAccess, changeInterceptorAccess, changeChainDialog, popupChangeActiveRpc, enableSimulationMode, addOrModifyAddressBookEntry, getAddressBookData, removeAddressBookEntry, refreshHomeData, interceptorAccessChangeAddressOrRefresh, refreshPopupConfirmTransactionMetadata, changeSettings, importSettings, exportSettings, setNewRpcList, simulateGovernanceContractExecutionOnPass, openNewTab, settingsOpened, changeAddOrModifyAddressWindowState, requestAbiAndNameFromBlockExplorer, openWebPage, disableInterceptor, requestNewHomeData, setEnsNameForHash, simulateGnosisSafeTransactionOnPass, retrieveWebsiteAccess, blockOrAllowExternalRequests, removeWebsiteAccess, allowOrPreventAddressAccessForWebsite, removeWebsiteAddressAccess, forceSetGasLimitForTransaction, changePreSimulationBlockTimeManipulation, setTransactionOrMessageBlockTimeManipulator, modifyMakeMeRich, requestMakeMeRichList, requestActiveAddresses, requestSimulationMode, requestLatestUnexpectedError, fetchSimulationStackRequestConfirmation, reportUnexpectedErrorInWindow, requestInterceptorSimulationInput, importSimulationStack, requestCompleteVisualizedSimulation, requestSimulationMetadata, requestIdentifyAddress, popupReadyAndListening } from './popupMessageHandlers.js'
+import { changeActiveAddress, changePage, confirmDialog, removeTransactionOrSignedMessage, requestAccountsFromSigner, refreshPopupConfirmTransactionSimulation, confirmRequestAccess, changeInterceptorAccess, changeChainDialog, popupChangeActiveRpc, enableSimulationMode, addOrModifyAddressBookEntry, getAddressBookData, removeAddressBookEntry, refreshHomeData, interceptorAccessChangeAddressOrRefresh, refreshPopupConfirmTransactionMetadata, changeSettings, importSettings, exportSettings, setNewRpcList, simulateGovernanceContractExecutionOnPass, openNewTab, settingsOpened, changeAddOrModifyAddressWindowState, requestAbiAndNameFromBlockExplorer, openWebPage, disableInterceptor, requestNewHomeData, setEnsNameForHash, simulateGnosisSafeTransactionOnPass, retrieveWebsiteAccess, blockOrAllowExternalRequests, removeWebsiteAccess, allowOrPreventAddressAccessForWebsite, removeWebsiteAddressAccess, forceSetGasLimitForTransaction, changePreSimulationBlockTimeManipulation, setTransactionOrMessageBlockTimeManipulator, modifyMakeMeRich, requestMakeMeRichList, requestActiveAddresses, requestSimulationMode, requestLatestUnexpectedError, fetchSimulationStackRequestConfirmation, reportUnexpectedErrorInWindow, requestInterceptorSimulationInput, importSimulationStack, requestCompleteVisualizedSimulation, requestSimulationMetadata, requestIdentifyAddress, popupReadyAndListening, requestDiagnostics, clearDiagnostics } from './popupMessageHandlers.js'
+import { getManagementTabTarget, getSimulationStackManagementTabTarget } from '../utils/managementPages.js'
 import { PASSTHROUGH_STATE, type ResolvedExecutionSimulationState, type ResolvedSimulationInput, type ResolvedSimulationState, type WebsiteCreatedEthereumUnsignedTransactionOrFailed, toResolvedExecutionSimulationState, toResolvedSimulationInput, toResolvedSimulationState } from '../types/visualizer-types.js'
 import type { WebsiteTabConnections } from '../types/user-interface-types.js'
 import { askForSignerAccountsFromSignerIfNotAvailable, interceptorAccessMetadataRefresh, requestAccessFromUser } from './windows/interceptorAccess.js'
@@ -17,7 +18,6 @@ import { appendTransactionsToInput, mockSignTransaction } from '../simulation/se
 import { Semaphore } from '../utils/semaphore.js'
 import { JsonRpcResponseError, reportUnexpectedError, isExpectedInfrastructureError, isFailedToFetchError, isNewBlockAbort } from '../utils/errors.js'
 import { InterceptedRequest, type UniqueRequestIdentifier, type WebsiteSocket } from '../utils/requests.js'
-import { getSimulationStackTargetHash } from '../utils/simulationStackTargets.js'
 import { replyToInterceptedRequest } from './messageSending.js'
 import { bumpPopupRefreshGeneration } from './popupRefreshGeneration.js'
 import { type EthGetStorageAtParams, EthereumJsonRpcRequest, type SendRawTransactionParams, type SendTransactionParams, SupportedEthereumJsonRpcRequestMethods, type WalletAddEthereumChain, WalletRevokePermissions } from '../types/JsonRpc-types.js'
@@ -722,7 +722,12 @@ export async function popupMessageHandler(
 				case 'popup_addOrModifyAddressBookEntry': return await addOrModifyAddressBookEntry(ethereum, tokenPriceService, resetSimulationServices, websiteTabConnections, parsedRequest)
 				case 'popup_getAddressBookData': return await getAddressBookData(parsedRequest)
 				case 'popup_removeAddressBookEntry': return await removeAddressBookEntry(ethereum, tokenPriceService, resetSimulationServices, websiteTabConnections, parsedRequest)
-				case 'popup_openAddressBook': return await openNewTab('addressBook')
+				case 'popup_openAddressBook':
+				case 'popup_openSettings':
+				case 'popup_openWebsiteAccess': {
+					const target = getManagementTabTarget(parsedRequest.method)
+					return await openNewTab(target.tabName, target.targetHash)
+				}
 				case 'popup_requestNewHomeData': return await requestNewHomeData(ethereum, websiteTabConnections, parsedRequest.data.refreshSignerAccounts, parsedRequest.data.includeWebsiteAccessAddressMetadata, simulationAbortController, bumpPopupRefreshGeneration())
 				case 'popup_refreshHomeData': return await refreshHomeData(ethereum, tokenPriceService, websiteTabConnections, true, bumpPopupRefreshGeneration(), publishRpcConnectionStatus)
 				case 'popup_requestSettings': return await settingsOpened()
@@ -730,7 +735,6 @@ export async function popupMessageHandler(
 				case 'popup_interceptorAccessChangeAddress': return await interceptorAccessChangeAddressOrRefresh(websiteTabConnections, parsedRequest)
 				case 'popup_interceptorAccessRefresh': return await interceptorAccessChangeAddressOrRefresh(websiteTabConnections, parsedRequest)
 				case 'popup_ChangeSettings': return await changeSettings(ethereum, tokenPriceService, resetSimulationServices, parsedRequest, simulationAbortController)
-				case 'popup_openSettings': return await openNewTab('settingsView')
 				case 'popup_import_settings': {
 					const importSettingsReply = await importSettings(parsedRequest)
 					await sendPopupMessageToOpenWindows(importSettingsReply)
@@ -750,8 +754,10 @@ export async function popupMessageHandler(
 				case 'popup_setDisableInterceptor': return await disableInterceptor(ethereum, tokenPriceService, resetSimulationServices, websiteTabConnections, parsedRequest)
 				case 'popup_clearUnexpectedError': return await setLatestUnexpectedError(undefined)
 				case 'popup_setEnsNameForHash': return await setEnsNameForHash(parsedRequest)
-				case 'popup_openWebsiteAccess': return await openNewTab('websiteAccess')
-				case 'popup_openSimulationStack': return await openNewTab('simulationStack', 'data' in parsedRequest ? getSimulationStackTargetHash(parsedRequest.data) : undefined)
+				case 'popup_openSimulationStack': {
+					const target = getSimulationStackManagementTabTarget('data' in parsedRequest ? parsedRequest.data : undefined)
+					return await openNewTab(target.tabName, target.targetHash)
+				}
 				case 'popup_retrieveWebsiteAccess': return await retrieveWebsiteAccess(parsedRequest)
 				case 'popup_blockOrAllowExternalRequests': return await blockOrAllowExternalRequests(ethereum, tokenPriceService, resetSimulationServices, websiteTabConnections, parsedRequest)
 				case 'popup_allowOrPreventAddressAccessForWebsite': return await allowOrPreventAddressAccessForWebsite(websiteTabConnections, parsedRequest)
@@ -764,6 +770,8 @@ export async function popupMessageHandler(
 				case 'popup_requestActiveAddresses': return await requestActiveAddresses()
 				case 'popup_requestSimulationMode': return await requestSimulationMode()
 				case 'popup_requestLatestUnexpectedError': return await requestLatestUnexpectedError()
+				case 'popup_requestDiagnostics': return await requestDiagnostics()
+				case 'popup_clearDiagnostics': return await clearDiagnostics()
 				case 'popup_fetchSimulationStackRequestConfirmation': return await fetchSimulationStackRequestConfirmation(ethereum, websiteTabConnections, parsedRequest)
 				case 'popup_readyAndListening': return await popupReadyAndListening(ethereum, parsedRequest.data.page)
 				case 'popup_UnexpectedErrorOccured': return await reportUnexpectedErrorInWindow(parsedRequest)

--- a/app/ts/background/popupMessageHandlers.ts
+++ b/app/ts/background/popupMessageHandlers.ts
@@ -1,6 +1,6 @@
 import { changeActiveAddressAndChain, changeActiveRpc, getUpdatedSimulationState, refreshConfirmTransactionSimulation } from './background.js'
 import { getSettings, setUseTabsInsteadOfPopup, setPage, setUseSignersAddressAsActiveAddress, updateWebsiteAccess, exportSettingsAndAddressBook, importSettingsAndAddressBook, getMakeCurrentAddressRich, getUseTabsInsteadOfPopup, getMetamaskCompatibilityMode, setMetamaskCompatibilityMode, getPage, setPreSimulationBlockTimeManipulation, getPreSimulationBlockTimeManipulation, getFixedAddressRichList, getWebsiteAccess, updateMakeCurrentAddressRich, updateFixedMakeMeRichList } from './settings.js'
-import { getPendingTransactionsAndMessages, getCurrentTabId, getTabState, saveCurrentTabId, setRpcList, getRpcList, getPrimaryRpcForChain, getRpcConnectionStatus, updateUserAddressBookEntries, getPopupVisualisationState, setIdsOfOpenedTabs, getIdsOfOpenedTabs, updatePendingTransactionOrMessage, addEnsLabelHash, addEnsNodeHash, updateInterceptorTransactionStack, getLatestUnexpectedError, getInterceptorTransactionStack, getChainChangeConfirmationPromise, getFetchSimulationStackRequestPromise, getPendingAccessRequests } from './storageVariables.js'
+import { getPendingTransactionsAndMessages, getCurrentTabId, getTabState, saveCurrentTabId, setRpcList, getRpcList, getPrimaryRpcForChain, getRpcConnectionStatus, updateUserAddressBookEntries, getPopupVisualisationState, setIdsOfOpenedTabs, getIdsOfOpenedTabs, updatePendingTransactionOrMessage, addEnsLabelHash, addEnsNodeHash, updateInterceptorTransactionStack, getLatestUnexpectedError, getInterceptorTransactionStack, getChainChangeConfirmationPromise, getFetchSimulationStackRequestPromise, getPendingAccessRequests, clearInterceptorErrorDiagnostics, getInterceptorErrorDiagnostics } from './storageVariables.js'
 import { parseEvents, parseInputData } from '../simulation/parsing.js'
 import { type ChangeActiveAddress, type ModifyMakeMeRich, type ChangePage, type RemoveTransaction, type RequestAccountsFromSigner, type TransactionConfirmation, type InterceptorAccess, type ChangeInterceptorAccess, type ChainChangeConfirmation, type EnableSimulationMode, type ChangeActiveChain, type AddOrEditAddressBookEntry, type GetAddressBookData, type RemoveAddressBookEntry, type InterceptorAccessRefresh, type InterceptorAccessChangeAddress, type Settings, type ChangeSettings, type ImportSettings, type ImportSettingsReply, type SetRpcList, type UpdateHomePage, type SimulateGovernanceContractExecution, type ChangeAddOrModifyAddressWindowState, type OpenWebPage, type DisableInterceptor, type SetEnsNameForHash, UpdateConfirmTransactionDialog, UpdateConfirmTransactionDialogPendingTransactions, type BlockOrAllowExternalRequests, type RemoveWebsiteAccess, type AllowOrPreventAddressAccessForWebsite, type RemoveWebsiteAddressAccess, type ForceSetGasLimitForTransaction, type RetrieveWebsiteAccess, type ChangePreSimulationBlockTimeManipulation, type SetTransactionOrMessageBlockTimeManipulator, type FetchSimulationStackRequestConfirmation, type ImportSimulationStack, type PopupReadyAndListeningPage } from '../types/interceptor-messages.js'
 import { formEthSendTransaction, formSendRawTransaction, resolvePendingTransactionOrMessage, updateConfirmTransactionView, setGasLimitForTransaction, toPopupPendingTransactionOrSignableMessage } from './windows/confirmTransaction.js'
@@ -957,6 +957,13 @@ export const requestActiveAddresses = async () => ({ method: 'popup_requestActiv
 export const requestSimulationMode = async () => ({ method: 'popup_requestSimulationMode' as const, simulationMode: (await getSettings()).simulationMode })
 
 export const requestLatestUnexpectedError = async () => ({ method: 'popup_requestLatestUnexpectedError' as const, latestUnexpectedError: await getLatestUnexpectedError() })
+
+export const requestDiagnostics = async () => ({ method: 'popup_requestDiagnostics' as const, diagnostics: await getInterceptorErrorDiagnostics() })
+
+export const clearDiagnostics = async () => {
+	await clearInterceptorErrorDiagnostics()
+	return { method: 'popup_clearDiagnostics' as const, diagnostics: await getInterceptorErrorDiagnostics() }
+}
 
 async function getCachedRichData() {
 	const [makeCurrentAddressRich, fixedAddressRichList] = await Promise.all([

--- a/app/ts/background/storageVariables.ts
+++ b/app/ts/background/storageVariables.ts
@@ -321,7 +321,9 @@ export async function appendInterceptorErrorDiagnostic(diagnostic: InterceptorEr
 }
 
 export async function clearInterceptorErrorDiagnostics() {
-	await browserStorageLocalRemove('interceptorErrorDiagnostics')
+	await interceptorErrorDiagnosticsSemaphore.execute(async () => {
+		await browserStorageLocalRemove('interceptorErrorDiagnostics')
+	})
 }
 
 export const getEnsNodeHashes = async () => (await browserStorageLocalGet('ensNameHashes'))?.ensNameHashes ?? []

--- a/app/ts/components/pages/DiagnosticsView.tsx
+++ b/app/ts/components/pages/DiagnosticsView.tsx
@@ -1,0 +1,93 @@
+import { useSignal } from '@preact/signals'
+import { useEffect } from 'preact/hooks'
+import type { InterceptorErrorDiagnostic } from '../../types/errorDiagnostics.js'
+import { getMissingPopupReplyErrorMessage, sendPopupMessageWithReply } from '../../background/backgroundUtils.js'
+import { useAsyncState } from '../../utils/preact-utilities.js'
+import { AsyncActionButton } from '../subcomponents/AsyncAction.js'
+import { ErrorComponent } from '../subcomponents/Error.js'
+import { clipboardCopy } from '../subcomponents/clipboardcopy.js'
+import { formatDiagnosticsForClipboard, summarizeDiagnostics } from '../../utils/diagnostics.js'
+
+function DiagnosticCard({ diagnostic }: { diagnostic: InterceptorErrorDiagnostic }) {
+	const metadata = [diagnostic.source, diagnostic.code, diagnostic.category].join(' · ')
+	return <li class = { `diagnostics-card diagnostics-card--${ diagnostic.severity }` }>
+		<header class = 'diagnostics-card-header'>
+			<div>
+				<strong>{ diagnostic.message }</strong>
+				<p>{ metadata }</p>
+			</div>
+			<div class = 'diagnostics-card-time'>
+				<span class = { `diagnostics-severity diagnostics-severity--${ diagnostic.severity }` }>{ diagnostic.severity }</span>
+				<time dateTime = { diagnostic.timestamp.toISOString() }>{ diagnostic.timestamp.toLocaleString() }</time>
+			</div>
+		</header>
+		{ diagnostic.cause === undefined && diagnostic.details === undefined && diagnostic.debugId === undefined ? <></> :
+			<details class = 'diagnostics-details'>
+				<summary>Technical details</summary>
+				{ diagnostic.cause === undefined ? <></> : <div><strong>Cause</strong><pre>{ diagnostic.cause }</pre></div> }
+				{ diagnostic.details === undefined ? <></> : <div><strong>Context</strong><pre>{ diagnostic.details }</pre></div> }
+				{ diagnostic.debugId === undefined ? <></> : <p><strong>Debug ID:</strong> <code>{ diagnostic.debugId }</code></p> }
+			</details>
+		}
+	</li>
+}
+
+export function DiagnosticsView() {
+	const diagnostics = useSignal<readonly InterceptorErrorDiagnostic[]>([])
+	const { value: loadState, waitFor: waitForLoad } = useAsyncState<void>()
+	const { value: copyState, waitFor: waitForCopy } = useAsyncState<void>()
+	const { value: clearState, waitFor: waitForClear } = useAsyncState<void>()
+	const summary = summarizeDiagnostics(diagnostics.value)
+
+	async function loadDiagnostics() {
+		const reply = await sendPopupMessageWithReply({ method: 'popup_requestDiagnostics' })
+		if (reply === undefined) throw new Error(getMissingPopupReplyErrorMessage('Loading diagnostics'))
+		diagnostics.value = reply.diagnostics
+	}
+
+	async function clearDiagnostics() {
+		if (!globalThis.confirm('Clear all stored diagnostics?')) return
+		const reply = await sendPopupMessageWithReply({ method: 'popup_clearDiagnostics' })
+		if (reply === undefined) throw new Error(getMissingPopupReplyErrorMessage('Clearing diagnostics'))
+		diagnostics.value = reply.diagnostics
+	}
+
+	async function copyDiagnostics() {
+		await clipboardCopy(formatDiagnosticsForClipboard(diagnostics.peek()))
+	}
+
+	useEffect(() => { void waitForLoad(loadDiagnostics) }, [])
+
+	const loadError = loadState.value.state === 'rejected' ? loadState.value.error.message : undefined
+	const copyError = copyState.value.state === 'rejected' ? copyState.value.error.message : undefined
+	const clearError = clearState.value.state === 'rejected' ? clearState.value.error.message : undefined
+	const newestFirst = [...diagnostics.value].reverse()
+
+	return <main class = 'diagnostics-page'>
+		<header class = 'diagnostics-header'>
+			<div>
+				<h1>Diagnostics</h1>
+				<p>The latest internal errors and recovered failures. The Interceptor retains up to 50 records.</p>
+			</div>
+			<div class = 'diagnostics-actions'>
+				<AsyncActionButton class = 'btn btn--outline' state = { loadState.value.state } onClick = { () => { void waitForLoad(loadDiagnostics) } } text = 'Refresh' pendingText = 'Refreshing...' />
+				<AsyncActionButton class = 'btn btn--outline' state = { copyState.value.state } disabled = { diagnostics.value.length === 0 } onClick = { () => { void waitForCopy(copyDiagnostics) } } text = 'Copy diagnostics' pendingText = 'Copying...' />
+				<AsyncActionButton class = 'btn btn--destructive' state = { clearState.value.state } disabled = { diagnostics.value.length === 0 } onClick = { () => { void waitForClear(clearDiagnostics) } } text = 'Clear diagnostics' pendingText = 'Clearing...' />
+			</div>
+		</header>
+		{ loadError === undefined ? <></> : <ErrorComponent warning = { true } text = { loadError } /> }
+		{ copyError === undefined ? <></> : <ErrorComponent warning = { true } text = { copyError } /> }
+		{ clearError === undefined ? <></> : <ErrorComponent warning = { true } text = { clearError } /> }
+		<section class = 'diagnostics-summary' aria-label = 'Diagnostic summary'>
+			<div><strong>{ summary.total }</strong><span>Total</span></div>
+			<div><strong>{ summary.error }</strong><span>Errors</span></div>
+			<div><strong>{ summary.warning }</strong><span>Warnings</span></div>
+			<div><strong>{ summary.info }</strong><span>Info</span></div>
+		</section>
+		{ loadState.value.state === 'pending' && diagnostics.value.length === 0 ? <p class = 'diagnostics-empty'>Loading diagnostics...</p>
+		: diagnostics.value.length === 0 ? <p class = 'diagnostics-empty'>No diagnostics have been recorded.</p>
+		: <ol class = 'diagnostics-list'>
+			{ newestFirst.map((diagnostic, index) => <DiagnosticCard key = { `${ diagnostic.timestamp.valueOf() }-${ diagnostic.code }-${ index }` } diagnostic = { diagnostic } />) }
+		</ol> }
+	</main>
+}

--- a/app/ts/components/pages/ManagementView.tsx
+++ b/app/ts/components/pages/ManagementView.tsx
@@ -1,0 +1,135 @@
+import { useEffect } from 'preact/hooks'
+import { batch, useSignal } from '@preact/signals'
+import type { JSX } from 'preact'
+import { AddressBook } from '../../AddressBook.js'
+import { WebsiteAccessView } from './WebsiteAccess.js'
+import { SettingsView } from './SettingsView.js'
+import { SimulationStackPage } from './SimulationStackPage.js'
+import { DiagnosticsView } from './DiagnosticsView.js'
+import Hint from '../subcomponents/Hint.js'
+import { createMountedManagementPages, getManagementPageFromHash, getManagementPageFromNavigationKey, getManagementPageHash, mountManagementPage, type ManagementPage } from '../../utils/managementPages.js'
+
+type ManagementTabParams = {
+	page: ManagementPage
+	selectedPage: ManagementPage
+	label: string
+	icon: string
+	selectPage: (page: ManagementPage) => void
+}
+
+function ManagementTab({ page, selectedPage, label, icon, selectPage }: ManagementTabParams) {
+	const selected = page === selectedPage
+	return <button
+		type = 'button'
+		role = 'tab'
+		class = { `management-tab${ selected ? ' is-active' : '' }` }
+		aria-selected = { selected }
+		aria-controls = { `management-panel-${ page }` }
+		id = { `management-tab-${ page }` }
+		tabIndex = { selected ? 0 : -1 }
+		onClick = { () => selectPage(page) }
+	>
+		<img src = { icon } width = '24' height = '24' alt = '' />
+		<span>{ label }</span>
+	</button>
+}
+
+export function ManagementView() {
+	const initialPage = getManagementPageFromHash(globalThis.location.hash)
+	const selectedPage = useSignal<ManagementPage>(initialPage)
+	const mountedPages = useSignal(createMountedManagementPages(initialPage))
+
+	useEffect(() => {
+		const updateSelectedPage = () => {
+			activatePage(getManagementPageFromHash(globalThis.location.hash))
+		}
+		globalThis.addEventListener('hashchange', updateSelectedPage)
+		return () => globalThis.removeEventListener('hashchange', updateSelectedPage)
+	}, [])
+
+	function activatePage(page: ManagementPage) {
+		batch(() => {
+			mountedPages.value = mountManagementPage(mountedPages.peek(), page)
+			selectedPage.value = page
+		})
+	}
+
+	function selectPage(page: ManagementPage) {
+		activatePage(page)
+		globalThis.location.hash = getManagementPageHash(page)
+	}
+
+	function handleTabKeyDown(event: JSX.TargetedKeyboardEvent<HTMLElement>) {
+		const page = getManagementPageFromNavigationKey(selectedPage.value, event.key)
+		if (page === undefined) return
+		event.preventDefault()
+		selectPage(page)
+		globalThis.document.getElementById(`management-tab-${ page }`)?.focus()
+	}
+
+	return <div class = 'management-page'>
+		<header class = 'management-header window-header'>
+			<div class = 'management-brand'>
+				<img src = '../img/LOGOA.svg' alt = 'The Interceptor' width = '32' height = '32' />
+				<h1>The Interceptor</h1>
+			</div>
+			<nav class = 'management-tabs' role = 'tablist' aria-label = 'Interceptor management' onKeyDown = { handleTabKeyDown }>
+				<ManagementTab page = 'websites' selectedPage = { selectedPage.value } label = 'Websites' icon = '../img/internet.svg' selectPage = { selectPage } />
+				<ManagementTab page = 'address-book' selectedPage = { selectedPage.value } label = 'Address Book' icon = '../img/address-book.svg' selectPage = { selectPage } />
+				<ManagementTab page = 'simulation-stack' selectedPage = { selectedPage.value } label = 'Simulation Stack' icon = '../img/refresh.svg' selectPage = { selectPage } />
+				<ManagementTab page = 'diagnostics' selectedPage = { selectedPage.value } label = 'Diagnostics' icon = '../img/warning-sign.svg' selectPage = { selectPage } />
+				<ManagementTab page = 'settings' selectedPage = { selectedPage.value } label = 'Settings' icon = '../img/settings.svg' selectPage = { selectPage } />
+			</nav>
+		</header>
+		<section
+			id = 'management-panel-websites'
+			class = 'management-panel'
+			role = 'tabpanel'
+			aria-labelledby = 'management-tab-websites'
+			tabIndex = { selectedPage.value === 'websites' ? 0 : -1 }
+			hidden = { selectedPage.value !== 'websites' }
+		>
+			{ mountedPages.value.websites ? <WebsiteAccessView /> : <></> }
+		</section>
+		<section
+			id = 'management-panel-address-book'
+			class = 'management-panel'
+			role = 'tabpanel'
+			aria-labelledby = 'management-tab-address-book'
+			tabIndex = { selectedPage.value === 'address-book' ? 0 : -1 }
+			hidden = { selectedPage.value !== 'address-book' }
+		>
+			{ mountedPages.value['address-book'] ? <AddressBook /> : <></> }
+		</section>
+		<section
+			id = 'management-panel-simulation-stack'
+			class = 'management-panel'
+			role = 'tabpanel'
+			aria-labelledby = 'management-tab-simulation-stack'
+			tabIndex = { selectedPage.value === 'simulation-stack' ? 0 : -1 }
+			hidden = { selectedPage.value !== 'simulation-stack' }
+		>
+			{ mountedPages.value['simulation-stack'] ? <Hint><SimulationStackPage /></Hint> : <></> }
+		</section>
+		<section
+			id = 'management-panel-diagnostics'
+			class = 'management-panel'
+			role = 'tabpanel'
+			aria-labelledby = 'management-tab-diagnostics'
+			tabIndex = { selectedPage.value === 'diagnostics' ? 0 : -1 }
+			hidden = { selectedPage.value !== 'diagnostics' }
+		>
+			{ mountedPages.value.diagnostics ? <DiagnosticsView /> : <></> }
+		</section>
+		<section
+			id = 'management-panel-settings'
+			class = 'management-panel'
+			role = 'tabpanel'
+			aria-labelledby = 'management-tab-settings'
+			tabIndex = { selectedPage.value === 'settings' ? 0 : -1 }
+			hidden = { selectedPage.value !== 'settings' }
+		>
+			{ mountedPages.value.settings ? <SettingsView /> : <></> }
+		</section>
+	</div>
+}

--- a/app/ts/components/pages/SimulationStackPage.tsx
+++ b/app/ts/components/pages/SimulationStackPage.tsx
@@ -282,7 +282,7 @@ export function SimulationStackPage() {
 	useEffect(() => {
 		const scrollOnHashChange = () => {
 			handledStackTargetHash.value = undefined
-			scrollToRequestedStackRow()
+			scheduleStackTargetFrame(scrollToRequestedStackRow)
 		}
 		const browserWindow = globalThis.window
 		if (browserWindow === undefined || typeof browserWindow.addEventListener !== 'function' || typeof browserWindow.removeEventListener !== 'function') {

--- a/app/ts/components/pages/WebsiteAccess.tsx
+++ b/app/ts/components/pages/WebsiteAccess.tsx
@@ -79,7 +79,7 @@ const WebsiteAccessProvider = ({ children }: { children: ComponentChildren }) =>
 	const listenForWindowHashChanges = () => {
 		const handleHashChange = () => {
 			const hash = window.location.hash
-			const domainInHash = hash.slice(URL_HASH_PREFIX.length)
+			const domainInHash = hash.startsWith(URL_HASH_PREFIX) ? hash.slice(URL_HASH_PREFIX.length) : ''
 			selectedDomain.value = domainInHash || undefined
 		}
 

--- a/app/ts/components/subcomponents/DynamicScroller.tsx
+++ b/app/ts/components/subcomponents/DynamicScroller.tsx
@@ -1,45 +1,65 @@
-import { type Signal, useComputed, useSignal, useSignalEffect } from '@preact/signals'
+import { type Signal, useComputed, useSignal } from '@preact/signals'
 import type { ComponentChild } from 'preact'
-import { useRef } from 'preact/hooks'
+import { useLayoutEffect, useRef } from 'preact/hooks'
 
 interface DynamicScrollerProps<T extends {}> {
 	items: Signal<Readonly<T[]>>
 	renderItem: (item: T) => ComponentChild
 }
 
+function isPositiveFinite(value: number) {
+	return Number.isFinite(value) && value > 0
+}
+
+export function calculateMaxVisibleItems(containerHeight: number, itemHeight: number) {
+	if (!isPositiveFinite(containerHeight) || !isPositiveFinite(itemHeight)) return 0
+	const maxItems = Math.ceil(containerHeight / itemHeight)
+	return Number.isFinite(maxItems) ? maxItems : 0
+}
+
 export const DynamicScroller = <T extends {}>({ items, renderItem, }: DynamicScrollerProps<T>) => {
 	const startIndex = useSignal(0)
-	const maxItems = useSignal(0)
+	const containerHeight = useSignal(0)
 	const itemHeight = useSignal(0)
 	const scrollViewRef = useRef<HTMLDivElement>(null)
 	const itemRef = useRef<HTMLDivElement>(null)
 
 	const recalculateStartIndex = (event: Event) => {
 		if (!(event.currentTarget instanceof HTMLDivElement)) return
+		if (!isPositiveFinite(itemHeight.peek())) return
 		startIndex.value = Math.floor(event.currentTarget.scrollTop / itemHeight.value)
 	}
 
+	const maxItems = useComputed(() => calculateMaxVisibleItems(containerHeight.value, itemHeight.value))
 	const scrollViewHeight = useComputed(() => itemHeight.value * maxItems.value)
 	const scrollAreaHeight = useComputed(() => items.value.length * itemHeight.value)
 	const visibleItems = useComputed(() => items.value.slice(startIndex.value, startIndex.value + maxItems.value + 1))
-	const scrollOffset = useComputed(() => Math.min(startIndex.value * itemHeight.value, scrollAreaHeight.value - scrollViewHeight.value))
+	const scrollOffset = useComputed(() => Math.max(0, Math.min(startIndex.value * itemHeight.value, scrollAreaHeight.value - scrollViewHeight.value)))
 
-	// calculate item height
-	useSignalEffect(() => {
-		if (!itemRef.current || itemHeight.value > itemRef.current.clientHeight) return
-		const { height } = itemRef.current.getBoundingClientRect()
-		itemHeight.value = height
+	// The first row can render while an owning tab panel is hidden. ResizeObserver
+	// remeasures it once visible, while zero-sized hidden measurements are ignored.
+	useLayoutEffect(() => {
+		if (itemRef.current === null) return
+		const itemObserver = new ResizeObserver((entries) => {
+			const entry = entries[0]
+			if (entry === undefined || !isPositiveFinite(entry.contentRect.height)) return
+			itemHeight.value = entry.contentRect.height
+		})
+		itemObserver.observe(itemRef.current)
+		return () => { itemObserver.disconnect() }
 	})
 
 	// scroll view occupies the same height as parent
-	useSignalEffect(() => {
-		if (!scrollViewRef.current) return
-		const containerObserver = new ResizeObserver(([entry]) => {
-			maxItems.value = Math.ceil(entry!.contentRect.height / itemHeight.value)
+	useLayoutEffect(() => {
+		if (scrollViewRef.current === null) return
+		const containerObserver = new ResizeObserver((entries) => {
+			const entry = entries[0]
+			if (entry === undefined || !isPositiveFinite(entry.contentRect.height)) return
+			containerHeight.value = entry.contentRect.height
 		})
 		containerObserver.observe(scrollViewRef.current)
 		return () => { containerObserver.disconnect() }
-	})
+	}, [])
 
 	return (
 		<div ref = { scrollViewRef } style = { { overflowY: 'scroll', maxHeight: '100%' } } onScroll = { recalculateStartIndex }>

--- a/app/ts/settingsView.ts
+++ b/app/ts/settingsView.ts
@@ -1,9 +1,9 @@
 import * as preact from 'preact'
-import { SettingsView } from './components/pages/SettingsView.js'
+import { ManagementView } from './components/pages/ManagementView.js'
 import { ErrorBoundary } from './components/subcomponents/Error.js'
 
 function rerender() {
-	preact.render(preact.createElement(ErrorBoundary, {}, preact.createElement(SettingsView, {})), document.body)
+	preact.render(preact.createElement(ErrorBoundary, {}, preact.createElement(ManagementView, {})), document.body)
 }
 
 rerender()

--- a/app/ts/types/interceptor-reply-messages.ts
+++ b/app/ts/types/interceptor-reply-messages.ts
@@ -8,6 +8,7 @@ import { PopupPendingTransactionOrSignableMessage } from './accessRequest.js'
 import { RpcConnectionStatus } from './user-interface-types.js'
 import { SimulateExecutionReply as PopupSimulateExecutionReply } from './simulateExecutionReply.js'
 import { SimulateGnosisSafeTransaction as RequestSimulateGnosisSafeTransaction, SimulateGovernanceContractExecution as RequestSimulateGovernanceContractExecution } from './simulateExecutionRequests.js'
+import { InterceptorErrorDiagnostic } from './errorDiagnostics.js'
 
 export type UnexpectedErrorOccured = funtypes.Static<typeof UnexpectedErrorOccured>
 export const UnexpectedErrorOccured = funtypes.ReadonlyObject({
@@ -51,6 +52,18 @@ type RequestLatestUnexpectedErrorReply = funtypes.Static<typeof RequestLatestUne
 const RequestLatestUnexpectedErrorReply = funtypes.ReadonlyObject({
 	method: funtypes.Literal('popup_requestLatestUnexpectedError'),
 	latestUnexpectedError: funtypes.Union(funtypes.Undefined, UnexpectedErrorOccured),
+})
+
+type RequestDiagnosticsReply = funtypes.Static<typeof RequestDiagnosticsReply>
+const RequestDiagnosticsReply = funtypes.ReadonlyObject({
+	method: funtypes.Literal('popup_requestDiagnostics'),
+	diagnostics: funtypes.ReadonlyArray(InterceptorErrorDiagnostic),
+})
+
+type ClearDiagnosticsReply = funtypes.Static<typeof ClearDiagnosticsReply>
+const ClearDiagnosticsReply = funtypes.ReadonlyObject({
+	method: funtypes.Literal('popup_clearDiagnostics'),
+	diagnostics: funtypes.ReadonlyArray(InterceptorErrorDiagnostic),
 })
 
 type RequestInterceptorSimulationInputReply = funtypes.Static<typeof RequestInterceptorSimulationInputReply>
@@ -170,6 +183,8 @@ type PopupRequestsRepliesMap = {
 	popup_requestActiveAddresses: typeof RequestActiveAddressesReply
 	popup_requestSimulationMode: typeof RequestSimulationModeReply
 	popup_requestLatestUnexpectedError: typeof RequestLatestUnexpectedErrorReply
+	popup_requestDiagnostics: typeof RequestDiagnosticsReply
+	popup_clearDiagnostics: typeof ClearDiagnosticsReply
 	popup_requestInterceptorSimulationInput: typeof RequestInterceptorSimulationInputReply
 	popup_importSimulationStack: typeof ImportSimulationStackReply
 	popup_requestCompleteVisualizedSimulation: typeof RequestCompleteVisualizedSimulationReply
@@ -188,6 +203,8 @@ export const PopupRequestsReplies: PopupRequestsRepliesMap = {
 	popup_requestActiveAddresses: RequestActiveAddressesReply,
 	popup_requestSimulationMode: RequestSimulationModeReply,
 	popup_requestLatestUnexpectedError: RequestLatestUnexpectedErrorReply,
+	popup_requestDiagnostics: RequestDiagnosticsReply,
+	popup_clearDiagnostics: ClearDiagnosticsReply,
 	popup_requestInterceptorSimulationInput: RequestInterceptorSimulationInputReply,
 	popup_importSimulationStack: ImportSimulationStackReply,
 	popup_requestCompleteVisualizedSimulation: RequestCompleteVisualizedSimulationReply,
@@ -220,6 +237,8 @@ export const PopupMessageReplyRequests = funtypes.Union(
 	funtypes.ReadonlyObject({ method: funtypes.Literal('popup_requestActiveAddresses') }),
 	funtypes.ReadonlyObject({ method: funtypes.Literal('popup_requestSimulationMode') }),
 	funtypes.ReadonlyObject({ method: funtypes.Literal('popup_requestLatestUnexpectedError') }),
+	funtypes.ReadonlyObject({ method: funtypes.Literal('popup_requestDiagnostics') }),
+	funtypes.ReadonlyObject({ method: funtypes.Literal('popup_clearDiagnostics') }),
 	funtypes.ReadonlyObject({ method: funtypes.Literal('popup_requestInterceptorSimulationInput') }),
 	funtypes.ReadonlyObject({ method: funtypes.Literal('popup_importSimulationStack'), data: InterceptorSimulationExport }),
 	funtypes.ReadonlyObject({ method: funtypes.Literal('popup_requestCompleteVisualizedSimulation') }),
@@ -247,6 +266,8 @@ export type PopupReplyOption =
 	| RequestActiveAddressesReply
 	| RequestSimulationModeReply
 	| RequestLatestUnexpectedErrorReply
+	| RequestDiagnosticsReply
+	| ClearDiagnosticsReply
 	| RequestInterceptorSimulationInputReply
 	| ImportSimulationStackReply
 	| RequestCompleteVisualizedSimulationReply
@@ -264,6 +285,8 @@ export const PopupReplyOption: funtypes.Codec<PopupReplyOption> = funtypes.Union
 	RequestActiveAddressesReply,
 	RequestSimulationModeReply,
 	RequestLatestUnexpectedErrorReply,
+	RequestDiagnosticsReply,
+	ClearDiagnosticsReply,
 	RequestInterceptorSimulationInputReply,
 	ImportSimulationStackReply,
 	RequestCompleteVisualizedSimulationReply,

--- a/app/ts/utils/diagnostics.ts
+++ b/app/ts/utils/diagnostics.ts
@@ -1,0 +1,22 @@
+import { InterceptorErrorDiagnostic, type InterceptorErrorSeverity } from '../types/errorDiagnostics.js'
+import { serialize } from '../types/wire-types.js'
+
+export type DiagnosticSummary = Readonly<Record<InterceptorErrorSeverity, number>> & { total: number }
+
+export function summarizeDiagnostics(diagnostics: readonly InterceptorErrorDiagnostic[]): DiagnosticSummary {
+	let info = 0
+	let warning = 0
+	let error = 0
+	for (const diagnostic of diagnostics) {
+		switch (diagnostic.severity) {
+			case 'info': info += 1; break
+			case 'warning': warning += 1; break
+			case 'error': error += 1; break
+		}
+	}
+	return { total: diagnostics.length, info, warning, error }
+}
+
+export function formatDiagnosticsForClipboard(diagnostics: readonly InterceptorErrorDiagnostic[]) {
+	return JSON.stringify(diagnostics.map((diagnostic) => serialize(InterceptorErrorDiagnostic, diagnostic)), undefined, 2)
+}

--- a/app/ts/utils/managementPages.ts
+++ b/app/ts/utils/managementPages.ts
@@ -1,0 +1,84 @@
+import type { TransactionOrMessageIdentifier } from '../types/interceptor-messages.js'
+import { getSimulationStackTargetElementIdFromHash, getSimulationStackTargetHash } from './simulationStackTargets.js'
+
+export type ManagementPage = 'websites' | 'address-book' | 'simulation-stack' | 'diagnostics' | 'settings'
+export type ManagementOpenRequest = 'popup_openWebsiteAccess' | 'popup_openAddressBook' | 'popup_openSettings'
+type ManagementTabTarget = {
+	tabName: 'settingsView'
+	targetHash: string
+}
+export type MountedManagementPages = Readonly<{
+	websites: boolean
+	'address-book': boolean
+	'simulation-stack': boolean
+	diagnostics: boolean
+	settings: boolean
+}>
+
+const managementPages: readonly ManagementPage[] = ['websites', 'address-book', 'simulation-stack', 'diagnostics', 'settings']
+
+export function getManagementPageFromHash(hash: string): ManagementPage {
+	if (hash.startsWith('#origin:')) return 'websites'
+	if (getSimulationStackTargetElementIdFromHash(hash) !== undefined) return 'simulation-stack'
+	const hashPage = hash.startsWith('#') ? hash.slice(1) : hash
+	return managementPages.find((page) => page === hashPage) ?? 'websites'
+}
+
+export function getManagementPageHash(page: ManagementPage) {
+	return `#${ page }`
+}
+
+export function createMountedManagementPages(initialPage: ManagementPage): MountedManagementPages {
+	return {
+		websites: initialPage === 'websites',
+		'address-book': initialPage === 'address-book',
+		'simulation-stack': initialPage === 'simulation-stack',
+		diagnostics: initialPage === 'diagnostics',
+		settings: initialPage === 'settings',
+	}
+}
+
+export function mountManagementPage(mountedPages: MountedManagementPages, page: ManagementPage): MountedManagementPages {
+	if (mountedPages[page]) return mountedPages
+	switch (page) {
+		case 'websites': return { ...mountedPages, websites: true }
+		case 'address-book': return { ...mountedPages, 'address-book': true }
+		case 'simulation-stack': return { ...mountedPages, 'simulation-stack': true }
+		case 'diagnostics': return { ...mountedPages, diagnostics: true }
+		case 'settings': return { ...mountedPages, settings: true }
+	}
+}
+
+function getManagementPageFromOpenRequest(method: ManagementOpenRequest): ManagementPage {
+	switch (method) {
+		case 'popup_openWebsiteAccess': return 'websites'
+		case 'popup_openAddressBook': return 'address-book'
+		case 'popup_openSettings': return 'settings'
+	}
+}
+
+export function getManagementTabTarget(method: ManagementOpenRequest): ManagementTabTarget {
+	const page = getManagementPageFromOpenRequest(method)
+	return {
+		tabName: 'settingsView',
+		targetHash: getManagementPageHash(page),
+	}
+}
+
+export function getSimulationStackManagementTabTarget(identifier?: TransactionOrMessageIdentifier): ManagementTabTarget {
+	return {
+		tabName: 'settingsView',
+		targetHash: identifier === undefined ? getManagementPageHash('simulation-stack') : getSimulationStackTargetHash(identifier),
+	}
+}
+
+export function getManagementPageFromNavigationKey(currentPage: ManagementPage, key: string): ManagementPage | undefined {
+	if (key === 'Home') return managementPages[0]
+	if (key === 'End') return managementPages[managementPages.length - 1]
+	if (key !== 'ArrowLeft' && key !== 'ArrowRight') return undefined
+
+	const currentIndex = managementPages.indexOf(currentPage)
+	const offset = key === 'ArrowRight' ? 1 : -1
+	const nextIndex = (currentIndex + offset + managementPages.length) % managementPages.length
+	return managementPages[nextIndex]
+}

--- a/test/tests/diagnosticsView.test.ts
+++ b/test/tests/diagnosticsView.test.ts
@@ -1,0 +1,34 @@
+import * as assert from 'assert'
+import { describe, test } from 'bun:test'
+import type { InterceptorErrorDiagnostic } from '../../app/ts/types/errorDiagnostics.js'
+import { formatDiagnosticsForClipboard, summarizeDiagnostics } from '../../app/ts/utils/diagnostics.js'
+
+const diagnostic = (severity: InterceptorErrorDiagnostic['severity'], index: number): InterceptorErrorDiagnostic => ({
+	timestamp: new Date(`2026-01-0${ index }T00:00:00.000Z`),
+	source: 'test',
+	code: `test_${ index }`,
+	category: 'unexpected',
+	severity,
+	message: `Diagnostic ${ index }`,
+	cause: index === 1 ? 'root failure' : undefined,
+	userVisible: severity === 'error',
+	debugId: `debug-${ index }`,
+	details: undefined,
+})
+
+describe('diagnostics view data', () => {
+	const diagnostics = [diagnostic('error', 1), diagnostic('warning', 2), diagnostic('info', 3), diagnostic('error', 4)]
+
+	test('summarizes diagnostics by severity', () => {
+		assert.deepEqual(summarizeDiagnostics(diagnostics), { total: 4, error: 2, warning: 1, info: 1 })
+	})
+
+	test('formats diagnostics with serialized timestamps for copying', () => {
+		const formatted = formatDiagnosticsForClipboard(diagnostics)
+		const parsed = JSON.parse(formatted)
+
+		assert.equal(parsed.length, 4)
+		assert.match(parsed[0].timestamp, /^0x[0-9a-f]+$/)
+		assert.equal(parsed[0].cause, 'root failure')
+	})
+})

--- a/test/tests/dynamicScroller.test.ts
+++ b/test/tests/dynamicScroller.test.ts
@@ -1,0 +1,18 @@
+import * as assert from 'assert'
+import { describe, test } from 'bun:test'
+import { calculateMaxVisibleItems } from '../../app/ts/components/subcomponents/DynamicScroller.js'
+
+describe('dynamic scroller measurements', () => {
+	test('ignores hidden and invalid measurements', () => {
+		assert.equal(calculateMaxVisibleItems(0, 0), 0)
+		assert.equal(calculateMaxVisibleItems(600, 0), 0)
+		assert.equal(calculateMaxVisibleItems(0, 60), 0)
+		assert.equal(calculateMaxVisibleItems(Number.POSITIVE_INFINITY, 60), 0)
+		assert.equal(calculateMaxVisibleItems(600, Number.NaN), 0)
+	})
+
+	test('calculates a finite viewport after hidden content becomes measurable', () => {
+		assert.equal(calculateMaxVisibleItems(600, 60), 10)
+		assert.equal(calculateMaxVisibleItems(601, 60), 11)
+	})
+})

--- a/test/tests/managementView.test.ts
+++ b/test/tests/managementView.test.ts
@@ -1,0 +1,77 @@
+import * as assert from 'assert'
+import { describe, test } from 'bun:test'
+import { createMountedManagementPages, getManagementPageFromHash, getManagementPageFromNavigationKey, getManagementPageHash, getManagementTabTarget, getSimulationStackManagementTabTarget, mountManagementPage } from '../../app/ts/utils/managementPages.js'
+import { getSimulationStackTargetHash } from '../../app/ts/utils/simulationStackTargets.js'
+import type { TransactionOrMessageIdentifier } from '../../app/ts/types/interceptor-messages.js'
+
+const managementViewSource = await Bun.file(new URL('../../app/ts/components/pages/ManagementView.tsx', import.meta.url)).text()
+
+describe('management view routing', () => {
+	test('maps each management tab to a stable hash', () => {
+		assert.equal(getManagementPageHash('websites'), '#websites')
+		assert.equal(getManagementPageHash('address-book'), '#address-book')
+		assert.equal(getManagementPageHash('simulation-stack'), '#simulation-stack')
+		assert.equal(getManagementPageHash('diagnostics'), '#diagnostics')
+		assert.equal(getManagementPageHash('settings'), '#settings')
+	})
+
+	test('routes simulation stack links into the shared management tab', () => {
+		const identifier: TransactionOrMessageIdentifier = { type: 'Transaction', transactionIdentifier: 1n }
+		const targetHash = getSimulationStackTargetHash(identifier, 'test-focus')
+
+		assert.deepEqual(getSimulationStackManagementTabTarget(), { tabName: 'settingsView', targetHash: '#simulation-stack' })
+		assert.equal(getSimulationStackManagementTabTarget(identifier).tabName, 'settingsView')
+		assert.equal(getManagementPageFromHash(targetHash), 'simulation-stack')
+	})
+
+	test('maps all three popup controls into the shared management navigation', () => {
+		assert.deepEqual(getManagementTabTarget('popup_openWebsiteAccess'), { tabName: 'settingsView', targetHash: '#websites' })
+		assert.deepEqual(getManagementTabTarget('popup_openAddressBook'), { tabName: 'settingsView', targetHash: '#address-book' })
+		assert.deepEqual(getManagementTabTarget('popup_openSettings'), { tabName: 'settingsView', targetHash: '#settings' })
+	})
+
+	test('selects management tabs from their hashes', () => {
+		assert.equal(getManagementPageFromHash('#websites'), 'websites')
+		assert.equal(getManagementPageFromHash('#address-book'), 'address-book')
+		assert.equal(getManagementPageFromHash('#simulation-stack'), 'simulation-stack')
+		assert.equal(getManagementPageFromHash('#diagnostics'), 'diagnostics')
+		assert.equal(getManagementPageFromHash('#settings'), 'settings')
+	})
+
+	test('keeps website details in the websites tab and safely defaults unknown hashes', () => {
+		assert.equal(getManagementPageFromHash('#origin:https://example.com'), 'websites')
+		assert.equal(getManagementPageFromHash('#unknown'), 'websites')
+		assert.equal(getManagementPageFromHash(''), 'websites')
+	})
+
+	test('supports standard tablist keyboard navigation with wrapping', () => {
+		assert.equal(getManagementPageFromNavigationKey('websites', 'ArrowRight'), 'address-book')
+		assert.equal(getManagementPageFromNavigationKey('address-book', 'ArrowRight'), 'simulation-stack')
+		assert.equal(getManagementPageFromNavigationKey('simulation-stack', 'ArrowRight'), 'diagnostics')
+		assert.equal(getManagementPageFromNavigationKey('diagnostics', 'ArrowRight'), 'settings')
+		assert.equal(getManagementPageFromNavigationKey('settings', 'ArrowRight'), 'websites')
+		assert.equal(getManagementPageFromNavigationKey('websites', 'ArrowLeft'), 'settings')
+		assert.equal(getManagementPageFromNavigationKey('settings', 'Home'), 'websites')
+		assert.equal(getManagementPageFromNavigationKey('websites', 'End'), 'settings')
+		assert.equal(getManagementPageFromNavigationKey('websites', 'Enter'), undefined)
+	})
+
+	test('mounts only the initial data view and retains views after their first selection', () => {
+		const initialPages = createMountedManagementPages('websites')
+		assert.deepEqual(initialPages, { websites: true, 'address-book': false, 'simulation-stack': false, diagnostics: false, settings: false })
+
+		const withAddressBook = mountManagementPage(initialPages, 'address-book')
+		assert.deepEqual(withAddressBook, { websites: true, 'address-book': true, 'simulation-stack': false, diagnostics: false, settings: false })
+
+		const withSimulationStack = mountManagementPage(withAddressBook, 'simulation-stack')
+		const withDiagnostics = mountManagementPage(withSimulationStack, 'diagnostics')
+
+		const withSettings = mountManagementPage(withDiagnostics, 'settings')
+		assert.deepEqual(withSettings, { websites: true, 'address-book': true, 'simulation-stack': true, diagnostics: true, settings: true })
+		assert.equal(mountManagementPage(withSettings, 'websites'), withSettings)
+	})
+
+	test('keeps simulation copy feedback available in the embedded stack', () => {
+		assert.match(managementViewSource, /<Hint><SimulationStackPage\s*\/><\/Hint>/)
+	})
+})

--- a/test/tests/managementViewCss.test.ts
+++ b/test/tests/managementViewCss.test.ts
@@ -1,0 +1,24 @@
+import * as assert from 'assert'
+import { describe, test } from 'bun:test'
+
+const css = await Bun.file(new URL('../../app/css/interceptor.css', import.meta.url)).text()
+
+function getRuleBody(selector: string) {
+	const escapedSelector = selector.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')
+	const match = css.match(new RegExp(`${ escapedSelector }\\s*\\{([^}]*)\\}`))
+	assert.notEqual(match, null, `Missing CSS rule for ${ selector }`)
+	return match?.[1] ?? ''
+}
+
+describe('management view CSS', () => {
+	test('website details render above the sticky management navigation', () => {
+		const managementHeader = getRuleBody('.management-header')
+		const websiteDetails = getRuleBody('.access-details')
+		const managementHeaderZIndex = Number(managementHeader.match(/z-index:\s*(\d+)/)?.[1])
+		const websiteDetailsZIndex = Number(websiteDetails.match(/z-index:\s*(\d+)/)?.[1])
+
+		assert.equal(Number.isFinite(managementHeaderZIndex), true)
+		assert.equal(Number.isFinite(websiteDetailsZIndex), true)
+		assert.equal(websiteDetailsZIndex > managementHeaderZIndex, true)
+	})
+})

--- a/test/tests/openSimulationStackTab.test.ts
+++ b/test/tests/openSimulationStackTab.test.ts
@@ -1,5 +1,6 @@
 import * as assert from 'assert'
 import { describe, test } from 'bun:test'
+import { getManagementTabTarget, getSimulationStackManagementTabTarget, type ManagementOpenRequest } from '../../app/ts/utils/managementPages.js'
 import { getSimulationStackTargetHash } from '../../app/ts/utils/simulationStackTargets.js'
 
 type TabRecord = {
@@ -109,6 +110,32 @@ const emptyOpenedTabs = (): OpenedTabIds => ({
 	settingsView: undefined,
 	websiteAccess: undefined,
 	simulationStack: undefined,
+})
+
+describe('open management tab', () => {
+	test('reuses the tracked settings tab for all three popup management controls', async () => {
+		const { createdTabs, updatedTabs } = installBrowserMock(
+			[{ id: 42, url: 'chrome-extension://test-extension/html3/settingsViewV3.html#websites' }],
+			{ ...emptyOpenedTabs(), settingsView: 42 },
+		)
+		const openNewTab = await loadOpenNewTab()
+		const requests: readonly ManagementOpenRequest[] = ['popup_openWebsiteAccess', 'popup_openAddressBook', 'popup_openSettings']
+
+		for (const request of requests) {
+			const target = getManagementTabTarget(request)
+			await openNewTab(target.tabName, target.targetHash)
+		}
+		const simulationStackTarget = getSimulationStackManagementTabTarget()
+		await openNewTab(simulationStackTarget.tabName, simulationStackTarget.targetHash)
+
+		assert.deepEqual(createdTabs, [])
+		assert.deepEqual(updatedTabs, [
+			{ tabId: 42, update: { active: true, highlighted: true, url: '/html3/settingsViewV3.html#websites' } },
+			{ tabId: 42, update: { active: true, highlighted: true, url: '/html3/settingsViewV3.html#address-book' } },
+			{ tabId: 42, update: { active: true, highlighted: true, url: '/html3/settingsViewV3.html#settings' } },
+			{ tabId: 42, update: { active: true, highlighted: true, url: '/html3/settingsViewV3.html#simulation-stack' } },
+		])
+	})
 })
 
 describe('open simulation stack tab', () => {

--- a/test/tests/simulationVisualizerOpen.test.tsx
+++ b/test/tests/simulationVisualizerOpen.test.tsx
@@ -982,6 +982,70 @@ describe('simulation visualizer open replies', () => {
 		}
 	})
 
+	test('stack visualizer defers a hidden-panel hash target until the management panel can become visible', async () => {
+		const dom = installDomMock()
+		const flushAnimationFrames = installQueuedAnimationFrames()
+		const { listeners } = installBrowserMock()
+		const hashChangeListeners = new Set<EventListenerOrEventListenerObject>()
+		const scrollCalls: ScrollIntoViewOptions[] = []
+		let panelVisible = false
+		globalThis.window.addEventListener = (type, listener) => {
+			if (type === 'hashchange') hashChangeListeners.add(listener)
+		}
+		globalThis.window.removeEventListener = (type, listener) => {
+			if (type === 'hashchange') hashChangeListeners.delete(listener)
+		}
+		Object.defineProperty(globalThis.window, 'location', {
+			configurable: true,
+			writable: true,
+			value: { hash: '#simulation-stack' },
+		})
+		Object.defineProperty(dom.document, 'getElementById', {
+			configurable: true,
+			value: (id: string) => {
+				const element = findElementById(dom.document.body, id)
+				if (element === undefined) return null
+				element.scrollIntoView = (options?: ScrollIntoViewOptions) => {
+					if (panelVisible && options !== undefined) scrollCalls.push(options)
+				}
+				return element
+			},
+		})
+		try {
+			await act(() => {
+				render(h(SimulationStackPage, {}), dom.document.body)
+			})
+			const listener = listeners[0]
+			if (listener === undefined) throw new Error('Expected page to register a runtime listener')
+
+			await act(() => {
+				listener({ role: 'all', ...serialize(UpdateHomePage, createStackHomePageUpdate(18, 1, 'Stack tab')) }, {}, () => undefined)
+				flushAnimationFrames()
+			})
+			globalThis.window.location.hash = getSimulationStackTargetHash({ type: 'Transaction', transactionIdentifier: 1n }, 'hidden-panel')
+			await act(() => {
+				const event = new Event('hashchange')
+				for (const hashChangeListener of hashChangeListeners) {
+					if (typeof hashChangeListener === 'function') hashChangeListener(event)
+					else hashChangeListener.handleEvent(event)
+				}
+			})
+			assert.equal(scrollCalls.length, 0)
+
+			panelVisible = true
+			await act(() => {
+				flushAnimationFrames()
+				flushAnimationFrames()
+			})
+			assert.deepStrictEqual(scrollCalls, [{ behavior: 'smooth', block: 'center' }])
+			const targetRow = findElementById(dom.document.body, 'simulation-stack-transaction-0x1')
+			assert.ok(targetRow)
+			assert.equal(targetRow.getAttribute?.('class')?.includes('simulation-stack-row--highlighted'), true)
+		} finally {
+			dom.restore()
+		}
+	})
+
 	test('stack visualizer target hash does not replay after same-hash updates', async () => {
 		const dom = installDomMock()
 		const flushAnimationFrames = installQueuedAnimationFrames()

--- a/test/tests/unexpectedErrorDiagnostics.test.ts
+++ b/test/tests/unexpectedErrorDiagnostics.test.ts
@@ -120,6 +120,9 @@ function createBrowserMock() {
 		setStorageSet(set: (items: Record<string, unknown>) => Promise<void>) {
 			browserMock.storage.local.set = set
 		},
+		async writeStorage(items: Record<string, unknown>) {
+			await defaultSetStorage(items)
+		},
 	}
 }
 
@@ -137,6 +140,74 @@ async function loadModules() {
 const modulesPromise = loadModules()
 
 describe('unexpected error diagnostics', () => {
+	test('returns and clears stored diagnostics for the management page', async () => {
+		browserMock.reset()
+		const { appendInterceptorErrorDiagnostic, getInterceptorErrorDiagnostics } = await import('../../app/ts/background/storageVariables.js')
+		const { clearDiagnostics, requestDiagnostics } = await import('../../app/ts/background/popupMessageHandlers.js')
+		await appendInterceptorErrorDiagnostic({
+			timestamp: new Date('2026-01-01T00:00:00.000Z'),
+			source: 'test',
+			code: 'test_diagnostic',
+			category: 'unexpected',
+			severity: 'error',
+			message: 'Test diagnostic',
+			cause: 'root failure',
+			userVisible: true,
+			debugId: 'debug-1',
+			details: undefined,
+		})
+
+		const requestReply = await requestDiagnostics()
+		assert.equal(requestReply.method, 'popup_requestDiagnostics')
+		assert.equal(requestReply.diagnostics.length, 1)
+		assert.equal(requestReply.diagnostics[0]?.code, 'test_diagnostic')
+
+		const clearReply = await clearDiagnostics()
+		assert.deepEqual(clearReply, { method: 'popup_clearDiagnostics', diagnostics: [] })
+		assert.deepEqual(await getInterceptorErrorDiagnostics(), [])
+	})
+
+	test('clearing diagnostics waits for an earlier append and removes its completed result', async () => {
+		browserMock.reset()
+		const { appendInterceptorErrorDiagnostic, getInterceptorErrorDiagnostics } = await import('../../app/ts/background/storageVariables.js')
+		const { clearDiagnostics } = await import('../../app/ts/background/popupMessageHandlers.js')
+		let releaseStorageWrite = () => undefined
+		const storageWriteGate = new Promise<void>((resolve) => { releaseStorageWrite = resolve })
+		let reportStorageWriteStarted = () => undefined
+		const storageWriteStarted = new Promise<void>((resolve) => { reportStorageWriteStarted = resolve })
+		browserMock.setStorageSet(async (items) => {
+			reportStorageWriteStarted()
+			await storageWriteGate
+			await browserMock.writeStorage(items)
+		})
+
+		const appendPromise = appendInterceptorErrorDiagnostic({
+			timestamp: new Date('2026-01-01T00:00:00.000Z'),
+			source: 'test',
+			code: 'concurrent_diagnostic',
+			category: 'unexpected',
+			severity: 'error',
+			message: 'Concurrent diagnostic',
+			cause: undefined,
+			userVisible: false,
+			debugId: undefined,
+			details: undefined,
+		})
+		await storageWriteStarted
+		let clearSettled = false
+		const clearPromise = clearDiagnostics().then((reply) => {
+			clearSettled = true
+			return reply
+		})
+		await Promise.resolve()
+		assert.equal(clearSettled, false)
+
+		releaseStorageWrite()
+		await appendPromise
+		assert.deepEqual(await clearPromise, { method: 'popup_clearDiagnostics', diagnostics: [] })
+		assert.deepEqual(await getInterceptorErrorDiagnostics(), [])
+	})
+
 	test('recognizes expected infrastructure errors from unknown thrown values', async () => {
 		const { classifyCaughtError, createInterceptorInternalError, isExpectedInfrastructureError, isFailedToFetchError, isNewBlockAbort } = await modulesPromise
 


### PR DESCRIPTION
## Summary
- Introduce a unified management view with tabs for Websites, Address Book, Simulation Stack, Diagnostics, and Settings.
- Add a new Diagnostics page with summary counters, copy/clear actions, and detailed error records.
- Route popup entry points through tab targets so management pages open in the correct tab and hash state.
- Improve dynamic scroller and hash handling so hidden tab panels and navigation updates render reliably.

## Testing
- `bun test`
- `bun run setup-chrome`
- `bun run typecheck`
- `bun run lint`