### PR TITLE
Remove retired hosted RPC defaults

### DIFF
--- a/app/ts/background/settings.ts
+++ b/app/ts/background/settings.ts
@@ -55,36 +55,6 @@ export const defaultRpcs = [
 		primary: true,
 		minimized: true,
 	},
-	{
-		name: 'Sepolia',
-		chainId: 11155111n,
-		httpsRpc: 'https://sepolia.dark.florist',
-		currencyName: 'Sepolia Testnet ETH',
-		currencyTicker: 'SEETH',
-		currencyLogoUri: ETHEREUM_COIN_ICON,
-		primary: true,
-		minimized: true,
-	},
-	{
-		name: 'Holesky',
-		chainId: 17000n,
-		httpsRpc: 'https://holesky.dark.florist',
-		currencyName: 'Holesky Testnet ETH',
-		currencyTicker: 'HOETH',
-		currencyLogoUri: ETHEREUM_COIN_ICON,
-		primary: true,
-		minimized: true,
-	},
-	{
-		name: 'Ethereum (experimental nethermind)',
-		chainId: 1n,
-		httpsRpc: 'https://nethermind.dark.florist',
-		currencyName: 'Ether',
-		currencyTicker: 'ETH',
-		currencyLogoUri: ETHEREUM_COIN_ICON,
-		primary: false,
-		minimized: true,
-	},
 ] as const
 
 export const defaultSimulationMode = true

--- a/app/ts/components/pages/SettingsView.tsx
+++ b/app/ts/components/pages/SettingsView.tsx
@@ -208,15 +208,13 @@ export function SettingsView() {
 
 const RpcListings = () => {
 	const rpcEntries = useRpcConnectionsList()
-	const latestEntry = useComputed(() => rpcEntries.value[0])
 	const { value: resetRpcListState, waitFor: waitForResetDefaultRpcs } = useAsyncState<void>()
 	const loadDefaultRpcs = () => void waitForResetDefaultRpcs(() => sendPopupMessageToBackgroundPage({ method: 'popup_set_rpc_list', data: defaultRpcs }))
 
-	if (shouldOfferBundledRpcReset(rpcEntries.value, defaultRpcs) && latestEntry.value !== undefined) {
+	if (shouldOfferBundledRpcReset(rpcEntries.value)) {
 		return (
-			<>
-				<aside class = 'report' style = { { display: 'grid', height: '9rem', textAlign: 'center', rowGap: '0.5rem'} }>
-					<p style = { { color: 'var(--disabled-text-color)' } }>You have one RPC connection configured. Do you want to restore the bundled default RPC list?</p>
+			<aside class = 'report' style = { { display: 'grid', height: '9rem', textAlign: 'center', rowGap: '0.5rem'} }>
+				<p style = { { color: 'var(--disabled-text-color)' } }>Interceptor requires at least one RPC connection. Do you want to restore the bundled default RPC list?</p>
 				<AsyncActionButton
 					class = 'btn btn--outline'
 					style = 'font-weight: 600'
@@ -224,12 +222,8 @@ const RpcListings = () => {
 					text = 'Yes, load the default RPC list'
 					pendingText = 'Loading default RPC list'
 					onClick = { loadDefaultRpcs }
-						/>
-				</aside>
-				<ul class = 'grid' style = '--gap-y: 0.5rem'>
-						<RpcSummary info = { latestEntry } />
-				</ul>
-			</>
+				/>
+			</aside>
 		)
 	}
 

--- a/app/ts/components/pages/SettingsView.tsx
+++ b/app/ts/components/pages/SettingsView.tsx
@@ -16,6 +16,7 @@ import { noReplyExpectingBrowserRuntimeOnMessageListener } from '../../utils/bro
 import { resolveSignal, type SignalOrValue } from '../../utils/signals.js'
 import { useAsyncState } from '../../utils/preact-utilities.js'
 import { AsyncActionButton } from '../subcomponents/AsyncAction.js'
+import { shouldOfferBundledRpcReset } from '../../utils/rpcConnectionUi.js'
 
 type CheckBoxSettingParam = {
 	text: string
@@ -211,11 +212,11 @@ const RpcListings = () => {
 	const { value: resetRpcListState, waitFor: waitForResetDefaultRpcs } = useAsyncState<void>()
 	const loadDefaultRpcs = () => void waitForResetDefaultRpcs(() => sendPopupMessageToBackgroundPage({ method: 'popup_set_rpc_list', data: defaultRpcs }))
 
-	if (rpcEntries.value.length < 2 && latestEntry.value !== undefined) {
+	if (shouldOfferBundledRpcReset(rpcEntries.value, defaultRpcs) && latestEntry.value !== undefined) {
 		return (
 			<>
 				<aside class = 'report' style = { { display: 'grid', height: '9rem', textAlign: 'center', rowGap: '0.5rem'} }>
-					<p style = { { color: 'var(--disabled-text-color)' } }>Interceptor requires at least 1 active RPC connection to work, do you want to reset to the default list instead?</p>
+					<p style = { { color: 'var(--disabled-text-color)' } }>You have one RPC connection configured. Do you want to restore the bundled default RPC list?</p>
 				<AsyncActionButton
 					class = 'btn btn--outline'
 					style = 'font-weight: 600'

--- a/app/ts/utils/rpcConnectionUi.ts
+++ b/app/ts/utils/rpcConnectionUi.ts
@@ -1,4 +1,6 @@
 import type { RpcConnectionStatus, RpcSlowRequest } from '../types/user-interface-types.js'
+import { type RpcEntries, RpcEntry } from '../types/rpc.js'
+import { serialize } from '../types/wire-types.js'
 import { TIME_BETWEEN_BLOCKS } from './constants.js'
 
 type RpcWarningBase = {
@@ -42,4 +44,13 @@ export function shouldShowRpcWarningCountdown(warningState: RpcWarningState, now
 	return warningState.retryState === 'active'
 		&& warningState.nextRetryAt !== undefined
 		&& warningState.nextRetryAt.getTime() > now.getTime()
+}
+
+export function shouldOfferBundledRpcReset(rpcEntries: RpcEntries, bundledRpcEntries: RpcEntries) {
+	if (rpcEntries.length !== 1) return false
+	if (rpcEntries.length !== bundledRpcEntries.length) return true
+	return rpcEntries.some((entry, index) => {
+		const bundledEntry = bundledRpcEntries[index]
+		return bundledEntry === undefined || JSON.stringify(serialize(RpcEntry, entry)) !== JSON.stringify(serialize(RpcEntry, bundledEntry))
+	})
 }

--- a/app/ts/utils/rpcConnectionUi.ts
+++ b/app/ts/utils/rpcConnectionUi.ts
@@ -1,6 +1,5 @@
 import type { RpcConnectionStatus, RpcSlowRequest } from '../types/user-interface-types.js'
-import { type RpcEntries, RpcEntry } from '../types/rpc.js'
-import { serialize } from '../types/wire-types.js'
+import type { RpcEntries } from '../types/rpc.js'
 import { TIME_BETWEEN_BLOCKS } from './constants.js'
 
 type RpcWarningBase = {
@@ -46,11 +45,6 @@ export function shouldShowRpcWarningCountdown(warningState: RpcWarningState, now
 		&& warningState.nextRetryAt.getTime() > now.getTime()
 }
 
-export function shouldOfferBundledRpcReset(rpcEntries: RpcEntries, bundledRpcEntries: RpcEntries) {
-	if (rpcEntries.length !== 1) return false
-	if (rpcEntries.length !== bundledRpcEntries.length) return true
-	return rpcEntries.some((entry, index) => {
-		const bundledEntry = bundledRpcEntries[index]
-		return bundledEntry === undefined || JSON.stringify(serialize(RpcEntry, entry)) !== JSON.stringify(serialize(RpcEntry, bundledEntry))
-	})
+export function shouldOfferBundledRpcReset(rpcEntries: RpcEntries) {
+	return rpcEntries.length === 0
 }

--- a/test/tests/popupClearReset.test.ts
+++ b/test/tests/popupClearReset.test.ts
@@ -3,6 +3,7 @@ import * as funtypes from 'funtypes'
 import type { CompleteVisualizedSimulation } from '../../app/ts/types/visualizer-types.js'
 import { CompleteVisualizedSimulation as CompleteVisualizedSimulationCodec, toResolvedSimulationState } from '../../app/ts/types/visualizer-types.js'
 import { serialize } from '../../app/ts/types/wire-types.js'
+import type { RpcNetwork } from '../../app/ts/types/rpc.js'
 import { describe, test } from 'bun:test'
 
 type RuntimeMessage = {
@@ -318,9 +319,20 @@ const {
 
 const activeAddress = defaultActiveAddresses[0]?.address
 const rpcNetwork = defaultRpcs[0]
-const sameChainRpcNetwork = defaultRpcs[3]
-const otherChainRpcNetwork = defaultRpcs[1]
-if (activeAddress === undefined || rpcNetwork === undefined || sameChainRpcNetwork === undefined || otherChainRpcNetwork === undefined) throw new Error('test defaults are missing')
+if (activeAddress === undefined || rpcNetwork === undefined) throw new Error('test defaults are missing')
+const sameChainRpcNetwork: RpcNetwork = {
+	...rpcNetwork,
+	name: 'Alternative Ethereum Mainnet',
+	httpsRpc: 'https://mainnet.example.com',
+	primary: false,
+}
+const otherChainRpcNetwork: RpcNetwork = {
+	...rpcNetwork,
+	name: 'Test Chain',
+	chainId: 2n,
+	httpsRpc: 'https://chain.example.com',
+	primary: false,
+}
 
 const stalePopupVisualisation = buildStalePopupVisualisationState(rpcNetwork, DEFAULT_BLOCK_MANIPULATION)
 const fakeEthereum = createFakeEthereum(rpcNetwork) as never as Parameters<typeof updatePopupVisualisationIfNeeded>[0]
@@ -455,8 +467,8 @@ describe('popup clear reset', () => {
 	test('preserves the interceptor stack when changing rpc within the same chain', async () => {
 		browserMock.reset()
 		browserMock.setPopupOpen(false)
-		const resets: TestModules['defaultRpcs'][number][] = []
-		const resetSimulationServices = (nextRpcEntry: TestModules['defaultRpcs'][number]) => {
+		const resets: RpcNetwork[] = []
+		const resetSimulationServices = (nextRpcEntry: RpcNetwork) => {
 			resets.push(nextRpcEntry)
 		}
 		const interceptorTransactionStack = { operations: [{ type: 'TimeManipulation', blockTimeManipulation: DEFAULT_BLOCK_MANIPULATION }] as const }
@@ -483,8 +495,8 @@ describe('popup clear reset', () => {
 
 	test('clears the interceptor stack when changing rpc to another chain', async () => {
 		browserMock.reset()
-		const resets: TestModules['defaultRpcs'][number][] = []
-		const resetSimulationServices = (nextRpcEntry: TestModules['defaultRpcs'][number]) => {
+		const resets: RpcNetwork[] = []
+		const resetSimulationServices = (nextRpcEntry: RpcNetwork) => {
 			resets.push(nextRpcEntry)
 		}
 		await browserStorageLocalSet({

--- a/test/tests/rpcConnectionUi.test.ts
+++ b/test/tests/rpcConnectionUi.test.ts
@@ -1,6 +1,6 @@
 import * as assert from 'assert'
 import { describe, test } from 'bun:test'
-import { getNextRpcRetryAt, getRpcWarningState, noNewBlockForOverTwoMins, shouldShowRpcWarningCountdown } from '../../app/ts/utils/rpcConnectionUi.js'
+import { getNextRpcRetryAt, getRpcWarningState, noNewBlockForOverTwoMins, shouldOfferBundledRpcReset, shouldShowRpcWarningCountdown } from '../../app/ts/utils/rpcConnectionUi.js'
 
 const rpcNetwork = {
 	name: 'Test Chain',
@@ -43,6 +43,20 @@ function makeBlock(timestamp: Date, number = 123n) {
 }
 
 describe('rpcConnectionUi', () => {
+	test('does not offer to reset the bundled singleton RPC list to itself', () => {
+		assert.equal(shouldOfferBundledRpcReset([rpcNetwork], [rpcNetwork]), false)
+	})
+
+	test('offers to restore the bundled RPC list when only a custom RPC remains', () => {
+		const customRpcNetwork = {
+			...rpcNetwork,
+			name: 'Custom Chain',
+			httpsRpc: 'https://custom.example.invalid',
+		}
+
+		assert.equal(shouldOfferBundledRpcReset([customRpcNetwork], [rpcNetwork]), true)
+	})
+
 	test('treats an active disconnect as an immediate warning with a retry countdown', () => {
 		const status = {
 			isConnected: false,

--- a/test/tests/rpcConnectionUi.test.ts
+++ b/test/tests/rpcConnectionUi.test.ts
@@ -44,17 +44,21 @@ function makeBlock(timestamp: Date, number = 123n) {
 
 describe('rpcConnectionUi', () => {
 	test('does not offer to reset the bundled singleton RPC list to itself', () => {
-		assert.equal(shouldOfferBundledRpcReset([rpcNetwork], [rpcNetwork]), false)
+		assert.equal(shouldOfferBundledRpcReset([rpcNetwork]), false)
 	})
 
-	test('offers to restore the bundled RPC list when only a custom RPC remains', () => {
+	test('does not offer to reset when only a custom RPC remains', () => {
 		const customRpcNetwork = {
 			...rpcNetwork,
 			name: 'Custom Chain',
 			httpsRpc: 'https://custom.example.invalid',
 		}
 
-		assert.equal(shouldOfferBundledRpcReset([customRpcNetwork], [rpcNetwork]), true)
+		assert.equal(shouldOfferBundledRpcReset([customRpcNetwork]), false)
+	})
+
+	test('offers to restore the bundled RPC list when no RPCs remain', () => {
+		assert.equal(shouldOfferBundledRpcReset([]), true)
 	})
 
 	test('treats an active disconnect as an immediate warning with a retry countdown', () => {


### PR DESCRIPTION
## Summary

- remove the bundled Sepolia, Holesky, and experimental Nethermind RPC defaults
- keep Ethereum Mainnet as the bundled default RPC
- decouple RPC reset tests from production default-list positions
- offer the bundled RPC reset only when no RPC connections remain

## Why

We no longer host the removed chain RPC endpoints, so they should no longer be offered as defaults.

## Validation

- `bun test` (690 tests passed)
- `bun run setup-chrome`
- `bun run typecheck`
- `bun run lint`