### PR TITLE
Return the latest simulation stack after approval

### DIFF
--- a/app/ts/background/background.ts
+++ b/app/ts/background/background.ts
@@ -4,7 +4,7 @@ import { getTabState, promoteRpcAsPrimary, setLatestUnexpectedError, updateInter
 import { changeSimulationMode, getSettings, trackPreviousActiveAddressForMakeMeRichList, updateWebsiteAccess } from './settings.js'
 import { blockNumber, call, chainId, estimateGas, gasPrice, getAccounts, getBalance, getBlockByNumber, getBlockByHash, getCode, getFilterChanges, getFilterLogs, getLogs, getPermissions, getTransactionByHash, getTransactionCount, getTransactionReceipt, handleIterceptorError, installNewFilter, netVersion, personalSign, requestInterceptorSimulatorStack, requestPermissions, sendTransaction, subscribe, switchEthereumChain, ethSimulateV1, feeHistory, uninstallNewFilter, unsubscribe, web3ClientVersion } from './simulationModeHanders.js'
 import { changeActiveAddress, changePage, confirmDialog, removeTransactionOrSignedMessage, requestAccountsFromSigner, refreshPopupConfirmTransactionSimulation, confirmRequestAccess, changeInterceptorAccess, changeChainDialog, popupChangeActiveRpc, enableSimulationMode, addOrModifyAddressBookEntry, getAddressBookData, removeAddressBookEntry, refreshHomeData, interceptorAccessChangeAddressOrRefresh, refreshPopupConfirmTransactionMetadata, changeSettings, importSettings, exportSettings, setNewRpcList, simulateGovernanceContractExecutionOnPass, openNewTab, settingsOpened, changeAddOrModifyAddressWindowState, requestAbiAndNameFromBlockExplorer, openWebPage, disableInterceptor, requestNewHomeData, requestHomePageBootstrap, setEnsNameForHash, simulateGnosisSafeTransactionOnPass, retrieveWebsiteAccess, blockOrAllowExternalRequests, removeWebsiteAccess, allowOrPreventAddressAccessForWebsite, removeWebsiteAddressAccess, forceSetGasLimitForTransaction, changePreSimulationBlockTimeManipulation, setTransactionOrMessageBlockTimeManipulator, modifyMakeMeRich, requestMakeMeRichList, requestActiveAddresses, requestSimulationMode, requestLatestUnexpectedError, fetchSimulationStackRequestConfirmation, reportUnexpectedErrorInWindow, requestInterceptorSimulationInput, importSimulationStack, requestCompleteVisualizedSimulation, requestSimulationMetadata, requestIdentifyAddress, popupReadyAndListening } from './popupMessageHandlers.js'
-import { PASSTHROUGH_STATE, type ResolvedExecutionSimulationState, type ResolvedSimulationInput, type ResolvedSimulationState, type WebsiteCreatedEthereumUnsignedTransactionOrFailed, toResolvedExecutionSimulationState, toResolvedSimulationInput, toResolvedSimulationState } from '../types/visualizer-types.js'
+import { PASSTHROUGH_STATE, type ResolvedExecutionSimulationState, type ResolvedSimulationInput, type SimulationStateInput, type WebsiteCreatedEthereumUnsignedTransactionOrFailed, toResolvedExecutionSimulationState, toResolvedSimulationInput, toResolvedSimulationState } from '../types/visualizer-types.js'
 import type { WebsiteTabConnections } from '../types/user-interface-types.js'
 import { askForSignerAccountsFromSignerIfNotAvailable, interceptorAccessMetadataRefresh, requestAccessFromUser } from './windows/interceptorAccess.js'
 import { METAMASK_ERROR_FAILED_TO_PARSE_REQUEST, METAMASK_ERROR_NOT_AUTHORIZED, METAMASK_ERROR_NOT_CONNECTED_TO_CHAIN, METAMASK_ERROR_PROVIDER_DISCONNECTED, METAMASK_ERROR_USER_REJECTED_REQUEST, ERROR_INTERCEPTOR_DISABLED, NEW_BLOCK_ABORT, JSON_RPC_ERROR_CODE_INTERNAL_ERROR } from '../utils/constants.js'
@@ -30,7 +30,7 @@ import { connectedToSigner, ethAccountsReply, signerChainChanged, signerReply, w
 import { makeSureInterceptorIsNotSleeping } from './sleeping.js'
 import type { PublishRpcConnectionStatus } from './rpcSlowRequestTracking.js'
 import { decodeEthereumError } from '../utils/errorDecoding.js'
-import { buildExecutionSimulationStateFromPreparedInput, buildSimulationStateFromPreparedInput, createSimulationStateWithNonceAndBaseFeeFixing, getCurrentSimulationInput, prepareSimulationInputForRpc, visualizeSimulatorState } from './simulationUpdating.js'
+import { buildExecutionSimulationStateFromPreparedInput, createSimulationStateWithNonceAndBaseFeeFixing, getCurrentSimulationInput, prepareSimulationInputForRpc, visualizeSimulatorState } from './simulationUpdating.js'
 import { PopupReplyOption } from '../types/interceptor-reply-messages.js'
 import { updatePopupVisualisationIfNeeded } from './popupVisualisationUpdater.js'
 import type { TokenPriceService } from '../simulation/services/priceEstimator.js'
@@ -53,14 +53,23 @@ const INTERNAL_PROVIDER_METHODS = [
 
 const isInternalProviderMethod = (method: string) => INTERNAL_PROVIDER_METHODS.some((internalMethod) => internalMethod === method)
 
-export async function getUpdatedSimulationState(ethereum: EthereumClientService) {
+export async function getUpdatedSimulationState(ethereum: EthereumClientService, simulationInput?: SimulationStateInput) {
 	try {
-		return toResolvedSimulationState(await createSimulationStateWithNonceAndBaseFeeFixing(await getCurrentSimulationInput(), ethereum))
+		return toResolvedSimulationState(await createSimulationStateWithNonceAndBaseFeeFixing(simulationInput ?? await getCurrentSimulationInput(), ethereum))
 	} catch(error: unknown) {
 		if (isExpectedInfrastructureError(error)) return PASSTHROUGH_STATE
 		await reportUnexpectedError(error, { code: 'simulation_state_refresh_failed' })
 	}
 	return PASSTHROUGH_STATE
+}
+
+export async function getUpdatedSimulationStackSnapshot(ethereum: EthereumClientService, simulationMode: boolean) {
+	if (!simulationMode) return { simulationInput: PASSTHROUGH_STATE, simulationState: PASSTHROUGH_STATE }
+	const simulationInput = await getCurrentSimulationInput()
+	return {
+		simulationInput: toResolvedSimulationInput(simulationInput),
+		simulationState: await getUpdatedSimulationState(ethereum, simulationInput),
+	}
 }
 
 let confirmTransactionAbortController = new AbortController()
@@ -169,7 +178,6 @@ async function handleRPCRequest(
 	resetSimulationServices: ResetSimulationServices,
 	getSimulationInput: () => Promise<ResolvedSimulationInput>,
 	getExecutionSimulationState: () => Promise<ResolvedExecutionSimulationState>,
-	getSimulationState: () => Promise<ResolvedSimulationState>,
 	websiteTabConnections: WebsiteTabConnections,
 	socket: WebsiteSocket,
 	website: Website,
@@ -208,7 +216,6 @@ async function handleRPCRequest(
 	}
 	const withSimulationInput = async (handler: (simulationInput: ResolvedSimulationInput) => Promise<RPCReply>) => await handler(await getSimulationInput())
 	const withExecutionSimulationState = async (handler: (simulationState: ResolvedExecutionSimulationState) => Promise<RPCReply>) => await handler(await getExecutionSimulationState())
-	const withSimulationState = async (handler: (simulationState: ResolvedSimulationState) => Promise<RPCReply>) => await handler(await getSimulationState())
 	if (!accountOnlyMethod) await makeSureInterceptorIsNotSleeping(ethereum, publishRpcConnectionStatus)
 	switch (parsedRequest.method) {
 		case 'eth_getBlockByHash': return await withSimulationInput((simulationInput) => getBlockByHash(ethereum, simulationInput, parsedRequest))
@@ -237,7 +244,7 @@ async function handleRPCRequest(
 		case 'eth_requestAccounts': return await getAccounts(activeAddress)
 		case 'eth_gasPrice': return await gasPrice(ethereum)
 		case 'eth_getTransactionCount': return await withSimulationInput((simulationInput) => getTransactionCount(ethereum, simulationInput, parsedRequest))
-		case 'interceptor_getSimulationStack': return await withSimulationState((simulationState) => requestInterceptorSimulatorStack(simulationState, websiteTabConnections, parsedRequest, website, request, socket))
+		case 'interceptor_getSimulationStack': return await requestInterceptorSimulatorStack(await getUpdatedSimulationStackSnapshot(ethereum, settings.simulationMode), websiteTabConnections, parsedRequest, website, request, socket)
 		case 'eth_simulateV1': return await withSimulationInput((simulationInput) => ethSimulateV1(ethereum, simulationInput, parsedRequest))
 		case 'wallet_addEthereumChain': {
 			if (forwardToSigner) return getForwardingMessage(parsedRequest)
@@ -651,7 +658,6 @@ async function handleContentScriptMessage(ethereum: EthereumClientService, token
 		const settings = await getSettings()
 		let simulationInputPromise: Promise<ResolvedSimulationInput> | undefined
 		let executionSimulationStatePromise: Promise<ResolvedExecutionSimulationState> | undefined
-		let simulationStatePromise: Promise<ResolvedSimulationState> | undefined
 		const getSimulationInput = async () => {
 			if (!settings.simulationMode) return PASSTHROUGH_STATE
 			if (simulationInputPromise === undefined) simulationInputPromise = (async () => toResolvedSimulationInput(await prepareSimulationInputForRpc(await getCurrentSimulationInput(), ethereum)))()
@@ -666,16 +672,7 @@ async function handleContentScriptMessage(ethereum: EthereumClientService, token
 			})()
 			return await executionSimulationStatePromise
 		}
-		const getSimulationState = async () => {
-			if (!settings.simulationMode) return PASSTHROUGH_STATE
-			if (simulationStatePromise === undefined) simulationStatePromise = (async () => {
-				const simulationInput = await getSimulationInput()
-				if (simulationInput.kind === 'passthrough') return PASSTHROUGH_STATE
-				return toResolvedSimulationState(await buildSimulationStateFromPreparedInput(simulationInput.value, ethereum))
-			})()
-			return await simulationStatePromise
-		}
-		const resolved = await handleRPCRequest(ethereum, tokenPriceService, resetSimulationServices, getSimulationInput, getExecutionSimulationState, getSimulationState, websiteTabConnections, request.uniqueRequestIdentifier.requestSocket, website, request, settings, activeAddress, publishRpcConnectionStatus)
+		const resolved = await handleRPCRequest(ethereum, tokenPriceService, resetSimulationServices, getSimulationInput, getExecutionSimulationState, websiteTabConnections, request.uniqueRequestIdentifier.requestSocket, website, request, settings, activeAddress, publishRpcConnectionStatus)
 		const refreshedSettings = await persistApprovedAccountsForAccountRequest(
 			ethereum,
 			tokenPriceService,

--- a/app/ts/background/popupMessageHandlers.ts
+++ b/app/ts/background/popupMessageHandlers.ts
@@ -1,4 +1,4 @@
-import { changeActiveAddressAndChain, changeActiveRpc, getUpdatedSimulationState, refreshConfirmTransactionSimulation } from './background.js'
+import { changeActiveAddressAndChain, changeActiveRpc, getUpdatedSimulationStackSnapshot, getUpdatedSimulationState, refreshConfirmTransactionSimulation } from './background.js'
 import { getSettings, setUseTabsInsteadOfPopup, setPage, setUseSignersAddressAsActiveAddress, updateWebsiteAccess, exportSettingsAndAddressBook, importSettingsAndAddressBook, getMakeCurrentAddressRich, getUseTabsInsteadOfPopup, getMetamaskCompatibilityMode, setMetamaskCompatibilityMode, getPage, setPreSimulationBlockTimeManipulation, getPreSimulationBlockTimeManipulation, getFixedAddressRichList, getWebsiteAccess, updateMakeCurrentAddressRich, updateFixedMakeMeRichList } from './settings.js'
 import { getPendingTransactionsAndMessages, getCurrentTabId, getTabState, saveCurrentTabId, setRpcList, getRpcList, getPrimaryRpcForChain, getRpcConnectionStatus, updateUserAddressBookEntries, getPopupVisualisationState, setIdsOfOpenedTabs, getIdsOfOpenedTabs, updatePendingTransactionOrMessage, addEnsLabelHash, addEnsNodeHash, updateInterceptorTransactionStack, getLatestUnexpectedError, getInterceptorTransactionStack, getChainChangeConfirmationPromise, getFetchSimulationStackRequestPromise, getPendingAccessRequests } from './storageVariables.js'
 import { parseEvents, parseInputData } from '../simulation/parsing.js'
@@ -1071,8 +1071,8 @@ async function buildHomePageUpdate(
 }
 
 export async function fetchSimulationStackRequestConfirmation(ethereumClientService: EthereumClientService, websiteTabConnections: WebsiteTabConnections, confirmation: FetchSimulationStackRequestConfirmation) {
-	const simulationState = await getUpdatedSimulationState(ethereumClientService)
-	await resolveFetchSimulationStackRequest(simulationState, websiteTabConnections, confirmation)
+	const snapshot = await getUpdatedSimulationStackSnapshot(ethereumClientService, (await getSettings()).simulationMode)
+	await resolveFetchSimulationStackRequest(snapshot, websiteTabConnections, confirmation)
 }
 
 export async function reportUnexpectedErrorInWindow(parsedRequest: UnexpectedErrorOccured) {

--- a/app/ts/background/simulationModeHanders.ts
+++ b/app/ts/background/simulationModeHanders.ts
@@ -215,7 +215,5 @@ export async function handleIterceptorError(request: InterceptorError) {
 }
 
 export async function requestInterceptorSimulatorStack(snapshot: SimulationStackSnapshot, websiteTabConnections: WebsiteTabConnections, params: GetSimulationStack, website: Website, request: InterceptedRequest, socket: WebsiteSocket) {
-	const result = await openFetchSimulationStackDialogOrGetCachedResult(snapshot, websiteTabConnections, params, website, request, socket)
-	if ('error' in result && result.error !== undefined) return { type: 'result' as const, method: params.method, error: result.error }
-	return { type: 'result' as const, method: params.method, ...result }
+	return await openFetchSimulationStackDialogOrGetCachedResult(snapshot, websiteTabConnections, params, website, request, socket)
 }

--- a/app/ts/background/simulationModeHanders.ts
+++ b/app/ts/background/simulationModeHanders.ts
@@ -3,7 +3,7 @@ import { createEthereumSubscription, createNewFilter, getEthFilterChanges, getEt
 import { getSimulatedBalanceFromInput, getSimulatedBlockByHashFromInput, getSimulatedBlockFromInput, getSimulatedBlockNumberFromInput, getSimulatedCodeFromInput, getSimulatedLogs, getSimulatedTransactionByHashFromInput, getSimulatedTransactionReceipt, simulatedCallFromInput, simulateEstimateGasFromInput, getInputFieldFromDataOrInput, getSimulatedFeeHistory, getSimulatedTransactionCountFromInput, ethSimulateV1FromInput } from '../simulation/services/SimulationModeEthereumClientService.js'
 import { DEFAULT_CALL_ADDRESS, ERROR_INTERCEPTOR_GET_CODE_FAILED } from '../utils/constants.js'
 import type { WebsiteTabConnections } from '../types/user-interface-types.js'
-import type { ResolvedExecutionSimulationState, ResolvedSimulationInput, ResolvedSimulationState } from '../types/visualizer-types.js'
+import type { ResolvedExecutionSimulationState, ResolvedSimulationInput } from '../types/visualizer-types.js'
 import { openChangeChainDialog } from './windows/changeChain.js'
 import type { InterceptedRequest, WebsiteSocket } from '../utils/requests.js'
 import type { EstimateGasParams, EthBalanceParams, EthBlockByHashParams, EthBlockByNumberParams, EthCallParams, EthNewFilter, EthGetLogsParams, EthSubscribeParams, EthUnSubscribeParams, FeeHistory, GetCode, GetFilterChanges, GetSimulationStack, GetTransactionCount, SendRawTransactionParams, SendTransactionParams, SwitchEthereumChainParams, TransactionByHashParams, TransactionReceiptParams, UninstallFilter, GetFilterLogs, InterceptorError } from '../types/JsonRpc-types.js'
@@ -13,7 +13,7 @@ import type { SignMessageParams } from '../types/jsonRpc-signing-types.js'
 import { METAMASK_ERROR_BLANKET_ERROR } from '../utils/constants.js'
 import { openConfirmTransactionDialogForMessage, openConfirmTransactionDialogForTransaction } from './windows/confirmTransaction.js'
 import { printError } from '../utils/errors.js'
-import { openFetchSimulationStackDialogOrGetCachedResult } from './windows/fetchSimulationStack.js'
+import { openFetchSimulationStackDialogOrGetCachedResult, type SimulationStackSnapshot } from './windows/fetchSimulationStack.js'
 import { POPUP_PERFORMANCE_MARKS, markPerformance } from '../utils/popupPerformance.js'
 import type { TokenPriceService } from '../simulation/services/priceEstimator.js'
 import type { ResetSimulationServices } from '../simulation/serviceLifecycle.js'
@@ -214,8 +214,8 @@ export async function handleIterceptorError(request: InterceptorError) {
 	return { type: 'doNotReply' as const }
 }
 
-export async function requestInterceptorSimulatorStack(simulationState: ResolvedSimulationState, websiteTabConnections: WebsiteTabConnections, params: GetSimulationStack, website: Website, request: InterceptedRequest, socket: WebsiteSocket) {
-	const result = await openFetchSimulationStackDialogOrGetCachedResult(simulationState, websiteTabConnections, params, website, request, socket)
+export async function requestInterceptorSimulatorStack(snapshot: SimulationStackSnapshot, websiteTabConnections: WebsiteTabConnections, params: GetSimulationStack, website: Website, request: InterceptedRequest, socket: WebsiteSocket) {
+	const result = await openFetchSimulationStackDialogOrGetCachedResult(snapshot, websiteTabConnections, params, website, request, socket)
 	if ('error' in result && result.error !== undefined) return { type: 'result' as const, method: params.method, error: result.error }
 	return { type: 'result' as const, method: params.method, ...result }
 }

--- a/app/ts/background/windows/fetchSimulationStack.ts
+++ b/app/ts/background/windows/fetchSimulationStack.ts
@@ -9,14 +9,23 @@ import { type InterceptedRequest, type UniqueRequestIdentifier, type WebsiteSock
 import { replyToInterceptedRequest } from '../messageSending.js'
 import type { GetSimulationStack, SimulationStackVersion } from '../../types/JsonRpc-types.js'
 import type { PopupOrTabId, Website } from '../../types/websiteAccessTypes.js'
-import { type ResolvedSimulationInput, type ResolvedSimulationState, toResolvedSimulationInput } from '../../types/visualizer-types.js'
+import type { ResolvedSimulationInput, ResolvedSimulationState } from '../../types/visualizer-types.js'
 import { getSimulatedStackV1, getSimulatedStackV2 } from '../../simulation/SimulationStackExtraction.js'
 import { getAddressToMakeRich } from '../../simulation/services/SimulationModeEthereumClientService.js'
 import { assertNever } from '../../utils/typescript.js'
-import { getCurrentSimulationInput } from '../simulationUpdating.js'
 import { type PopupOrTab, addWindowTabListeners, closePopupOrTabById, getPopupOrTabById, openPopupOrTab, removeWindowTabListeners } from '../../utils/popupOrTab.js'
 
-let pendForUserReply: Future<FetchSimulationStackRequestConfirmation> | undefined 
+export type SimulationStackSnapshot = {
+	simulationInput: ResolvedSimulationInput
+	simulationState: ResolvedSimulationState
+}
+
+type FetchSimulationStackReply = {
+	confirmation: FetchSimulationStackRequestConfirmation
+	snapshot: SimulationStackSnapshot
+}
+
+let pendForUserReply: Future<FetchSimulationStackReply> | undefined
 
 let openedDialog: PopupOrTab | undefined 
 const MAX_DECISION_CACHE = 100
@@ -40,14 +49,14 @@ export async function getSimulationStack(simulationState: ResolvedSimulationStat
 	}
 }
 
-export async function resolveFetchSimulationStackRequest(simulationState: ResolvedSimulationState, websiteTabConnections: WebsiteTabConnections, confirmation: FetchSimulationStackRequestConfirmation) {
+export async function resolveFetchSimulationStackRequest(snapshot: SimulationStackSnapshot, websiteTabConnections: WebsiteTabConnections, confirmation: FetchSimulationStackRequestConfirmation) {
 	if (pendForUserReply !== undefined) {
-		pendForUserReply.resolve(confirmation)
+		pendForUserReply.resolve({ confirmation, snapshot })
 		return
 	}
 	const data = await getFetchSimulationStackRequestPromise()
 	if (data === undefined || !doesUniqueRequestIdentifiersMatch(confirmation.data.uniqueRequestIdentifier, data.uniqueRequestIdentifier)) throw new Error('Unique request identifier mismatch in change chain')
-	const resolved = await getSimulationStack(simulationState, data.simulationStackVersion)
+	const resolved = await getSimulationStack(snapshot.simulationState, data.simulationStackVersion)
 	replyToInterceptedRequest(websiteTabConnections, { type: 'result', method: 'interceptor_getSimulationStack' as const, result: resolved, uniqueRequestIdentifier: data.uniqueRequestIdentifier })
 	if (openedDialog) await closePopupOrTabById(openedDialog)
 	openedDialog = undefined
@@ -72,7 +81,7 @@ const userDeniedChange = {
 } as const
 
 export const openFetchSimulationStackDialog = async (
-	simulationState: ResolvedSimulationState,
+	initialSnapshot: SimulationStackSnapshot,
 	websiteTabConnections: WebsiteTabConnections,
 	uniqueRequestIdentifier: UniqueRequestIdentifier,
 	params: GetSimulationStack,
@@ -80,13 +89,14 @@ export const openFetchSimulationStackDialog = async (
 ) => {
 	if (openedDialog !== undefined || pendForUserReply) return userDeniedChange
 
-	pendForUserReply = new Future<FetchSimulationStackRequestConfirmation>()
+	const replyFuture = new Future<FetchSimulationStackReply>()
+	pendForUserReply = replyFuture
 	const rejectMessage = getRejectMessage(uniqueRequestIdentifier, params.params[0])
 	const onCloseWindowOrTab = async (popupOrTab: PopupOrTabId) => { // check if user has closed the window on their own, if so, reject signature
 		if (openedDialog === undefined || openedDialog.id !== popupOrTab.id || openedDialog.type !== popupOrTab.type) return
 		openedDialog = undefined
 		if (pendForUserReply === undefined) return
-		resolveFetchSimulationStackRequest(simulationState, websiteTabConnections, rejectMessage)
+		resolveFetchSimulationStackRequest(initialSnapshot, websiteTabConnections, rejectMessage)
 	}
 	const onCloseWindow = async (id: number) => onCloseWindowOrTab({ type: 'popup' as const, id })
 	const onCloseTab = async (id: number) => onCloseWindowOrTab({ type: 'tab' as const, id })
@@ -113,12 +123,15 @@ export const openFetchSimulationStackDialog = async (
 				uniqueRequestIdentifier: uniqueRequestIdentifier,
 			})
 		} else {
-			await resolveFetchSimulationStackRequest(simulationState, websiteTabConnections, rejectMessage)
+			await resolveFetchSimulationStackRequest(initialSnapshot, websiteTabConnections, rejectMessage)
 		}
-		const reply = await pendForUserReply
+		const reply = await replyFuture
 		await setFetchSimulationStackRequestPromise(undefined)
-		if (reply.data.accept) {
-			return { result: await getSimulationStack(simulationState, params.params[0]) }
+		if (reply.confirmation.data.accept) {
+			return {
+				result: await getSimulationStack(reply.snapshot.simulationState, params.params[0]),
+				simulationStackHash: getSimulationStackHash(reply.snapshot.simulationInput),
+			}
 		}
 		return userDeniedChange
 	} finally {
@@ -134,19 +147,18 @@ export const getSimulationStackHash = (simulationState: ResolvedSimulationInput)
 	return getSimulationInputHash(simulationState.value)
 }
 
-export async function openFetchSimulationStackDialogOrGetCachedResult(simulationState: ResolvedSimulationState, websiteTabConnections: WebsiteTabConnections, params: GetSimulationStack, website: Website, request: InterceptedRequest, socket: WebsiteSocket) {
-	const input = await getCurrentSimulationInput()
+export async function openFetchSimulationStackDialogOrGetCachedResult(initialSnapshot: SimulationStackSnapshot, websiteTabConnections: WebsiteTabConnections, params: GetSimulationStack, website: Website, request: InterceptedRequest, socket: WebsiteSocket) {
 	const identifier = websiteSocketToString(socket)
-	const newHash = getSimulationStackHash(toResolvedSimulationInput(input))
+	const newHash = getSimulationStackHash(initialSnapshot.simulationInput)
 	const previousDecision = simulationStackDecisions.find((x) => x.identifier === identifier)
 	if (previousDecision !== undefined && previousDecision.hash === newHash) {
-		if (previousDecision.accept) return { result: await getSimulationStack(simulationState, params.params[0]) }
+		if (previousDecision.accept) return { result: await getSimulationStack(initialSnapshot.simulationState, params.params[0]) }
 		return { type: 'result' as const, method: params.method, error: userDeniedChange.error }
 	}
-	const result = await openFetchSimulationStackDialog(simulationState, websiteTabConnections, request.uniqueRequestIdentifier, params, website)
+	const result = await openFetchSimulationStackDialog(initialSnapshot, websiteTabConnections, request.uniqueRequestIdentifier, params, website)
 	simulationStackDecisions = simulationStackDecisions.filter((x) => x.identifier !== identifier)
-	simulationStackDecisions.push({ identifier, hash: newHash, accept: !('error' in result) })
+	simulationStackDecisions.push({ identifier, hash: 'error' in result ? newHash : result.simulationStackHash, accept: !('error' in result) })
 	if (simulationStackDecisions.length > MAX_DECISION_CACHE) simulationStackDecisions.shift()
 	if ('error' in result) return { type: 'result' as const, method: params.method, error: result.error }
-	return { type: 'result' as const, method: params.method, ...result }
+	return { type: 'result' as const, method: params.method, result: result.result }
 }

--- a/app/ts/background/windows/fetchSimulationStack.ts
+++ b/app/ts/background/windows/fetchSimulationStack.ts
@@ -80,14 +80,40 @@ const userDeniedChange = {
 	}
 } as const
 
+type FetchSimulationStackDialogResult =
+	| {
+		outcome: 'accepted'
+		result: Awaited<ReturnType<typeof getSimulationStack>>
+		simulationStackHash: string
+	}
+	| {
+		outcome: 'rejected'
+		error: typeof userDeniedChange.error
+		simulationStackHash: string
+	}
+
+type FetchSimulationStackRequestResult = {
+	type: 'result'
+	method: GetSimulationStack['method']
+} & (
+	| { result: Awaited<ReturnType<typeof getSimulationStack>> }
+	| { error: typeof userDeniedChange.error }
+)
+
+const getRejectedDialogResult = (snapshot: SimulationStackSnapshot): FetchSimulationStackDialogResult => ({
+	outcome: 'rejected',
+	error: userDeniedChange.error,
+	simulationStackHash: getSimulationStackHash(snapshot.simulationInput),
+})
+
 export const openFetchSimulationStackDialog = async (
 	initialSnapshot: SimulationStackSnapshot,
 	websiteTabConnections: WebsiteTabConnections,
 	uniqueRequestIdentifier: UniqueRequestIdentifier,
 	params: GetSimulationStack,
 	website: Website,
-) => {
-	if (openedDialog !== undefined || pendForUserReply) return userDeniedChange
+): Promise<FetchSimulationStackDialogResult> => {
+	if (openedDialog !== undefined || pendForUserReply) return getRejectedDialogResult(initialSnapshot)
 
 	const replyFuture = new Future<FetchSimulationStackReply>()
 	pendForUserReply = replyFuture
@@ -104,7 +130,7 @@ export const openFetchSimulationStackDialog = async (
 	try {
 		const oldPromise = await getFetchSimulationStackRequestPromise()
 		if (oldPromise !== undefined) {
-			if (await getPopupOrTabById(oldPromise.popupOrTabId) !== undefined) return userDeniedChange
+			if (await getPopupOrTabById(oldPromise.popupOrTabId) !== undefined) return getRejectedDialogResult(initialSnapshot)
 			await setFetchSimulationStackRequestPromise(undefined)
 		}
 		openedDialog = await openPopupOrTab({
@@ -129,14 +155,12 @@ export const openFetchSimulationStackDialog = async (
 		await setFetchSimulationStackRequestPromise(undefined)
 		if (reply.confirmation.data.accept) {
 			return {
+				outcome: 'accepted',
 				result: await getSimulationStack(reply.snapshot.simulationState, params.params[0]),
 				simulationStackHash: getSimulationStackHash(reply.snapshot.simulationInput),
 			}
 		}
-		return {
-			...userDeniedChange,
-			simulationStackHash: getSimulationStackHash(reply.snapshot.simulationInput),
-		}
+		return getRejectedDialogResult(reply.snapshot)
 	} finally {
 		removeWindowTabListeners(onCloseWindow, onCloseTab)
 		pendForUserReply = undefined
@@ -150,18 +174,18 @@ export const getSimulationStackHash = (simulationState: ResolvedSimulationInput)
 	return getSimulationInputHash(simulationState.value)
 }
 
-export async function openFetchSimulationStackDialogOrGetCachedResult(initialSnapshot: SimulationStackSnapshot, websiteTabConnections: WebsiteTabConnections, params: GetSimulationStack, website: Website, request: InterceptedRequest, socket: WebsiteSocket) {
+export async function openFetchSimulationStackDialogOrGetCachedResult(initialSnapshot: SimulationStackSnapshot, websiteTabConnections: WebsiteTabConnections, params: GetSimulationStack, website: Website, request: InterceptedRequest, socket: WebsiteSocket): Promise<FetchSimulationStackRequestResult> {
 	const identifier = websiteSocketToString(socket)
 	const newHash = getSimulationStackHash(initialSnapshot.simulationInput)
 	const previousDecision = simulationStackDecisions.find((x) => x.identifier === identifier)
 	if (previousDecision !== undefined && previousDecision.hash === newHash) {
-		if (previousDecision.accept) return { result: await getSimulationStack(initialSnapshot.simulationState, params.params[0]) }
-		return { type: 'result' as const, method: params.method, error: userDeniedChange.error }
+		if (previousDecision.accept) return { type: 'result', method: params.method, result: await getSimulationStack(initialSnapshot.simulationState, params.params[0]) }
+		return { type: 'result', method: params.method, error: userDeniedChange.error }
 	}
 	const result = await openFetchSimulationStackDialog(initialSnapshot, websiteTabConnections, request.uniqueRequestIdentifier, params, website)
 	simulationStackDecisions = simulationStackDecisions.filter((x) => x.identifier !== identifier)
-	simulationStackDecisions.push({ identifier, hash: 'simulationStackHash' in result ? result.simulationStackHash : newHash, accept: !('error' in result) })
+	simulationStackDecisions.push({ identifier, hash: result.simulationStackHash, accept: result.outcome === 'accepted' })
 	if (simulationStackDecisions.length > MAX_DECISION_CACHE) simulationStackDecisions.shift()
-	if ('error' in result) return { type: 'result' as const, method: params.method, error: result.error }
-	return { type: 'result' as const, method: params.method, result: result.result }
+	if (result.outcome === 'rejected') return { type: 'result', method: params.method, error: result.error }
+	return { type: 'result', method: params.method, result: result.result }
 }

--- a/test/tests/fetchSimulationStackFreshness.test.ts
+++ b/test/tests/fetchSimulationStackFreshness.test.ts
@@ -132,7 +132,7 @@ describe('fetch simulation stack freshness', () => {
 		await modules.resolveFetchSimulationStackRequest(confirmationSnapshot, new Map(), confirmation)
 		const result = await pendingResult
 
-		assert.ok('result' in result)
+		assert.equal(result.outcome, 'accepted')
 		assert.deepEqual(result.result.payload.stateOverrides, confirmationSnapshot.simulationInput.value[0]?.stateOverrides)
 		assert.equal(result.simulationStackHash, modules.getSimulationStackHash(confirmationSnapshot.simulationInput))
 		assert.notEqual(result.simulationStackHash, modules.getSimulationStackHash(initialSnapshot.simulationInput))

--- a/test/tests/fetchSimulationStackFreshness.test.ts
+++ b/test/tests/fetchSimulationStackFreshness.test.ts
@@ -1,0 +1,137 @@
+import * as assert from 'assert'
+import { describe, test } from 'bun:test'
+import type { FetchSimulationStackRequestConfirmation } from '../../app/ts/types/interceptor-messages.js'
+import type { SimulationStackSnapshot } from '../../app/ts/background/windows/fetchSimulationStack.js'
+
+const storageState: Record<string, unknown> = {}
+let popupWindowExists = false
+
+function installBrowserMock() {
+	Object.defineProperty(globalThis, 'browser', {
+		configurable: true,
+		writable: true,
+		value: {
+			runtime: {
+				lastError: null,
+				getManifest: () => ({ manifest_version: 3 }),
+				getURL: (path: string) => `chrome-extension://test-extension${ path }`,
+			},
+			storage: {
+				local: {
+					async get(keys?: string | string[]) {
+						const requestedKeys = Array.isArray(keys) ? keys : keys === undefined ? Object.keys(storageState) : [keys]
+						return Object.fromEntries(requestedKeys.filter((key) => key in storageState).map((key) => [key, storageState[key]]))
+					},
+					async set(items: Record<string, unknown>) {
+						Object.assign(storageState, items)
+					},
+					async remove(keys: string | string[]) {
+						for (const key of Array.isArray(keys) ? keys : [keys]) delete storageState[key]
+					},
+				},
+			},
+			tabs: {
+				async create() { return undefined },
+				async get() { return undefined },
+				async remove() { return undefined },
+				onRemoved: { addListener: () => undefined, removeListener: () => undefined },
+			},
+			windows: {
+				async create() {
+					popupWindowExists = true
+					return { id: 41 }
+				},
+				async get() {
+					return popupWindowExists ? { id: 41 } : undefined
+				},
+				async remove() {
+					popupWindowExists = false
+				},
+				onRemoved: { addListener: () => undefined, removeListener: () => undefined },
+			},
+		},
+	})
+}
+
+installBrowserMock()
+
+const modulesPromise = import('../../app/ts/background/windows/fetchSimulationStack.js')
+
+const blockTimeManipulation = { type: 'AddToTimestamp', deltaToAdd: 12n, deltaUnit: 'Seconds' } as const
+const rpcNetwork = {
+	name: 'Test RPC',
+	chainId: 1n,
+	httpsRpc: 'https://rpc.example',
+	currencyName: 'Ether',
+	currencyTicker: 'ETH',
+	primary: true,
+	minimized: false,
+} as const
+
+function createSnapshot(balance: bigint): SimulationStackSnapshot {
+	const stateOverrides = { '0x0000000000000000000000000000000000000001': { balance } }
+	const simulationInput = [{
+		stateOverrides,
+		transactions: [],
+		signedMessages: [],
+		blockTimeManipulation,
+		simulateWithZeroBaseFee: false,
+	}]
+	return {
+		simulationInput: { kind: 'simulated', value: simulationInput },
+		simulationState: {
+			kind: 'simulated',
+			value: {
+				success: true,
+				simulationStateInput: simulationInput,
+				simulatedBlocks: [{
+					stateOverrides,
+					simulatedTransactions: [],
+					signedMessages: [],
+					blockTimestamp: new Date('2026-01-01T00:00:12.000Z'),
+					blockTimeManipulation,
+					blockBaseFeePerGas: 1n,
+				}],
+				blockNumber: 1n,
+				blockTimestamp: new Date('2026-01-01T00:00:00.000Z'),
+				baseFeePerGas: 1n,
+				simulationConductedTimestamp: new Date('2026-01-01T00:00:13.000Z'),
+				rpcNetwork,
+			},
+		},
+	}
+}
+
+describe('fetch simulation stack freshness', () => {
+	test('returns and fingerprints the confirmation-time snapshot', async () => {
+		for (const key of Object.keys(storageState)) delete storageState[key]
+		popupWindowExists = false
+		const modules = await modulesPromise
+		const initialSnapshot = createSnapshot(1n)
+		const confirmationSnapshot = createSnapshot(2n)
+		const uniqueRequestIdentifier = { requestId: 7, requestSocket: { tabId: 3, connectionName: 5n } }
+		const confirmation: FetchSimulationStackRequestConfirmation = {
+			method: 'popup_fetchSimulationStackRequestConfirmation',
+			data: {
+				accept: true,
+				simulationStackVersion: '2.0.0',
+				uniqueRequestIdentifier,
+			},
+		}
+
+		const pendingResult = modules.openFetchSimulationStackDialog(
+			initialSnapshot,
+			new Map(),
+			uniqueRequestIdentifier,
+			{ method: 'interceptor_getSimulationStack', params: ['2.0.0'] },
+			{ websiteOrigin: 'https://requester.example', icon: undefined, title: undefined },
+		)
+		await modules.resolveFetchSimulationStackRequest(confirmationSnapshot, new Map(), confirmation)
+		const result = await pendingResult
+
+		assert.ok('result' in result)
+		assert.deepEqual(result.result.payload.stateOverrides, confirmationSnapshot.simulationInput.value[0]?.stateOverrides)
+		assert.equal(result.simulationStackHash, modules.getSimulationStackHash(confirmationSnapshot.simulationInput))
+		assert.notEqual(result.simulationStackHash, modules.getSimulationStackHash(initialSnapshot.simulationInput))
+	})
+})


### PR DESCRIPTION
## Why

`interceptor_getSimulationStack` captured its simulation state before opening the approval popup. The popup and confirmation handler could refresh to a newer stack, but the normal in-memory path discarded that refreshed state and returned the older snapshot. This made callers receive stale data unless the Interceptor popup had already refreshed the simulation.

The approval decision cache could also be keyed to a different snapshot than the one accepted or rejected, allowing a decision to be reused for the wrong stack. The dialog response additionally relied on inferred, inconsistent object shapes, so callers had to inspect property existence instead of a compiler-enforced outcome.

## What changed

- capture the simulation input and resolved state together as one snapshot
- return the confirmation-time snapshot after approval instead of the pre-dialog state
- key accepted and rejected cached decisions to that same confirmation-time input
- retain the request-time fingerprint only for failures that occur before confirmation
- define an explicit accepted/rejected dialog result contract in which every branch carries the relevant stack hash
- normalize the wrapper to one typed JSON-RPC reply shape and remove property-existence duck typing from its caller
- preserve background/service-worker recovery behavior
- add regression coverage for accepted and rejected requests when the stack changes while approval is pending
- merge the latest `main` EIP-7702 simulation changes and resolve the overlapping background type update

## Validation

- `bun run test` — 728 tests passed
- `bun run setup-chrome`
- `bun run typecheck`
- `bun run lint`
- focused simulation-stack freshness tests — 2 passed
- `git diff --check`

`bun run test:chrome-communication` was not run because this change affects background approval snapshot/cache contracts, not content-script registration, injection, or page/background transport.