### PR TITLE
Negotiate signer protocol across extension updates

### DIFF
--- a/app/inpage/ts/inpage.ts
+++ b/app/inpage/ts/inpage.ts
@@ -5,6 +5,8 @@ const METAMASK_METHOD_NOT_SUPPORTED = -32004
 const METAMASK_INVALID_METHOD_PARAMS = -32602
 const SIGNER_DISCOVERY_TIMEOUT_MS = 3000
 const SIGNER_DISCOVERY_RETRY_INTERVAL_MS = 100
+const SIGNER_PROTOCOL_VERSION = 1
+const INCOMPATIBLE_PROTOCOL_MESSAGE = 'Interceptor was updated while this page was open. Reload the page to reconnect.'
 
 interface IJsonRpcSuccess<TResult> {
 	readonly jsonrpc: '2.0'
@@ -335,11 +337,6 @@ type OutstandingRequest = {
 type OnMessage = 'accountsChanged' | 'message' | 'connect' | 'close' | 'disconnect' | 'chainChanged'
 type Signer = 'NoSigner' | 'NotRecognizedSigner' | 'MetaMask' | 'Ambire' | 'Brave' | 'CoinbaseWallet' | 'Rabby'
 
-function getLegacyCompatibleSignerName(signerName: Signer): Exclude<Signer, 'Ambire' | 'Rabby'> {
-	if (signerName === 'Ambire' || signerName === 'Rabby') return 'NotRecognizedSigner'
-	return signerName
-}
-
 function getSignerNameFromWalletMarkers(markers: { readonly isAmbire: boolean, readonly isBrave: boolean, readonly isCoinbase: boolean, readonly isMetaMask: boolean, readonly isRabby: boolean }): Signer {
 	if (markers.isCoinbase) return 'CoinbaseWallet'
 	if (markers.isAmbire) return 'Ambire'
@@ -499,7 +496,7 @@ class InterceptorMessageListener {
 	private connected = false
 	private requestId = 0
 	private metamaskCompatibilityMode = false
-	private signerProviderGenerationSupported = false
+	private signerProtocolStatus: 'checking' | 'compatible' | 'incompatible' = 'checking'
 	private signerName: Signer = 'NoSigner'
 	private signerWindowEthereumProvider: WindowEthereum | undefined = undefined
 	private signerWindowEthereumRequest: EthereumRequest | undefined = undefined
@@ -511,6 +508,8 @@ class InterceptorMessageListener {
 	private acceptingAnnouncedMetaMaskProviders = false
 	private signerSelectionGeneration = 0
 	private signerProviderGeneration = 0
+	private lastReportedSignerProviderGeneration: number | undefined = undefined
+	private signerProtocolConfirmation: Promise<boolean> | undefined = undefined
 	private latestSignerConnectionTransition: Promise<void> = Promise.resolve()
 	private readonly signerConnectionTransitionChangeWaiters = new Set<InterceptorFuture<void>>()
 	private readonly signerProviderChangeWaiters = new Set<InterceptorFuture<void>>()
@@ -714,6 +713,7 @@ class InterceptorMessageListener {
 	private readonly WindowEthereumRequest = async (methodAndParams: { readonly method: string, readonly params?: readonly unknown[] }) => {
 		try {
 			if (isInternalBackgroundMethod(methodAndParams.method)) throw new EthereumJsonRpcError(METAMASK_METHOD_NOT_SUPPORTED, `Method not supported: ${ methodAndParams.method }`)
+			if (!await this.ensureSignerProtocolCompatibility()) throw new EthereumJsonRpcError(METAMASK_ERROR_PROVIDER_DISCONNECTED, INCOMPATIBLE_PROTOCOL_MESSAGE)
 			// make a message that the background script will catch and reply us. We'll wait until the background script replies to us and return only after that
 			return await this.sendMessageToBackgroundPage({
 				method: methodAndParams.method,
@@ -748,6 +748,7 @@ class InterceptorMessageListener {
 		try {
 			register('accountsChanged', (accounts: readonly string[]) => {
 				if (this.signerWindowEthereumProvider !== provider) return
+				if (this.signerProtocolStatus !== 'compatible') return
 				if (!Array.isArray(accounts)) return
 				if (!InterceptorMessageListener.isStringArray([...accounts])) return
 				this.signerAccounts = [...accounts]
@@ -758,7 +759,7 @@ class InterceptorMessageListener {
 						type: 'success',
 						accounts: this.signerAccounts,
 						requestAccounts: false,
-						...(this.signerProviderGenerationSupported ? { signerProviderGeneration: this.signerProviderGeneration } : {}),
+						signerProviderGeneration: this.signerProviderGeneration,
 					}],
 				})
 			})
@@ -768,18 +769,15 @@ class InterceptorMessageListener {
 			})
 			register('disconnect', (_error: ProviderRpcError) => {
 				if (this.signerWindowEthereumProvider !== provider) return
+				if (this.signerProtocolStatus !== 'compatible') return
 				const signerProviderGeneration = this.advanceSignerProviderGeneration()
-				const reportedSignerName = this.signerProviderGenerationSupported ? signerName : getLegacyCompatibleSignerName(signerName)
-				const params: readonly unknown[] = this.signerProviderGenerationSupported
-					? [false, reportedSignerName, signerProviderGeneration]
-					: [false, reportedSignerName]
-				this.sendInternalMessageToBackgroundPage({ method: 'connected_to_signer', params })
+				this.sendInternalMessageToBackgroundPage({ method: 'connected_to_signer', params: [false, signerName, signerProviderGeneration] })
 			})
 			register('chainChanged', (chainId: string) => {
 				if (this.signerWindowEthereumProvider !== provider) return
+				if (this.signerProtocolStatus !== 'compatible') return
 				// TODO: this is a hack to get coinbase working that calls this numbers in base 10 instead of in base 16
-				const normalizedChainId = /\d/.test(chainId) ? `0x${parseInt(chainId).toString(16)}` : chainId
-				const params = this.signerProviderGenerationSupported ? [normalizedChainId, this.signerProviderGeneration] : [normalizedChainId]
+				const params = /\d/.test(chainId) ? [`0x${parseInt(chainId).toString(16)}`, this.signerProviderGeneration] : [chainId, this.signerProviderGeneration]
 				this.sendInternalMessageToBackgroundPage({ method: 'signer_chainChanged', params })
 			})
 			this.subscribedSignerProviders.add(provider)
@@ -1122,13 +1120,11 @@ class InterceptorMessageListener {
 
 	private readonly sendSignerAccountsResolution = async (resolution: SignerAccountsResolution) => {
 		await this.waitForLatestSignerConnectionTransition()
+		if (this.signerProtocolStatus !== 'compatible') return false
 		if (resolution.signerProviderGeneration !== this.signerProviderGeneration) return false
 		await this.sendInternalMessageToBackgroundPage({
 			method: 'eth_accounts_reply',
-			params: [{
-				...resolution.reply,
-				...(this.signerProviderGenerationSupported ? { signerProviderGeneration: resolution.signerProviderGeneration } : {}),
-			}],
+			params: [{ ...resolution.reply, signerProviderGeneration: resolution.signerProviderGeneration }],
 		})
 		return true
 	}
@@ -1171,8 +1167,7 @@ class InterceptorMessageListener {
 				this.reportInterceptorError(serializeForwardedDiagnostics('inpage', 'request signer chain id', new Error('Signer eth_chainId returned a non-string reply.'), { requestMethod: 'eth_chainId' }))
 				return
 			}
-			const params = this.signerProviderGenerationSupported ? [reply, outcome.signerProviderGeneration] : [reply]
-			return await this.sendInternalMessageToBackgroundPage({ method: 'signer_chainChanged', params })
+			return await this.sendInternalMessageToBackgroundPage({ method: 'signer_chainChanged', params: [reply, outcome.signerProviderGeneration] })
 		}
 		console.error('failed to get chain Id from signer')
 		console.error(outcome.error)
@@ -1215,8 +1210,8 @@ class InterceptorMessageListener {
 				params: [{
 					accept: false,
 					chainId,
+					signerProviderGeneration: this.signerProviderGeneration,
 					error: { code: METAMASK_ERROR_PROVIDER_DISCONNECTED, message: 'No signer wallet is available to this page. Enable your wallet extension for this site, then try again.' },
-					...(this.signerProviderGenerationSupported ? { signerProviderGeneration: this.signerProviderGeneration } : {}),
 				}],
 			})
 			return
@@ -1225,16 +1220,12 @@ class InterceptorMessageListener {
 		const outcome = await this.requestFromCurrentSigner({ method: 'wallet_switchEthereumChain', params: [{ chainId }] })
 		if (outcome.type === 'success') {
 			const params = outcome.reply === null
-				? {
-					accept: true as const,
-					chainId,
-					...(this.signerProviderGenerationSupported ? { signerProviderGeneration: outcome.signerProviderGeneration } : {}),
-				}
+				? { accept: true as const, chainId, signerProviderGeneration: outcome.signerProviderGeneration }
 				: {
 					accept: false as const,
 					chainId,
+					signerProviderGeneration: outcome.signerProviderGeneration,
 					error: { code: METAMASK_ERROR_BLANKET_ERROR, message: 'Signer returned an invalid wallet_switchEthereumChain reply.' },
-					...(this.signerProviderGenerationSupported ? { signerProviderGeneration: outcome.signerProviderGeneration } : {}),
 				}
 			await this.sendInternalMessageToBackgroundPage({ method: 'wallet_switchEthereumChain_reply', params: [params] })
 			return
@@ -1244,12 +1235,7 @@ class InterceptorMessageListener {
 			: this.normalizeSignerErrorForBackground(outcome.error)
 		await this.sendInternalMessageToBackgroundPage({
 			method: 'wallet_switchEthereumChain_reply',
-			params: [{
-				accept: false,
-				chainId,
-				error,
-				...(this.signerProviderGenerationSupported ? { signerProviderGeneration: outcome.signerProviderGeneration } : {}),
-			}],
+			params: [{ accept: false, chainId, error, signerProviderGeneration: outcome.signerProviderGeneration }],
 		})
 	}
 
@@ -1445,23 +1431,13 @@ class InterceptorMessageListener {
 
 			const sendToSignerWithCatchError = async () => {
 				const outcome = await this.requestFromCurrentSigner({ method: forwardRequest.method, params: 'params' in forwardRequest ? forwardRequest.params : [] })
-				if (outcome.type === 'success') return {
-					success: true as const,
-					forwardRequest,
-					reply: outcome.reply,
-					...(this.signerProviderGenerationSupported ? { signerProviderGeneration: outcome.signerProviderGeneration } : {}),
-				}
-				if (outcome.type === 'error') return {
-					success: false as const,
-					forwardRequest,
-					error: this.normalizeSignerErrorForBackground(outcome.error),
-					...(this.signerProviderGenerationSupported ? { signerProviderGeneration: outcome.signerProviderGeneration } : {}),
-				}
+				if (outcome.type === 'success') return { success: true as const, forwardRequest, reply: outcome.reply, signerProviderGeneration: outcome.signerProviderGeneration }
+				if (outcome.type === 'error') return { success: false as const, forwardRequest, error: this.normalizeSignerErrorForBackground(outcome.error), signerProviderGeneration: outcome.signerProviderGeneration }
 				return {
 					success: false as const,
 					forwardRequest,
 					error: { code: METAMASK_ERROR_PROVIDER_DISCONNECTED, message: 'Signer connection changed before the previous wallet replied.' },
-					...(this.signerProviderGenerationSupported ? { signerProviderGeneration: outcome.signerProviderGeneration } : {}),
+					signerProviderGeneration: outcome.signerProviderGeneration,
 				}
 			}
 			const signerReply = await sendToSignerWithCatchError()
@@ -1511,6 +1487,94 @@ class InterceptorMessageListener {
 		}
 	}
 
+	private readonly invalidateInpageProtocol = () => {
+		if (this.signerProtocolStatus === 'incompatible') return
+		this.signerProtocolStatus = 'incompatible'
+		this.connected = false
+		this.stopSignerDiscoveryRetries()
+		const error = new EthereumJsonRpcError(METAMASK_ERROR_PROVIDER_DISCONNECTED, INCOMPATIBLE_PROTOCOL_MESSAGE)
+		for (const pendingRequest of this.outstandingRequests.values()) pendingRequest.future.reject(error)
+		this.outstandingRequests.clear()
+		const extensionMessagePort = this.extensionMessagePort
+		this.extensionMessagePort = undefined
+		extensionMessagePort?.close()
+		for (const callback of this.onDisconnectCallBacks) queueMicrotask(() => callback(error))
+	}
+
+	private readonly isIncompatibleProtocolError = (error: unknown) => {
+		return error instanceof Error
+			&& 'code' in error
+			&& error.code === METAMASK_ERROR_PROVIDER_DISCONNECTED
+			&& error.message === INCOMPATIBLE_PROTOCOL_MESSAGE
+	}
+
+	private readonly parseSignerProtocolReply = (reply: unknown) => {
+		if (typeof reply !== 'object'
+			|| reply === null
+			|| !('metamaskCompatibilityMode' in reply)
+			|| typeof reply.metamaskCompatibilityMode !== 'boolean'
+			|| !('signerProtocolVersion' in reply)
+			|| reply.signerProtocolVersion !== SIGNER_PROTOCOL_VERSION) return undefined
+		return { metamaskCompatibilityMode: reply.metamaskCompatibilityMode }
+	}
+
+	private readonly getSignerProtocolStatus = (): 'checking' | 'compatible' | 'incompatible' => this.signerProtocolStatus
+
+	private readonly confirmSignerProtocol = async (selectionGeneration: number) => {
+		const statusReply = await this.sendInternalMessageToBackgroundPage({
+			method: 'connected_to_signer',
+			params: [this.signerName !== 'NoSigner', this.signerName, this.signerProviderGeneration],
+		})
+		if (this.signerProtocolStatus === 'compatible') return true
+		if (this.signerProtocolStatus === 'incompatible') return false
+		const connection = this.parseSignerProtocolReply(statusReply)
+		if (connection === undefined) {
+			this.invalidateInpageProtocol()
+			return false
+		}
+		if (selectionGeneration !== this.signerSelectionGeneration) return false
+		this.signerProtocolStatus = 'compatible'
+		this.lastReportedSignerProviderGeneration = this.signerProviderGeneration
+		this.enableMetamaskCompatibilityMode(connection.metamaskCompatibilityMode)
+		return true
+	}
+
+	private readonly ensureSignerProtocolCompatibility = async () => {
+		try {
+			while (this.signerProtocolStatus === 'checking') {
+				const selectionGeneration = this.signerSelectionGeneration
+				// Keep this probe on the former two-field shape so an older worker can answer it
+				// without treating a routine extension update as an unexpected validation error.
+				// No signer state is conveyed or accepted until the version is confirmed.
+				const probeReply = await this.sendInternalMessageToBackgroundPage({ method: 'connected_to_signer', params: [false, 'NoSigner'] })
+				const protocolStatus = this.getSignerProtocolStatus()
+				if (protocolStatus === 'compatible') return true
+				if (protocolStatus === 'incompatible') return false
+				if (this.parseSignerProtocolReply(probeReply) === undefined) {
+					this.invalidateInpageProtocol()
+					return false
+				}
+				if (selectionGeneration !== this.signerSelectionGeneration) continue
+				// A successful probe is not enough to release public traffic: the background
+				// remains negotiating until it has applied an exact current-format signer status.
+				let confirmation = this.signerProtocolConfirmation
+				if (confirmation === undefined) {
+					confirmation = this.confirmSignerProtocol(selectionGeneration)
+					this.signerProtocolConfirmation = confirmation
+				}
+				try {
+					if (await confirmation) return true
+				} finally {
+					if (this.signerProtocolConfirmation === confirmation) this.signerProtocolConfirmation = undefined
+				}
+			}
+			return this.signerProtocolStatus === 'compatible'
+		} catch (error: unknown) {
+			if (this.signerProtocolStatus === 'incompatible' && this.isIncompatibleProtocolError(error)) return false
+			throw error
+		}
+	}
+
 	private readonly connectToSigner = (signerName: Signer) => {
 		this.signerName = signerName
 		const signerProviderGeneration = this.advanceSignerProviderGeneration()
@@ -1524,35 +1588,28 @@ class InterceptorMessageListener {
 			if (this.signerAvailabilityWaiters.size === 0 && this.metaMaskAvailabilityWaiters.size === 0) this.stopSignerDiscoveryRetries()
 		}
 		const selectionGeneration = ++this.signerSelectionGeneration
-		const connectToSigner = async (): Promise<{ metamaskCompatibilityMode: boolean }> => {
-			const usedSignerProviderGeneration = this.signerProviderGenerationSupported
-			const reportedSignerName = usedSignerProviderGeneration ? signerName : getLegacyCompatibleSignerName(signerName)
-			const params: readonly unknown[] = usedSignerProviderGeneration
-				? [signerName !== 'NoSigner', reportedSignerName, signerProviderGeneration]
-				: [signerName !== 'NoSigner', reportedSignerName]
-			const connectSignerReply = await this.sendInternalMessageToBackgroundPage({ method: 'connected_to_signer', params })
-			if (typeof connectSignerReply === 'object' && connectSignerReply !== null
-				&& 'metamaskCompatibilityMode' in connectSignerReply && connectSignerReply.metamaskCompatibilityMode !== null
-				&& connectSignerReply.metamaskCompatibilityMode !== undefined && typeof connectSignerReply.metamaskCompatibilityMode === 'boolean') {
-				if (!usedSignerProviderGeneration
-					&& 'signerProviderGenerationSupported' in connectSignerReply
-					&& connectSignerReply.signerProviderGenerationSupported === true) {
-					this.signerProviderGenerationSupported = true
-					if (reportedSignerName !== signerName) {
-						if (selectionGeneration !== this.signerSelectionGeneration) {
-							await this.connectToSigner(this.signerName)
-							return { metamaskCompatibilityMode: connectSignerReply.metamaskCompatibilityMode }
-						}
-						return await connectToSigner()
-					}
-				}
-				return { metamaskCompatibilityMode: connectSignerReply.metamaskCompatibilityMode }
+		const reportSignerConnection = async (): Promise<{ metamaskCompatibilityMode: boolean } | undefined> => {
+			if (!await this.ensureSignerProtocolCompatibility()) return undefined
+			if (selectionGeneration !== this.signerSelectionGeneration) return undefined
+			if (this.lastReportedSignerProviderGeneration === signerProviderGeneration) {
+				return { metamaskCompatibilityMode: this.metamaskCompatibilityMode }
 			}
-			throw new Error('Failed to parse connected_to_signer reply')
+			const connectSignerReply = await this.sendInternalMessageToBackgroundPage({
+				method: 'connected_to_signer',
+				params: [signerName !== 'NoSigner', signerName, signerProviderGeneration],
+			})
+			const connection = this.parseSignerProtocolReply(connectSignerReply)
+			if (connection !== undefined) {
+				this.lastReportedSignerProviderGeneration = signerProviderGeneration
+				return connection
+			}
+			this.invalidateInpageProtocol()
+			return undefined
 		}
 
 		const completeTransition = async () => {
-			const connection = await connectToSigner()
+			const connection = await reportSignerConnection()
+			if (connection === undefined) return
 			if (selectionGeneration !== this.signerSelectionGeneration) return
 			this.enableMetamaskCompatibilityMode(connection.metamaskCompatibilityMode)
 			if (signerName !== 'NoSigner') await this.requestChainIdFromSigner()
@@ -1561,6 +1618,7 @@ class InterceptorMessageListener {
 		// during a background-worker or content-port replacement. The generation checks on both sides make
 		// late replies from superseded reports harmless.
 		const transition = completeTransition().catch((error: unknown) => {
+			if (this.signerProtocolStatus === 'incompatible' && this.isIncompatibleProtocolError(error)) return
 			this.reportSignerDiscoveryError('report signer connection status', error)
 		})
 		this.latestSignerConnectionTransition = transition

--- a/app/inpage/ts/inpage.ts
+++ b/app/inpage/ts/inpage.ts
@@ -335,6 +335,11 @@ type OutstandingRequest = {
 type OnMessage = 'accountsChanged' | 'message' | 'connect' | 'close' | 'disconnect' | 'chainChanged'
 type Signer = 'NoSigner' | 'NotRecognizedSigner' | 'MetaMask' | 'Ambire' | 'Brave' | 'CoinbaseWallet' | 'Rabby'
 
+function getLegacyCompatibleSignerName(signerName: Signer): Exclude<Signer, 'Ambire' | 'Rabby'> {
+	if (signerName === 'Ambire' || signerName === 'Rabby') return 'NotRecognizedSigner'
+	return signerName
+}
+
 function getSignerNameFromWalletMarkers(markers: { readonly isAmbire: boolean, readonly isBrave: boolean, readonly isCoinbase: boolean, readonly isMetaMask: boolean, readonly isRabby: boolean }): Signer {
 	if (markers.isCoinbase) return 'CoinbaseWallet'
 	if (markers.isAmbire) return 'Ambire'
@@ -494,6 +499,7 @@ class InterceptorMessageListener {
 	private connected = false
 	private requestId = 0
 	private metamaskCompatibilityMode = false
+	private signerProviderGenerationSupported = false
 	private signerName: Signer = 'NoSigner'
 	private signerWindowEthereumProvider: WindowEthereum | undefined = undefined
 	private signerWindowEthereumRequest: EthereumRequest | undefined = undefined
@@ -746,7 +752,15 @@ class InterceptorMessageListener {
 				if (!InterceptorMessageListener.isStringArray([...accounts])) return
 				this.signerAccounts = [...accounts]
 				if (this.pendingSignerAddressRequest !== undefined) return
-				this.sendInternalMessageToBackgroundPage({ method: 'eth_accounts_reply', params: [{ type: 'success', accounts: this.signerAccounts, requestAccounts: false, signerProviderGeneration: this.signerProviderGeneration }] })
+				this.sendInternalMessageToBackgroundPage({
+					method: 'eth_accounts_reply',
+					params: [{
+						type: 'success',
+						accounts: this.signerAccounts,
+						requestAccounts: false,
+						...(this.signerProviderGenerationSupported ? { signerProviderGeneration: this.signerProviderGeneration } : {}),
+					}],
+				})
 			})
 			register('connect', (_connectInfo: ProviderConnectInfo) => {
 				if (this.signerWindowEthereumProvider !== provider) return
@@ -755,12 +769,17 @@ class InterceptorMessageListener {
 			register('disconnect', (_error: ProviderRpcError) => {
 				if (this.signerWindowEthereumProvider !== provider) return
 				const signerProviderGeneration = this.advanceSignerProviderGeneration()
-				this.sendInternalMessageToBackgroundPage({ method: 'connected_to_signer', params: [false, signerName, signerProviderGeneration] })
+				const reportedSignerName = this.signerProviderGenerationSupported ? signerName : getLegacyCompatibleSignerName(signerName)
+				const params: readonly unknown[] = this.signerProviderGenerationSupported
+					? [false, reportedSignerName, signerProviderGeneration]
+					: [false, reportedSignerName]
+				this.sendInternalMessageToBackgroundPage({ method: 'connected_to_signer', params })
 			})
 			register('chainChanged', (chainId: string) => {
 				if (this.signerWindowEthereumProvider !== provider) return
 				// TODO: this is a hack to get coinbase working that calls this numbers in base 10 instead of in base 16
-				const params = /\d/.test(chainId) ? [`0x${parseInt(chainId).toString(16)}`, this.signerProviderGeneration] : [chainId, this.signerProviderGeneration]
+				const normalizedChainId = /\d/.test(chainId) ? `0x${parseInt(chainId).toString(16)}` : chainId
+				const params = this.signerProviderGenerationSupported ? [normalizedChainId, this.signerProviderGeneration] : [normalizedChainId]
 				this.sendInternalMessageToBackgroundPage({ method: 'signer_chainChanged', params })
 			})
 			this.subscribedSignerProviders.add(provider)
@@ -1104,7 +1123,13 @@ class InterceptorMessageListener {
 	private readonly sendSignerAccountsResolution = async (resolution: SignerAccountsResolution) => {
 		await this.waitForLatestSignerConnectionTransition()
 		if (resolution.signerProviderGeneration !== this.signerProviderGeneration) return false
-		await this.sendInternalMessageToBackgroundPage({ method: 'eth_accounts_reply', params: [{ ...resolution.reply, signerProviderGeneration: resolution.signerProviderGeneration }] })
+		await this.sendInternalMessageToBackgroundPage({
+			method: 'eth_accounts_reply',
+			params: [{
+				...resolution.reply,
+				...(this.signerProviderGenerationSupported ? { signerProviderGeneration: resolution.signerProviderGeneration } : {}),
+			}],
+		})
 		return true
 	}
 
@@ -1146,7 +1171,8 @@ class InterceptorMessageListener {
 				this.reportInterceptorError(serializeForwardedDiagnostics('inpage', 'request signer chain id', new Error('Signer eth_chainId returned a non-string reply.'), { requestMethod: 'eth_chainId' }))
 				return
 			}
-			return await this.sendInternalMessageToBackgroundPage({ method: 'signer_chainChanged', params: [reply, outcome.signerProviderGeneration] })
+			const params = this.signerProviderGenerationSupported ? [reply, outcome.signerProviderGeneration] : [reply]
+			return await this.sendInternalMessageToBackgroundPage({ method: 'signer_chainChanged', params })
 		}
 		console.error('failed to get chain Id from signer')
 		console.error(outcome.error)
@@ -1189,8 +1215,8 @@ class InterceptorMessageListener {
 				params: [{
 					accept: false,
 					chainId,
-					signerProviderGeneration: this.signerProviderGeneration,
 					error: { code: METAMASK_ERROR_PROVIDER_DISCONNECTED, message: 'No signer wallet is available to this page. Enable your wallet extension for this site, then try again.' },
+					...(this.signerProviderGenerationSupported ? { signerProviderGeneration: this.signerProviderGeneration } : {}),
 				}],
 			})
 			return
@@ -1199,12 +1225,16 @@ class InterceptorMessageListener {
 		const outcome = await this.requestFromCurrentSigner({ method: 'wallet_switchEthereumChain', params: [{ chainId }] })
 		if (outcome.type === 'success') {
 			const params = outcome.reply === null
-				? { accept: true as const, chainId, signerProviderGeneration: outcome.signerProviderGeneration }
+				? {
+					accept: true as const,
+					chainId,
+					...(this.signerProviderGenerationSupported ? { signerProviderGeneration: outcome.signerProviderGeneration } : {}),
+				}
 				: {
 					accept: false as const,
 					chainId,
-					signerProviderGeneration: outcome.signerProviderGeneration,
 					error: { code: METAMASK_ERROR_BLANKET_ERROR, message: 'Signer returned an invalid wallet_switchEthereumChain reply.' },
+					...(this.signerProviderGenerationSupported ? { signerProviderGeneration: outcome.signerProviderGeneration } : {}),
 				}
 			await this.sendInternalMessageToBackgroundPage({ method: 'wallet_switchEthereumChain_reply', params: [params] })
 			return
@@ -1214,7 +1244,12 @@ class InterceptorMessageListener {
 			: this.normalizeSignerErrorForBackground(outcome.error)
 		await this.sendInternalMessageToBackgroundPage({
 			method: 'wallet_switchEthereumChain_reply',
-			params: [{ accept: false, chainId, error, signerProviderGeneration: outcome.signerProviderGeneration }],
+			params: [{
+				accept: false,
+				chainId,
+				error,
+				...(this.signerProviderGenerationSupported ? { signerProviderGeneration: outcome.signerProviderGeneration } : {}),
+			}],
 		})
 	}
 
@@ -1410,13 +1445,23 @@ class InterceptorMessageListener {
 
 			const sendToSignerWithCatchError = async () => {
 				const outcome = await this.requestFromCurrentSigner({ method: forwardRequest.method, params: 'params' in forwardRequest ? forwardRequest.params : [] })
-				if (outcome.type === 'success') return { success: true as const, forwardRequest, reply: outcome.reply, signerProviderGeneration: outcome.signerProviderGeneration }
-				if (outcome.type === 'error') return { success: false as const, forwardRequest, error: this.normalizeSignerErrorForBackground(outcome.error), signerProviderGeneration: outcome.signerProviderGeneration }
+				if (outcome.type === 'success') return {
+					success: true as const,
+					forwardRequest,
+					reply: outcome.reply,
+					...(this.signerProviderGenerationSupported ? { signerProviderGeneration: outcome.signerProviderGeneration } : {}),
+				}
+				if (outcome.type === 'error') return {
+					success: false as const,
+					forwardRequest,
+					error: this.normalizeSignerErrorForBackground(outcome.error),
+					...(this.signerProviderGenerationSupported ? { signerProviderGeneration: outcome.signerProviderGeneration } : {}),
+				}
 				return {
 					success: false as const,
 					forwardRequest,
 					error: { code: METAMASK_ERROR_PROVIDER_DISCONNECTED, message: 'Signer connection changed before the previous wallet replied.' },
-					signerProviderGeneration: outcome.signerProviderGeneration,
+					...(this.signerProviderGenerationSupported ? { signerProviderGeneration: outcome.signerProviderGeneration } : {}),
 				}
 			}
 			const signerReply = await sendToSignerWithCatchError()
@@ -1480,10 +1525,27 @@ class InterceptorMessageListener {
 		}
 		const selectionGeneration = ++this.signerSelectionGeneration
 		const connectToSigner = async (): Promise<{ metamaskCompatibilityMode: boolean }> => {
-			const connectSignerReply = await this.sendInternalMessageToBackgroundPage({ method: 'connected_to_signer', params: [signerName !== 'NoSigner', signerName, signerProviderGeneration] })
+			const usedSignerProviderGeneration = this.signerProviderGenerationSupported
+			const reportedSignerName = usedSignerProviderGeneration ? signerName : getLegacyCompatibleSignerName(signerName)
+			const params: readonly unknown[] = usedSignerProviderGeneration
+				? [signerName !== 'NoSigner', reportedSignerName, signerProviderGeneration]
+				: [signerName !== 'NoSigner', reportedSignerName]
+			const connectSignerReply = await this.sendInternalMessageToBackgroundPage({ method: 'connected_to_signer', params })
 			if (typeof connectSignerReply === 'object' && connectSignerReply !== null
 				&& 'metamaskCompatibilityMode' in connectSignerReply && connectSignerReply.metamaskCompatibilityMode !== null
 				&& connectSignerReply.metamaskCompatibilityMode !== undefined && typeof connectSignerReply.metamaskCompatibilityMode === 'boolean') {
+				if (!usedSignerProviderGeneration
+					&& 'signerProviderGenerationSupported' in connectSignerReply
+					&& connectSignerReply.signerProviderGenerationSupported === true) {
+					this.signerProviderGenerationSupported = true
+					if (reportedSignerName !== signerName) {
+						if (selectionGeneration !== this.signerSelectionGeneration) {
+							await this.connectToSigner(this.signerName)
+							return { metamaskCompatibilityMode: connectSignerReply.metamaskCompatibilityMode }
+						}
+						return await connectToSigner()
+					}
+				}
 				return { metamaskCompatibilityMode: connectSignerReply.metamaskCompatibilityMode }
 			}
 			throw new Error('Failed to parse connected_to_signer reply')

--- a/app/ts/background/background-startup.ts
+++ b/app/ts/background/background-startup.ts
@@ -34,6 +34,7 @@ import { createRetriableTerminalStateRecovery } from './terminalStateRecovery.js
 import { acknowledgeAndTrackBridgeRequest, INTERCEPTOR_BRIDGE_ACKNOWLEDGEMENT_MESSAGE } from './bridgeRequestDelivery.js'
 import { registerWebsiteConnectionAndProvisionallyClaimSignerState } from './signerStateOwnership.js'
 import { sendSubscriptionReplyOrCallBackToPort } from './messageSending.js'
+import { initializeInpageProtocolNegotiation } from './providerMessageHandlers.js'
 
 const websiteTabConnections = new Map<number, TabConnection>()
 let simulationServices: SimulationServices | undefined
@@ -129,6 +130,8 @@ async function onContentScriptConnected(waitForStartup: () => Promise<{ resetAct
 		printError(`Could not connect to a port: ${ port.name}`)
 		return
 	}
+	// The port must be protocol-confirmed before listeners can release queued page traffic.
+	initializeInpageProtocolNegotiation(port)
 	const websiteOrigin = getHostWithPort(port.sender.url)
 	const identifier = websiteSocketToString(socket)
 	const websitePromise = (async () => {

--- a/app/ts/background/background.ts
+++ b/app/ts/background/background.ts
@@ -26,7 +26,7 @@ import type { ConfirmTransactionTransactionSingleVisualization } from '../types/
 import type { RpcNetwork } from '../types/rpc.js'
 import { serialize } from '../types/wire-types.js'
 import { last } from '../utils/array.js'
-import { connectedToSigner, ethAccountsReply, signerChainChanged, signerReply, walletSwitchEthereumChainReply } from './providerMessageHandlers.js'
+import { connectedToSigner, ethAccountsReply, hasCompatibleInpageProtocol, notifyIncompatibleInpageProtocol, signerChainChanged, signerReply, walletSwitchEthereumChainReply } from './providerMessageHandlers.js'
 import { makeSureInterceptorIsNotSleeping } from './sleeping.js'
 import type { PublishRpcConnectionStatus } from './rpcSlowRequestTracking.js'
 import { decodeEthereumError } from '../utils/errorDecoding.js'
@@ -556,6 +556,18 @@ function replyWithSignerAccountError(websiteTabConnections: WebsiteTabConnection
 }
 
 export const handleInterceptedRequest = async (port: browser.runtime.Port | undefined, websiteOrigin: string, websitePromise: Promise<Website> | Website, ethereum: EthereumClientService, tokenPriceService: TokenPriceService, resetSimulationServices: ResetSimulationServices, socket: WebsiteSocket, request: InterceptedRequest, websiteTabConnections: WebsiteTabConnections, publishRpcConnectionStatus: PublishRpcConnectionStatus): Promise<unknown> => {
+	if (port !== undefined && request.method !== 'connected_to_signer' && !await hasCompatibleInpageProtocol(port)) {
+		notifyIncompatibleInpageProtocol(port)
+		if (request.interceptorInternalRequest === true) return
+		return replyToInterceptedRequest(websiteTabConnections, {
+			type: 'result',
+			...getRequestWithDefinedParams(request),
+			error: {
+				code: METAMASK_ERROR_PROVIDER_DISCONNECTED,
+				message: 'Interceptor was updated while this page was open. Reload the page to reconnect.',
+			},
+		})
+	}
 	const initialSettings = await getSettings()
 	if (request.method === 'wallet_revokePermissions') {
 		const parsedRequest = parseWalletRevokePermissionsRequest(websiteTabConnections, request)

--- a/app/ts/background/providerMessageHandlers.ts
+++ b/app/ts/background/providerMessageHandlers.ts
@@ -19,18 +19,25 @@ import type { ResetSimulationServices } from '../simulation/serviceLifecycle.js'
 import { isSignerMissing } from '../utils/signerMetadata.js'
 import { beginSignerStateConfirmation, clearSignerDerivedTabState, confirmSignerState, getConfirmedSignerStateToken, isCurrentWebsiteConnection, isSignerStateTokenCurrent, runSignerStateOperation, signerConnectionReplacedError, tabHasApprovedWebsiteConnection, type SignerStateToken } from './signerStateOwnership.js'
 
-function getSignerCallbackToken(websiteTabConnections: WebsiteTabConnections, port: browser.runtime.Port, signerProviderGeneration: number) {
+function getSignerCallbackToken(websiteTabConnections: WebsiteTabConnections, port: browser.runtime.Port, signerProviderGeneration: number | undefined) {
 	const socket = getSocketFromPort(port)
 	if (socket === undefined) return undefined
 	const token = getConfirmedSignerStateToken(websiteTabConnections, socket.tabId)
 	if (token === undefined) return undefined
 	if (token.socket.connectionName !== socket.connectionName || token.port !== port) return undefined
-	if (token.signerProviderGeneration !== signerProviderGeneration) return undefined
+	if (signerProviderGeneration !== undefined && token.signerProviderGeneration !== signerProviderGeneration) return undefined
 	return token
 }
 
 async function getConnectedToSignerResult() {
-	return { type: 'result' as const, method: 'connected_to_signer' as const, result: { metamaskCompatibilityMode: await getMetamaskCompatibilityMode() } }
+	return {
+		type: 'result' as const,
+		method: 'connected_to_signer' as const,
+		result: {
+			metamaskCompatibilityMode: await getMetamaskCompatibilityMode(),
+			signerProviderGenerationSupported: true,
+		},
+	}
 }
 
 function hasSignerCallbackAccess(websiteTabConnections: WebsiteTabConnections, tabId: number, approval: ApprovalState) {
@@ -154,32 +161,33 @@ export async function walletSwitchEthereumChainReply(ethereum: EthereumClientSer
 	return await runSignerStateOperation(websiteTabConnections, socket.tabId, async () => {
 		const currentSignerStateToken = getConfirmedSignerStateToken(websiteTabConnections, socket.tabId)
 		if (currentSignerStateToken?.socket.connectionName !== socket.connectionName || currentSignerStateToken.port !== port) return returnValue
-		const pendingSignerStateToken = getPendingSignerChainChangeTokenForCallback(port, params.signerProviderGeneration, params.chainId)
+		const signerProviderGeneration = params.signerProviderGeneration ?? currentSignerStateToken.signerProviderGeneration
+		const pendingSignerStateToken = getPendingSignerChainChangeTokenForCallback(port, signerProviderGeneration, params.chainId)
 		const callbackSignerStateToken = pendingSignerStateToken
-			?? (currentSignerStateToken.signerProviderGeneration === params.signerProviderGeneration ? currentSignerStateToken : undefined)
+			?? (currentSignerStateToken.signerProviderGeneration === signerProviderGeneration ? currentSignerStateToken : undefined)
 		if (callbackSignerStateToken === undefined) return returnValue
 		const solicitedReply = isPendingSignerChainChangeReply(callbackSignerStateToken, params.chainId)
 		// A solicited wallet reply retains the tab authorization captured when its command was dispatched.
 		// Unsolicited chainChanged-style updates still require a currently approved frame.
 		if (!solicitedReply && !hasSignerCallbackAccess(websiteTabConnections, socket.tabId, approval)) return returnValue
-		if (currentSignerStateToken.signerProviderGeneration !== params.signerProviderGeneration) {
+		if (currentSignerStateToken.signerProviderGeneration !== signerProviderGeneration) {
 			resolveSignerChainChange(callbackSignerStateToken, {
 				method: 'popup_signerChangeChainDialog',
-				data: [{ accept: false, chainId: params.chainId, error: signerConnectionReplacedError, signerProviderGeneration: params.signerProviderGeneration }],
+				data: [{ accept: false, chainId: params.chainId, error: signerConnectionReplacedError, signerProviderGeneration }],
 			})
 			return returnValue
 		}
 		if (params.accept) await changeSignerChain(ethereum, tokenPriceService, resetSimulationServices, websiteTabConnections, currentSignerStateToken, params.chainId, 'hasAccess', activeAddress)
 		resolveSignerChainChange(callbackSignerStateToken, {
 			method: 'popup_signerChangeChainDialog',
-			data: [params],
+			data: [{ ...params, signerProviderGeneration }],
 		})
 		return returnValue
 	})
 }
 
 export async function connectedToSigner(_ethereum: EthereumClientService, _tokenPriceService: TokenPriceService, _resetSimulationServices: ResetSimulationServices, websiteTabConnections: WebsiteTabConnections, port: browser.runtime.Port, request: ProviderMessage, approval: ApprovalState, _activeAddress: bigint | undefined) {
-	const [signerConnected, signerName, signerProviderGeneration] = ConnectedToSigner.parse(request).params
+	const [signerConnected, signerName, reportedSignerProviderGeneration] = ConnectedToSigner.parse(request).params
 	// MV2 and test ports may omit frameId. Treat those as the top frame, while preventing an
 	// unapproved MV3 child frame from taking ownership of tab-wide signer state.
 	const isTopFrame = port.sender?.frameId === undefined || port.sender.frameId === 0
@@ -195,6 +203,9 @@ export async function connectedToSigner(_ethereum: EthereumClientService, _token
 			return await getConnectedToSignerResult()
 		}
 		const previousSignerProviderGeneration = tabConnection.signerStateOwner.providerGeneration
+		// A two-element report is the compatibility handshake used by both pre-generation inpage
+		// scripts and a newly updated inpage script that may still be talking to an older worker.
+		const signerProviderGeneration = reportedSignerProviderGeneration ?? (previousSignerProviderGeneration ?? 0) + 1
 		if (tabConnection.signerStateOwner.confirmed
 			&& previousSignerProviderGeneration !== undefined
 			&& signerProviderGeneration < previousSignerProviderGeneration) {
@@ -219,7 +230,9 @@ export async function connectedToSigner(_ethereum: EthereumClientService, _token
 		confirmSignerState(tabConnection, signerProviderGeneration)
 		await setDefaultSignerName(signerName)
 		await sendPopupMessageToOpenWindows({ method: 'popup_signer_name_changed' })
-		if (hasSignerCallbackAccess(websiteTabConnections, socket.tabId, approval)) {
+		// A legacy report may be the capability probe from a current inpage script. Wait for its
+		// generation-aware follow-up before requesting callbacks that the current worker validates.
+		if (reportedSignerProviderGeneration !== undefined && hasSignerCallbackAccess(websiteTabConnections, socket.tabId, approval)) {
 			const settings = await getSettings()
 			if (!signerMissing && (!settings.simulationMode || settings.useSignersAddressAsActiveAddress)) {
 				sendSubscriptionReplyOrCallBackToPort(port, { type: 'result', method: 'request_signer_chainId', result: [] })
@@ -239,12 +252,16 @@ export async function signerReply(ethereum: EthereumClientService, tokenPriceSer
 		const requestSocket = request.uniqueRequestIdentifier.requestSocket
 		const uniqueRequestIdentifier = { requestId: params.forwardRequest.requestId, requestSocket }
 		const tabConnection = websiteTabConnections.get(socket.tabId)
+		const currentSignerStateToken = getConfirmedSignerStateToken(websiteTabConnections, socket.tabId)
+		const signerProviderGenerationChanged = params.signerProviderGeneration !== undefined
+			&& currentSignerStateToken?.signerProviderGeneration !== params.signerProviderGeneration
 		// Signing is routed back through the frame that originated the request, which may be a child frame.
-		// Unlike tab-wide account and chain cache updates, this reply is scoped by its request id and exact port;
-		// the inpage bridge converts a provider-generation change into a terminal disconnected error.
+		// The request remains scoped by its request id and exact child-frame port, while the provider generation
+		// belongs to the tab-wide signer owner. Legacy replies omit that generation and retain the socket checks.
 		if (!isCurrentWebsiteConnection(tabConnection, socket, port)
 			|| requestSocket.tabId !== socket.tabId
-			|| requestSocket.connectionName !== socket.connectionName) {
+			|| requestSocket.connectionName !== socket.connectionName
+			|| signerProviderGenerationChanged) {
 			await updatePendingTransactionOrMessage(uniqueRequestIdentifier, async (transaction) => modifyObject(transaction, { approvalStatus: { status: 'SignerError', ...signerConnectionReplacedError } }))
 			await updateConfirmTransactionView(ethereum, tokenPriceService)
 			return doNotReply

--- a/app/ts/background/providerMessageHandlers.ts
+++ b/app/ts/background/providerMessageHandlers.ts
@@ -19,23 +19,99 @@ import type { ResetSimulationServices } from '../simulation/serviceLifecycle.js'
 import { isSignerMissing } from '../utils/signerMetadata.js'
 import { beginSignerStateConfirmation, clearSignerDerivedTabState, confirmSignerState, getConfirmedSignerStateToken, isCurrentWebsiteConnection, isSignerStateTokenCurrent, runSignerStateOperation, signerConnectionReplacedError, tabHasApprovedWebsiteConnection, type SignerStateToken } from './signerStateOwnership.js'
 
-function getSignerCallbackToken(websiteTabConnections: WebsiteTabConnections, port: browser.runtime.Port, signerProviderGeneration: number | undefined) {
+const SIGNER_PROTOCOL_VERSION = 1
+const INPAGE_PROTOCOL_CONFIRMATION_TIMEOUT_MS = 250
+type InpageProtocolState = {
+	status: 'negotiating' | 'confirming' | 'compatible' | 'incompatible'
+	readonly confirmation: Promise<void>
+	readonly confirm: () => void
+}
+const inpageProtocolStates = new WeakMap<browser.runtime.Port, InpageProtocolState>()
+const incompatibleInpageProtocolNotifiedPorts = new WeakSet<browser.runtime.Port>()
+
+export function initializeInpageProtocolNegotiation(port: browser.runtime.Port) {
+	const existingState = inpageProtocolStates.get(port)
+	if (existingState !== undefined) return
+	let confirm: () => void = () => undefined
+	const confirmation = new Promise<void>((resolve) => { confirm = resolve })
+	inpageProtocolStates.set(port, { status: 'negotiating', confirmation, confirm })
+}
+
+function beginInpageProtocolConfirmation(port: browser.runtime.Port) {
+	initializeInpageProtocolNegotiation(port)
+	const state = inpageProtocolStates.get(port)
+	if (state === undefined || state.status === 'incompatible') return false
+	if (state.status === 'compatible') return true
+	state.status = 'confirming'
+	return true
+}
+
+function confirmInpageProtocol(port: browser.runtime.Port) {
+	const existingState = inpageProtocolStates.get(port)
+	if (existingState === undefined) {
+		inpageProtocolStates.set(port, { status: 'compatible', confirmation: Promise.resolve(), confirm: () => undefined })
+		return
+	}
+	if (existingState.status === 'incompatible') return
+	existingState.status = 'compatible'
+	existingState.confirm()
+}
+
+export async function hasCompatibleInpageProtocol(port: browser.runtime.Port) {
+	const state = inpageProtocolStates.get(port)
+	if (state === undefined || state.status === 'compatible') return true
+	if (state.status === 'incompatible') return false
+	let timeout: ReturnType<typeof setTimeout> | undefined
+	const confirmationTimeout = new Promise<void>((resolve) => {
+		timeout = setTimeout(resolve, INPAGE_PROTOCOL_CONFIRMATION_TIMEOUT_MS)
+	})
+	try {
+		await Promise.race([state.confirmation, confirmationTimeout])
+	} finally {
+		if (timeout !== undefined) clearTimeout(timeout)
+	}
+	let resolvedState = inpageProtocolStates.get(port)
+	if (resolvedState?.status === 'confirming') {
+		await resolvedState.confirmation
+		resolvedState = inpageProtocolStates.get(port)
+	}
+	if (resolvedState?.status === 'compatible') return true
+	if (resolvedState === undefined) return true
+	resolvedState.status = 'incompatible'
+	resolvedState.confirm()
+	return false
+}
+
+export function notifyIncompatibleInpageProtocol(port: browser.runtime.Port) {
+	if (incompatibleInpageProtocolNotifiedPorts.has(port)) return
+	incompatibleInpageProtocolNotifiedPorts.add(port)
+	sendSubscriptionReplyOrCallBackToPort(port, { type: 'result', method: 'disconnect', result: [] })
+}
+
+function getSignerCallbackToken(websiteTabConnections: WebsiteTabConnections, port: browser.runtime.Port, signerProviderGeneration: number) {
 	const socket = getSocketFromPort(port)
 	if (socket === undefined) return undefined
 	const token = getConfirmedSignerStateToken(websiteTabConnections, socket.tabId)
 	if (token === undefined) return undefined
 	if (token.socket.connectionName !== socket.connectionName || token.port !== port) return undefined
-	if (signerProviderGeneration !== undefined && token.signerProviderGeneration !== signerProviderGeneration) return undefined
+	if (token.signerProviderGeneration !== signerProviderGeneration) return undefined
 	return token
 }
 
-async function getConnectedToSignerResult() {
+async function getConnectedToSignerResult(): Promise<{
+	readonly type: 'result'
+	readonly method: 'connected_to_signer'
+	readonly result: {
+		readonly metamaskCompatibilityMode: boolean
+		readonly signerProtocolVersion: 1
+	}
+}> {
 	return {
 		type: 'result' as const,
 		method: 'connected_to_signer' as const,
 		result: {
 			metamaskCompatibilityMode: await getMetamaskCompatibilityMode(),
-			signerProviderGenerationSupported: true,
+			signerProtocolVersion: SIGNER_PROTOCOL_VERSION,
 		},
 	}
 }
@@ -161,85 +237,97 @@ export async function walletSwitchEthereumChainReply(ethereum: EthereumClientSer
 	return await runSignerStateOperation(websiteTabConnections, socket.tabId, async () => {
 		const currentSignerStateToken = getConfirmedSignerStateToken(websiteTabConnections, socket.tabId)
 		if (currentSignerStateToken?.socket.connectionName !== socket.connectionName || currentSignerStateToken.port !== port) return returnValue
-		const signerProviderGeneration = params.signerProviderGeneration ?? currentSignerStateToken.signerProviderGeneration
-		const pendingSignerStateToken = getPendingSignerChainChangeTokenForCallback(port, signerProviderGeneration, params.chainId)
+		const pendingSignerStateToken = getPendingSignerChainChangeTokenForCallback(port, params.signerProviderGeneration, params.chainId)
 		const callbackSignerStateToken = pendingSignerStateToken
-			?? (currentSignerStateToken.signerProviderGeneration === signerProviderGeneration ? currentSignerStateToken : undefined)
+			?? (currentSignerStateToken.signerProviderGeneration === params.signerProviderGeneration ? currentSignerStateToken : undefined)
 		if (callbackSignerStateToken === undefined) return returnValue
 		const solicitedReply = isPendingSignerChainChangeReply(callbackSignerStateToken, params.chainId)
 		// A solicited wallet reply retains the tab authorization captured when its command was dispatched.
 		// Unsolicited chainChanged-style updates still require a currently approved frame.
 		if (!solicitedReply && !hasSignerCallbackAccess(websiteTabConnections, socket.tabId, approval)) return returnValue
-		if (currentSignerStateToken.signerProviderGeneration !== signerProviderGeneration) {
+		if (currentSignerStateToken.signerProviderGeneration !== params.signerProviderGeneration) {
 			resolveSignerChainChange(callbackSignerStateToken, {
 				method: 'popup_signerChangeChainDialog',
-				data: [{ accept: false, chainId: params.chainId, error: signerConnectionReplacedError, signerProviderGeneration }],
+				data: [{ accept: false, chainId: params.chainId, error: signerConnectionReplacedError, signerProviderGeneration: params.signerProviderGeneration }],
 			})
 			return returnValue
 		}
 		if (params.accept) await changeSignerChain(ethereum, tokenPriceService, resetSimulationServices, websiteTabConnections, currentSignerStateToken, params.chainId, 'hasAccess', activeAddress)
 		resolveSignerChainChange(callbackSignerStateToken, {
 			method: 'popup_signerChangeChainDialog',
-			data: [{ ...params, signerProviderGeneration }],
+			data: [params],
 		})
 		return returnValue
 	})
 }
 
 export async function connectedToSigner(_ethereum: EthereumClientService, _tokenPriceService: TokenPriceService, _resetSimulationServices: ResetSimulationServices, websiteTabConnections: WebsiteTabConnections, port: browser.runtime.Port, request: ProviderMessage, approval: ApprovalState, _activeAddress: bigint | undefined) {
-	const [signerConnected, signerName, reportedSignerProviderGeneration] = ConnectedToSigner.parse(request).params
-	// MV2 and test ports may omit frameId. Treat those as the top frame, while preventing an
-	// unapproved MV3 child frame from taking ownership of tab-wide signer state.
-	const isTopFrame = port.sender?.frameId === undefined || port.sender.frameId === 0
-	if (approval !== 'hasAccess' && !isTopFrame) {
+	const connectedToSigner = ConnectedToSigner.parse(request)
+	if (connectedToSigner.params.length === 2) {
+		// The former two-field message is understood only well enough to identify an injected
+		// script from an incompatible extension version. It must never mutate signer state.
+		initializeInpageProtocolNegotiation(port)
 		return await getConnectedToSignerResult()
 	}
-	const socket = getSocketFromPort(port)
-	const requestSocket = request.uniqueRequestIdentifier.requestSocket
-	if (socket === undefined || socket.tabId !== requestSocket.tabId || socket.connectionName !== requestSocket.connectionName) return await getConnectedToSignerResult()
-	return await runSignerStateOperation(websiteTabConnections, socket.tabId, async () => {
-		const tabConnection = websiteTabConnections.get(socket.tabId)
-		if (!isCurrentWebsiteConnection(tabConnection, socket, port) || tabConnection?.signerStateOwner?.connectionName !== socket.connectionName) {
-			return await getConnectedToSignerResult()
-		}
-		const previousSignerProviderGeneration = tabConnection.signerStateOwner.providerGeneration
-		// A two-element report is the compatibility handshake used by both pre-generation inpage
-		// scripts and a newly updated inpage script that may still be talking to an older worker.
-		const signerProviderGeneration = reportedSignerProviderGeneration ?? (previousSignerProviderGeneration ?? 0) + 1
-		if (tabConnection.signerStateOwner.confirmed
-			&& previousSignerProviderGeneration !== undefined
-			&& signerProviderGeneration < previousSignerProviderGeneration) {
-			return await getConnectedToSignerResult()
-		}
-		const signerStateWasConfirmed = tabConnection.signerStateOwner.confirmed
-		beginSignerStateConfirmation(tabConnection)
-		const signerMissing = isSignerMissing(signerName)
-		await updateTabState(socket.tabId, (previousState: TabState) => {
-			const signerIdentityChanged = previousState.signerName !== signerName
-			const clearSignerState = !signerStateWasConfirmed
-				|| previousSignerProviderGeneration !== signerProviderGeneration
-				|| signerIdentityChanged
-				|| signerMissing
-				|| !signerConnected
-			const baseState = clearSignerState ? clearSignerDerivedTabState(previousState) : previousState
-			return modifyObject(baseState, { signerName, signerConnected: signerMissing ? false : signerConnected })
-		})
-		if (!isCurrentWebsiteConnection(tabConnection, socket, port) || tabConnection.signerStateOwner.connectionName !== socket.connectionName) {
-			return await getConnectedToSignerResult()
-		}
-		confirmSignerState(tabConnection, signerProviderGeneration)
-		await setDefaultSignerName(signerName)
-		await sendPopupMessageToOpenWindows({ method: 'popup_signer_name_changed' })
-		// A legacy report may be the capability probe from a current inpage script. Wait for its
-		// generation-aware follow-up before requesting callbacks that the current worker validates.
-		if (reportedSignerProviderGeneration !== undefined && hasSignerCallbackAccess(websiteTabConnections, socket.tabId, approval)) {
-			const settings = await getSettings()
-			if (!signerMissing && (!settings.simulationMode || settings.useSignersAddressAsActiveAddress)) {
-				sendSubscriptionReplyOrCallBackToPort(port, { type: 'result', method: 'request_signer_chainId', result: [] })
+	if (!beginInpageProtocolConfirmation(port)) return await getConnectedToSignerResult()
+	try {
+		const [signerConnected, signerName, signerProviderGeneration] = connectedToSigner.params
+		// MV2 and test ports may omit frameId. Treat those as the top frame, while preventing an
+		// unapproved MV3 child frame from taking ownership of tab-wide signer state.
+		const isTopFrame = port.sender?.frameId === undefined || port.sender.frameId === 0
+		let result: Awaited<ReturnType<typeof getConnectedToSignerResult>>
+		if (approval !== 'hasAccess' && !isTopFrame) {
+			result = await getConnectedToSignerResult()
+		} else {
+			const socket = getSocketFromPort(port)
+			const requestSocket = request.uniqueRequestIdentifier.requestSocket
+			if (socket === undefined || socket.tabId !== requestSocket.tabId || socket.connectionName !== requestSocket.connectionName) {
+				result = await getConnectedToSignerResult()
+			} else {
+				result = await runSignerStateOperation(websiteTabConnections, socket.tabId, async () => {
+					const tabConnection = websiteTabConnections.get(socket.tabId)
+					if (!isCurrentWebsiteConnection(tabConnection, socket, port) || tabConnection?.signerStateOwner?.connectionName !== socket.connectionName) {
+						return await getConnectedToSignerResult()
+					}
+					const previousSignerProviderGeneration = tabConnection.signerStateOwner.providerGeneration
+					if (tabConnection.signerStateOwner.confirmed
+						&& previousSignerProviderGeneration !== undefined
+						&& signerProviderGeneration < previousSignerProviderGeneration) {
+						return await getConnectedToSignerResult()
+					}
+					const signerStateWasConfirmed = tabConnection.signerStateOwner.confirmed
+					beginSignerStateConfirmation(tabConnection)
+					const signerMissing = isSignerMissing(signerName)
+					await updateTabState(socket.tabId, (previousState: TabState) => {
+						const signerIdentityChanged = previousState.signerName !== signerName
+						const clearSignerState = !signerStateWasConfirmed
+							|| previousSignerProviderGeneration !== signerProviderGeneration
+							|| signerIdentityChanged
+							|| signerMissing
+							|| !signerConnected
+						const baseState = clearSignerState ? clearSignerDerivedTabState(previousState) : previousState
+						return modifyObject(baseState, { signerName, signerConnected: signerMissing ? false : signerConnected })
+					})
+					if (!isCurrentWebsiteConnection(tabConnection, socket, port) || tabConnection.signerStateOwner.connectionName !== socket.connectionName) {
+						return await getConnectedToSignerResult()
+					}
+					confirmSignerState(tabConnection, signerProviderGeneration)
+					await setDefaultSignerName(signerName)
+					await sendPopupMessageToOpenWindows({ method: 'popup_signer_name_changed' })
+					if (hasSignerCallbackAccess(websiteTabConnections, socket.tabId, approval)) {
+						const settings = await getSettings()
+						if (!signerMissing && (!settings.simulationMode || settings.useSignersAddressAsActiveAddress)) {
+							sendSubscriptionReplyOrCallBackToPort(port, { type: 'result', method: 'request_signer_chainId', result: [] })
+						}
+					}
+					return await getConnectedToSignerResult()
+				})
 			}
 		}
-		return await getConnectedToSignerResult()
-	})
+		return result
+	} finally {
+		confirmInpageProtocol(port)
+	}
 }
 
 export async function signerReply(ethereum: EthereumClientService, tokenPriceService: TokenPriceService, _resetSimulationServices: ResetSimulationServices, websiteTabConnections: WebsiteTabConnections, port: browser.runtime.Port, request: ProviderMessage, _approval: ApprovalState, _activeAddress: bigint | undefined) {
@@ -253,11 +341,10 @@ export async function signerReply(ethereum: EthereumClientService, tokenPriceSer
 		const uniqueRequestIdentifier = { requestId: params.forwardRequest.requestId, requestSocket }
 		const tabConnection = websiteTabConnections.get(socket.tabId)
 		const currentSignerStateToken = getConfirmedSignerStateToken(websiteTabConnections, socket.tabId)
-		const signerProviderGenerationChanged = params.signerProviderGeneration !== undefined
-			&& currentSignerStateToken?.signerProviderGeneration !== params.signerProviderGeneration
+		const signerProviderGenerationChanged = currentSignerStateToken?.signerProviderGeneration !== params.signerProviderGeneration
 		// Signing is routed back through the frame that originated the request, which may be a child frame.
 		// The request remains scoped by its request id and exact child-frame port, while the provider generation
-		// belongs to the tab-wide signer owner. Legacy replies omit that generation and retain the socket checks.
+		// belongs to the tab-wide signer owner.
 		if (!isCurrentWebsiteConnection(tabConnection, socket, port)
 			|| requestSocket.tabId !== socket.tabId
 			|| requestSocket.connectionName !== socket.connectionName

--- a/app/ts/types/JsonRpc-types.ts
+++ b/app/ts/types/JsonRpc-types.ts
@@ -188,7 +188,7 @@ export const SendRawTransactionParams = funtypes.ReadonlyObject({
 export type EthereumAccountsReply = funtypes.Static<typeof EthereumAccountsReply>
 export const EthereumAccountsReply = funtypes.ReadonlyTuple(
 	funtypes.Intersect(
-		funtypes.ReadonlyPartial({
+		funtypes.ReadonlyObject({
 			signerProviderGeneration: funtypes.Number,
 		}),
 		funtypes.Union(
@@ -220,10 +220,7 @@ export const EthereumAccountsReply = funtypes.ReadonlyTuple(
 )
 
 export type EthereumChainReply = funtypes.Static<typeof EthereumChainReply>
-export const EthereumChainReply = funtypes.Union(
-	funtypes.ReadonlyTuple(EthereumQuantity),
-	funtypes.ReadonlyTuple(EthereumQuantity, funtypes.Number),
-)
+export const EthereumChainReply = funtypes.ReadonlyTuple(EthereumQuantity, funtypes.Number)
 
 export type TransactionReceiptParams = funtypes.Static<typeof TransactionReceiptParams>
 export const TransactionReceiptParams = funtypes.ReadonlyObject({

--- a/app/ts/types/JsonRpc-types.ts
+++ b/app/ts/types/JsonRpc-types.ts
@@ -188,7 +188,7 @@ export const SendRawTransactionParams = funtypes.ReadonlyObject({
 export type EthereumAccountsReply = funtypes.Static<typeof EthereumAccountsReply>
 export const EthereumAccountsReply = funtypes.ReadonlyTuple(
 	funtypes.Intersect(
-		funtypes.ReadonlyObject({
+		funtypes.ReadonlyPartial({
 			signerProviderGeneration: funtypes.Number,
 		}),
 		funtypes.Union(
@@ -220,7 +220,10 @@ export const EthereumAccountsReply = funtypes.ReadonlyTuple(
 )
 
 export type EthereumChainReply = funtypes.Static<typeof EthereumChainReply>
-export const EthereumChainReply = funtypes.ReadonlyTuple(EthereumQuantity, funtypes.Number)
+export const EthereumChainReply = funtypes.Union(
+	funtypes.ReadonlyTuple(EthereumQuantity),
+	funtypes.ReadonlyTuple(EthereumQuantity, funtypes.Number),
+)
 
 export type TransactionReceiptParams = funtypes.Static<typeof TransactionReceiptParams>
 export const TransactionReceiptParams = funtypes.ReadonlyObject({

--- a/app/ts/types/interceptor-messages.ts
+++ b/app/ts/types/interceptor-messages.ts
@@ -19,18 +19,19 @@ import { SimulateGnosisSafeTransaction as SharedSimulateGnosisSafeTransaction, S
 import { EthSimulateV1Result } from './ethSimulate-types.js'
 
 type WalletSwitchEthereumChainReplyParams = funtypes.Static<typeof WalletSwitchEthereumChainReplyParams>
-const WalletSwitchEthereumChainReplyParams = funtypes.Tuple(funtypes.Union(
-	funtypes.ReadonlyObject({
-		accept: funtypes.Literal(true),
-		chainId: EthereumQuantity,
-		signerProviderGeneration: funtypes.Number,
-	}),
-	funtypes.ReadonlyObject({
-		accept: funtypes.Literal(false),
-		chainId: EthereumQuantity,
-		error: ErrorWithCodeAndOptionalData,
-		signerProviderGeneration: funtypes.Number,
-	})
+const WalletSwitchEthereumChainReplyParams = funtypes.Tuple(funtypes.Intersect(
+	funtypes.ReadonlyPartial({ signerProviderGeneration: funtypes.Number }),
+	funtypes.Union(
+		funtypes.ReadonlyObject({
+			accept: funtypes.Literal(true),
+			chainId: EthereumQuantity,
+		}),
+		funtypes.ReadonlyObject({
+			accept: funtypes.Literal(false),
+			chainId: EthereumQuantity,
+			error: ErrorWithCodeAndOptionalData,
+		})
+	),
 ))
 
 export type WalletSwitchEthereumChainReply = funtypes.Static<typeof WalletSwitchEthereumChainReply>
@@ -46,7 +47,13 @@ const InpageScriptRequestWithoutIdentifier = funtypes.Union(
 	funtypes.ReadonlyObject({ method: funtypes.Literal('signer_reply'), result: funtypes.Unknown }),
 	funtypes.ReadonlyObject({ method: funtypes.Literal('eth_accounts_reply'), result: funtypes.Literal('0x') }),
 	funtypes.ReadonlyObject({ method: funtypes.Literal('signer_chainChanged'), result: funtypes.Literal('0x') }),
-	funtypes.ReadonlyObject({ method: funtypes.Literal('connected_to_signer'), result: funtypes.ReadonlyObject({ metamaskCompatibilityMode: funtypes.Boolean }) }),
+	funtypes.ReadonlyObject({
+		method: funtypes.Literal('connected_to_signer'),
+		result: funtypes.ReadonlyObject({
+			metamaskCompatibilityMode: funtypes.Boolean,
+			signerProviderGenerationSupported: funtypes.Boolean,
+		}),
+	}),
 	funtypes.ReadonlyObject({ method: funtypes.Literal('wallet_switchEthereumChain_reply'), result: funtypes.Literal('0x') }),
 )
 
@@ -400,7 +407,10 @@ export const SignerChainChangeConfirmation = funtypes.ReadonlyObject({
 export type ConnectedToSigner = funtypes.Static<typeof ConnectedToSigner>
 export const ConnectedToSigner = funtypes.ReadonlyObject({
 	method: funtypes.Literal('connected_to_signer'),
-	params: funtypes.Tuple(funtypes.Boolean, SignerName, funtypes.Number),
+	params: funtypes.Union(
+		funtypes.Tuple(funtypes.Boolean, SignerName),
+		funtypes.Tuple(funtypes.Boolean, SignerName, funtypes.Number),
+	),
 }).asReadonly()
 
 
@@ -414,7 +424,7 @@ export type SignerReply = funtypes.Static<typeof SignerReply>
 export const SignerReply = funtypes.ReadonlyObject({
 	method: funtypes.Literal('signer_reply'),
 	params: funtypes.Tuple(funtypes.Intersect(
-		funtypes.ReadonlyObject({ signerProviderGeneration: funtypes.Number }),
+		funtypes.ReadonlyPartial({ signerProviderGeneration: funtypes.Number }),
 		funtypes.Union(
 			funtypes.ReadonlyObject({
 				success: funtypes.Literal(true),

--- a/app/ts/types/interceptor-messages.ts
+++ b/app/ts/types/interceptor-messages.ts
@@ -19,19 +19,18 @@ import { SimulateGnosisSafeTransaction as SharedSimulateGnosisSafeTransaction, S
 import { EthSimulateV1Result } from './ethSimulate-types.js'
 
 type WalletSwitchEthereumChainReplyParams = funtypes.Static<typeof WalletSwitchEthereumChainReplyParams>
-const WalletSwitchEthereumChainReplyParams = funtypes.Tuple(funtypes.Intersect(
-	funtypes.ReadonlyPartial({ signerProviderGeneration: funtypes.Number }),
-	funtypes.Union(
-		funtypes.ReadonlyObject({
-			accept: funtypes.Literal(true),
-			chainId: EthereumQuantity,
-		}),
-		funtypes.ReadonlyObject({
-			accept: funtypes.Literal(false),
-			chainId: EthereumQuantity,
-			error: ErrorWithCodeAndOptionalData,
-		})
-	),
+const WalletSwitchEthereumChainReplyParams = funtypes.Tuple(funtypes.Union(
+	funtypes.ReadonlyObject({
+		accept: funtypes.Literal(true),
+		chainId: EthereumQuantity,
+		signerProviderGeneration: funtypes.Number,
+	}),
+	funtypes.ReadonlyObject({
+		accept: funtypes.Literal(false),
+		chainId: EthereumQuantity,
+		error: ErrorWithCodeAndOptionalData,
+		signerProviderGeneration: funtypes.Number,
+	})
 ))
 
 export type WalletSwitchEthereumChainReply = funtypes.Static<typeof WalletSwitchEthereumChainReply>
@@ -51,7 +50,7 @@ const InpageScriptRequestWithoutIdentifier = funtypes.Union(
 		method: funtypes.Literal('connected_to_signer'),
 		result: funtypes.ReadonlyObject({
 			metamaskCompatibilityMode: funtypes.Boolean,
-			signerProviderGenerationSupported: funtypes.Boolean,
+			signerProtocolVersion: funtypes.Literal(1),
 		}),
 	}),
 	funtypes.ReadonlyObject({ method: funtypes.Literal('wallet_switchEthereumChain_reply'), result: funtypes.Literal('0x') }),
@@ -424,7 +423,7 @@ export type SignerReply = funtypes.Static<typeof SignerReply>
 export const SignerReply = funtypes.ReadonlyObject({
 	method: funtypes.Literal('signer_reply'),
 	params: funtypes.Tuple(funtypes.Intersect(
-		funtypes.ReadonlyPartial({ signerProviderGeneration: funtypes.Number }),
+		funtypes.ReadonlyObject({ signerProviderGeneration: funtypes.Number }),
 		funtypes.Union(
 			funtypes.ReadonlyObject({
 				success: funtypes.Literal(true),

--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
 		"build-firefox": "bun run compile-app && bun run bundle && bun run firefox",
 		"build-chrome": "bun run compile-app && bun run bundle && bun run chrome",
 		"benchmark:popup-lifecycle": "bun ./test/benchmarks/popupLifecycleChrome.ts",
+		"benchmark:signer-connection": "bun ./test/benchmarks/signerConnectionChrome.ts",
 		"test:chrome-communication": "bun ./test/benchmarks/chromeCommunication.ts",
 		"test:chrome-signing-communication": "bun ./test/benchmarks/chromeSigningCommunication.ts",
 		"vendor": "cd build && bun install --frozen-lockfile && bun run vendor",

--- a/test/benchmarks/README.md
+++ b/test/benchmarks/README.md
@@ -55,3 +55,19 @@ BENCH_SCENARIO=stacked bun run benchmark:popup-lifecycle
 
 The real browser benchmark does not seed `browser.storage.local` and it does not use a local JSON-RPC fixture server.
 For the `stacked` scenario, it prints the send-transaction setup phases, the end-to-end send-transaction-to-main-popup path, the RPCs from the transaction/balance setup, and the RPCs observed while the main popup itself is opening.
+
+## Signer connection benchmark
+
+The signer connection benchmark measures document-start injection through the first
+`eth_chainId` request sent to an injected signer. It runs five warmups followed by
+30 measured page connections:
+
+```bash
+bun run benchmark:signer-connection
+```
+
+To benchmark a separately built extension directory:
+
+```bash
+INTERCEPTOR_BENCH_EXTENSION_DIR=/path/to/extension bun run benchmark:signer-connection
+```

--- a/test/benchmarks/signerConnectionChrome.ts
+++ b/test/benchmarks/signerConnectionChrome.ts
@@ -1,0 +1,109 @@
+import { closeTarget, connectTarget, createTargetPage, launchChromeSession, waitForAnyExtensionServiceWorker, waitForPerformanceMarks, waitForRegisteredContentScripts } from './chromeHarness.js'
+import { startChromeCommunicationPageServer } from './chromeCommunicationPageServer.js'
+import type { CdpConnection } from './chromeHarness.js'
+
+const extensionDir = globalThis.process.env.INTERCEPTOR_BENCH_EXTENSION_DIR
+const warmupCount = 5
+const sampleCount = 30
+
+function sleep(ms: number) {
+	return new Promise<void>((resolve) => setTimeout(resolve, ms))
+}
+
+async function waitForSignerConnectionLatency(connection: CdpConnection, timeoutMs: number) {
+	const start = Date.now()
+	while (Date.now() - start <= timeoutMs) {
+		const latency = await connection.evaluate<number | undefined>('globalThis.__interceptorSignerConnectionLatencyMs').catch(() => undefined)
+		if (typeof latency === 'number') return latency
+		await sleep(5)
+	}
+	throw new Error(`Timed out waiting for signer connection after ${ timeoutMs }ms`)
+}
+
+const fakeSignerPreload = `(() => {
+	const startedAt = performance.now()
+	const listeners = new Map()
+	const signer = {
+		isMetaMask: true,
+		isConnected: () => true,
+		request: async ({ method }) => {
+			if (method === 'eth_chainId') {
+				globalThis.__interceptorSignerConnectionLatencyMs ??= performance.now() - startedAt
+				return '0x1'
+			}
+			if (method === 'eth_accounts' || method === 'eth_requestAccounts') return []
+			throw Object.assign(new Error('Unsupported benchmark signer method: ' + method), { code: -32601 })
+		},
+		on: (event, callback) => {
+			listeners.set(event, [...listeners.get(event) ?? [], callback])
+			return signer
+		},
+		removeListener: (event, callback) => {
+			listeners.set(event, (listeners.get(event) ?? []).filter((candidate) => candidate !== callback))
+			return signer
+		},
+	}
+	globalThis.ethereum = signer
+})()`
+
+function percentile(sortedValues: readonly number[], percentileValue: number) {
+	const index = Math.min(sortedValues.length - 1, Math.ceil(sortedValues.length * percentileValue) - 1)
+	const value = sortedValues[index]
+	if (value === undefined) throw new Error('Cannot calculate a percentile without samples')
+	return value
+}
+
+function summarize(samples: readonly number[]) {
+	const sortedSamples = [...samples].sort((first, second) => first - second)
+	const total = samples.reduce((sum, sample) => sum + sample, 0)
+	return {
+		samples: samples.length,
+		meanMs: total / samples.length,
+		medianMs: percentile(sortedSamples, 0.5),
+		p95Ms: percentile(sortedSamples, 0.95),
+		minMs: sortedSamples[0],
+		maxMs: sortedSamples.at(-1),
+	}
+}
+
+async function main() {
+	const server = await startChromeCommunicationPageServer()
+	const chrome = extensionDir === undefined ? await launchChromeSession() : await launchChromeSession(extensionDir)
+	try {
+		const workerTarget = await waitForAnyExtensionServiceWorker(chrome.browserDebugPort, 30_000)
+		const workerConnection = await connectTarget(chrome.browserDebugPort, workerTarget.id)
+		try {
+			await waitForPerformanceMarks(workerConnection, ['interceptor:background:loaded'], 30_000)
+			await waitForRegisteredContentScripts(workerConnection, ['inpage', 'inpage2'], 30_000)
+		} finally {
+			workerConnection.close()
+		}
+
+		const latencies: number[] = []
+		for (let iteration = 0; iteration < warmupCount + sampleCount; iteration++) {
+			const pageTargetId = await createTargetPage(chrome.browserConnection, 'about:blank')
+			const pageConnection = await connectTarget(chrome.browserDebugPort, pageTargetId)
+			try {
+				await pageConnection.send('Page.enable')
+				await pageConnection.send('Page.addScriptToEvaluateOnNewDocument', { source: fakeSignerPreload })
+				await pageConnection.send('Page.navigate', { url: `${ server.baseUrl }?signer-connection-benchmark=${ iteration }` })
+				const latency = await waitForSignerConnectionLatency(pageConnection, 10_000)
+				if (iteration >= warmupCount) latencies.push(latency)
+			} finally {
+				pageConnection.close()
+				await closeTarget(chrome.browserConnection, pageTargetId).catch(() => undefined)
+			}
+		}
+
+		console.warn(JSON.stringify({
+			extensionDir: extensionDir ?? 'app',
+			warmupCount,
+			...summarize(latencies),
+		}, undefined, 2))
+	} finally {
+		await chrome.close().catch(() => undefined)
+		await server.close().catch(() => undefined)
+	}
+}
+
+await main()

--- a/test/tests/backgroundEthAccounts.test.ts
+++ b/test/tests/backgroundEthAccounts.test.ts
@@ -105,6 +105,7 @@ async function loadModules() {
 		...await import('../../app/ts/background/background.js'),
 		...await import('../../app/ts/background/backgroundUtils.js'),
 		...await import('../../app/ts/background/popupMessageHandlers.js'),
+		...await import('../../app/ts/background/providerMessageHandlers.js'),
 		...await import('../../app/ts/background/settings.js'),
 		...await import('../../app/ts/background/storageVariables.js'),
 		...await import('../../app/ts/background/websiteTabConnections.js'),
@@ -1959,10 +1960,10 @@ params: [{ signerProviderGeneration: 1, type: 'success', accounts: ['0x333333333
 		await handleInterceptedRequest(port, websiteOrigin, website, ethereum, tokenPriceService, resetSimulationServices, socket, request, websiteTabConnections, noopPublishRpcConnectionStatus)
 
 		const connectedReplies = messages.filter((message) => message.method === 'connected_to_signer' && message.requestId === 12)
-		assert.deepEqual(connectedReplies.at(-1)?.result, { metamaskCompatibilityMode: false, signerProviderGenerationSupported: true })
+		assert.deepEqual(connectedReplies.at(-1)?.result, { metamaskCompatibilityMode: false, signerProtocolVersion: 1 })
 	})
 
-	test('accepts the legacy connected_to_signer shape during an extension update', async () => {
+	test('invalidates a legacy signer protocol without accepting its callbacks', async () => {
 		installBrowserMock()
 		const { getTabState, handleInterceptedRequest, websiteSocketToString } = await loadModules()
 		const websiteOrigin = 'https://example.test'
@@ -1986,7 +1987,7 @@ params: [{ signerProviderGeneration: 1, type: 'success', accounts: ['0x333333333
 		await handleInterceptedRequest(port, websiteOrigin, website, ethereum, tokenPriceService, resetSimulationServices, socket, request, websiteTabConnections, noopPublishRpcConnectionStatus)
 
 		const connectedReply = messages.find((message) => message.method === 'connected_to_signer' && message.requestId === 12)
-		assert.deepEqual(connectedReply?.result, { metamaskCompatibilityMode: false, signerProviderGenerationSupported: true })
+		assert.deepEqual(connectedReply?.result, { metamaskCompatibilityMode: false, signerProtocolVersion: 1 })
 
 		await handleInterceptedRequest(port, websiteOrigin, website, ethereum, tokenPriceService, resetSimulationServices, socket, {
 			...request,
@@ -1995,15 +1996,183 @@ params: [{ signerProviderGeneration: 1, type: 'success', accounts: ['0x333333333
 			params: [{ type: 'success', accounts: ['0x1111111111111111111111111111111111111111'], requestAccounts: false }],
 		}, websiteTabConnections, noopPublishRpcConnectionStatus)
 		await handleInterceptedRequest(port, websiteOrigin, website, ethereum, tokenPriceService, resetSimulationServices, socket, {
-			...request,
+			interceptorRequest: true,
+			usingInterceptorWithoutSigner: false,
 			uniqueRequestIdentifier: { requestId: 14, requestSocket: socket },
-			method: 'signer_chainChanged',
-			params: ['0x1'],
+			method: 'eth_chainId',
+			params: [],
 		}, websiteTabConnections, noopPublishRpcConnectionStatus)
 
 		const tabState = await getTabState(socket.tabId)
-		assert.deepEqual(tabState.signerAccounts, [0x1111111111111111111111111111111111111111n])
-		assert.equal(tabState.signerChain, 1n)
+		assert.deepEqual(tabState.signerAccounts, [])
+		assert.equal(tabState.signerChain, undefined)
+		assert.equal(messages.filter((message) => message.method === 'disconnect').length, 1)
+		const publicReply = messages.find((message) => message.method === 'eth_chainId' && message.requestId === 14)
+		assert.equal(publicReply?.error?.code, 4900)
+		assert.equal(publicReply?.error?.message, 'Interceptor was updated while this page was open. Reload the page to reconnect.')
+	})
+
+	test('waits for a raced current signer status instead of invalidating the page', async () => {
+		installBrowserMock()
+		const { handleInterceptedRequest, websiteSocketToString } = await loadModules()
+		const websiteOrigin = 'https://example.test'
+		const website = { websiteOrigin, icon: undefined, title: undefined }
+		const socket = { tabId: 1, connectionName: 0n }
+		const { port, messages } = createPort(socket.tabId)
+		const connectionKey = websiteSocketToString(socket)
+		const websiteTabConnections = new Map([[socket.tabId, { ...confirmedSignerOwnership(socket), connections: {
+			[connectionKey]: { port, socket, websiteOrigin, approved: true, wantsToConnect: true },
+		} }]])
+		const { ethereum, tokenPriceService, resetSimulationServices } = createEthereumWithGetBlockCounter({ count: 0 })
+		const baseRequest = {
+			interceptorRequest: true,
+			usingInterceptorWithoutSigner: false,
+			uniqueRequestIdentifier: { requestId: 12, requestSocket: socket },
+		}
+
+		await handleInterceptedRequest(port, websiteOrigin, website, ethereum, tokenPriceService, resetSimulationServices, socket, {
+			...baseRequest,
+			interceptorInternalRequest: true,
+			method: 'connected_to_signer',
+			params: [false, 'NoSigner'],
+		}, websiteTabConnections, noopPublishRpcConnectionStatus)
+		const racedPublicRequest = handleInterceptedRequest(port, websiteOrigin, website, ethereum, tokenPriceService, resetSimulationServices, socket, {
+			...baseRequest,
+			uniqueRequestIdentifier: { requestId: 13, requestSocket: socket },
+			method: 'eth_chainId',
+			params: [],
+		}, websiteTabConnections, noopPublishRpcConnectionStatus)
+		await handleInterceptedRequest(port, websiteOrigin, website, ethereum, tokenPriceService, resetSimulationServices, socket, {
+			...baseRequest,
+			interceptorInternalRequest: true,
+			uniqueRequestIdentifier: { requestId: 14, requestSocket: socket },
+			method: 'connected_to_signer',
+			params: [true, 'MetaMask', 2],
+		}, websiteTabConnections, noopPublishRpcConnectionStatus)
+		await racedPublicRequest
+
+		assert.equal(messages.filter((message) => message.method === 'disconnect').length, 0)
+		const publicReply = messages.find((message) => message.method === 'eth_chainId' && message.requestId === 13)
+		assert.equal(publicReply?.error, undefined)
+		assert.equal(publicReply?.result, '0x1')
+	})
+
+	test('waits for current signer status before releasing traffic from a newly registered port', async () => {
+		installBrowserMock()
+		const { handleInterceptedRequest, initializeInpageProtocolNegotiation, websiteSocketToString } = await loadModules()
+		const websiteOrigin = 'https://example.test'
+		const website = { websiteOrigin, icon: undefined, title: undefined }
+		const socket = { tabId: 1, connectionName: 0n }
+		const { port, messages } = createPort(socket.tabId)
+		initializeInpageProtocolNegotiation(port)
+		const connectionKey = websiteSocketToString(socket)
+		const websiteTabConnections = new Map([[socket.tabId, { ...confirmedSignerOwnership(socket), connections: {
+			[connectionKey]: { port, socket, websiteOrigin, approved: true, wantsToConnect: true },
+		} }]])
+		const { ethereum, tokenPriceService, resetSimulationServices } = createEthereumWithGetBlockCounter({ count: 0 })
+		const baseRequest = {
+			interceptorRequest: true,
+			usingInterceptorWithoutSigner: false,
+			uniqueRequestIdentifier: { requestId: 20, requestSocket: socket },
+		}
+
+		const racedPublicRequest = handleInterceptedRequest(port, websiteOrigin, website, ethereum, tokenPriceService, resetSimulationServices, socket, {
+			...baseRequest,
+			method: 'eth_chainId',
+			params: [],
+		}, websiteTabConnections, noopPublishRpcConnectionStatus)
+		await handleInterceptedRequest(port, websiteOrigin, website, ethereum, tokenPriceService, resetSimulationServices, socket, {
+			...baseRequest,
+			interceptorInternalRequest: true,
+			uniqueRequestIdentifier: { requestId: 21, requestSocket: socket },
+			method: 'connected_to_signer',
+			params: [true, 'MetaMask', 2],
+		}, websiteTabConnections, noopPublishRpcConnectionStatus)
+		await racedPublicRequest
+
+		assert.equal(messages.filter((message) => message.method === 'disconnect').length, 0)
+		const publicReply = messages.find((message) => message.method === 'eth_chainId' && message.requestId === 20)
+		assert.equal(publicReply?.error, undefined)
+		assert.equal(publicReply?.result, '0x1')
+	})
+
+	test('invalidates traffic when a newly registered port never confirms its signer protocol', async () => {
+		installBrowserMock()
+		const { handleInterceptedRequest, initializeInpageProtocolNegotiation, websiteSocketToString } = await loadModules()
+		const websiteOrigin = 'https://example.test'
+		const website = { websiteOrigin, icon: undefined, title: undefined }
+		const socket = { tabId: 1, connectionName: 0n }
+		const { port, messages } = createPort(socket.tabId)
+		initializeInpageProtocolNegotiation(port)
+		const connectionKey = websiteSocketToString(socket)
+		const websiteTabConnections = new Map([[socket.tabId, { ...confirmedSignerOwnership(socket), connections: {
+			[connectionKey]: { port, socket, websiteOrigin, approved: true, wantsToConnect: true },
+		} }]])
+		const { ethereum, tokenPriceService, resetSimulationServices } = createEthereumWithGetBlockCounter({ count: 0 })
+
+		await handleInterceptedRequest(port, websiteOrigin, website, ethereum, tokenPriceService, resetSimulationServices, socket, {
+			interceptorRequest: true,
+			usingInterceptorWithoutSigner: false,
+			uniqueRequestIdentifier: { requestId: 22, requestSocket: socket },
+			method: 'eth_chainId',
+			params: [],
+		}, websiteTabConnections, noopPublishRpcConnectionStatus)
+
+		assert.equal(messages.filter((message) => message.method === 'disconnect').length, 1)
+		const publicReply = messages.find((message) => message.method === 'eth_chainId' && message.requestId === 22)
+		assert.equal(publicReply?.error?.code, 4900)
+		assert.equal(publicReply?.error?.message, 'Interceptor was updated while this page was open. Reload the page to reconnect.')
+	})
+
+	test('keeps a confirmed port compatible while a later signer status update is pending', async () => {
+		installBrowserMock()
+		const { handleInterceptedRequest, initializeInpageProtocolNegotiation, runSignerStateOperation, websiteSocketToString } = await loadModules()
+		const websiteOrigin = 'https://example.test'
+		const website = { websiteOrigin, icon: undefined, title: undefined }
+		const socket = { tabId: 1, connectionName: 0n }
+		const { port, messages } = createPort(socket.tabId)
+		initializeInpageProtocolNegotiation(port)
+		const connectionKey = websiteSocketToString(socket)
+		const websiteTabConnections = new Map([[socket.tabId, { ...confirmedSignerOwnership(socket), connections: {
+			[connectionKey]: { port, socket, websiteOrigin, approved: true, wantsToConnect: true },
+		} }]])
+		const { ethereum, tokenPriceService, resetSimulationServices } = createEthereumWithGetBlockCounter({ count: 0 })
+		const statusRequest = {
+			interceptorRequest: true,
+			interceptorInternalRequest: true,
+			usingInterceptorWithoutSigner: false,
+			uniqueRequestIdentifier: { requestId: 23, requestSocket: socket },
+			method: 'connected_to_signer',
+			params: [true, 'MetaMask', 2],
+		}
+		await handleInterceptedRequest(port, websiteOrigin, website, ethereum, tokenPriceService, resetSimulationServices, socket, statusRequest, websiteTabConnections, noopPublishRpcConnectionStatus)
+
+		const blockerStarted = createDeferredSignal()
+		const releaseBlocker = createDeferredSignal()
+		const blocker = runSignerStateOperation(websiteTabConnections, socket.tabId, async () => {
+			blockerStarted.resolve()
+			await releaseBlocker.promise
+		})
+		await blockerStarted.promise
+		const laterStatus = handleInterceptedRequest(port, websiteOrigin, website, ethereum, tokenPriceService, resetSimulationServices, socket, {
+			...statusRequest,
+			uniqueRequestIdentifier: { requestId: 24, requestSocket: socket },
+			params: [true, 'MetaMask', 3],
+		}, websiteTabConnections, noopPublishRpcConnectionStatus)
+		const racedPublicRequest = handleInterceptedRequest(port, websiteOrigin, website, ethereum, tokenPriceService, resetSimulationServices, socket, {
+			interceptorRequest: true,
+			usingInterceptorWithoutSigner: false,
+			uniqueRequestIdentifier: { requestId: 25, requestSocket: socket },
+			method: 'eth_chainId',
+			params: [],
+		}, websiteTabConnections, noopPublishRpcConnectionStatus)
+		releaseBlocker.resolve()
+		await Promise.all([blocker, laterStatus, racedPublicRequest])
+
+		assert.equal(messages.filter((message) => message.method === 'disconnect').length, 0)
+		const publicReply = messages.find((message) => message.method === 'eth_chainId' && message.requestId === 25)
+		assert.equal(publicReply?.error, undefined)
+		assert.equal(publicReply?.result, '0x1')
 	})
 
 	test('opens address access dialog after signer account discovery for site-approved eth_requestAccounts', async () => {

--- a/test/tests/backgroundEthAccounts.test.ts
+++ b/test/tests/backgroundEthAccounts.test.ts
@@ -1959,7 +1959,51 @@ params: [{ signerProviderGeneration: 1, type: 'success', accounts: ['0x333333333
 		await handleInterceptedRequest(port, websiteOrigin, website, ethereum, tokenPriceService, resetSimulationServices, socket, request, websiteTabConnections, noopPublishRpcConnectionStatus)
 
 		const connectedReplies = messages.filter((message) => message.method === 'connected_to_signer' && message.requestId === 12)
-		assert.deepEqual(connectedReplies.at(-1)?.result, { metamaskCompatibilityMode: false })
+		assert.deepEqual(connectedReplies.at(-1)?.result, { metamaskCompatibilityMode: false, signerProviderGenerationSupported: true })
+	})
+
+	test('accepts the legacy connected_to_signer shape during an extension update', async () => {
+		installBrowserMock()
+		const { getTabState, handleInterceptedRequest, websiteSocketToString } = await loadModules()
+		const websiteOrigin = 'https://example.test'
+		const website = { websiteOrigin, icon: undefined, title: undefined }
+		const socket = { tabId: 1, connectionName: 0n }
+		const { port, messages } = createPort(socket.tabId)
+		const connectionKey = websiteSocketToString(socket)
+		const websiteTabConnections = new Map([[socket.tabId, { ...confirmedSignerOwnership(socket), connections: {
+			[connectionKey]: { port, socket, websiteOrigin, approved: true, wantsToConnect: true },
+		} }]])
+		const { ethereum, tokenPriceService, resetSimulationServices } = createEthereumWithGetBlockCounter({ count: 0 })
+		const request = {
+			interceptorRequest: true,
+			interceptorInternalRequest: true,
+			usingInterceptorWithoutSigner: false,
+			uniqueRequestIdentifier: { requestId: 12, requestSocket: socket },
+			method: 'connected_to_signer',
+			params: [true, 'MetaMask'],
+		}
+
+		await handleInterceptedRequest(port, websiteOrigin, website, ethereum, tokenPriceService, resetSimulationServices, socket, request, websiteTabConnections, noopPublishRpcConnectionStatus)
+
+		const connectedReply = messages.find((message) => message.method === 'connected_to_signer' && message.requestId === 12)
+		assert.deepEqual(connectedReply?.result, { metamaskCompatibilityMode: false, signerProviderGenerationSupported: true })
+
+		await handleInterceptedRequest(port, websiteOrigin, website, ethereum, tokenPriceService, resetSimulationServices, socket, {
+			...request,
+			uniqueRequestIdentifier: { requestId: 13, requestSocket: socket },
+			method: 'eth_accounts_reply',
+			params: [{ type: 'success', accounts: ['0x1111111111111111111111111111111111111111'], requestAccounts: false }],
+		}, websiteTabConnections, noopPublishRpcConnectionStatus)
+		await handleInterceptedRequest(port, websiteOrigin, website, ethereum, tokenPriceService, resetSimulationServices, socket, {
+			...request,
+			uniqueRequestIdentifier: { requestId: 14, requestSocket: socket },
+			method: 'signer_chainChanged',
+			params: ['0x1'],
+		}, websiteTabConnections, noopPublishRpcConnectionStatus)
+
+		const tabState = await getTabState(socket.tabId)
+		assert.deepEqual(tabState.signerAccounts, [0x1111111111111111111111111111111111111111n])
+		assert.equal(tabState.signerChain, 1n)
 	})
 
 	test('opens address access dialog after signer account discovery for site-approved eth_requestAccounts', async () => {

--- a/test/tests/confirmTransactionRefreshTimestamp.test.ts
+++ b/test/tests/confirmTransactionRefreshTimestamp.test.ts
@@ -481,7 +481,7 @@ test('accepts a signer reply from the current approved child-frame port', async 
 		method: 'signer_reply',
 		params: [{
 			success: true,
-			signerProviderGeneration: 12,
+			signerProviderGeneration: 8,
 			forwardRequest: {
 				type: 'forwardToSigner',
 				replyWithSignersReply: true,
@@ -502,6 +502,65 @@ test('accepts a signer reply from the current approved child-frame port', async 
 	const childReply = childMessages.find((message) => isRecord(message) && message.method === 'eth_sendTransaction' && message.requestId === childRequestIdentifier.requestId)
 	if (!isRecord(childReply)) throw new Error('Missing child-frame signer reply')
 	assert.equal(childReply.result, modules.EthereumBytes32.serialize(signedTransaction.hash))
+})
+
+test('rejects a signer reply from a replaced provider on the current child-frame port', async () => {
+	const topSocket = { tabId: 1, connectionName: 40n }
+	const childSocket = { tabId: 1, connectionName: 41n }
+	const childRequestIdentifier = { requestId: 77, requestSocket: childSocket }
+	const topMessages: unknown[] = []
+	const childMessages: unknown[] = []
+	const topPort = createWebsitePort(topSocket, 0, topMessages)
+	const childPort = createWebsitePort(childSocket, 2, childMessages)
+	const websiteOrigin = 'https://example.com'
+	const websiteTabConnections = new Map([[topSocket.tabId, {
+		signerStateOwner: {
+			connectionName: topSocket.connectionName,
+			confirmed: true,
+			generation: 3,
+			providerGeneration: 8,
+		},
+		connections: {
+			[modules.websiteSocketToString(topSocket)]: { port: topPort, socket: topSocket, websiteOrigin, approved: true, wantsToConnect: true },
+			[modules.websiteSocketToString(childSocket)]: { port: childPort, socket: childSocket, websiteOrigin, approved: true, wantsToConnect: true },
+		},
+	}]])
+	await modules.browserStorageLocalSet2({
+		pendingTransactionsAndMessages: [{
+			...pendingTransaction,
+			uniqueRequestIdentifier: childRequestIdentifier,
+			simulationMode: false,
+			approvalStatus: { status: 'WaitingForSigner' },
+		}],
+	})
+
+	await modules.signerReply(simulator.ethereum, simulator.tokenPriceService, () => undefined, websiteTabConnections, childPort, {
+		method: 'signer_reply',
+		params: [{
+			success: true,
+			signerProviderGeneration: 7,
+			forwardRequest: {
+				type: 'forwardToSigner',
+				replyWithSignersReply: true,
+				method: pendingTransaction.originalRequestParameters.method,
+				params: pendingTransaction.originalRequestParameters.params,
+				requestId: childRequestIdentifier.requestId,
+			},
+			reply: modules.EthereumBytes32.serialize(signedTransaction.hash),
+		}],
+		interceptorRequest: true,
+		interceptorInternalRequest: true,
+		usingInterceptorWithoutSigner: false,
+		uniqueRequestIdentifier: { requestId: 78, requestSocket: childSocket },
+	}, 'hasAccess', activeAddress)
+
+	const retainedRequest = (await modules.getPendingTransactionsAndMessages()).at(0)
+	assert.equal(retainedRequest?.approvalStatus.status, 'SignerError')
+	if (retainedRequest?.approvalStatus.status !== 'SignerError') throw new Error('Missing replaced-signer error')
+	assert.equal(retainedRequest.approvalStatus.code, 4900)
+	assert.equal(retainedRequest.approvalStatus.message, 'Signer connection changed before the previous wallet replied.')
+	assert.equal(topMessages.length, 0)
+	assert.equal(childMessages.some((message) => isRecord(message) && message.method === 'eth_sendTransaction'), false)
 })
 
 test('failed signer delivery keeps the request and replaces the waiting spinner with a wallet-neutral error', async () => {

--- a/test/tests/inpageSignerBridge.test.ts
+++ b/test/tests/inpageSignerBridge.test.ts
@@ -130,7 +130,7 @@ function createFakeWindow({ onConnectedToSignerRequest, handleRequest, handleSig
 						requestId: request.requestId,
 						type: 'result',
 						method: 'connected_to_signer',
-						result: { metamaskCompatibilityMode: true, signerProviderGenerationSupported: true },
+						result: { metamaskCompatibilityMode: true, signerProtocolVersion: 1 },
 					})
 					return
 				case 'InterceptorError':
@@ -338,7 +338,7 @@ describe('inpage signer bridge', () => {
 		let pendingAccountRequest: InpageRequest | undefined
 		const { fakeWindow, signerAccounts, sendBackgroundMessage } = createFakeWindow({
 			handleRequest: (request, sendBackgroundMessageForRequest) => {
-				if (request.method === 'connected_to_signer') {
+				if (request.method === 'connected_to_signer' && request.params?.length === 3) {
 					connectedSignerNames.push(request.params?.[1])
 					return false
 				}
@@ -459,7 +459,7 @@ describe('inpage signer bridge', () => {
 		let resolveBraveAccounts: ((accounts: string[]) => void) | undefined
 		const { fakeWindow, signerAccounts, backgroundEthAccountsReplies, sendBackgroundMessage } = createFakeWindow({
 			handleRequest: (request) => {
-				if (request.method === 'connected_to_signer') connectedSignerNames.push(request.params?.[1])
+				if (request.method === 'connected_to_signer' && request.params?.length === 3) connectedSignerNames.push(request.params[1])
 				return false
 			},
 		})
@@ -524,7 +524,7 @@ describe('inpage signer bridge', () => {
 						requestId: request.requestId,
 						type: 'result',
 						method: 'connected_to_signer',
-						result: { metamaskCompatibilityMode: true, signerProviderGenerationSupported: true },
+						result: { metamaskCompatibilityMode: true, signerProtocolVersion: 1 },
 					})
 				return true
 			},
@@ -548,7 +548,7 @@ describe('inpage signer bridge', () => {
 			signerUnavailable: true,
 			error: { code: 4900, message: 'No signer wallet is available to this page. Enable your wallet extension for this site, then try again.' },
 		}])
-		assert.deepEqual(connectedToSignerParams, [[false, 'NoSigner']])
+		assert.deepEqual(connectedToSignerParams, [[false, 'NoSigner'], [false, 'NoSigner', 1]])
 	})
 
 	test('reports a fresh signer epoch when the background requests reconnect status', async () => {
@@ -562,34 +562,37 @@ describe('inpage signer bridge', () => {
 					requestId: request.requestId,
 					type: 'result',
 					method: 'connected_to_signer',
-					result: { metamaskCompatibilityMode: true, signerProviderGenerationSupported: true },
+					result: { metamaskCompatibilityMode: true, signerProtocolVersion: 1 },
 				})
 				return true
 			},
 		})
 
 		await withFakeInpageWindow(fakeWindow, '../../app/inpage/ts/inpage.js?explicit-signer-status-handshake', async () => {
-			await waitFor(() => connectedToSignerParams.length === 1)
+			await waitFor(() => connectedToSignerParams.length === 2)
 			sendBackgroundMessage({
 				interceptorApproved: true,
 				type: 'result',
 				method: 'request_signer_connection_status',
 				result: [],
 			})
-			await waitFor(() => connectedToSignerParams.length === 2)
+			await waitFor(() => connectedToSignerParams.length === 3)
 		})
 
-		const secondGeneration = connectedToSignerParams[1]?.[2]
+		const firstGeneration = connectedToSignerParams[1]?.[2]
+		const secondGeneration = connectedToSignerParams[2]?.[2]
 		assert.equal(connectedToSignerParams[0]?.length, 2)
 		assert.equal(connectedToSignerParams[1]?.[1], 'MetaMask')
+		assert.equal(connectedToSignerParams[2]?.[1], 'MetaMask')
+		assert.equal(typeof firstGeneration, 'number')
 		assert.equal(typeof secondGeneration, 'number')
-		if (typeof secondGeneration !== 'number') throw new Error('Missing signer provider generation')
-		assert.equal(secondGeneration > 0, true)
+		if (typeof firstGeneration !== 'number' || typeof secondGeneration !== 'number') throw new Error('Missing signer provider generation')
+		assert.equal(secondGeneration > firstGeneration, true)
 	})
 
-	test('uses legacy signer callback payloads when an older background does not advertise generation support', async () => {
+	test('invalidates the page connection when an older background does not advertise the signer protocol', async () => {
 		const connectedToSignerParams: unknown[][] = []
-		const { backgroundEthAccountsReplies, fakeWindow, sendBackgroundMessage } = createFakeWindow({
+		const { backgroundEthAccountsReplies, fakeWindow, interceptorErrorPayloads } = createFakeWindow({
 			handleRequest: (request, sendBackgroundReply) => {
 				if (request.method !== 'connected_to_signer') return false
 				connectedToSignerParams.push(request.params ?? [])
@@ -606,31 +609,24 @@ describe('inpage signer bridge', () => {
 
 		await withFakeInpageWindow(fakeWindow, '../../app/inpage/ts/inpage.js?legacy-background-signer-protocol', async () => {
 			await waitFor(() => connectedToSignerParams.length === 1)
-			sendBackgroundMessage({
-				interceptorApproved: true,
-				type: 'result',
-				method: 'request_signer_connection_status',
-				result: [],
+			const provider = fakeWindow.ethereum as { isConnected: () => boolean, request: (payload: { method: string }) => Promise<unknown> }
+			await assert.rejects(provider.request({ method: 'eth_chainId' }), (error: unknown) => {
+				return error instanceof Error
+					&& 'code' in error
+					&& error.code === 4900
+					&& error.message === 'Interceptor was updated while this page was open. Reload the page to reconnect.'
 			})
-			await waitFor(() => connectedToSignerParams.length === 2)
-			sendBackgroundMessage({
-				interceptorApproved: true,
-				type: 'result',
-				method: 'request_signer_to_eth_accounts',
-				result: [],
-			})
-			await waitFor(() => backgroundEthAccountsReplies.length === 1)
+			assert.equal(provider.isConnected(), false)
 		})
 
-		assert.deepEqual(connectedToSignerParams.map((params) => params.length), [2, 2])
-		const accountsReply = backgroundEthAccountsReplies.at(0)
-		if (accountsReply === undefined) throw new Error('Missing signer accounts reply')
-		assert.equal('signerProviderGeneration' in accountsReply, false)
+		assert.deepEqual(connectedToSignerParams, [[false, 'NoSigner']])
+		assert.equal(backgroundEthAccountsReplies.length, 0)
+		assert.equal(interceptorErrorPayloads.length, 0)
 	})
 
-	test('reports reconnect status without waiting for a lost previous status reply', async () => {
+	test('does not report an expected incompatibility when concurrent probes are rejected', async () => {
 		const connectedToSignerParams: unknown[][] = []
-		const { backgroundEthAccountsReplies, fakeWindow, sendBackgroundMessage, signerRequests } = createFakeWindow({
+		const { fakeWindow, interceptorErrorPayloads } = createFakeWindow({
 			handleRequest: (request, sendBackgroundReply) => {
 				if (request.method !== 'connected_to_signer') return false
 				connectedToSignerParams.push(request.params ?? [])
@@ -640,7 +636,41 @@ describe('inpage signer bridge', () => {
 					requestId: request.requestId,
 					type: 'result',
 					method: 'connected_to_signer',
-					result: { metamaskCompatibilityMode: true, signerProviderGenerationSupported: true },
+					result: { metamaskCompatibilityMode: true },
+				})
+				return true
+			},
+		})
+
+		await withFakeInpageWindow(fakeWindow, '../../app/inpage/ts/inpage.js?concurrent-legacy-background-probes', async () => {
+			await waitFor(() => connectedToSignerParams.length === 1)
+			const provider = fakeWindow.ethereum as { isConnected: () => boolean, request: (payload: { method: string }) => Promise<unknown> }
+			await assert.rejects(provider.request({ method: 'eth_chainId' }), (error: unknown) => {
+				return error instanceof Error
+					&& 'code' in error
+					&& error.code === 4900
+					&& error.message === 'Interceptor was updated while this page was open. Reload the page to reconnect.'
+			})
+			assert.equal(provider.isConnected(), false)
+		})
+
+		assert.deepEqual(connectedToSignerParams, [[false, 'NoSigner'], [false, 'NoSigner']])
+		assert.equal(interceptorErrorPayloads.length, 0)
+	})
+
+	test('retries protocol negotiation when the previous probe reply was lost', async () => {
+		const connectedToSignerParams: unknown[][] = []
+		const { fakeWindow } = createFakeWindow({
+			handleRequest: (request, sendBackgroundReply) => {
+				if (request.method !== 'connected_to_signer') return false
+				connectedToSignerParams.push(request.params ?? [])
+				if (connectedToSignerParams.length === 1) return true
+				sendBackgroundReply({
+					interceptorApproved: true,
+					requestId: request.requestId,
+					type: 'result',
+					method: 'connected_to_signer',
+					result: { metamaskCompatibilityMode: true, signerProtocolVersion: 1 },
 				})
 				return true
 			},
@@ -648,26 +678,13 @@ describe('inpage signer bridge', () => {
 
 		await withFakeInpageWindow(fakeWindow, '../../app/inpage/ts/inpage.js?lost-signer-status-reply', async () => {
 			await waitFor(() => connectedToSignerParams.length === 1)
-			sendBackgroundMessage({
-				interceptorApproved: true,
-				type: 'result',
-				method: 'request_signer_to_eth_accounts',
-				result: [],
-			})
-			await new Promise((resolve) => setTimeout(resolve, 0))
-			assert.equal(backgroundEthAccountsReplies.length, 0)
-			sendBackgroundMessage({
-				interceptorApproved: true,
-				type: 'result',
-				method: 'request_signer_connection_status',
-				result: [],
-			})
-			await waitFor(() => connectedToSignerParams.length === 2)
-			await waitFor(() => signerRequests.includes('eth_chainId'))
-			await waitFor(() => backgroundEthAccountsReplies.length === 1)
+			const provider = fakeWindow.ethereum as { request: (payload: { method: string }) => Promise<unknown> }
+			const chainId = provider.request({ method: 'eth_chainId' })
+			await waitFor(() => connectedToSignerParams.length === 3)
+			assert.equal(await chainId, '0x')
 		})
 
-		assert.deepEqual(connectedToSignerParams.map((params) => params.length), [2, 2])
+		assert.deepEqual(connectedToSignerParams.map((params) => params.length), [2, 2, 3])
 	})
 
 	test('settles a pending chain switch when the signer provider changes', async () => {
@@ -1325,7 +1342,7 @@ describe('inpage signer bridge', () => {
 			const announcedSignerRequests: string[] = []
 			const { fakeWindow } = createFakeWindow({
 				handleRequest: (request) => {
-					if (request.method === 'connected_to_signer' && (request.params?.length === 3 || request.params?.[1] !== 'NotRecognizedSigner')) connectedSignerNames.push(request.params?.[1])
+					if (request.method === 'connected_to_signer' && request.params?.length === 3) connectedSignerNames.push(request.params[1])
 					return false
 				},
 			})
@@ -1364,9 +1381,9 @@ describe('inpage signer bridge', () => {
 		}
 	})
 
-	test('re-reports the selected MetaMask after a delayed legacy Ambire compatibility probe', async () => {
+	test('reports only the latest selected signer after a delayed protocol handshake', async () => {
 		const connectedToSignerParams: unknown[][] = []
-		let replyToLegacyAmbireProbe: (() => void) | undefined
+		let replyToProtocolProbe: (() => void) | undefined
 		const { fakeWindow } = createFakeWindow({
 			handleRequest: (request, sendBackgroundReply) => {
 				if (request.method !== 'connected_to_signer') return false
@@ -1376,10 +1393,10 @@ describe('inpage signer bridge', () => {
 					requestId: request.requestId,
 					type: 'result',
 					method: 'connected_to_signer',
-					result: { metamaskCompatibilityMode: true, signerProviderGenerationSupported: true },
+					result: { metamaskCompatibilityMode: true, signerProtocolVersion: 1 },
 				})
-				if (request.params?.length === 2 && request.params[1] === 'NotRecognizedSigner' && replyToLegacyAmbireProbe === undefined) {
-					replyToLegacyAmbireProbe = reply
+				if (request.params?.length === 2 && replyToProtocolProbe === undefined) {
+					replyToProtocolProbe = reply
 					return true
 				}
 				reply()
@@ -1410,10 +1427,9 @@ describe('inpage signer bridge', () => {
 			},
 		}))
 
-		await withFakeInpageWindow(fakeWindow, '../../app/inpage/ts/inpage.js?delayed-ambire-compatibility-probe', async () => {
-			await waitFor(() => replyToLegacyAmbireProbe !== undefined)
-			await waitFor(() => connectedToSignerParams.some((params) => params.length === 2 && params[1] === 'MetaMask'))
-			replyToLegacyAmbireProbe?.()
+		await withFakeInpageWindow(fakeWindow, '../../app/inpage/ts/inpage.js?delayed-signer-protocol-handshake', async () => {
+			await waitFor(() => replyToProtocolProbe !== undefined)
+			replyToProtocolProbe?.()
 			await waitFor(() => connectedToSignerParams.some((params) => params.length === 3 && params[1] === 'MetaMask'))
 		})
 
@@ -1473,19 +1489,19 @@ describe('inpage signer bridge', () => {
 		assert.doesNotThrow(() => SignerReply.parse({ method: 'signer_reply', params: [signerReply] }))
 	})
 
-	test('reports unusable-root NoSigner before EIP-6963 MetaMask recovery', async () => {
+	test('does not report stale NoSigner after EIP-6963 MetaMask recovery', async () => {
 		const connectedSignerNames: unknown[] = []
 		const { fakeWindow, signerRequests } = createFakeWindow({
 			handleRequest: (request, sendBackgroundMessage) => {
 				if (request.method !== 'connected_to_signer') return false
-				connectedSignerNames.push(request.params?.[1])
-				const delay = request.params?.[1] === 'NoSigner' ? 10 : 0
+				if (request.params?.length === 3) connectedSignerNames.push(request.params[1])
+				const delay = request.params?.length === 3 && request.params[1] === 'NoSigner' ? 10 : 0
 				setTimeout(() => sendBackgroundMessage({
 					interceptorApproved: true,
 					requestId: request.requestId,
 					type: 'result',
 					method: 'connected_to_signer',
-					result: { metamaskCompatibilityMode: true },
+					result: { metamaskCompatibilityMode: true, signerProtocolVersion: 1 },
 				}), delay)
 				return true
 			},
@@ -1506,11 +1522,11 @@ describe('inpage signer bridge', () => {
 		}))
 
 		await withFakeInpageWindow(fakeWindow, '../../app/inpage/ts/inpage.js?serialized-no-signer-eip-recovery', async () => {
-			await waitFor(() => connectedSignerNames.length === 2)
+			await waitFor(() => connectedSignerNames.length === 1)
 			await waitFor(() => signerRequests.includes('eth_chainId'))
 		})
 
-		assert.deepEqual(connectedSignerNames, ['NoSigner', 'MetaMask'])
+		assert.deepEqual(connectedSignerNames, ['MetaMask'])
 	})
 
 	test('recognizes supported MetaMask-compatible wallets and does not replace selected non-MetaMask signers from announcements', async () => {
@@ -1526,9 +1542,7 @@ describe('inpage signer bridge', () => {
 			let announcedProviderSubscriptionCount = 0
 			const { fakeWindow } = createFakeWindow({
 				handleRequest: (request) => {
-					const legacyCompatibilityProbe = (signerCase.name === 'Ambire' || signerCase.name === 'Rabby')
-						&& request.params?.length === 2 && request.params[1] === 'NotRecognizedSigner'
-					if (request.method === 'connected_to_signer' && !legacyCompatibilityProbe) connectedSignerNames.push(request.params?.[1])
+					if (request.method === 'connected_to_signer' && request.params?.length === 3) connectedSignerNames.push(request.params[1])
 					return false
 				},
 			})
@@ -1567,7 +1581,7 @@ describe('inpage signer bridge', () => {
 		let announcedProviderSubscriptionCount = 0
 		const { fakeWindow, sendBackgroundMessage } = createFakeWindow({
 			handleRequest: (request) => {
-				if (request.method === 'connected_to_signer') connectedSignerNames.push(request.params?.[1])
+				if (request.method === 'connected_to_signer' && request.params?.length === 3) connectedSignerNames.push(request.params[1])
 				return false
 			},
 		})
@@ -2147,14 +2161,14 @@ describe('inpage signer bridge', () => {
 		}
 		const { fakeWindow } = createFakeWindow({
 			handleRequest: (request, sendBackgroundMessage) => {
-				if (request.method === 'connected_to_signer') {
+				if (request.method === 'connected_to_signer' && request.params?.length === 3) {
 					signerName = request.params?.[1] as string
 					sendBackgroundMessage({
 						interceptorApproved: true,
 						requestId: request.requestId,
 						type: 'result',
 						method: 'connected_to_signer',
-						result: { metamaskCompatibilityMode: true },
+						result: { metamaskCompatibilityMode: true, signerProtocolVersion: 1 },
 					})
 					return true
 				}
@@ -2207,14 +2221,14 @@ describe('inpage signer bridge', () => {
 		}
 		const { fakeWindow } = createFakeWindow({
 			handleRequest: (request, sendBackgroundMessage) => {
-				if (request.method === 'connected_to_signer') {
+				if (request.method === 'connected_to_signer' && request.params?.length === 3) {
 					signerName = request.params?.[1] as string
 					sendBackgroundMessage({
 						interceptorApproved: true,
 						requestId: request.requestId,
 						type: 'result',
 						method: 'connected_to_signer',
-						result: { metamaskCompatibilityMode: true },
+						result: { metamaskCompatibilityMode: true, signerProtocolVersion: 1 },
 					})
 					return true
 				}
@@ -2265,14 +2279,14 @@ describe('inpage signer bridge', () => {
 		}
 		const { fakeWindow } = createFakeWindow({
 			handleRequest: (request, sendBackgroundMessage) => {
-				if (request.method === 'connected_to_signer') {
+				if (request.method === 'connected_to_signer' && request.params?.length === 3) {
 					signerName = request.params?.[1] as string
 					sendBackgroundMessage({
 						interceptorApproved: true,
 						requestId: request.requestId,
 						type: 'result',
 						method: 'connected_to_signer',
-						result: { metamaskCompatibilityMode: true },
+						result: { metamaskCompatibilityMode: true, signerProtocolVersion: 1 },
 					})
 					return true
 				}
@@ -2311,14 +2325,14 @@ describe('inpage signer bridge', () => {
 			interceptorErrorPayloads,
 		} = createFakeWindow({
 			handleRequest: (request, sendBackgroundMessage) => {
-				if (request.method === 'connected_to_signer') {
+				if (request.method === 'connected_to_signer' && request.params?.length === 3) {
 					signerName = request.params?.[1] as string
 					sendBackgroundMessage({
 						interceptorApproved: true,
 						requestId: request.requestId,
 						type: 'result',
 						method: 'connected_to_signer',
-						result: { metamaskCompatibilityMode: true },
+						result: { metamaskCompatibilityMode: true, signerProtocolVersion: 1 },
 					})
 					return true
 				}
@@ -2379,14 +2393,14 @@ describe('inpage signer bridge', () => {
 			sendBackgroundMessage,
 		} = createFakeWindow({
 			handleRequest: (request, sendBackgroundMessageInternal) => {
-				if (request.method === 'connected_to_signer') {
+				if (request.method === 'connected_to_signer' && request.params?.length === 3) {
 					signerName = request.params?.[1] as string
 					sendBackgroundMessageInternal({
 						interceptorApproved: true,
 						requestId: request.requestId,
 						type: 'result',
 						method: 'connected_to_signer',
-						result: { metamaskCompatibilityMode: true },
+						result: { metamaskCompatibilityMode: true, signerProtocolVersion: 1 },
 					})
 					return true
 				}
@@ -2450,14 +2464,14 @@ describe('inpage signer bridge', () => {
 			sendBackgroundMessage,
 		} = createFakeWindow({
 			handleRequest: (request, sendBackgroundMessageInternal) => {
-				if (request.method === 'connected_to_signer') {
+				if (request.method === 'connected_to_signer' && request.params?.length === 3) {
 					signerName = request.params?.[1] as string
 					sendBackgroundMessageInternal({
 						interceptorApproved: true,
 						requestId: request.requestId,
 						type: 'result',
 						method: 'connected_to_signer',
-						result: { metamaskCompatibilityMode: true },
+						result: { metamaskCompatibilityMode: true, signerProtocolVersion: 1 },
 					})
 					return true
 				}
@@ -2524,14 +2538,14 @@ describe('inpage signer bridge', () => {
 			sendBackgroundMessage,
 		} = createFakeWindow({
 			handleRequest: (request, sendBackgroundMessageInternal) => {
-				if (request.method === 'connected_to_signer') {
+				if (request.method === 'connected_to_signer' && request.params?.length === 3) {
 					signerName = request.params?.[1] as string
 					sendBackgroundMessageInternal({
 						interceptorApproved: true,
 						requestId: request.requestId,
 						type: 'result',
 						method: 'connected_to_signer',
-						result: { metamaskCompatibilityMode: true },
+						result: { metamaskCompatibilityMode: true, signerProtocolVersion: 1 },
 					})
 					return true
 				}
@@ -2596,14 +2610,14 @@ describe('inpage signer bridge', () => {
 			sendBackgroundMessage,
 		} = createFakeWindow({
 			handleRequest: (request, sendBackgroundMessageInternal) => {
-				if (request.method === 'connected_to_signer') {
+				if (request.method === 'connected_to_signer' && request.params?.length === 3) {
 					signerName = request.params?.[1] as string
 					sendBackgroundMessageInternal({
 						interceptorApproved: true,
 						requestId: request.requestId,
 						type: 'result',
 						method: 'connected_to_signer',
-						result: { metamaskCompatibilityMode: true },
+						result: { metamaskCompatibilityMode: true, signerProtocolVersion: 1 },
 					})
 					return true
 				}
@@ -2668,14 +2682,14 @@ describe('inpage signer bridge', () => {
 			sendBackgroundMessage,
 		} = createFakeWindow({
 			handleRequest: (request, sendBackgroundMessageInternal) => {
-				if (request.method === 'connected_to_signer') {
+				if (request.method === 'connected_to_signer' && request.params?.length === 3) {
 					signerName = request.params?.[1] as string
 					sendBackgroundMessageInternal({
 						interceptorApproved: true,
 						requestId: request.requestId,
 						type: 'result',
 						method: 'connected_to_signer',
-						result: { metamaskCompatibilityMode: true },
+						result: { metamaskCompatibilityMode: true, signerProtocolVersion: 1 },
 					})
 					return true
 				}
@@ -2737,14 +2751,14 @@ describe('inpage signer bridge', () => {
 		let signerName: string | undefined
 		const { fakeWindow } = createFakeWindow({
 			handleRequest: (request, sendBackgroundMessage) => {
-				if (request.method === 'connected_to_signer') {
+				if (request.method === 'connected_to_signer' && request.params?.length === 3) {
 					signerName = request.params?.[1] as string
 					sendBackgroundMessage({
 						interceptorApproved: true,
 						requestId: request.requestId,
 						type: 'result',
 						method: 'connected_to_signer',
-						result: { metamaskCompatibilityMode: true },
+						result: { metamaskCompatibilityMode: true, signerProtocolVersion: 1 },
 					})
 					return true
 				}
@@ -2791,7 +2805,7 @@ describe('inpage signer bridge', () => {
 						requestId: request.requestId,
 						type: 'result',
 						method: 'connected_to_signer',
-						result: { metamaskCompatibilityMode: true },
+						result: { metamaskCompatibilityMode: true, signerProtocolVersion: 1 },
 					})
 					return true
 				}

--- a/test/tests/inpageSignerBridge.test.ts
+++ b/test/tests/inpageSignerBridge.test.ts
@@ -130,7 +130,7 @@ function createFakeWindow({ onConnectedToSignerRequest, handleRequest, handleSig
 						requestId: request.requestId,
 						type: 'result',
 						method: 'connected_to_signer',
-						result: { metamaskCompatibilityMode: true },
+						result: { metamaskCompatibilityMode: true, signerProviderGenerationSupported: true },
 					})
 					return
 				case 'InterceptorError':
@@ -516,16 +516,16 @@ describe('inpage signer bridge', () => {
 	test('settles signer account discovery when no signer initializes', async () => {
 		const connectedToSignerParams: unknown[][] = []
 		const { fakeWindow, backgroundEthAccountsReplies, sendBackgroundMessage } = createFakeWindow({
-			handleRequest: (request, sendBackgroundReply) => {
-				if (request.method !== 'connected_to_signer') return false
-				connectedToSignerParams.push(request.params ?? [])
-				sendBackgroundReply({
-					interceptorApproved: true,
-					requestId: request.requestId,
-					type: 'result',
-					method: 'connected_to_signer',
-					result: { metamaskCompatibilityMode: true },
-				})
+				handleRequest: (request, sendBackgroundReply) => {
+					if (request.method !== 'connected_to_signer') return false
+					connectedToSignerParams.push(request.params ?? [])
+					sendBackgroundReply({
+						interceptorApproved: true,
+						requestId: request.requestId,
+						type: 'result',
+						method: 'connected_to_signer',
+						result: { metamaskCompatibilityMode: true, signerProviderGenerationSupported: true },
+					})
 				return true
 			},
 		})
@@ -548,7 +548,7 @@ describe('inpage signer bridge', () => {
 			signerUnavailable: true,
 			error: { code: 4900, message: 'No signer wallet is available to this page. Enable your wallet extension for this site, then try again.' },
 		}])
-		assert.deepEqual(connectedToSignerParams, [[false, 'NoSigner', 1]])
+		assert.deepEqual(connectedToSignerParams, [[false, 'NoSigner']])
 	})
 
 	test('reports a fresh signer epoch when the background requests reconnect status', async () => {
@@ -562,7 +562,7 @@ describe('inpage signer bridge', () => {
 					requestId: request.requestId,
 					type: 'result',
 					method: 'connected_to_signer',
-					result: { metamaskCompatibilityMode: true },
+					result: { metamaskCompatibilityMode: true, signerProviderGenerationSupported: true },
 				})
 				return true
 			},
@@ -579,13 +579,53 @@ describe('inpage signer bridge', () => {
 			await waitFor(() => connectedToSignerParams.length === 2)
 		})
 
-		const firstGeneration = connectedToSignerParams[0]?.[2]
 		const secondGeneration = connectedToSignerParams[1]?.[2]
+		assert.equal(connectedToSignerParams[0]?.length, 2)
 		assert.equal(connectedToSignerParams[1]?.[1], 'MetaMask')
-		assert.equal(typeof firstGeneration, 'number')
 		assert.equal(typeof secondGeneration, 'number')
-		if (typeof firstGeneration !== 'number' || typeof secondGeneration !== 'number') throw new Error('Missing signer provider generation')
-		assert.equal(secondGeneration > firstGeneration, true)
+		if (typeof secondGeneration !== 'number') throw new Error('Missing signer provider generation')
+		assert.equal(secondGeneration > 0, true)
+	})
+
+	test('uses legacy signer callback payloads when an older background does not advertise generation support', async () => {
+		const connectedToSignerParams: unknown[][] = []
+		const { backgroundEthAccountsReplies, fakeWindow, sendBackgroundMessage } = createFakeWindow({
+			handleRequest: (request, sendBackgroundReply) => {
+				if (request.method !== 'connected_to_signer') return false
+				connectedToSignerParams.push(request.params ?? [])
+				sendBackgroundReply({
+					interceptorApproved: true,
+					requestId: request.requestId,
+					type: 'result',
+					method: 'connected_to_signer',
+					result: { metamaskCompatibilityMode: true },
+				})
+				return true
+			},
+		})
+
+		await withFakeInpageWindow(fakeWindow, '../../app/inpage/ts/inpage.js?legacy-background-signer-protocol', async () => {
+			await waitFor(() => connectedToSignerParams.length === 1)
+			sendBackgroundMessage({
+				interceptorApproved: true,
+				type: 'result',
+				method: 'request_signer_connection_status',
+				result: [],
+			})
+			await waitFor(() => connectedToSignerParams.length === 2)
+			sendBackgroundMessage({
+				interceptorApproved: true,
+				type: 'result',
+				method: 'request_signer_to_eth_accounts',
+				result: [],
+			})
+			await waitFor(() => backgroundEthAccountsReplies.length === 1)
+		})
+
+		assert.deepEqual(connectedToSignerParams.map((params) => params.length), [2, 2])
+		const accountsReply = backgroundEthAccountsReplies.at(0)
+		if (accountsReply === undefined) throw new Error('Missing signer accounts reply')
+		assert.equal('signerProviderGeneration' in accountsReply, false)
 	})
 
 	test('reports reconnect status without waiting for a lost previous status reply', async () => {
@@ -600,7 +640,7 @@ describe('inpage signer bridge', () => {
 					requestId: request.requestId,
 					type: 'result',
 					method: 'connected_to_signer',
-					result: { metamaskCompatibilityMode: true },
+					result: { metamaskCompatibilityMode: true, signerProviderGenerationSupported: true },
 				})
 				return true
 			},
@@ -627,12 +667,7 @@ describe('inpage signer bridge', () => {
 			await waitFor(() => backgroundEthAccountsReplies.length === 1)
 		})
 
-		const firstGeneration = connectedToSignerParams[0]?.[2]
-		const secondGeneration = connectedToSignerParams[1]?.[2]
-		assert.equal(typeof firstGeneration, 'number')
-		assert.equal(typeof secondGeneration, 'number')
-		if (typeof firstGeneration !== 'number' || typeof secondGeneration !== 'number') throw new Error('Missing signer provider generation')
-		assert.equal(secondGeneration > firstGeneration, true)
+		assert.deepEqual(connectedToSignerParams.map((params) => params.length), [2, 2])
 	})
 
 	test('settles a pending chain switch when the signer provider changes', async () => {
@@ -1290,7 +1325,7 @@ describe('inpage signer bridge', () => {
 			const announcedSignerRequests: string[] = []
 			const { fakeWindow } = createFakeWindow({
 				handleRequest: (request) => {
-					if (request.method === 'connected_to_signer') connectedSignerNames.push(request.params?.[1])
+					if (request.method === 'connected_to_signer' && (request.params?.length === 3 || request.params?.[1] !== 'NotRecognizedSigner')) connectedSignerNames.push(request.params?.[1])
 					return false
 				},
 			})
@@ -1325,8 +1360,65 @@ describe('inpage signer bridge', () => {
 				await waitFor(() => announcedSignerRequests.includes('eth_chainId'))
 			})
 
-			assert.deepEqual(connectedSignerNames, [walletCase.name, 'MetaMask'])
+			assert.deepEqual([...new Set(connectedSignerNames)], ['MetaMask'])
 		}
+	})
+
+	test('re-reports the selected MetaMask after a delayed legacy Ambire compatibility probe', async () => {
+		const connectedToSignerParams: unknown[][] = []
+		let replyToLegacyAmbireProbe: (() => void) | undefined
+		const { fakeWindow } = createFakeWindow({
+			handleRequest: (request, sendBackgroundReply) => {
+				if (request.method !== 'connected_to_signer') return false
+				connectedToSignerParams.push(request.params ?? [])
+				const reply = () => sendBackgroundReply({
+					interceptorApproved: true,
+					requestId: request.requestId,
+					type: 'result',
+					method: 'connected_to_signer',
+					result: { metamaskCompatibilityMode: true, signerProviderGenerationSupported: true },
+				})
+				if (request.params?.length === 2 && request.params[1] === 'NotRecognizedSigner' && replyToLegacyAmbireProbe === undefined) {
+					replyToLegacyAmbireProbe = reply
+					return true
+				}
+				reply()
+				return true
+			},
+		})
+		const ambireProvider = {
+			isAmbire: true,
+			isMetaMask: true,
+			isConnected: () => true,
+			request: async ({ method }: { method: string }) => method === 'eth_chainId' ? '0x1' : [],
+			on: () => ambireProvider,
+			removeListener: () => ambireProvider,
+		}
+		const announcedMetaMaskProvider = {
+			isMetaMask: true,
+			isConnected: () => true,
+			request: async ({ method }: { method: string }) => method === 'eth_chainId' ? '0x1' : [],
+			on: () => announcedMetaMaskProvider,
+			removeListener: () => announcedMetaMaskProvider,
+		}
+		Object.defineProperty(fakeWindow, 'ethereum', { configurable: true, writable: true, value: ambireProvider })
+		fakeWindow.addEventListener('eip6963:requestProvider', () => fakeWindow.dispatchEvent({
+			type: 'eip6963:announceProvider',
+			detail: {
+				info: { uuid: '55555555-5555-4555-8555-555555555555', name: 'MetaMask', icon: 'data:image/svg+xml,<svg/>', rdns: 'io.metamask' },
+				provider: announcedMetaMaskProvider,
+			},
+		}))
+
+		await withFakeInpageWindow(fakeWindow, '../../app/inpage/ts/inpage.js?delayed-ambire-compatibility-probe', async () => {
+			await waitFor(() => replyToLegacyAmbireProbe !== undefined)
+			await waitFor(() => connectedToSignerParams.some((params) => params.length === 2 && params[1] === 'MetaMask'))
+			replyToLegacyAmbireProbe?.()
+			await waitFor(() => connectedToSignerParams.some((params) => params.length === 3 && params[1] === 'MetaMask'))
+		})
+
+		assert.equal(connectedToSignerParams.at(-1)?.[1], 'MetaMask')
+		assert.equal(connectedToSignerParams.at(-1)?.length, 3)
 	})
 
 	test('normalizes object-valued MetaMask rejection data before sending signer_reply', async () => {
@@ -1434,7 +1526,9 @@ describe('inpage signer bridge', () => {
 			let announcedProviderSubscriptionCount = 0
 			const { fakeWindow } = createFakeWindow({
 				handleRequest: (request) => {
-					if (request.method === 'connected_to_signer') connectedSignerNames.push(request.params?.[1])
+					const legacyCompatibilityProbe = (signerCase.name === 'Ambire' || signerCase.name === 'Rabby')
+						&& request.params?.length === 2 && request.params[1] === 'NotRecognizedSigner'
+					if (request.method === 'connected_to_signer' && !legacyCompatibilityProbe) connectedSignerNames.push(request.params?.[1])
 					return false
 				},
 			})


### PR DESCRIPTION
## Summary

- Fixes the `connected_to_signer` tuple-length error that can occur when an updated inpage script communicates with an older background worker during an extension update.
- Adds an explicit signer protocol v1 negotiation before current generation-aware signer state or public RPC traffic is accepted.
- Treats the former two-field `connected_to_signer` shape only as a compatibility probe in current code; it is never accepted as signer state.
- Disconnects incompatible open pages with a 4900 reload-required error instead of recording an unexpected Interceptor error. Reloading the page is the recovery path.
- Keeps account, chain, wallet-switch, and signer replies on their current mandatory generation-aware schemas; this PR does not add broad legacy-message compatibility.
- Initializes protocol negotiation before website-port listeners can release queued traffic, and keeps compatibility monotonic after it is confirmed.
- Rejects stale signer replies from replaced provider generations, including child-frame signer owners.

## Race coverage

Regression tests cover:

- old background replies without a protocol version;
- concurrent and lost compatibility probes;
- public RPC racing initial signer status;
- fresh/reconnected ports receiving traffic before status confirmation;
- protocol confirmation timeout and single disconnect behavior;
- later signer-status updates racing public RPC after compatibility is established;
- stale account, chain, wallet-switch, and signer replies.

## Performance

Adds `bun run benchmark:signer-connection`, a real-Chromium benchmark with five warmups and 30 measured fresh-page connections.

Observed fixed-build runs were approximately 59–74 ms from document start to the first signer `eth_chainId`. The conservative adjacent baseline comparison was 56.14 ms baseline versus 74.46 ms fixed (+18.32 ms mean, roughly one 60 Hz frame). The final post-rebase run measured 70.92 ms mean, 70.1 ms median, and 80.0 ms p95.

The protocol check is measurable but remains small in absolute connection time. An optimization that moved the measurement before protocol readiness was intentionally not used.

## Validation

- `bun run test` — 737 passed, 0 failed across 104 files
- `bun run setup-chrome`
- `bun run typecheck`
- `bun run lint` — 349 files checked
- `bun run test:chrome-communication`
- `bun run test:chrome-signing-communication`
- `bun run benchmark:signer-connection`
- `git diff --check origin/main..HEAD`

The branch is rebased onto current `origin/main` (`2b06afe5`). Final read-only review found no High, Medium, or Low issues.
