### PR TITLE
Fix Coinbase Payments account connection flow

### DIFF
--- a/app/ts/background/accessManagement.ts
+++ b/app/ts/background/accessManagement.ts
@@ -237,13 +237,19 @@ export function sendProviderConnectionEventsToPort(
 	socket: WebsiteSocket,
 	settings: Settings,
 	accounts: readonly bigint[],
-	options: { readonly requestId?: number, readonly includeChainChanged?: boolean } = {},
 ) {
-	const requestScope = options.requestId === undefined ? {} : { requestId: options.requestId }
-	sendSubscriptionReplyOrCallBack(websiteTabConnections, socket, { type: 'result' as const, method: 'connect', result: [settings.activeRpcNetwork.chainId], ...requestScope })
-	sendSubscriptionReplyOrCallBack(websiteTabConnections, socket, { type: 'result' as const, method: 'accountsChanged', result: accounts, ...requestScope })
-	if (options.includeChainChanged === false) return
-	sendSubscriptionReplyOrCallBack(websiteTabConnections, socket, { type: 'result' as const, method: 'chainChanged', result: settings.activeRpcNetwork.chainId, ...requestScope })
+	sendSubscriptionReplyOrCallBack(websiteTabConnections, socket, { type: 'result' as const, method: 'connect', result: [settings.activeRpcNetwork.chainId] })
+	sendSubscriptionReplyOrCallBack(websiteTabConnections, socket, { type: 'result' as const, method: 'accountsChanged', result: accounts })
+	sendSubscriptionReplyOrCallBack(websiteTabConnections, socket, { type: 'result' as const, method: 'chainChanged', result: settings.activeRpcNetwork.chainId })
+}
+
+export function sendAccountsChangedToPort(
+	websiteTabConnections: WebsiteTabConnections,
+	socket: WebsiteSocket,
+	accounts: readonly bigint[],
+	requestId: number,
+) {
+	sendSubscriptionReplyOrCallBack(websiteTabConnections, socket, { type: 'result' as const, method: 'accountsChanged', result: accounts, requestId })
 }
 
 function disconnectFromPort(

--- a/app/ts/background/background.ts
+++ b/app/ts/background/background.ts
@@ -7,7 +7,7 @@ import { PASSTHROUGH_STATE, type ResolvedExecutionSimulationState, type Resolved
 import type { WebsiteTabConnections } from '../types/user-interface-types.js'
 import { askForSignerAccountsFromSignerIfNotAvailable, requestAccessFromUser } from './windows/interceptorAccess.js'
 import { METAMASK_ERROR_FAILED_TO_PARSE_REQUEST, METAMASK_ERROR_NOT_AUTHORIZED, METAMASK_ERROR_NOT_CONNECTED_TO_CHAIN, METAMASK_ERROR_PROVIDER_DISCONNECTED, METAMASK_ERROR_USER_REJECTED_REQUEST, ERROR_INTERCEPTOR_DISABLED, NEW_BLOCK_ABORT, JSON_RPC_ERROR_CODE_INTERNAL_ERROR } from '../utils/constants.js'
-import { clearWebsiteConnectionIntent, hasAccess as getWebsiteAccessApprovalState, hasAddressAccess as getWebsiteAddressAccessApprovalState, persistWebsiteAccessChange, sendActiveAccountChangeToApprovedWebsitePorts, sendMessageToApprovedWebsitePorts, sendProviderConnectionEventsToPort, updateWebsiteApprovalAccesses, verifyAccess, withSuppressedUnscopedConnectionEventsForSocket } from './accessManagement.js'
+import { clearWebsiteConnectionIntent, hasAccess as getWebsiteAccessApprovalState, hasAddressAccess as getWebsiteAddressAccessApprovalState, persistWebsiteAccessChange, sendAccountsChangedToPort, sendActiveAccountChangeToApprovedWebsitePorts, sendMessageToApprovedWebsitePorts, updateWebsiteApprovalAccesses, verifyAccess, withSuppressedUnscopedConnectionEventsForSocket } from './accessManagement.js'
 import { getActiveAddressEntry, identifyAddress } from './metadataUtils.js'
 import { getActiveAddress, sendPopupMessageToOpenWindows } from './backgroundUtils.js'
 import { assertNever } from '../utils/typescript.js'
@@ -439,10 +439,10 @@ function getApprovedAccountsForAccountRequest(request: InterceptedRequest, resol
 	return getAccountRequestResultAccounts(resolved)
 }
 
-function replayProviderStateForAccountRequest(websiteTabConnections: WebsiteTabConnections, request: InterceptedRequest, settings: Settings, resolved: RPCReply, activeAddress: bigint | undefined) {
+function replayProviderStateForAccountRequest(websiteTabConnections: WebsiteTabConnections, request: InterceptedRequest, resolved: RPCReply, activeAddress: bigint | undefined) {
 	const accounts = getApprovedAccountsForAccountRequest(request, resolved, activeAddress)
 	if (accounts === undefined || accounts.length === 0) return
-	sendProviderConnectionEventsToPort(websiteTabConnections, request.uniqueRequestIdentifier.requestSocket, settings, accounts, { requestId: request.uniqueRequestIdentifier.requestId, includeChainChanged: false })
+	sendAccountsChangedToPort(websiteTabConnections, request.uniqueRequestIdentifier.requestSocket, accounts, request.uniqueRequestIdentifier.requestId)
 }
 
 async function persistApprovedAccountsForAccountRequest(
@@ -454,12 +454,11 @@ async function persistApprovedAccountsForAccountRequest(
 	website: Website,
 	resolved: RPCReply,
 	activeAddress: bigint | undefined,
-): Promise<Settings | undefined> {
+): Promise<void> {
 	const accounts = getApprovedAccountsForAccountRequest(request, resolved, activeAddress)
-	if (accounts === undefined || accounts.length === 0) return undefined
+	if (accounts === undefined || accounts.length === 0) return
 
 	const settings = await getSettings()
-	let storedAddressAccess = false
 	for (const account of accounts) {
 		const addressEntry = await getActiveAddressEntry(account)
 		const existingApprovalState = getWebsiteAddressAccessApprovalState(settings.websiteAccess, website.websiteOrigin, addressEntry)
@@ -475,11 +474,7 @@ async function persistApprovedAccountsForAccountRequest(
 			account,
 			false,
 		)
-		storedAddressAccess = true
 	}
-
-	if (!storedAddressAccess) return settings
-	return await getSettings()
 }
 
 async function revokeWebsitePermissions(
@@ -680,7 +675,7 @@ async function handleContentScriptMessage(ethereum: EthereumClientService, token
 			return await executionSimulationStatePromise
 		}
 		const resolved = await handleRPCRequest(ethereum, tokenPriceService, resetSimulationServices, getSimulationInput, getExecutionSimulationState, websiteTabConnections, request.uniqueRequestIdentifier.requestSocket, website, request, settings, activeAddress, publishRpcConnectionStatus)
-		const refreshedSettings = await persistApprovedAccountsForAccountRequest(
+		await persistApprovedAccountsForAccountRequest(
 			ethereum,
 			tokenPriceService,
 			resetSimulationServices,
@@ -690,7 +685,7 @@ async function handleContentScriptMessage(ethereum: EthereumClientService, token
 			resolved,
 			activeAddress,
 		)
-		replayProviderStateForAccountRequest(websiteTabConnections, request, refreshedSettings ?? settings, resolved, activeAddress)
+		replayProviderStateForAccountRequest(websiteTabConnections, request, resolved, activeAddress)
 		return replyToInterceptedRequest(websiteTabConnections, { ...requestWithDefinedParams, ...resolved })
 	} catch (error: unknown) {
 		if (isFailedToFetchError(error)) {

--- a/test/benchmarks/chromeCommunication.ts
+++ b/test/benchmarks/chromeCommunication.ts
@@ -8,6 +8,9 @@ type CommunicationPageState = {
 	accounts?: readonly string[]
 	error?: string
 	errorCode?: number
+	connectEvents: number
+	accountsChangedEvents: number
+	eventOrder: readonly string[]
 }
 
 const COMMUNICATION_PAGE_STATE_GLOBAL = '__interceptorChromeCommunicationState' as const
@@ -111,7 +114,7 @@ async function main() {
 			workerConnection.close()
 		}
 
-		pageTargetId = await createTargetPage(chrome.browserConnection, server.baseUrl)
+		pageTargetId = await createTargetPage(chrome.browserConnection, `${ server.baseUrl }?flow=wallet-request-permissions`)
 		const pageConnection = await connectTarget(chrome.browserDebugPort, pageTargetId)
 		try {
 			await waitForCommunicationPagePhase(pageConnection, 'requesting-access', 30_000)
@@ -127,6 +130,9 @@ async function main() {
 
 			await waitForCommunicationPagePhase(pageConnection, 'access-granted', 30_000)
 			const accessGrantedState = await getCommunicationPageState(pageConnection)
+			if (accessGrantedState?.connectEvents !== 0) throw new Error(`Account authorization emitted ${ accessGrantedState?.connectEvents ?? 'an unknown number of' } connect events`)
+			if (accessGrantedState.accountsChangedEvents !== 1) throw new Error(`Account authorization emitted ${ accessGrantedState.accountsChangedEvents } accountsChanged events instead of one`)
+			if (accessGrantedState.eventOrder.join(',') !== 'accountsChanged,permissionsResolved,accountsResolved') throw new Error(`Unexpected account authorization event order: ${ accessGrantedState.eventOrder.join(',') }`)
 
 			await pageConnection.evaluate(`(() => {
 				globalThis.__raw7702Result = { status: 'pending' }

--- a/test/benchmarks/chromeCommunicationPage.html
+++ b/test/benchmarks/chromeCommunicationPage.html
@@ -72,6 +72,9 @@
 					accounts: undefined,
 					error: undefined,
 					errorCode: undefined,
+					connectEvents: 0,
+					accountsChangedEvents: 0,
+					eventOrder: [],
 				}
 				const statusElement = document.getElementById('status')
 
@@ -100,10 +103,29 @@
 					try {
 						const ethereum = await waitForEthereum()
 						updateState('provider-ready')
-						updateState('requesting-access')
-						const accounts = await ethereum.request({
-							method: 'eth_requestAccounts',
+						ethereum.on('connect', () => {
+							state.connectEvents += 1
+							state.eventOrder.push('connect')
 						})
+						ethereum.on('accountsChanged', () => {
+							state.accountsChangedEvents += 1
+							state.eventOrder.push('accountsChanged')
+						})
+						updateState('requesting-access')
+						const useWalletRequestPermissions = new URLSearchParams(location.search).get('flow') === 'wallet-request-permissions'
+						let accounts
+						if (useWalletRequestPermissions) {
+							await ethereum.request({
+								method: 'wallet_requestPermissions',
+								params: [{ eth_accounts: {} }],
+							})
+							state.eventOrder.push('permissionsResolved')
+							accounts = await ethereum.request({ method: 'eth_accounts' })
+							state.eventOrder.push('accountsResolved')
+						} else {
+							accounts = await ethereum.request({ method: 'eth_requestAccounts' })
+							state.eventOrder.push('accountsResolved')
+						}
 						updateState('access-granted', { accounts: Array.isArray(accounts) ? accounts : [] })
 					} catch (error) {
 						const message = error instanceof Error ? error.message : String(error)

--- a/test/tests/backgroundEthAccounts.test.ts
+++ b/test/tests/backgroundEthAccounts.test.ts
@@ -19,18 +19,23 @@ function createDeferredSignal() {
 	return { promise, resolve: () => resolveSignal() }
 }
 
-function installBrowserMock({ deferFirstChainChangeRemoval = false } = {}) {
+function installBrowserMock({ deferFirstChainChangeRemoval = false, manifestVersion = 3 }: { readonly deferFirstChainChangeRemoval?: boolean, readonly manifestVersion?: 2 | 3 } = {}) {
 	const storageState: Record<string, unknown> = {}
 	const chainChangeRemovalStarted = createDeferredSignal()
 	const chainChangeRemovalRelease = createDeferredSignal()
 	let chainChangeRemovalDeferred = false
+	const requestBlockingCalls = {
+		declarativeNetRequestUpdates: 0,
+		webRequestListenerAdds: 0,
+		webRequestListenerRemovals: 0,
+	}
 	;(globalThis as typeof globalThis & { browser: typeof globalThis.browser }).browser = {
 		runtime: {
 			lastError: null,
 			async sendMessage() {
 				return undefined
 			},
-			getManifest: () => ({ manifest_version: 3 }),
+			getManifest: () => ({ manifest_version: manifestVersion }),
 			onMessage: { addListener: (_listener: Listener) => undefined, removeListener: (_listener: Listener) => undefined },
 			onConnect: { addListener: (_listener: Listener) => undefined, removeListener: (_listener: Listener) => undefined },
 		},
@@ -87,8 +92,24 @@ function installBrowserMock({ deferFirstChainChangeRemoval = false } = {}) {
 		declarativeNetRequest: {
 			async getDynamicRules() { return [] },
 			async getSessionRules() { return [] },
-			async updateDynamicRules() { return undefined },
-			async updateSessionRules() { return undefined },
+			async updateDynamicRules() {
+				requestBlockingCalls.declarativeNetRequestUpdates += 1
+				return undefined
+			},
+			async updateSessionRules() {
+				requestBlockingCalls.declarativeNetRequestUpdates += 1
+				return undefined
+			},
+		},
+		webRequest: {
+			onBeforeRequest: {
+				addListener() {
+					requestBlockingCalls.webRequestListenerAdds += 1
+				},
+				removeListener() {
+					requestBlockingCalls.webRequestListenerRemovals += 1
+				},
+			},
 		},
 	} as unknown as typeof globalThis.browser
 	;(globalThis as typeof globalThis & { chrome: { runtime: { id: string } } }).chrome = { runtime: { id: 'test-extension' } }
@@ -96,6 +117,8 @@ function installBrowserMock({ deferFirstChainChangeRemoval = false } = {}) {
 	return {
 		waitForDeferredChainChangeRemoval: async () => await chainChangeRemovalStarted.promise,
 		releaseDeferredChainChangeRemoval: chainChangeRemovalRelease.resolve,
+		requestBlockingCalls,
+		readStoredValue: (key: string) => storageState[key],
 	}
 }
 
@@ -1735,17 +1758,12 @@ params: [{ signerProviderGeneration: 1, type: 'success', accounts: ['0x333333333
 		const requestAccountsReplies = messages.filter((message) => message.method === 'eth_accounts' && message.requestId === 9)
 		assert.deepEqual(requestAccountsReplies.at(-1)?.result, ['0x4444444444444444444444444444444444444444'])
 		const requestAccountsReplyIndex = messages.findIndex((message) => message.method === 'eth_accounts' && message.requestId === 9)
-		const connectMessages = messages.filter((message) => message.method === 'connect')
-		const connectIndex = messages.findIndex((message) => message.method === 'connect')
 		const accountChangedMessages = messages.filter((message) => message.method === 'accountsChanged')
 		const accountChangedIndex = messages.findIndex((message) => message.method === 'accountsChanged')
 		assert.notEqual(requestAccountsReplyIndex, -1)
-		assert.notEqual(connectIndex, -1)
 		assert.notEqual(accountChangedIndex, -1)
-		assert.equal(connectIndex < accountChangedIndex, true)
 		assert.equal(accountChangedIndex < requestAccountsReplyIndex, true)
-		assert.deepEqual(connectMessages.map((message) => message.result), [['0x1']])
-		assert.deepEqual(connectMessages.map((message) => message.requestId), [9])
+		assert.equal(messages.some((message) => message.method === 'connect'), false)
 		assert.deepEqual(accountChangedMessages.map((message) => message.result), [[accountString]])
 		assert.deepEqual(accountChangedMessages.map((message) => message.requestId), [9])
 		const siblingAccountChangedMessages = siblingMessages.filter((message) => message.method === 'accountsChanged')
@@ -1810,72 +1828,80 @@ params: [{ signerProviderGeneration: 1, type: 'success', accounts: ['0x333333333
 
 		await handleInterceptedRequest(port, websiteOrigin, website, ethereum, tokenPriceService, resetSimulationServices, socket, request, websiteTabConnections, noopPublishRpcConnectionStatus)
 
-		assert.deepEqual(messages.filter((message) => message.method === 'connect').map((message) => message.requestId), [17])
+		assert.equal(messages.some((message) => message.method === 'connect'), false)
 		assert.deepEqual(messages.filter((message) => message.method === 'accountsChanged').map((message) => message.requestId), [17])
 		assert.deepEqual(messages.filter((message) => message.method === 'eth_accounts' && message.requestId === 17).map((message) => message.result), [[accountString]])
-		assert.deepEqual(messages.filter((message) => message.method !== 'eth_accounts_reply').map((message) => message.method), ['request_signer_to_eth_requestAccounts', 'connect', 'accountsChanged', 'eth_accounts'])
+		assert.deepEqual(messages.filter((message) => message.method !== 'eth_accounts_reply').map((message) => message.method), ['request_signer_to_eth_requestAccounts', 'accountsChanged', 'eth_accounts'])
 		assert.deepEqual(siblingMessages.filter((message) => message.method === 'accountsChanged').map((message) => message.requestId), [undefined])
 		assert.deepEqual(siblingMessages.filter((message) => message.method === 'accountsChanged').map((message) => message.result), [[accountString]])
 	})
 
-	test('replays account state before resolving wallet_requestPermissions after signer refresh', async () => {
-		installBrowserMock()
-		const {
-			handleInterceptedRequest,
-			websiteSocketToString,
-			changeSimulationMode,
-			setUseSignersAddressAsActiveAddress,
-			updateWebsiteAccess,
-		} = await loadModules()
-		const websiteOrigin = 'https://example.test'
-		const website = { websiteOrigin, icon: undefined, title: undefined }
-		const account = 0x4646464646464646464646464646464646464646n
-		const accountString = '0x4646464646464646464646464646464646464646'
-		await changeSimulationMode({ simulationMode: false, activeSimulationAddress: undefined, activeSigningAddress: undefined })
-		await setUseSignersAddressAsActiveAddress(false)
-		await updateWebsiteAccess(() => [{ website, access: true, addressAccess: [{ address: account, access: true }] }])
+	for (const manifestVersion of [2, 3] as const) {
+		test(`replays only accountsChanged before wallet_requestPermissions resolves for manifest v${ manifestVersion }`, async () => {
+			const browserMock = installBrowserMock({ manifestVersion })
+			const {
+				handleInterceptedRequest,
+				websiteSocketToString,
+				changeSimulationMode,
+				setUseSignersAddressAsActiveAddress,
+				updateWebsiteAccess,
+				updateDeclarativeNetRequestBlocks,
+			} = await loadModules()
+			const websiteOrigin = `https://manifest-v${ manifestVersion }.example.test`
+			const website = { websiteOrigin, icon: undefined, title: undefined }
+			const account = 0x4646464646464646464646464646464646464646n
+			const accountString = '0x4646464646464646464646464646464646464646'
+			await changeSimulationMode({ simulationMode: false, activeSimulationAddress: undefined, activeSigningAddress: undefined })
+			await setUseSignersAddressAsActiveAddress(false)
+			await updateWebsiteAccess(() => [{ website, access: true, addressAccess: [{ address: account, access: true }], declarativeNetRequestBlockMode: 'block-all' }])
 
-		const socket = { tabId: 1, connectionName: 0n }
-		const { port: createdPort, messages } = createPort(socket.tabId, (message) => {
-			if (message.method !== 'request_signer_to_eth_requestAccounts') return
-			void handleInterceptedRequest(port, websiteOrigin, website, ethereum, tokenPriceService, resetSimulationServices, socket, {
+			const socket = { tabId: 1, connectionName: 0n }
+			const { port: createdPort, messages } = createPort(socket.tabId, (message) => {
+				if (message.method !== 'request_signer_to_eth_requestAccounts') return
+				void handleInterceptedRequest(port, websiteOrigin, website, ethereum, tokenPriceService, resetSimulationServices, socket, {
+					interceptorRequest: true,
+					interceptorInternalRequest: true,
+					usingInterceptorWithoutSigner: false,
+					uniqueRequestIdentifier: { requestId: 104, requestSocket: socket },
+					method: 'eth_accounts_reply',
+					params: [{ signerProviderGeneration: 1, type: 'success', accounts: [accountString], requestAccounts: true }],
+				}, websiteTabConnections, noopPublishRpcConnectionStatus)
+			})
+			const port = createdPort
+			const connectionKey = websiteSocketToString(socket)
+			const websiteTabConnections = new Map([[socket.tabId, { ...confirmedSignerOwnership(socket), connections: {
+				[connectionKey]: { port, socket, websiteOrigin, approved: true, wantsToConnect: true },
+			} }]])
+			await updateDeclarativeNetRequestBlocks(websiteTabConnections)
+			const { ethereum, tokenPriceService, resetSimulationServices } = createEthereumWithGetBlockCounter({ count: 0 })
+			const request = {
 				interceptorRequest: true,
-				interceptorInternalRequest: true,
 				usingInterceptorWithoutSigner: false,
-				uniqueRequestIdentifier: { requestId: 104, requestSocket: socket },
-				method: 'eth_accounts_reply',
-				params: [{ signerProviderGeneration: 1, type: 'success', accounts: [accountString], requestAccounts: true }],
-			}, websiteTabConnections, noopPublishRpcConnectionStatus)
+				uniqueRequestIdentifier: { requestId: 19, requestSocket: socket },
+				method: 'wallet_requestPermissions',
+				params: [{ eth_accounts: {} }],
+			}
+
+			await handleInterceptedRequest(port, websiteOrigin, website, ethereum, tokenPriceService, resetSimulationServices, socket, request, websiteTabConnections, noopPublishRpcConnectionStatus)
+
+			const permissionResult = [{
+				parentCapability: 'eth_accounts',
+				caveats: [{
+					type: 'restrictReturnedAccounts',
+					value: [accountString],
+				}],
+				invoker: websiteOrigin,
+			}]
+			assert.equal(messages.some((message) => message.method === 'connect'), false)
+			assert.deepEqual(messages.filter((message) => message.method === 'accountsChanged').map((message) => message.requestId), [19])
+			assert.deepEqual(messages.filter((message) => message.method === 'wallet_requestPermissions' && message.requestId === 19).map((message) => message.result), [permissionResult])
+			assert.deepEqual(messages.filter((message) => message.method !== 'eth_accounts_reply').map((message) => message.method), ['request_signer_to_eth_requestAccounts', 'accountsChanged', 'wallet_requestPermissions'])
+			assert.equal(browserMock.readStoredValue('latestUnexpectedError'), undefined)
+			assert.equal(browserMock.requestBlockingCalls.webRequestListenerAdds > 0, manifestVersion === 2)
+			assert.equal(browserMock.requestBlockingCalls.webRequestListenerRemovals > 0, manifestVersion === 2)
+			assert.equal(browserMock.requestBlockingCalls.declarativeNetRequestUpdates > 0, manifestVersion === 3)
 		})
-		const port = createdPort
-		const connectionKey = websiteSocketToString(socket)
-		const websiteTabConnections = new Map([[socket.tabId, { ...confirmedSignerOwnership(socket), connections: {
-			[connectionKey]: { port, socket, websiteOrigin, approved: true, wantsToConnect: true },
-		} }]])
-		const { ethereum, tokenPriceService, resetSimulationServices } = createEthereumWithGetBlockCounter({ count: 0 })
-		const request = {
-			interceptorRequest: true,
-			usingInterceptorWithoutSigner: false,
-			uniqueRequestIdentifier: { requestId: 19, requestSocket: socket },
-			method: 'wallet_requestPermissions',
-			params: [{ eth_accounts: {} }],
-		}
-
-		await handleInterceptedRequest(port, websiteOrigin, website, ethereum, tokenPriceService, resetSimulationServices, socket, request, websiteTabConnections, noopPublishRpcConnectionStatus)
-
-		const permissionResult = [{
-			parentCapability: 'eth_accounts',
-			caveats: [{
-				type: 'restrictReturnedAccounts',
-				value: [accountString],
-			}],
-			invoker: websiteOrigin,
-		}]
-		assert.deepEqual(messages.filter((message) => message.method === 'connect').map((message) => message.requestId), [19])
-		assert.deepEqual(messages.filter((message) => message.method === 'accountsChanged').map((message) => message.requestId), [19])
-		assert.deepEqual(messages.filter((message) => message.method === 'wallet_requestPermissions' && message.requestId === 19).map((message) => message.result), [permissionResult])
-		assert.deepEqual(messages.filter((message) => message.method !== 'eth_accounts_reply').map((message) => message.method), ['request_signer_to_eth_requestAccounts', 'connect', 'accountsChanged', 'wallet_requestPermissions'])
-	})
+	}
 
 	test('replays account state after already-approved eth_requestAccounts with cached active signer address', async () => {
 		installBrowserMock()
@@ -1913,13 +1939,12 @@ params: [{ signerProviderGeneration: 1, type: 'success', accounts: ['0x333333333
 		await handleInterceptedRequest(port, websiteOrigin, website, ethereum, tokenPriceService, resetSimulationServices, socket, request, websiteTabConnections, noopPublishRpcConnectionStatus)
 
 		assert.equal(messages.some((message) => message.method === 'request_signer_to_eth_requestAccounts'), false)
-		assert.deepEqual(messages.filter((message) => message.method === 'connect').map((message) => message.result), [['0x1']])
-		assert.deepEqual(messages.filter((message) => message.method === 'connect').map((message) => message.requestId), [11])
+		assert.equal(messages.some((message) => message.method === 'connect'), false)
 		assert.deepEqual(messages.filter((message) => message.method === 'accountsChanged').map((message) => message.result), [[accountString]])
 		assert.deepEqual(messages.filter((message) => message.method === 'accountsChanged').map((message) => message.requestId), [11])
 		const requestAccountsReplies = messages.filter((message) => message.method === 'eth_accounts' && message.requestId === 11)
 		assert.deepEqual(requestAccountsReplies.at(-1)?.result, [accountString])
-		assert.deepEqual(messages.map((message) => message.method), ['connect', 'accountsChanged', 'eth_accounts'])
+		assert.deepEqual(messages.map((message) => message.method), ['accountsChanged', 'eth_accounts'])
 	})
 
 	test('replays account state for already-approved eth_requestAccounts on signer-only networks', async () => {
@@ -1974,11 +1999,10 @@ params: [{ signerProviderGeneration: 1, type: 'success', accounts: ['0x333333333
 		assert.equal(messages.some((message) => message.method === 'request_signer_to_eth_requestAccounts'), false)
 		const requestAccountsReplies = messages.filter((message) => message.method === 'eth_accounts' && message.requestId === 16)
 		assert.deepEqual(requestAccountsReplies.at(-1)?.result, [accountString])
-		assert.deepEqual(messages.filter((message) => message.method === 'connect').map((message) => message.result), [['0x1']])
-		assert.deepEqual(messages.filter((message) => message.method === 'connect').map((message) => message.requestId), [16])
+		assert.equal(messages.some((message) => message.method === 'connect'), false)
 		assert.deepEqual(messages.filter((message) => message.method === 'accountsChanged').map((message) => message.result), [[accountString]])
 		assert.deepEqual(messages.filter((message) => message.method === 'accountsChanged').map((message) => message.requestId), [16])
-		assert.deepEqual(messages.map((message) => message.method), ['connect', 'accountsChanged', 'eth_accounts'])
+		assert.deepEqual(messages.map((message) => message.method), ['accountsChanged', 'eth_accounts'])
 	})
 
 	test('does not expose an active address in connected_to_signer replies', async () => {
@@ -2639,8 +2663,8 @@ params: [{ signerProviderGeneration: 1, type: 'success', accounts: ['0x333333333
 		await siteApprovalResolution
 
 		const requestLifecycleMessages = messages.filter((message) => message.method === 'connect' || message.method === 'accountsChanged' || message.method === 'chainChanged')
-		assert.deepEqual(requestLifecycleMessages.map((message) => message.method), ['connect', 'accountsChanged'])
-		assert.deepEqual(requestLifecycleMessages.map((message) => message.requestId), [18, 18])
+		assert.deepEqual(requestLifecycleMessages.map((message) => message.method), ['accountsChanged'])
+		assert.deepEqual(requestLifecycleMessages.map((message) => message.requestId), [18])
 		assert.deepEqual(messages.filter((message) => message.method === 'eth_accounts' && message.requestId === 18).at(-1)?.result, [accountString])
 		const siblingLifecycleMessages = siblingMessages.filter((message) => message.method === 'connect' || message.method === 'accountsChanged' || message.method === 'chainChanged')
 		assert.deepEqual(siblingLifecycleMessages.map((message) => message.method), ['connect', 'accountsChanged', 'chainChanged'])

--- a/test/tests/inpageSignerBridge.test.ts
+++ b/test/tests/inpageSignerBridge.test.ts
@@ -1873,18 +1873,11 @@ describe('inpage signer bridge', () => {
 		})
 	})
 
-	test('delivers request-scoped connect and accountsChanged before eth_requestAccounts resumes even when address is cached', async () => {
+	test('delivers request-scoped accountsChanged without connect before eth_requestAccounts resumes even when address is cached', async () => {
 		const signerAccount = '0x1111111111111111111111111111111111111111'
 		const { fakeWindow, sendBackgroundMessage, signerRequests } = createFakeWindow({
 			handleRequest: (request, sendBackgroundMessageForRequest) => {
 				if (request.method !== 'eth_requestAccounts') return false
-				sendBackgroundMessageForRequest({
-					interceptorApproved: true,
-					requestId: request.requestId,
-					type: 'result',
-					method: 'connect',
-					result: ['0x1'],
-				})
 				sendBackgroundMessageForRequest({
 					interceptorApproved: true,
 					requestId: request.requestId,
@@ -1943,11 +1936,11 @@ describe('inpage signer bridge', () => {
 
 			assert.deepEqual(accountReply, [signerAccount])
 			assert.deepEqual(accountEvents, [[signerAccount]])
-			assert.deepEqual(events, ['connect', 'accountsChanged', 'resolved'])
+			assert.deepEqual(events, ['accountsChanged', 'resolved'])
 		})
 	})
 
-	test('delivers request-scoped connect and accountsChanged before wallet_requestPermissions resumes', async () => {
+	test('delivers request-scoped accountsChanged without connect before wallet_requestPermissions resumes', async () => {
 		const signerAccount = '0x1212121212121212121212121212121212121212'
 		const permissions = [{
 			parentCapability: 'eth_accounts',
@@ -1960,13 +1953,6 @@ describe('inpage signer bridge', () => {
 		const { fakeWindow, signerRequests } = createFakeWindow({
 			handleRequest: (request, sendBackgroundMessageForRequest) => {
 				if (request.method !== 'wallet_requestPermissions') return false
-				sendBackgroundMessageForRequest({
-					interceptorApproved: true,
-					requestId: request.requestId,
-					type: 'result',
-					method: 'connect',
-					result: ['0x1'],
-				})
 				sendBackgroundMessageForRequest({
 					interceptorApproved: true,
 					requestId: request.requestId,
@@ -2008,7 +1994,7 @@ describe('inpage signer bridge', () => {
 			})
 
 			assert.deepEqual(permissionReply, permissions)
-			assert.deepEqual(events, ['connect', 'accountsChanged', 'resolved'])
+			assert.deepEqual(events, ['accountsChanged', 'resolved'])
 		})
 	})
 

--- a/test/tests/interceptorAccessCloseRace.test.ts
+++ b/test/tests/interceptorAccessCloseRace.test.ts
@@ -152,11 +152,10 @@ describe('interceptor access close handling', () => {
 		await requestAccessFromUser(ethereum, tokenPriceService, resetSimulationServices, websiteTabConnections, socket, website, request, undefined, await getSettings(), account, async () => undefined)
 
 		const postedMessages = browserMock.postedMessages as Array<{ method?: string, result?: unknown, requestId?: number }>
-		assert.deepEqual(postedMessages.map((message) => message.method), ['connect', 'accountsChanged', 'eth_accounts'])
-		assert.deepEqual(postedMessages.map((message) => message.requestId), [7, 7, 7])
-		assert.deepEqual(postedMessages[0]?.result, ['0x1'])
+		assert.deepEqual(postedMessages.map((message) => message.method), ['accountsChanged', 'eth_accounts'])
+		assert.deepEqual(postedMessages.map((message) => message.requestId), [7, 7])
+		assert.deepEqual(postedMessages[0]?.result, ['0xd8da6bf26964af9d7eed9e03e53415d37aa96045'])
 		assert.deepEqual(postedMessages[1]?.result, ['0xd8da6bf26964af9d7eed9e03e53415d37aa96045'])
-		assert.deepEqual(postedMessages[2]?.result, ['0xd8da6bf26964af9d7eed9e03e53415d37aa96045'])
 	})
 
 	test('serializes dialog close cleanup with matching request creation', async () => {


### PR DESCRIPTION
## Summary

- stop emitting a request-scoped EIP-1193 connect event during account authorization
- continue delivering accountsChanged before eth_requestAccounts and wallet_requestPermissions resolve
- add manifest v2 webRequest and manifest v3 declarativeNetRequest regression coverage
- extend the Chromium communication harness with the Coinbase-style wallet_requestPermissions then eth_accounts flow

## Validation

- bun run test (862 passed)
- bun run setup-firefox
- bun run setup-chrome
- bun run typecheck
- bun run lint
- bun run test:chrome-communication

The real Chromium run observed zero connect events, one accountsChanged event, and the order accountsChanged, permissionsResolved, accountsResolved. Interactive Firefox was not available in the test environment; the MV2 bundle built successfully and the manifest-specific Firefox background branch is covered by tests.