### PR TITLE
Improve literal inference for satisfies expressions

### DIFF
--- a/app/ts/background/background.ts
+++ b/app/ts/background/background.ts
@@ -288,7 +288,7 @@ async function handleRPCRequest(
 		eth_getFilterChanges: rpcRequestHandler('eth_getFilterChanges', async (_context, rpcRequest) => await withExecutionSimulationState((simulationState) => getFilterChanges(rpcRequest, ethereum, simulationState))),
 		eth_getFilterLogs: rpcRequestHandler('eth_getFilterLogs', async (_context, rpcRequest) => await withExecutionSimulationState((simulationState) => getFilterLogs(rpcRequest, ethereum, simulationState))),
 		InterceptorError: rpcRequestHandler('InterceptorError', async (_context, rpcRequest) => await handleIterceptorError(rpcRequest)),
-	} satisfies Record<ParsedRpcRequest['method'], RpcRequestHandler>
+	} as const satisfies Record<ParsedRpcRequest['method'], RpcRequestHandler>
 	return await rpcRequestHandlers[parsedRequest.method](undefined, parsedRequest)
 }
 

--- a/app/ts/background/popupMessageDispatcher.ts
+++ b/app/ts/background/popupMessageDispatcher.ts
@@ -105,7 +105,7 @@ const popupMessageHandlers = {
 	popup_requestIdentifyAddress: popupMessageHandler('popup_requestIdentifyAddress', async (context, request) => await requestIdentifyAddress(context.ethereum, request)),
 	popup_isMainPopupWindowOpen: popupMessageHandler('popup_isMainPopupWindowOpen', async () => undefined),
 	popup_isSimulationVisualizerOpen: popupMessageHandler('popup_isSimulationVisualizerOpen', async () => undefined),
-} satisfies Record<PopupMessage['method'], PopupMessageHandler>
+} as const satisfies Record<PopupMessage['method'], PopupMessageHandler>
 
 export async function dispatchPopupMessage(context: PopupMessageDispatcherContext, request: PopupMessage): Promise<PopupReplyOption | void> {
 	return await popupMessageHandlers[request.method](context, request)

--- a/app/ts/utils/errors.ts
+++ b/app/ts/utils/errors.ts
@@ -46,7 +46,7 @@ export const ERROR_REPORTING_POLICY = {
 	externalService: { category: 'external_service', severity: 'warning', userVisible: false },
 	localRecovery: { category: 'local_recovery', severity: 'warning', userVisible: false },
 	unexpected: { category: 'unexpected', severity: 'error', userVisible: true },
-} satisfies Record<string, ErrorPolicyEntry>
+} as const satisfies Record<string, ErrorPolicyEntry>
 
 type InterceptorErrorReport = InterceptorErrorDiagnostic
 

--- a/app/ts/utils/solidityTypes.ts
+++ b/app/ts/utils/solidityTypes.ts
@@ -110,7 +110,7 @@ const solidityTypeCategories = {
 	address: 'address',
 	string: 'string',
 	bytes: 'bytes',
-} satisfies Record<SolidityType, SolidityTypeCategory>
+} as const satisfies Record<SolidityType, SolidityTypeCategory>
 
 function getSolidityTypeCategory(type: SolidityType) {
 	return solidityTypeCategories[type]

--- a/test/tests/methodHandlers.test.ts
+++ b/test/tests/methodHandlers.test.ts
@@ -12,7 +12,7 @@ const testHandler = createMethodHandlerFor<TestMessage, number, number>()
 const handlers = {
 	double: testHandler('double', (context, message) => context + message.value * 2),
 	length: testHandler('length', (context, message) => context + message.value.length),
-} satisfies Record<TestMessage['method'], TestHandler>
+} as const satisfies Record<TestMessage['method'], TestHandler>
 
 test('method handler tables dispatch narrowed messages and reject mismatched direct calls', () => {
 	assert.equal(handlers.double(1, { method: 'double', value: 3 }), 7)

--- a/test/tests/solidityTypeRendering.test.tsx
+++ b/test/tests/solidityTypeRendering.test.tsx
@@ -44,7 +44,7 @@ const addressMetaData = [
 		address: CONSIDERATION_RECIPIENT_ADDRESS,
 		entrySource: 'User',
 	},
-] satisfies readonly AddressBookEntry[]
+] as const satisfies readonly AddressBookEntry[]
 
 const web3jAbiV2Tuple = {
 	type: 'tuple',
@@ -52,7 +52,7 @@ const web3jAbiV2Tuple = {
 		{ paramName: 'id', typeValue: { type: 'string', value: 'foo-id' } },
 		{ paramName: 'name', typeValue: { type: 'string', value: 'Example Foo' } },
 	],
-} satisfies PureGroupedSolidityType
+} as const satisfies PureGroupedSolidityType
 
 const seaportTupleArray = {
 	type: 'tuple[]',
@@ -71,7 +71,7 @@ const seaportTupleArray = {
 			{ paramName: 'recipient', typeValue: { type: 'address', value: CONSIDERATION_RECIPIENT_ADDRESS } },
 		],
 	],
-} satisfies PureGroupedSolidityType
+} as const satisfies PureGroupedSolidityType
 
 describe('Solidity type rendering', () => {
 	test('renders generic unavailable input parser copy after tuple support', async () => {

--- a/test/tests/solidityTypes.test.ts
+++ b/test/tests/solidityTypes.test.ts
@@ -41,12 +41,12 @@ const tupleAbiParameters = [
 			{ name: 'amount', type: 'uint256' },
 		],
 	},
-] satisfies readonly AbiParameter[]
+] as const satisfies readonly AbiParameter[]
 
 const bytes32LikeBytesAbiParameters = [{
 	name: 'payload',
 	type: 'bytes',
-}] satisfies readonly AbiParameter[]
+}] as const satisfies readonly AbiParameter[]
 
 const tupleWithHashFieldAbiParameters = [{
 	name: 'proof',
@@ -54,7 +54,7 @@ const tupleWithHashFieldAbiParameters = [{
 	components: [
 		{ name: 'hash', type: 'bytes32' },
 	],
-}] satisfies readonly AbiParameter[]
+}] as const satisfies readonly AbiParameter[]
 
 const tupleInputFunctionAbi = [
 	{
@@ -81,7 +81,7 @@ const tupleInputFunctionAbi = [
 		],
 		outputs: [],
 	},
-] satisfies Abi
+] as const satisfies Abi
 
 const web3jAbiV2ExampleEvent = {
 	type: 'event',
@@ -105,7 +105,7 @@ const web3jAbiV2ExampleEvent = {
 			],
 		},
 	],
-} satisfies AbiEvent
+} as const satisfies AbiEvent
 
 const seaportOrderFulfilledEvent = {
 	type: 'event',
@@ -137,7 +137,7 @@ const seaportOrderFulfilledEvent = {
 			],
 		},
 	],
-} satisfies AbiEvent
+} as const satisfies AbiEvent
 
 const indexedTupleEvent = {
 	type: 'event',
@@ -151,7 +151,7 @@ const indexedTupleEvent = {
 			{ name: 'amount', type: 'uint256' },
 		],
 	}],
-} satisfies AbiEvent
+} as const satisfies AbiEvent
 
 const indexedTupleArrayEvent = {
 	type: 'event',
@@ -165,7 +165,7 @@ const indexedTupleArrayEvent = {
 			{ name: 'amount', type: 'uint256' },
 		],
 	}],
-} satisfies AbiEvent
+} as const satisfies AbiEvent
 
 const toIndexedAddressTopic = (address: string) => `0x${ address.slice(2).padStart(64, '0') }`
 const toAddressHex = (address: bigint) => `0x${ address.toString(16).padStart(40, '0') }`


### PR DESCRIPTION
## Summary

- retain `satisfies` checks because they validate target shapes and exhaustive records independently of const assertions
- use `as const satisfies` for immutable exhaustive dispatch tables, immutable lookup/policy tables, and nested ABI/rendering fixtures where readonly or readonly-tuple inference is useful
- leave ordinary callbacks, browser mocks, RPC entries, setup results, and incidental literals as plain `satisfies`

## Audit result

`as const` does not replace `satisfies`: const assertions preserve literal/readonly structure, while `satisfies` checks compatibility with the declared contract. Every tracked `satisfies` occurrence was reviewed. The RPC and popup dispatch tables use the combined form consistently, matching the intent of the review comments on PR #1553.

## Validation

- `bun run test` (841 passed)
- `bun run setup-chrome`
- `bun run typecheck`
- `bun run lint`
- `git diff --check`

## Review

Final project reviewer pass completed with no High, Medium, or Low findings (score: 96).