### PR TITLE
Show ABI function names for contract executions

### DIFF
--- a/app/ts/components/pages/ConfirmTransaction.tsx
+++ b/app/ts/components/pages/ConfirmTransaction.tsx
@@ -40,6 +40,7 @@ import { browserStorageLocalGet2 } from '../../utils/storageUtils.js'
 import { reportUnexpectedError } from '../../utils/errors.js'
 import { type AsyncStates, useAsyncState } from '../../utils/preact-utilities.js'
 import { AsyncActionButton } from '../subcomponents/AsyncAction.js'
+import type { SignerName } from '../../types/signerTypes.js'
 
 type UnderTransactionsParams = {
 	pendingTransactionsAndSignableMessages: ReadonlySignal<PendingTransactionOrSignableMessage[]>
@@ -548,7 +549,50 @@ type ButtonsParams = {
 	approveButtonState: AsyncStates
 	confirmDisabled: boolean
 }
-function Buttons({ currentPendingTransactionOrSignableMessage, reject, rejectButtonState, approve, approveButtonState, confirmDisabled }: ButtonsParams) {
+
+type ConfirmationActionButtonsParams = Omit<ButtonsParams, 'currentPendingTransactionOrSignableMessage'> & {
+	identified: {
+		signingAction: string
+		simulationAction: string
+		rejectAction: string
+	}
+	signerName: SignerName
+	simulationMode: boolean
+	waitingForSigner: boolean
+}
+
+export function ConfirmationActionButtons({ identified, signerName, simulationMode, waitingForSigner, reject, rejectButtonState, approve, approveButtonState, confirmDisabled }: ConfirmationActionButtonsParams) {
+	return <div style = 'display: flex; flex-direction: row;'>
+		<AsyncActionButton
+			class = 'button is-primary is-danger button-overflow dialog-action-button'
+			state = { rejectButtonState }
+			disabled = { approveButtonState === 'pending' }
+			text = { identified.rejectAction }
+			pendingText = 'Rejecting...'
+			onClick = { reject }
+		/>
+		<AsyncActionButton
+			class = 'button is-primary button-overflow dialog-action-button'
+			state = { approveButtonState }
+			text = { waitingForSigner
+				? <><span> <Spinner height = '1em' color = 'var(--text-color)' /> Waiting for <SignersLogoName signerName = { signerName } /> </span></>
+				: simulationMode
+					? `${ identified.simulationAction }!`
+					: <SignerLogoText signerName = { signerName } text = { identified.signingAction } />
+			}
+			pendingText = { waitingForSigner
+				? 'Waiting for signer...'
+				: simulationMode
+					? `${ identified.simulationAction }...`
+					: `Sign with ${ signerName }...`
+			}
+			onClick = { approve }
+			disabled = { confirmDisabled || rejectButtonState === 'pending' }
+		/>
+	</div>
+}
+
+function ConfirmationButtons({ currentPendingTransactionOrSignableMessage, reject, rejectButtonState, approve, approveButtonState, confirmDisabled }: ButtonsParams) {
 	if (currentPendingTransactionOrSignableMessage === undefined) return <RejectButton onClick = { reject } state = { rejectButtonState }/>
 	if (currentPendingTransactionOrSignableMessage.transactionOrMessageCreationStatus !== 'Simulated') return <RejectButton onClick = { reject } state = { rejectButtonState }/>
 
@@ -562,34 +606,17 @@ function Buttons({ currentPendingTransactionOrSignableMessage, reject, rejectBut
 	const identified = identify()
 	if (identified === undefined) return <RejectButton onClick = { reject } state = { rejectButtonState }/>
 
-	return <div style = 'display: flex; flex-direction: row;'>
-		<AsyncActionButton
-			class = 'button is-primary is-danger button-overflow dialog-action-button'
-			state = { rejectButtonState }
-			disabled = { approveButtonState === 'pending' }
-			text = { identified.rejectAction }
-			pendingText = 'Rejecting...'
-			onClick = { reject }
-		/>
-		<AsyncActionButton
-			class = 'button is-primary button-overflow dialog-action-button'
-			state = { approveButtonState }
-			text = { currentPendingTransactionOrSignableMessage.approvalStatus.status === 'WaitingForSigner'
-				? <><span> <Spinner height = '1em' color = 'var(--text-color)' /> Waiting for <SignersLogoName signerName = { signerName } /> </span></>
-				: currentPendingTransactionOrSignableMessage.simulationMode
-					? `${ identified.simulationAction }!`
-					: <SignerLogoText signerName = { signerName } text = { identified.signingAction } />
-			}
-			pendingText = { currentPendingTransactionOrSignableMessage.approvalStatus.status === 'WaitingForSigner'
-				? 'Waiting for signer...'
-				: currentPendingTransactionOrSignableMessage.simulationMode
-					? `${ identified.simulationAction }...`
-					: `Sign with ${ signerName }...`
-			}
-			onClick = { approve }
-			disabled = { confirmDisabled || rejectButtonState === 'pending' }
-		/>
-	</div>
+	return <ConfirmationActionButtons
+		identified = { identified }
+		signerName = { signerName }
+		simulationMode = { currentPendingTransactionOrSignableMessage.simulationMode }
+		waitingForSigner = { currentPendingTransactionOrSignableMessage.approvalStatus.status === 'WaitingForSigner' }
+		reject = { reject }
+		rejectButtonState = { rejectButtonState }
+		approve = { approve }
+		approveButtonState = { approveButtonState }
+		confirmDisabled = { confirmDisabled }
+	/>
 }
 
 export function ConfirmTransaction() {
@@ -941,7 +968,7 @@ export function ConfirmTransaction() {
 						</div>
 						<nav class = 'window-footer popup-button-row' style = 'position: sticky; bottom: 0; width: 100%;'>
 							<CheckBoxes currentPendingTransactionOrSignableMessage = { currentPendingTransactionOrSignableMessage } forceSend = { forceSend } />
-					<Buttons
+					<ConfirmationButtons
 						currentPendingTransactionOrSignableMessage = { currentPendingTransactionOrSignableMessage.value }
 						reject = { reject }
 						rejectButtonState = { rejectButtonState.value.state }

--- a/app/ts/components/simulationExplaining/identifyTransaction.tsx
+++ b/app/ts/components/simulationExplaining/identifyTransaction.tsx
@@ -362,7 +362,9 @@ export function identifyTransaction(simTx: MaybeSimulatedTransaction): Identifie
 		rejectAction: 'Reject Contract Execution',
 	}
 
-	const explanation = FourByteExplanations[fourByte]
+	const explanation = simTx.parsedInputData.type === 'Parsed'
+		? simTx.parsedInputData.name
+		: FourByteExplanations[fourByte]
 
 	if (explanation === undefined) {
 		return {
@@ -375,7 +377,7 @@ export function identifyTransaction(simTx: MaybeSimulatedTransaction): Identifie
 	}
 	return {
 		type: 'ArbitraryContractExecution',
-		title: explanation === undefined ? 'Contract Execution' : explanation,
+		title: explanation,
 		signingAction: `Sign ${ explanation }`,
 		simulationAction: `Simulate ${ explanation }`,
 		rejectAction: `Reject ${ explanation }`,

--- a/test/tests/popupHeaderMarkup.test.tsx
+++ b/test/tests/popupHeaderMarkup.test.tsx
@@ -4,15 +4,18 @@ import { h, render } from 'preact'
 import { act } from 'preact/test-utils'
 import { describe, test } from 'bun:test'
 import { SignatureHeader } from '../../app/ts/components/pages/PersonalSign.js'
-import { CheckBoxes } from '../../app/ts/components/pages/ConfirmTransaction.js'
+import { CheckBoxes, ConfirmationActionButtons } from '../../app/ts/components/pages/ConfirmTransaction.js'
 import { TransactionHeader } from '../../app/ts/components/simulationExplaining/SimulationSummary.js'
 import { PendingStackHeader } from '../../app/ts/components/simulationExplaining/Transactions.js'
+import { identifyTransaction } from '../../app/ts/components/simulationExplaining/identifyTransaction.js'
 import type { AddressBookEntry } from '../../app/ts/types/addressBookTypes.js'
 import type { VisualizedPersonalSignRequest } from '../../app/ts/types/personal-message-definitions.js'
 import type { RpcNetwork } from '../../app/ts/types/rpc.js'
 import type { Website } from '../../app/ts/types/websiteAccessTypes.js'
 import type { SimulatedAndVisualizedTransaction } from '../../app/ts/types/visualizer-types.js'
 import type { PopupPendingSignableMessage } from '../../app/ts/types/accessRequest.js'
+import { encodeFunctionCall } from '../../app/ts/utils/abiRuntime.js'
+import { bytesFromHex } from '../../app/ts/utils/ethereumBytes.js'
 import { installDomMock } from './domMock.js'
 
 type TestNode = {
@@ -82,6 +85,42 @@ const fallbackMethodTransaction: SimulatedAndVisualizedTransaction = {
 	events: [],
 }
 
+const abiFunctionName = 'issue734Function'
+const abi = [{
+	type: 'function',
+	name: abiFunctionName,
+	inputs: [],
+	outputs: [],
+	stateMutability: 'nonpayable',
+}] as const
+const abiFunctionInput = bytesFromHex(encodeFunctionCall(abi, abiFunctionName, []))
+const abiFunctionTransaction: SimulatedAndVisualizedTransaction = {
+	...fallbackMethodTransaction,
+	parsedInputData: {
+		type: 'Parsed',
+		input: abiFunctionInput,
+		name: abiFunctionName,
+		args: [],
+	},
+	originalRequestParameters: {
+		method: 'eth_sendTransaction',
+		params: [{
+			from: fromEntry.address,
+			to: toEntry.address,
+			value: 0n,
+			input: abiFunctionInput,
+		}],
+	},
+	transaction: {
+		...fallbackMethodTransaction.transaction,
+		to: {
+			...toEntry,
+			abi: JSON.stringify(abi),
+		},
+		input: abiFunctionInput,
+	},
+}
+
 const personalSignRequest: VisualizedPersonalSignRequest = {
 	method: 'personal_sign',
 	type: 'NotParsed',
@@ -137,6 +176,57 @@ describe('popup header markup', () => {
 		const titleText = findFirstByClass(dom.document.body, 'card-header-title-text')
 		assert.equal(titleText?.textContent, 'Contract Fallback Method')
 		assertClasses(findFirstByClass(dom.document.body, 'card-header-website'), ['card-header-website', 'card-header-website--flush'])
+
+		dom.restore()
+	})
+
+	test('TransactionHeader and confirmation actions use an ABI-decoded function name', async () => {
+		const identified = identifyTransaction(abiFunctionTransaction)
+		assert.equal(identified.title, abiFunctionName)
+
+		const dom = installDomMock()
+
+		await act(() => {
+			render(h(TransactionHeader, {
+				simTx: abiFunctionTransaction,
+				removeTransactionOrSignedMessage: () => undefined,
+			}), dom.document.body)
+		})
+
+		assert.equal(findFirstByClass(dom.document.body, 'card-header-title-text')?.textContent, abiFunctionName)
+
+		await act(() => {
+			render(h(ConfirmationActionButtons, {
+				identified,
+				signerName: 'NoSigner',
+				simulationMode: false,
+				waitingForSigner: false,
+				reject: () => undefined,
+				rejectButtonState: 'inactive',
+				approve: () => undefined,
+				approveButtonState: 'inactive',
+				confirmDisabled: false,
+			}), dom.document.body)
+		})
+
+		assert.equal(dom.document.body.textContent?.includes(`Reject ${ abiFunctionName }`), true)
+		assert.equal(dom.document.body.textContent?.includes(`Sign ${ abiFunctionName }`), true)
+
+		await act(() => {
+			render(h(ConfirmationActionButtons, {
+				identified,
+				signerName: 'NoSigner',
+				simulationMode: true,
+				waitingForSigner: false,
+				reject: () => undefined,
+				rejectButtonState: 'inactive',
+				approve: () => undefined,
+				approveButtonState: 'inactive',
+				confirmDisabled: false,
+			}), dom.document.body)
+		})
+
+		assert.equal(dom.document.body.textContent?.includes(`Simulate ${ abiFunctionName }!`), true)
 
 		dom.restore()
 	})


### PR DESCRIPTION
## Issue

Closes [#734](https://github.com/DarkFlorist/TheInterceptor/issues/734).

## What changed

- Use the ABI-decoded `parsedInputData.name` when identifying arbitrary contract executions.
- Show that function name in transaction headers and the sign, simulate, and reject action labels.
- Preserve the existing four-byte explanation and generic contract execution fallbacks when ABI decoding is unavailable.
- Extract the existing confirmation action-button markup into a presentational `ConfirmationActionButtons` component so the rendered labels can be tested directly without changing the surrounding pending-state behavior.

## Test coverage

- Add an encoded ABI/calldata transaction fixture.
- Verify the rendered transaction header uses the decoded function name.
- Verify the rendered reject, sign, and simulation buttons use the decoded function name.
- Retain coverage for the no-calldata fallback title.

## Validation

- `bun run test` — 729 tests passed
- `bun run setup-chrome`
- `bun run typecheck`
- `bun run lint`

`bun run test:chrome-communication` was not run because this change does not modify extension messaging, content-script registration, provider injection, or page-to-extension communication.