### PR TITLE
Fix access grant follow-up deadlock

### DIFF
--- a/app/ts/background/background.ts
+++ b/app/ts/background/background.ts
@@ -313,6 +313,7 @@ export async function changeActiveAddressAndChain(
 		activeAddress?: bigint,
 		rpcNetwork?: RpcNetwork,
 	},
+	promptForAccessesIfNeeded = true,
 ) {
 
 	if (change.simulationMode && change.activeAddress !== undefined) await keepTrackOfPreviousAddressforRichList()
@@ -333,7 +334,7 @@ export async function changeActiveAddressAndChain(
 	}
 
 	const updatedSettings = await getSettings()
-	const popupRefreshGeneration = await updateWebsiteApprovalAccesses(ethereum, tokenPriceService, resetSimulationServices, websiteTabConnections, updatedSettings, true)
+	const popupRefreshGeneration = await updateWebsiteApprovalAccesses(ethereum, tokenPriceService, resetSimulationServices, websiteTabConnections, updatedSettings, promptForAccessesIfNeeded)
 	sendPopupMessageToOpenWindows({ method: 'popup_settingsUpdated', data: updatedSettings, popupRefreshGeneration })
 	sendPopupMessageToOpenWindows({ method: 'popup_accounts_update' })
 	await changeActiveAddressAndChainSemaphore.execute(async () => {

--- a/app/ts/background/windows/interceptorAccess.ts
+++ b/app/ts/background/windows/interceptorAccess.ts
@@ -3,7 +3,7 @@ import { Future } from '../../utils/future.js'
 import type { InterceptorAccessChangeAddress, InterceptorAccessRefresh, InterceptorAccessReply, Settings, WindowMessage } from '../../types/interceptor-messages.js'
 import { createScopedKeyedSerialExecutor, Semaphore } from '../../utils/semaphore.js'
 import type { WebsiteTabConnections } from '../../types/user-interface-types.js'
-import { getAssociatedAddresses, persistWebsiteAccessChange, verifyAccess, withSuppressedUnscopedConnectionEventsForSocket, withSuppressedUnscopedConnectionEventsForSocketAsync } from '../accessManagement.js'
+import { getAssociatedAddresses, persistWebsiteAccessChange, updateWebsiteApprovalAccesses, verifyAccess, withSuppressedUnscopedConnectionEventsForSocket, withSuppressedUnscopedConnectionEventsForSocketAsync } from '../accessManagement.js'
 import { changeActiveAddressAndChain, handleInterceptedRequest, refuseAccess } from '../background.js'
 import { INTERNAL_CHANNEL_NAME, createInternalMessageListener, getHtmlFile, sendPopupMessageToOpenWindows, websiteSocketToString } from '../backgroundUtils.js'
 import { getActiveAddressEntry, getActiveAddresses } from '../metadataUtils.js'
@@ -79,7 +79,7 @@ export async function resolveInterceptorAccess(ethereum: EthereumClientService, 
 			originalRequestAccessToAddress: reply.originalRequestAccessToAddress ?? pendingRequest.originalRequestAccessToAddress?.address,
 		}
 		return {
-			pendingRequestsToReplay: await resolve(
+			...await resolve(
 				ethereum,
 				tokenPriceService,
 				resetSimulationServices,
@@ -94,6 +94,16 @@ export async function resolveInterceptorAccess(ethereum: EthereumClientService, 
 				: undefined,
 		}
 	})
+	if (resolution.promptForFollowUpAccesses) {
+		await updateWebsiteApprovalAccesses(
+			ethereum,
+			tokenPriceService,
+			resetSimulationServices,
+			websiteTabConnections,
+			await getSettings(),
+			true,
+		)
+	}
 	const replayPendingRequests = async () => await Promise.all(resolution.pendingRequestsToReplay.map((pendingRequest) => handleInterceptedRequest(
 			undefined,
 			pendingRequest.website.websiteOrigin,
@@ -390,16 +400,18 @@ export async function requestAccessFromUser(
 }
 
 async function resolve(ethereum: EthereumClientService, tokenPriceService: TokenPriceService, resetSimulationServices: ResetSimulationServices, websiteTabConnections: WebsiteTabConnections, accessReply: InterceptorAccessReply, request: InterceptedRequest | undefined, website: Website, publishRpcConnectionStatus: PublishRpcConnectionStatus | undefined) {
+	let promptForFollowUpAccesses = false
 	if (accessReply.userReply === 'noResponse') {
 		if (request !== undefined) refuseAccess(websiteTabConnections, request)
 	} else {
 		const userRequestedAddressChange = accessReply.requestAccessToAddress !== accessReply.originalRequestAccessToAddress
 		const replyCompletesAccountRequest = request !== undefined && isAccountConnectionMethod(request.method)
 		const shouldPromptForFollowUpAccesses = !(replyCompletesAccountRequest && accessReply.requestAccessToAddress === undefined)
+		promptForFollowUpAccesses = shouldPromptForFollowUpAccesses
 		const accountRequestSocket = replyCompletesAccountRequest ? request.uniqueRequestIdentifier.requestSocket : undefined
 		const applyAccessReply = async () => {
 			if (!userRequestedAddressChange) {
-				await changeAccess(ethereum, tokenPriceService, resetSimulationServices, websiteTabConnections, accessReply, website, shouldPromptForFollowUpAccesses)
+				await changeAccess(ethereum, tokenPriceService, resetSimulationServices, websiteTabConnections, accessReply, website, false)
 				return
 			}
 			if (accessReply.requestAccessToAddress === undefined) throw new Error('Changed request to page level')
@@ -408,7 +420,7 @@ async function resolve(ethereum: EthereumClientService, tokenPriceService: Token
 			await changeActiveAddressAndChain(ethereum, tokenPriceService, resetSimulationServices, websiteTabConnections, {
 				simulationMode: settings.simulationMode,
 				activeAddress: accessReply.requestAccessToAddress,
-			})
+			}, false)
 		}
 		if (accountRequestSocket === undefined) {
 			await applyAccessReply()
@@ -423,7 +435,7 @@ async function resolve(ethereum: EthereumClientService, tokenPriceService: Token
 
 	if (pendingRequests.current.length > 0) {
 		sendPopupMessageToOpenWindows({ method: 'popup_interceptorAccessDialog', data: { activeAddresses: await getActiveAddresses(), pendingAccessRequests: pendingRequests.current } })
-		return []
+		return { pendingRequestsToReplay: [], promptForFollowUpAccesses }
 	}
 
 	if (openedDialog) {
@@ -433,9 +445,9 @@ async function resolve(ethereum: EthereumClientService, tokenPriceService: Token
 	}
 	const affectedEntryWithPendingRequest = pendingRequests.previous.filter((pending): pending is PendingAccessRequest & { request: InterceptedRequest } => isAffectedEntry(pending) && pending.request !== undefined)
 
-	if (affectedEntryWithPendingRequest.length === 0) return []
+	if (affectedEntryWithPendingRequest.length === 0) return { pendingRequestsToReplay: [], promptForFollowUpAccesses }
 	if (publishRpcConnectionStatus === undefined) throw new Error('RPC connection status publisher is required to replay intercepted requests.')
-	return affectedEntryWithPendingRequest
+	return { pendingRequestsToReplay: affectedEntryWithPendingRequest, promptForFollowUpAccesses }
 }
 
 export async function requestAddressChange(websiteTabConnections: WebsiteTabConnections, message: InterceptorAccessChangeAddress | InterceptorAccessRefresh) {

--- a/test/tests/interceptorAccessCloseRace.test.ts
+++ b/test/tests/interceptorAccessCloseRace.test.ts
@@ -55,7 +55,7 @@ function installBrowserMock() {
 		},
 		tabs: {
 			async query() { return [] },
-			async get(tabId: number) { return { id: tabId, active: true } },
+			async get(tabId: number) { return { id: tabId, active: true, status: 'complete', favIconUrl: '' } },
 			async update() { return undefined },
 			onUpdated: { addListener: (_listener: Listener) => undefined, removeListener: (_listener: Listener) => undefined },
 			onRemoved: {
@@ -287,5 +287,115 @@ describe('interceptor access close handling', () => {
 		})
 		assert.equal(ethAccountsReplies.length, 1)
 		assert.notEqual(ethAccountsReplies[0]?.error?.code, 4100)
+	})
+
+	test('prompts another connection after releasing the popup resolution semaphore', async () => {
+		installBrowserMock()
+		const {
+			changeSimulationMode,
+			getPendingAccessRequests,
+			requestAccessFromUser,
+			resolveInterceptorAccess,
+			websiteSocketToString,
+		} = await loadModules()
+		const { getActiveAddressEntry } = await import('../../app/ts/background/metadataUtils.js')
+		const account = 0x1234567890123456789012345678901234567890n
+		const firstWebsite = { websiteOrigin: 'https://first.example.test', icon: undefined, title: undefined }
+		const secondWebsite = { websiteOrigin: 'https://second.example.test', icon: undefined, title: undefined }
+		const firstSocket: WebsiteSocket = { tabId: 1, connectionName: 1n }
+		const secondSocket: WebsiteSocket = { tabId: 2, connectionName: 2n }
+		const createPort = (tabId: number) => ({ name: '0x0', sender: { tab: { id: tabId } }, postMessage() { return undefined } }) as unknown as browser.runtime.Port
+		const websiteTabConnections: WebsiteTabConnections = new Map([
+			[firstSocket.tabId, { connections: {
+				[websiteSocketToString(firstSocket)]: {
+					port: createPort(firstSocket.tabId),
+					socket: firstSocket,
+					websiteOrigin: firstWebsite.websiteOrigin,
+					approved: false,
+					wantsToConnect: true,
+				},
+			} }],
+			[secondSocket.tabId, { connections: {
+				[websiteSocketToString(secondSocket)]: {
+					port: createPort(secondSocket.tabId),
+					socket: secondSocket,
+					websiteOrigin: secondWebsite.websiteOrigin,
+					approved: false,
+					wantsToConnect: true,
+				},
+			} }],
+		])
+		const ethereum = {} as never
+		const tokenPriceService = {} as never
+		const resetSimulationServices = (() => undefined) as never
+		const publishRpcConnectionStatus = async () => undefined
+		await changeSimulationMode({ simulationMode: true, activeSimulationAddress: account, activeSigningAddress: undefined })
+		const activeAddress = await getActiveAddressEntry(account)
+		const settings: Settings = {
+			activeSimulationAddress: account,
+			activeSigningAddress: undefined,
+			openedPage: { page: 'Home' },
+			useSignersAddressAsActiveAddress: false,
+			websiteAccess: [],
+			simulationMode: true,
+			activeRpcNetwork: {
+				name: 'Test RPC',
+				chainId: 1n,
+				httpsRpc: 'https://example.invalid',
+				currencyName: 'Ether',
+				currencyTicker: 'ETH',
+				primary: true,
+				minimized: true,
+			},
+		}
+
+		await requestAccessFromUser(
+			ethereum,
+			tokenPriceService,
+			resetSimulationServices,
+			websiteTabConnections,
+			firstSocket,
+			firstWebsite,
+			undefined,
+			activeAddress,
+			settings,
+			account,
+			undefined,
+		)
+		const firstRequest = (await getPendingAccessRequests())[0]
+		if (firstRequest === undefined) throw new Error('Missing first access request')
+
+		await Promise.race([
+			resolveInterceptorAccess(
+				ethereum,
+				tokenPriceService,
+				resetSimulationServices,
+				websiteTabConnections,
+				{
+					userReply: 'Approved',
+					requestAccessToAddress: firstRequest.requestAccessToAddress?.address,
+					originalRequestAccessToAddress: firstRequest.originalRequestAccessToAddress?.address,
+					accessRequestId: firstRequest.accessRequestId,
+				},
+				publishRpcConnectionStatus,
+			),
+			new Promise((_, reject) => setTimeout(() => reject(new Error('Access approval did not resolve')), 250)),
+		])
+
+		const followUpRequest = (await getPendingAccessRequests()).find((request) => request.website.websiteOrigin === secondWebsite.websiteOrigin)
+		if (followUpRequest === undefined) throw new Error('Missing follow-up access request')
+		await resolveInterceptorAccess(
+			ethereum,
+			tokenPriceService,
+			resetSimulationServices,
+			websiteTabConnections,
+			{
+				userReply: 'Rejected',
+				requestAccessToAddress: followUpRequest.requestAccessToAddress?.address,
+				originalRequestAccessToAddress: followUpRequest.originalRequestAccessToAddress?.address,
+				accessRequestId: followUpRequest.accessRequestId,
+			},
+			publishRpcConnectionStatus,
+		)
 	})
 })


### PR DESCRIPTION
## Summary

- prevent access approval from prompting for follow-up connections while holding the popup resolution semaphore
- refresh prompt-capable connections after releasing the semaphore while preserving request replay ordering
- add regression coverage for granting one request while another connection needs access

## Validation

- `bun run test` — 862 tests passed
- `bun run setup-chrome`
- `bun run typecheck`
- `bun run lint`
- focused access close-race tests — 4 passed
- independent reviewer — 94/100, no High, Medium, or Low findings

`test:chrome-communication` was not run because this change does not alter content-script registration, provider injection, or browser messaging transport.