### PR TITLE
Fix Safe delegatecall overrides in stacked simulations

### DIFF
--- a/app/ts/background/simulationUpdating.ts
+++ b/app/ts/background/simulationUpdating.ts
@@ -333,10 +333,20 @@ export const simulateGnosisSafeMetaTransaction = async (gnosisSafeMessage: Visua
 		if (simulationState.kind === 'passthrough') throw new Error('Failed to fetch simulation state for Gnosis Safe transaction.')
 		if (simulationState.value.success === false) throw new JsonRpcResponseError(simulationState.value.jsonRpcError)
 		const resolvedSimulationState = simulationState.value
+		const getTemporaryAccountOverrides = async () => {
+			if (!isDelegateCall) return {}
+			const gnosisSafeCode = await getSimulatedCode(ethereumClientService, undefined, { kind: 'simulated', value: resolvedSimulationState }, gnosisSafeMessage.verifyingContract.address)
+			if (gnosisSafeCode?.getCodeReturn === undefined) throw new Error('Failed to simulate gnosis safe transaction. Could not retrieve gnosis safe code.')
+			return {
+				[addressString(gnosisSafeMessage.verifyingContract.address)]: { code: getGnosisSafeProxyProxy() },
+				[addressString(ORIGINAL_GNOSIS_SAFE)]: { code: gnosisSafeCode.getCodeReturn }
+			}
+		}
+		const temporaryAccountOverrides = await getTemporaryAccountOverrides()
 		const gasLimit = gnosisSafeMessage.message.message.baseGas !== 0n ? {
 			gas: gnosisSafeMessage.message.message.baseGas
 		} : await (async () => {
-			const estimateGas = await simulateEstimateGasFromInput(ethereumClientService, undefined, toResolvedSimulationInput(simulationInput), transactionWithoutGas)
+			const estimateGas = await simulateEstimateGasFromInput(ethereumClientService, undefined, toResolvedSimulationInput(simulationInput), transactionWithoutGas, undefined, temporaryAccountOverrides)
 			if ('error' in estimateGas) throw new Error(estimateGas.error.message)
 			return { gas: estimateGas.gas }
 		})()
@@ -348,16 +358,6 @@ export const simulateGnosisSafeMetaTransaction = async (gnosisSafeMessage: Visua
 			originalRequestParameters: { method: 'eth_sendTransaction', params: [transaction] },
 			transactionIdentifier: gnosisSafeMessage.messageIdentifier,
 		}
-		const getTemporaryAccountOverrides = async () => {
-			if (!isDelegateCall) return {}
-			const gnosisSafeCode = await getSimulatedCode(ethereumClientService, undefined, { kind: 'simulated', value: resolvedSimulationState }, gnosisSafeMessage.verifyingContract.address)
-			if (gnosisSafeCode?.getCodeReturn === undefined) throw new Error('Failed to simulate gnosis safe transaction. Could not retrieve gnosis safe code.')
-			return {
-				[addressString(gnosisSafeMessage.verifyingContract.address)]: { code: getGnosisSafeProxyProxy() },
-				[addressString(ORIGINAL_GNOSIS_SAFE)]: { code: gnosisSafeCode.getCodeReturn }
-			}
-		}
-		const temporaryAccountOverrides = await getTemporaryAccountOverrides()
 		const simulationStateAfterGnosisSafeMetaTransaction = await appendTransactionToInputAndSimulate(ethereumClientService, undefined, simulationInput, [metaTransaction], undefined, temporaryAccountOverrides)
 		return { success: true as const, result: await visualizeSimulatorState(simulationStateAfterGnosisSafeMetaTransaction, ethereumClientService, tokenPriceService, undefined) }
 	} catch(error) {

--- a/app/ts/simulation/services/SimulationModeEthereumClientService.ts
+++ b/app/ts/simulation/services/SimulationModeEthereumClientService.ts
@@ -607,7 +607,7 @@ const createPreparedSimulatedExecutionBlocks = async (
 export const getPreSimulated = (simulatedTransactions: readonly SimulatedTransaction[]) => simulatedTransactions.map((transaction) => transaction.preSimulationTransaction)
 
 export const appendTransactionsToInput = (simulationStateInput: SimulationStateInput, transactions: PreSimulationTransaction[], blockDelta: number | undefined = undefined, stateOverrides: StateOverrides = {}, simulateWithZeroBaseFee = false): SimulationStateInput => {
-	const nonUndefinedBlockDelta = simulationStateInput.length
+	const blockToAppendTo = blockDelta ?? simulationStateInput.length
 	const mergeStateSets = (oldOverrides: StateOverrides, newOverrides: StateOverrides) => {
 		const copy = { ...oldOverrides }
 		for (const [key, value] of Object.entries(newOverrides)) {
@@ -616,25 +616,18 @@ export const appendTransactionsToInput = (simulationStateInput: SimulationStateI
 		return copy
 	}
 	const newTransactions = [...transactions]
-	if (simulationStateInput[nonUndefinedBlockDelta] !== undefined) {
+	if (simulationStateInput[blockToAppendTo] !== undefined) {
 		return simulationStateInput.map((block, index) => ({
-			stateOverrides: mergeStateSets(block.stateOverrides, stateOverrides),
-			transactions: index === blockDelta ? [...block.transactions, ...newTransactions] : block.transactions,
+			stateOverrides: index === blockToAppendTo ? mergeStateSets(block.stateOverrides, stateOverrides) : block.stateOverrides,
+			transactions: index === blockToAppendTo ? [...block.transactions, ...newTransactions] : block.transactions,
 			signedMessages: block.signedMessages,
 			blockTimeManipulation: block.blockTimeManipulation,
 			simulateWithZeroBaseFee: block.simulateWithZeroBaseFee,
 		}))
 	}
-	const oldBlocks = simulationStateInput.map((block) => ({
-		stateOverrides: mergeStateSets(block.stateOverrides, stateOverrides),
-		transactions: block.transactions,
-		signedMessages: block.signedMessages,
-		blockTimeManipulation: block.blockTimeManipulation,
-		simulateWithZeroBaseFee: block.simulateWithZeroBaseFee
-	}))
 	return [
-		...oldBlocks,
-		{ stateOverrides: {}, transactions: newTransactions, signedMessages: [], blockTimeManipulation: DEFAULT_BLOCK_MANIPULATION, simulateWithZeroBaseFee }
+		...simulationStateInput,
+		{ stateOverrides, transactions: newTransactions, signedMessages: [], blockTimeManipulation: DEFAULT_BLOCK_MANIPULATION, simulateWithZeroBaseFee }
 	]
 }
 
@@ -1358,6 +1351,7 @@ export const simulateEstimateGasFromInput = async (
 	simulationStateInput: ResolvedSimulationInput,
 	data: PartialEthereumTransaction,
 	blockDelta: number | undefined = undefined,
+	extraOverrides: StateOverrides = {},
 ): Promise<{ error: ErrorWithCodeAndOptionalData } | { gas: bigint }> => {
 	const context = await createPreparedSimulationExecutionContext(ethereumClientService, requestAbortController, simulationStateInput)
 	const sendAddress = data.from !== undefined ? data.from : MOCK_ADDRESS
@@ -1381,7 +1375,7 @@ export const simulateEstimateGasFromInput = async (
 		accessList: []
 	}
 	try {
-		const lastResult = await simulateBlockCallWithPreparedInputContext(ethereumClientService, requestAbortController, context, estimateGasTransaction, {}, true)
+		const lastResult = await simulateBlockCallWithPreparedInputContext(ethereumClientService, requestAbortController, context, estimateGasTransaction, extraOverrides, true)
 		if (lastResult === undefined) return { error: { code: ERROR_INTERCEPTOR_GAS_ESTIMATION_FAILED, message: 'ETH Simulate Failed to estimate gas', data: '0x' } }
 		if (lastResult.status === 'failure') return { error: { ...lastResult.error, data: dataStringWith0xStart(lastResult.returnData) } }
 		const gasSpent = lastResult.gasUsed * 125n * 64n / (100n * 63n)

--- a/test/tests/gnosisSafeStackSimulation.test.ts
+++ b/test/tests/gnosisSafeStackSimulation.test.ts
@@ -5,7 +5,7 @@ import type { SafeTx, VisualizedPersonalSignRequestSafeTx } from '../../app/ts/t
 import type { RpcEntry } from '../../app/ts/types/rpc.js'
 import { EthSimulateV1Result } from '../../app/ts/types/ethSimulate-types.js'
 import { EthereumBlockHeader, EthereumQuantity } from '../../app/ts/types/wire-types.js'
-import { stringifyJSONWithBigInts } from '../../app/ts/utils/bigint.js'
+import { addressString, stringifyJSONWithBigInts } from '../../app/ts/utils/bigint.js'
 import { MULTICALL3, Multicall3ABI } from '../../app/ts/utils/constants.js'
 
 type RuntimeMessage = {
@@ -207,7 +207,7 @@ function makeEthSimulateBlocks(callCount: number, lastReturnData = new Uint8Arra
 	})))
 }
 
-function createSafeMessage(fakeRpcNetwork: RpcEntry, activeAddress: TestModules['defaultActiveAddresses'][number], recipient: TestModules['defaultActiveAddresses'][number]) {
+function createSafeMessage(fakeRpcNetwork: RpcEntry, activeAddress: TestModules['defaultActiveAddresses'][number], recipient: TestModules['defaultActiveAddresses'][number], operation: 0n | 1n = 0n) {
 	const zeroAddressEntry = {
 		address: 0n,
 		name: '0x0 Address',
@@ -244,7 +244,7 @@ function createSafeMessage(fakeRpcNetwork: RpcEntry, activeAddress: TestModules[
 			to: recipient.address,
 			value: 0n,
 			data: new Uint8Array(),
-			operation: 0n,
+			operation,
 			safeTxGas: 0n,
 			baseGas: 0n,
 			gasPrice: 0n,
@@ -430,7 +430,13 @@ describe('Gnosis Safe stack simulation', () => {
 		assert.equal(tokenBalancesAfter[0]?.owner, activeAddress.address)
 	})
 
-	test('simulates a Safe transaction on top of the existing stack', async () => {
+	const safeSimulationCases = [
+		{ name: 'simulates a normal Safe call on top of the existing stack without temporary overrides', operation: 0n, seedStack: true },
+		{ name: 'applies Safe delegatecall overrides during estimation and final simulation on top of the existing stack', operation: 1n, seedStack: true },
+		{ name: 'applies Safe delegatecall overrides during estimation and final simulation with an empty stack', operation: 1n, seedStack: false },
+	] as const
+
+	for (const { name, operation, seedStack } of safeSimulationCases) test(name, async () => {
 		await browserMock.reset()
 		const modules = await modulesPromise
 		const activeAddress = modules.defaultActiveAddresses[0]
@@ -449,6 +455,8 @@ describe('Gnosis Safe stack simulation', () => {
 		}
 
 		const fakeBlock = makeFakeBlock(123n)
+		let gasEstimationCount = 0
+		let delegateCallSimulationCount = 0
 		const fakeRequestHandler = {
 			rpcUrl: fakeRpcNetwork.httpsRpc,
 			clearCache() { return undefined },
@@ -461,7 +469,7 @@ describe('Gnosis Safe stack simulation', () => {
 					case 'eth_getBalance':
 						return serializeForRpc(EthereumQuantity, 0n)
 					case 'eth_getCode':
-						return '0x'
+						return '0x6000'
 					case 'eth_gasPrice':
 						return serializeForRpc(EthereumQuantity, 1n)
 					case 'eth_blockNumber':
@@ -478,6 +486,45 @@ describe('Gnosis Safe stack simulation', () => {
 							throw new Error('Missing calls in eth_simulateV1 block')
 						}
 						const lastCall = lastBlock.calls[lastBlock.calls.length - 1]
+						const stateOverrides = 'stateOverrides' in lastBlock ? lastBlock.stateOverrides : undefined
+						const hasSafeDelegateCallTarget = typeof lastCall === 'object'
+							&& lastCall !== null
+							&& 'to' in lastCall
+							&& lastCall.to === activeAddress.address
+						if (hasSafeDelegateCallTarget) {
+							delegateCallSimulationCount += 1
+							if (typeof stateOverrides !== 'object' || stateOverrides === null) throw new Error('Missing Safe state overrides during delegatecall simulation')
+							const safeOverride = Object.entries(stateOverrides).find(([address]) => address === addressString(activeAddress.address))?.[1]
+							if (typeof safeOverride !== 'object' || safeOverride === null || !('code' in safeOverride) || !(safeOverride.code instanceof Uint8Array) || safeOverride.code.length === 0) {
+								throw new Error('Missing Safe wrapper code during delegatecall simulation')
+							}
+							const relocatedSafeOverride = Object.entries(stateOverrides).find(([address]) => address === '0x0000000000000000000000000000000000920515')?.[1]
+							if (typeof relocatedSafeOverride !== 'object' || relocatedSafeOverride === null || !('code' in relocatedSafeOverride) || !(relocatedSafeOverride.code instanceof Uint8Array) || relocatedSafeOverride.code.length === 0) {
+								throw new Error('Missing relocated Safe code during delegatecall simulation')
+							}
+						}
+						const blockOverrides = 'blockOverrides' in lastBlock ? lastBlock.blockOverrides : undefined
+						const isGasEstimation = typeof lastCall === 'object'
+							&& lastCall !== null
+							&& 'to' in lastCall
+							&& lastCall.to === (operation === 1n ? activeAddress.address : stackRecipient.address)
+							&& typeof blockOverrides === 'object'
+							&& blockOverrides !== null
+							&& 'baseFeePerGas' in blockOverrides
+							&& blockOverrides.baseFeePerGas === 0n
+						if (isGasEstimation) {
+							gasEstimationCount += 1
+							if (operation === 0n && typeof stateOverrides === 'object' && stateOverrides !== null && Object.keys(stateOverrides).length !== 0) {
+								throw new Error('Normal Safe call gas estimation received unexpected state overrides')
+							}
+						}
+						const isGetCodeCall = typeof lastCall === 'object'
+							&& lastCall !== null
+							&& 'to' in lastCall
+							&& lastCall.to === 0x1ce438391307f908756fefe0fe220c0f0d51508an
+						if (isGetCodeCall) {
+							return makeEthSimulateBlocks(callCount, hexToBytes(encodeAbiParameters([{ type: 'bytes' }], ['0x6000'])))
+						}
 						const isAggregate3BalanceCall = typeof lastCall === 'object'
 							&& lastCall !== null
 							&& 'to' in lastCall
@@ -517,41 +564,47 @@ describe('Gnosis Safe stack simulation', () => {
 			accessList: [],
 		})
 
+		const stackOperations = seedStack ? [{
+			type: 'Transaction' as const,
+			preSimulationTransaction: {
+				signedTransaction: currentStackTransaction,
+				website: { websiteOrigin: 'https://stack.example', icon: undefined, title: undefined },
+				created: new Date('2024-01-01T00:00:00.000Z'),
+				originalRequestParameters: { method: 'eth_sendTransaction' as const, params: [{}] },
+				transactionIdentifier: 1n,
+			},
+		}] : []
 		await modules.browserStorageLocalSet({
 			simulationMode: true,
 			activeSimulationAddress: activeAddress.address,
 			activeRpcNetwork: fakeRpcNetwork,
 			interceptorTransactionStack: {
-				operations: [{
-					type: 'Transaction',
-					preSimulationTransaction: {
-						signedTransaction: currentStackTransaction,
-						website: { websiteOrigin: 'https://stack.example', icon: undefined, title: undefined },
-						created: new Date('2024-01-01T00:00:00.000Z'),
-						originalRequestParameters: { method: 'eth_sendTransaction', params: [{}] },
-						transactionIdentifier: 1n,
-					},
-				}],
+				operations: stackOperations,
 			},
 		})
 
-		const safeMessage = createSafeMessage(fakeRpcNetwork, activeAddress, stackRecipient)
+		const safeMessage = createSafeMessage(fakeRpcNetwork, activeAddress, stackRecipient, operation)
 		const simulationInput = await modules.getCurrentSimulationInput()
-		assert.equal(simulationInput.length, 1)
-		assert.equal(simulationInput[0]?.transactions.length, 1)
+		assert.equal(simulationInput.length, seedStack ? 1 : 0)
+		assert.equal(simulationInput[0]?.transactions.length, seedStack ? 1 : undefined)
 
 		const reply = await modules.simulateGnosisSafeMetaTransaction(safeMessage, simulationInput, ethereum, tokenPriceService)
 		assert.equal(reply.success, true)
 		if (!reply.success) throw new Error(reply.errorMessage)
 
 		assert.equal(reply.result.simulationState.rpcNetwork.chainId, fakeRpcNetwork.chainId)
-		assert.equal(reply.result.simulationState.simulationStateInput.length, 2)
+		assert.equal(reply.result.simulationState.simulationStateInput.length, seedStack ? 2 : 1)
 		assert.equal(reply.result.simulationState.simulationStateInput[0]?.transactions.length, 1)
-		assert.equal(reply.result.simulationState.simulationStateInput[1]?.transactions.length, 1)
+		assert.equal(reply.result.simulationState.simulationStateInput[1]?.transactions.length, seedStack ? 1 : undefined)
+		const safeSimulationBlock = reply.result.simulationState.simulationStateInput[seedStack ? 1 : 0]
+		assert.equal(Object.keys(safeSimulationBlock?.stateOverrides ?? {}).length, operation === 1n ? 2 : 0)
+		if (seedStack) assert.equal(Object.keys(reply.result.simulationState.simulationStateInput[0]?.stateOverrides ?? {}).length, 0)
 		assert.equal(reply.result.visualizedSimulationState.success, true)
 		if (!reply.result.visualizedSimulationState.success) throw new Error('unexpected Safe visualization failure')
-		assert.equal(reply.result.visualizedSimulationState.visualizedBlocks.length, 2)
+		assert.equal(reply.result.visualizedSimulationState.visualizedBlocks.length, seedStack ? 2 : 1)
 		assert.equal(reply.result.visualizedSimulationState.visualizedBlocks[0]?.simulatedAndVisualizedTransactions.length, 1)
-		assert.equal(reply.result.visualizedSimulationState.visualizedBlocks[1]?.simulatedAndVisualizedTransactions.length, 1)
+		assert.equal(reply.result.visualizedSimulationState.visualizedBlocks[1]?.simulatedAndVisualizedTransactions.length, seedStack ? 1 : undefined)
+		assert.equal(gasEstimationCount, 1)
+		assert.equal(delegateCallSimulationCount, operation === 1n ? 2 : 0)
 	})
 })


### PR DESCRIPTION
## Summary
- Fixes Gnosis Safe delegatecall simulation so temporary code overrides are applied during gas estimation as well as final stacked simulation.
- Adjusts transaction appending logic to preserve existing stack state while attaching new overrides to the correct simulation block.
- Expands regression coverage for normal Safe calls, delegatecalls, and both seeded and empty stack scenarios.

## Testing
- `bun test`
- `bun run setup-chrome`
- `bun run typecheck`
- `bun run lint`