### PR TITLE
Show one address-aware approval dialog for account requests

### DIFF
--- a/app/ts/background/accessManagement.ts
+++ b/app/ts/background/accessManagement.ts
@@ -189,25 +189,27 @@ export async function setInterceptorDisabledForWebsite(website: Website, interce
 	})
 }
 
-export async function setAccess(website: Website, access: boolean, address: bigint | undefined) {
-	return await updateWebsiteAccess((previousWebsiteAccess) => {
-		const foundEntry = previousWebsiteAccess.find((entry) => entry.website.websiteOrigin === website.websiteOrigin)
-		if (foundEntry === undefined) return [...previousWebsiteAccess, { website, access, addressAccess: address === undefined || !access ? undefined : [ { address, access } ] }]
-		return previousWebsiteAccess.map((prevAccess) => {
-			if (prevAccess.website.websiteOrigin === website.websiteOrigin) {
-				const websiteData = mergeStoredWebsiteMetadata(prevAccess.website, website)
-				if (address === undefined) return modifyObject(prevAccess, { website: websiteData, access })
-				const addressAccess = { address, access }
-				const updatedEntry = modifyObject(prevAccess, { website: websiteData, access: prevAccess.access ? prevAccess.access : access })
-				if (prevAccess.addressAccess === undefined) return modifyObject(updatedEntry, { addressAccess: [addressAccess] })
-				if (prevAccess.addressAccess.find((x) => x.address === address) === undefined) {
-					return modifyObject(updatedEntry, { addressAccess: [ ...prevAccess.addressAccess, addressAccess ] })
-				}
-				return modifyObject(updatedEntry, { addressAccess: prevAccess.addressAccess.map((x) => (x.address === address ? addressAccess : x)) })
+function applyAccessDecision(previousWebsiteAccess: WebsiteAccessArray, website: Website, access: boolean, address: bigint | undefined) {
+	const foundEntry = previousWebsiteAccess.find((entry) => entry.website.websiteOrigin === website.websiteOrigin)
+	if (foundEntry === undefined) return [...previousWebsiteAccess, { website, access, addressAccess: address === undefined || !access ? undefined : [ { address, access } ] }]
+	return previousWebsiteAccess.map((prevAccess) => {
+		if (prevAccess.website.websiteOrigin === website.websiteOrigin) {
+			const websiteData = mergeStoredWebsiteMetadata(prevAccess.website, website)
+			if (address === undefined) return modifyObject(prevAccess, { website: websiteData, access })
+			const addressAccess = { address, access }
+			const updatedEntry = modifyObject(prevAccess, { website: websiteData, access: prevAccess.access ? prevAccess.access : access })
+			if (prevAccess.addressAccess === undefined) return modifyObject(updatedEntry, { addressAccess: [addressAccess] })
+			if (prevAccess.addressAccess.find((x) => x.address === address) === undefined) {
+				return modifyObject(updatedEntry, { addressAccess: [ ...prevAccess.addressAccess, addressAccess ] })
 			}
-			return prevAccess
-		})
+			return modifyObject(updatedEntry, { addressAccess: prevAccess.addressAccess.map((x) => (x.address === address ? addressAccess : x)) })
+		}
+		return prevAccess
 	})
+}
+
+export async function setAccess(website: Website, access: boolean, address: bigint | undefined) {
+	return await updateWebsiteAccess((previousWebsiteAccess) => applyAccessDecision(previousWebsiteAccess, website, access, address))
 }
 
 // gets active address if the website has been give access for it, otherwise returns undefined
@@ -468,6 +470,37 @@ export async function persistWebsiteAccessChange(
 		websiteTabConnections,
 		refreshedSettings,
 		promptForAccessesIfNeeded,
+	)
+	await sendPopupMessageToOpenWindows({ method: 'popup_websiteAccess_changed' })
+	return refreshedSettings
+}
+
+export async function persistAddressAccessForApprovedWebsite(
+	ethereum: EthereumClientService | undefined,
+	tokenPriceService: TokenPriceService | undefined,
+	resetSimulationServices: ResetSimulationServices | undefined,
+	websiteTabConnections: WebsiteTabConnections,
+	website: Website,
+	address: AddressBookEntry,
+): Promise<Settings | undefined> {
+	let accessStillAllowed = false
+	await updateWebsiteAccess((previousWebsiteAccess) => {
+		if (hasAccess(previousWebsiteAccess, website.websiteOrigin) !== 'hasAccess') return previousWebsiteAccess
+		const addressAccess = hasAddressAccess(previousWebsiteAccess, website.websiteOrigin, address)
+		if (addressAccess === 'noAccess' || addressAccess === 'interceptorDisabled') return previousWebsiteAccess
+		accessStillAllowed = true
+		if (addressAccess === 'hasAccess') return previousWebsiteAccess
+		return applyAccessDecision(previousWebsiteAccess, website, true, address.address)
+	})
+	if (!accessStillAllowed) return undefined
+	const refreshedSettings = await getSettings()
+	await updateWebsiteApprovalAccesses(
+		ethereum,
+		tokenPriceService,
+		resetSimulationServices,
+		websiteTabConnections,
+		refreshedSettings,
+		false,
 	)
 	await sendPopupMessageToOpenWindows({ method: 'popup_websiteAccess_changed' })
 	return refreshedSettings

--- a/app/ts/background/accessManagement.ts
+++ b/app/ts/background/accessManagement.ts
@@ -86,9 +86,16 @@ export async function withSuppressedUnscopedConnectionEventsForSocketAsync<T>(so
 
 export type ApprovalState = 'hasAccess' | 'noAccess' | 'askAccess' | 'interceptorDisabled'
 
-export function verifyAccess(websiteTabConnections: WebsiteTabConnections, socket: WebsiteSocket, askAccessIfUnknown: boolean, websiteOrigin: string, requestAccessForAddress: AddressBookEntry | undefined, settings: Settings, ignoreConnectionApproval = false) {
+export type AccessDecision = ApprovalState | 'websiteApprovalCanGrantAddressAccess'
+
+type VerifyAccessOptions = {
+	readonly ignoreConnectionApproval?: boolean
+	readonly allowWebsiteApprovalToGrantAddressAccess?: boolean
+}
+
+export function verifyAccess(websiteTabConnections: WebsiteTabConnections, socket: WebsiteSocket, askAccessIfUnknown: boolean, websiteOrigin: string, requestAccessForAddress: AddressBookEntry | undefined, settings: Settings, options: VerifyAccessOptions = {}): AccessDecision {
 	const connection = getConnectionDetails(websiteTabConnections, socket)
-	if (connection?.approved && !ignoreConnectionApproval) return 'hasAccess'
+	if (connection?.approved && options.ignoreConnectionApproval !== true) return 'hasAccess'
 	const access = requestAccessForAddress !== undefined ? hasAddressAccess(settings.websiteAccess, websiteOrigin, requestAccessForAddress) : hasAccess(settings.websiteAccess, websiteOrigin)
 	if (access === 'hasAccess') {
 		const popupRefreshGeneration = bumpPopupRefreshGeneration()
@@ -104,6 +111,11 @@ export function verifyAccess(websiteTabConnections: WebsiteTabConnections, socke
 		return 'hasAccess'
 	}
 	if (access === 'noAccess' || access === 'interceptorDisabled') return access
+	if (
+		options.allowWebsiteApprovalToGrantAddressAccess === true
+		&& requestAccessForAddress !== undefined
+		&& hasAccess(settings.websiteAccess, websiteOrigin) === 'hasAccess'
+	) return 'websiteApprovalCanGrantAddressAccess'
 	return askAccessIfUnknown ? 'askAccess' : 'noAccess'
 }
 
@@ -457,6 +469,26 @@ export async function updateWebsiteApprovalAccesses(
 	return popupRefreshGeneration
 }
 
+export async function finalizeWebsiteAccessChange(
+	ethereum: EthereumClientService | undefined,
+	tokenPriceService: TokenPriceService | undefined,
+	resetSimulationServices: ResetSimulationServices | undefined,
+	websiteTabConnections: WebsiteTabConnections,
+	settings: Settings,
+	promptForAccessesIfNeeded: boolean,
+): Promise<Settings> {
+	await updateWebsiteApprovalAccesses(
+		ethereum,
+		tokenPriceService,
+		resetSimulationServices,
+		websiteTabConnections,
+		settings,
+		promptForAccessesIfNeeded,
+	)
+	await sendPopupMessageToOpenWindows({ method: 'popup_websiteAccess_changed' })
+	return settings
+}
+
 export async function persistWebsiteAccessChange(
 	ethereum: EthereumClientService | undefined,
 	tokenPriceService: TokenPriceService | undefined,
@@ -468,20 +500,17 @@ export async function persistWebsiteAccessChange(
 	promptForAccessesIfNeeded: boolean,
 ): Promise<Settings> {
 	await setAccess(website, access, address)
-	const refreshedSettings = await getSettings()
-	await updateWebsiteApprovalAccesses(
+	return await finalizeWebsiteAccessChange(
 		ethereum,
 		tokenPriceService,
 		resetSimulationServices,
 		websiteTabConnections,
-		refreshedSettings,
+		await getSettings(),
 		promptForAccessesIfNeeded,
 	)
-	await sendPopupMessageToOpenWindows({ method: 'popup_websiteAccess_changed' })
-	return refreshedSettings
 }
 
-export async function persistAddressAccessForApprovedWebsite(
+export async function persistAddressAccessFromWebsiteApproval(
 	ethereum: EthereumClientService | undefined,
 	tokenPriceService: TokenPriceService | undefined,
 	resetSimulationServices: ResetSimulationServices | undefined,
@@ -499,15 +528,12 @@ export async function persistAddressAccessForApprovedWebsite(
 		return applyAccessDecision(previousWebsiteAccess, website, true, address.address)
 	})
 	if (!accessStillAllowed) return undefined
-	const refreshedSettings = await getSettings()
-	await updateWebsiteApprovalAccesses(
+	return await finalizeWebsiteAccessChange(
 		ethereum,
 		tokenPriceService,
 		resetSimulationServices,
 		websiteTabConnections,
-		refreshedSettings,
+		await getSettings(),
 		false,
 	)
-	await sendPopupMessageToOpenWindows({ method: 'popup_websiteAccess_changed' })
-	return refreshedSettings
 }

--- a/app/ts/background/accessManagement.ts
+++ b/app/ts/background/accessManagement.ts
@@ -86,14 +86,11 @@ export async function withSuppressedUnscopedConnectionEventsForSocketAsync<T>(so
 
 export type ApprovalState = 'hasAccess' | 'noAccess' | 'askAccess' | 'interceptorDisabled'
 
-export type AccessDecision = ApprovalState | 'websiteApprovalCanGrantAddressAccess'
-
 type VerifyAccessOptions = {
 	readonly ignoreConnectionApproval?: boolean
-	readonly allowWebsiteApprovalToGrantAddressAccess?: boolean
 }
 
-export function verifyAccess(websiteTabConnections: WebsiteTabConnections, socket: WebsiteSocket, askAccessIfUnknown: boolean, websiteOrigin: string, requestAccessForAddress: AddressBookEntry | undefined, settings: Settings, options: VerifyAccessOptions = {}): AccessDecision {
+export function verifyAccess(websiteTabConnections: WebsiteTabConnections, socket: WebsiteSocket, askAccessIfUnknown: boolean, websiteOrigin: string, requestAccessForAddress: AddressBookEntry | undefined, settings: Settings, options: VerifyAccessOptions = {}): ApprovalState {
 	const connection = getConnectionDetails(websiteTabConnections, socket)
 	if (connection?.approved && options.ignoreConnectionApproval !== true) return 'hasAccess'
 	const access = requestAccessForAddress !== undefined ? hasAddressAccess(settings.websiteAccess, websiteOrigin, requestAccessForAddress) : hasAccess(settings.websiteAccess, websiteOrigin)
@@ -111,11 +108,6 @@ export function verifyAccess(websiteTabConnections: WebsiteTabConnections, socke
 		return 'hasAccess'
 	}
 	if (access === 'noAccess' || access === 'interceptorDisabled') return access
-	if (
-		options.allowWebsiteApprovalToGrantAddressAccess === true
-		&& requestAccessForAddress !== undefined
-		&& hasAccess(settings.websiteAccess, websiteOrigin) === 'hasAccess'
-	) return 'websiteApprovalCanGrantAddressAccess'
 	return askAccessIfUnknown ? 'askAccess' : 'noAccess'
 }
 
@@ -201,27 +193,25 @@ export async function setInterceptorDisabledForWebsite(website: Website, interce
 	})
 }
 
-function applyAccessDecision(previousWebsiteAccess: WebsiteAccessArray, website: Website, access: boolean, address: bigint | undefined) {
-	const foundEntry = previousWebsiteAccess.find((entry) => entry.website.websiteOrigin === website.websiteOrigin)
-	if (foundEntry === undefined) return [...previousWebsiteAccess, { website, access, addressAccess: address === undefined || !access ? undefined : [ { address, access } ] }]
-	return previousWebsiteAccess.map((prevAccess) => {
-		if (prevAccess.website.websiteOrigin === website.websiteOrigin) {
-			const websiteData = mergeStoredWebsiteMetadata(prevAccess.website, website)
-			if (address === undefined) return modifyObject(prevAccess, { website: websiteData, access })
-			const addressAccess = { address, access }
-			const updatedEntry = modifyObject(prevAccess, { website: websiteData, access: prevAccess.access ? prevAccess.access : access })
-			if (prevAccess.addressAccess === undefined) return modifyObject(updatedEntry, { addressAccess: [addressAccess] })
-			if (prevAccess.addressAccess.find((x) => x.address === address) === undefined) {
-				return modifyObject(updatedEntry, { addressAccess: [ ...prevAccess.addressAccess, addressAccess ] })
-			}
-			return modifyObject(updatedEntry, { addressAccess: prevAccess.addressAccess.map((x) => (x.address === address ? addressAccess : x)) })
-		}
-		return prevAccess
-	})
-}
-
 export async function setAccess(website: Website, access: boolean, address: bigint | undefined) {
-	return await updateWebsiteAccess((previousWebsiteAccess) => applyAccessDecision(previousWebsiteAccess, website, access, address))
+	return await updateWebsiteAccess((previousWebsiteAccess) => {
+		const foundEntry = previousWebsiteAccess.find((entry) => entry.website.websiteOrigin === website.websiteOrigin)
+		if (foundEntry === undefined) return [...previousWebsiteAccess, { website, access, addressAccess: address === undefined || !access ? undefined : [ { address, access } ] }]
+		return previousWebsiteAccess.map((prevAccess) => {
+			if (prevAccess.website.websiteOrigin === website.websiteOrigin) {
+				const websiteData = mergeStoredWebsiteMetadata(prevAccess.website, website)
+				if (address === undefined) return modifyObject(prevAccess, { website: websiteData, access })
+				const addressAccess = { address, access }
+				const updatedEntry = modifyObject(prevAccess, { website: websiteData, access: prevAccess.access ? prevAccess.access : access })
+				if (prevAccess.addressAccess === undefined) return modifyObject(updatedEntry, { addressAccess: [addressAccess] })
+				if (prevAccess.addressAccess.find((x) => x.address === address) === undefined) {
+					return modifyObject(updatedEntry, { addressAccess: [ ...prevAccess.addressAccess, addressAccess ] })
+				}
+				return modifyObject(updatedEntry, { addressAccess: prevAccess.addressAccess.map((x) => (x.address === address ? addressAccess : x)) })
+			}
+			return prevAccess
+		})
+	})
 }
 
 // gets active address if the website has been give access for it, otherwise returns undefined
@@ -507,33 +497,5 @@ export async function persistWebsiteAccessChange(
 		websiteTabConnections,
 		await getSettings(),
 		promptForAccessesIfNeeded,
-	)
-}
-
-export async function persistAddressAccessFromWebsiteApproval(
-	ethereum: EthereumClientService | undefined,
-	tokenPriceService: TokenPriceService | undefined,
-	resetSimulationServices: ResetSimulationServices | undefined,
-	websiteTabConnections: WebsiteTabConnections,
-	website: Website,
-	address: AddressBookEntry,
-): Promise<Settings | undefined> {
-	let accessStillAllowed = false
-	await updateWebsiteAccess((previousWebsiteAccess) => {
-		if (hasAccess(previousWebsiteAccess, website.websiteOrigin) !== 'hasAccess') return previousWebsiteAccess
-		const addressAccess = hasAddressAccess(previousWebsiteAccess, website.websiteOrigin, address)
-		if (addressAccess === 'noAccess' || addressAccess === 'interceptorDisabled') return previousWebsiteAccess
-		accessStillAllowed = true
-		if (addressAccess === 'hasAccess') return previousWebsiteAccess
-		return applyAccessDecision(previousWebsiteAccess, website, true, address.address)
-	})
-	if (!accessStillAllowed) return undefined
-	return await finalizeWebsiteAccessChange(
-		ethereum,
-		tokenPriceService,
-		resetSimulationServices,
-		websiteTabConnections,
-		await getSettings(),
-		false,
 	)
 }

--- a/app/ts/background/background.ts
+++ b/app/ts/background/background.ts
@@ -7,7 +7,7 @@ import { PASSTHROUGH_STATE, type ResolvedExecutionSimulationState, type Resolved
 import type { WebsiteTabConnections } from '../types/user-interface-types.js'
 import { askForSignerAccountsFromSignerIfNotAvailable, requestAccessFromUser } from './windows/interceptorAccess.js'
 import { METAMASK_ERROR_FAILED_TO_PARSE_REQUEST, METAMASK_ERROR_NOT_AUTHORIZED, METAMASK_ERROR_NOT_CONNECTED_TO_CHAIN, METAMASK_ERROR_PROVIDER_DISCONNECTED, METAMASK_ERROR_USER_REJECTED_REQUEST, ERROR_INTERCEPTOR_DISABLED, NEW_BLOCK_ABORT, JSON_RPC_ERROR_CODE_INTERNAL_ERROR } from '../utils/constants.js'
-import { clearWebsiteConnectionIntent, finalizeWebsiteAccessChange, hasAccess as getWebsiteAccessApprovalState, hasAddressAccess as getWebsiteAddressAccessApprovalState, persistAddressAccessFromWebsiteApproval, persistWebsiteAccessChange, sendAccountsChangedToPort, sendActiveAccountChangeToApprovedWebsitePorts, sendMessageToApprovedWebsitePorts, updateWebsiteApprovalAccesses, verifyAccess, withSuppressedUnscopedConnectionEventsForSocket, withSuppressedUnscopedConnectionEventsForSocketAsync } from './accessManagement.js'
+import { clearWebsiteConnectionIntent, finalizeWebsiteAccessChange, hasAccess as getWebsiteAccessApprovalState, hasAddressAccess as getWebsiteAddressAccessApprovalState, persistWebsiteAccessChange, sendAccountsChangedToPort, sendActiveAccountChangeToApprovedWebsitePorts, sendMessageToApprovedWebsitePorts, updateWebsiteApprovalAccesses, verifyAccess, withSuppressedUnscopedConnectionEventsForSocket } from './accessManagement.js'
 import { getActiveAddressEntry, identifyAddress } from './metadataUtils.js'
 import { getActiveAddress, sendPopupMessageToOpenWindows } from './backgroundUtils.js'
 import { assertNever } from '../utils/typescript.js'
@@ -18,7 +18,7 @@ import { JsonRpcResponseError, reportUnexpectedError, isExpectedInfrastructureEr
 import { InterceptedRequest, type UniqueRequestIdentifier, type WebsiteSocket } from '../utils/requests.js'
 import { replyToInterceptedRequest } from './messageSending.js'
 import { bumpPopupRefreshGeneration } from './popupRefreshGeneration.js'
-import { EthereumJsonRpcRequest, type EthGetStorageAtParams, RequestPermissions, type SendRawTransactionParams, type SendTransactionParams, SupportedEthereumJsonRpcRequestMethods, type WalletAddEthereumChain, WalletRevokePermissions } from '../types/JsonRpc-types.js'
+import { EthereumJsonRpcRequest, type EthGetStorageAtParams, type SendRawTransactionParams, type SendTransactionParams, SupportedEthereumJsonRpcRequestMethods, type WalletAddEthereumChain, WalletRevokePermissions } from '../types/JsonRpc-types.js'
 import type { Website } from '../types/websiteAccessTypes.js'
 import type { ConfirmTransactionTransactionSingleVisualization } from '../types/accessRequest.js'
 import type { RpcNetwork } from '../types/rpc.js'
@@ -312,6 +312,7 @@ export async function changeActiveAddressAndChain(
 		simulationMode: boolean,
 		activeAddress?: bigint,
 		rpcNetwork?: RpcNetwork,
+		promptForAccessesIfNeeded?: boolean,
 	},
 ) {
 
@@ -333,7 +334,7 @@ export async function changeActiveAddressAndChain(
 	}
 
 	const updatedSettings = await getSettings()
-	const popupRefreshGeneration = await updateWebsiteApprovalAccesses(ethereum, tokenPriceService, resetSimulationServices, websiteTabConnections, updatedSettings, true)
+	const popupRefreshGeneration = await updateWebsiteApprovalAccesses(ethereum, tokenPriceService, resetSimulationServices, websiteTabConnections, updatedSettings, change.promptForAccessesIfNeeded ?? true)
 	sendPopupMessageToOpenWindows({ method: 'popup_settingsUpdated', data: updatedSettings, popupRefreshGeneration })
 	sendPopupMessageToOpenWindows({ method: 'popup_accounts_update' })
 	await changeActiveAddressAndChainSemaphore.execute(async () => {
@@ -525,16 +526,17 @@ async function discoverAccountRequestAddressContext(
 ) {
 	const settings = await getSettings()
 	const activeAddress = await getActiveAddressForRequest(settings, websiteTabConnections, socket.tabId)
-	if (activeAddress !== undefined) return { settings, activeAddress, requestedSignerAccountsForSiteAccess: false, signerAccountError: undefined }
-	if (!isAccountConnectionMethod(request.method)) return { settings, activeAddress, requestedSignerAccountsForSiteAccess: false, signerAccountError: undefined }
-	if (getWebsiteAccessApprovalState(settings.websiteAccess, websiteOrigin) !== 'hasAccess') return { settings, activeAddress, requestedSignerAccountsForSiteAccess: false, signerAccountError: undefined }
+	if (activeAddress !== undefined) return { settings, activeAddress, requestedSignerAccountsForAddressConsent: false, signerAccountError: undefined }
+	if (!isAccountConnectionMethod(request.method)) return { settings, activeAddress, requestedSignerAccountsForAddressConsent: false, signerAccountError: undefined }
+	const websiteAccess = getWebsiteAccessApprovalState(settings.websiteAccess, websiteOrigin)
+	if (websiteAccess === 'noAccess' || websiteAccess === 'interceptorDisabled') return { settings, activeAddress, requestedSignerAccountsForAddressConsent: false, signerAccountError: undefined }
 
 	const signerAccountsResult = await askForSignerAccountsFromSignerIfNotAvailable(websiteTabConnections, socket, true)
 	const refreshedSettings = await getSettings()
 	const refreshedActiveAddress = await getActiveAddressForRequest(refreshedSettings, websiteTabConnections, socket.tabId)
-	if (refreshedActiveAddress !== undefined) return { settings: refreshedSettings, activeAddress: refreshedActiveAddress, requestedSignerAccountsForSiteAccess: true, signerAccountError: signerAccountsResult.error }
+	if (refreshedActiveAddress !== undefined) return { settings: refreshedSettings, activeAddress: refreshedActiveAddress, requestedSignerAccountsForAddressConsent: true, signerAccountError: signerAccountsResult.error }
 	const firstSignerAddress = signerAccountsResult.accounts[0] === undefined ? undefined : await getActiveAddressEntry(signerAccountsResult.accounts[0])
-	return { settings: refreshedSettings, activeAddress: firstSignerAddress, requestedSignerAccountsForSiteAccess: true, signerAccountError: signerAccountsResult.error }
+	return { settings: refreshedSettings, activeAddress: firstSignerAddress, requestedSignerAccountsForAddressConsent: true, signerAccountError: signerAccountsResult.error }
 }
 
 const isSignerProviderDisconnectedError = (error: ErrorWithCodeAndOptionalData | undefined): error is ErrorWithCodeAndOptionalData => error?.code === METAMASK_ERROR_PROVIDER_DISCONNECTED
@@ -581,15 +583,14 @@ export const handleInterceptedRequest = async (port: browser.runtime.Port | unde
 		const message: InpageScriptRequest = { uniqueRequestIdentifier: request.uniqueRequestIdentifier, ...providerHandlerReturn }
 		return replyToInterceptedRequest(websiteTabConnections, message)
 	}
-	const { settings, activeAddress, requestedSignerAccountsForSiteAccess, signerAccountError } = await discoverAccountRequestAddressContext(websiteTabConnections, socket, request, websiteOrigin)
+	const { settings, activeAddress, requestedSignerAccountsForAddressConsent, signerAccountError } = await discoverAccountRequestAddressContext(websiteTabConnections, socket, request, websiteOrigin)
 	if (isTerminalSignerAccountConnectionError(signerAccountError)) return replyWithSignerAccountError(websiteTabConnections, request, signerAccountError)
-	if (requestedSignerAccountsForSiteAccess && activeAddress === undefined) {
+	if (requestedSignerAccountsForAddressConsent && activeAddress === undefined) {
 		if (getWebsiteAccessApprovalState(settings.websiteAccess, websiteOrigin) === 'interceptorDisabled') return replyToInterceptedRequest(websiteTabConnections, { type: 'result', ...getRequestWithDefinedParams(request), ...ERROR_INTERCEPTOR_DISABLED })
 		return refuseAccess(websiteTabConnections, request)
 	}
 	const accountConnectionRequest = isAccountConnectionMethod(request.method)
 	const accountIdentityRequest = isAccountOnlyMethod(request.method)
-	const requestsAccountPermission = request.method === 'eth_requestAccounts' || RequestPermissions.safeParse(request).success
 	const verifyRequestAccess = () => verifyAccess(
 		websiteTabConnections,
 		socket,
@@ -599,14 +600,13 @@ export const handleInterceptedRequest = async (port: browser.runtime.Port | unde
 		settings,
 		{
 			ignoreConnectionApproval: accountIdentityRequest,
-			allowWebsiteApprovalToGrantAddressAccess: requestsAccountPermission,
 		},
 	)
 	const access = accountConnectionRequest ? withSuppressedUnscopedConnectionEventsForSocket(socket, verifyRequestAccess) : verifyRequestAccess()
 	if (access === 'interceptorDisabled') return replyToInterceptedRequest(websiteTabConnections, { type: 'result', ...getRequestWithDefinedParams(request), ...ERROR_INTERCEPTOR_DISABLED })
 	if (access === 'hasAccess' && activeAddress === undefined && accountConnectionRequest) {
 		// user has granted access to the site, but not to this account and the application is requesting accounts
-		if (requestedSignerAccountsForSiteAccess) return refuseAccess(websiteTabConnections, request)
+		if (requestedSignerAccountsForAddressConsent) return refuseAccess(websiteTabConnections, request)
 		const signerAccountsResult = await askForSignerAccountsFromSignerIfNotAvailable(websiteTabConnections, socket, true)
 		if (isTerminalSignerAccountConnectionError(signerAccountsResult.error)) return replyWithSignerAccountError(websiteTabConnections, request, signerAccountsResult.error)
 		if (signerAccountsResult.accounts.length === 0) return refuseAccess(websiteTabConnections, request)
@@ -653,19 +653,6 @@ export const handleInterceptedRequest = async (port: browser.runtime.Port | unde
 			if (activeAddress === undefined) return refuseAccess(websiteTabConnections, request)
 			const website = await websitePromise
 			return await handleContentScriptMessage(ethereum, tokenPriceService, resetSimulationServices, websiteTabConnections, request, website, activeAddress.address, publishRpcConnectionStatus)
-		}
-		case 'websiteApprovalCanGrantAddressAccess': {
-			if (activeAddress === undefined) return refuseAccess(websiteTabConnections, request)
-			const website = await websitePromise
-			return await withSuppressedUnscopedConnectionEventsForSocketAsync(socket, async () => {
-				const persistedSettings = await persistAddressAccessFromWebsiteApproval(ethereum, tokenPriceService, resetSimulationServices, websiteTabConnections, website, activeAddress)
-				if (persistedSettings === undefined) {
-					const currentSiteAccess = getWebsiteAccessApprovalState((await getSettings()).websiteAccess, websiteOrigin)
-					if (currentSiteAccess === 'interceptorDisabled') return replyToInterceptedRequest(websiteTabConnections, { type: 'result', ...getRequestWithDefinedParams(request), ...ERROR_INTERCEPTOR_DISABLED })
-					return refuseAccess(websiteTabConnections, request)
-				}
-				return await handleContentScriptMessage(ethereum, tokenPriceService, resetSimulationServices, websiteTabConnections, request, website, activeAddress.address, publishRpcConnectionStatus)
-			})
 		}
 		default: assertNever(access)
 	}

--- a/app/ts/background/background.ts
+++ b/app/ts/background/background.ts
@@ -7,7 +7,7 @@ import { PASSTHROUGH_STATE, type ResolvedExecutionSimulationState, type Resolved
 import type { WebsiteTabConnections } from '../types/user-interface-types.js'
 import { askForSignerAccountsFromSignerIfNotAvailable, requestAccessFromUser } from './windows/interceptorAccess.js'
 import { METAMASK_ERROR_FAILED_TO_PARSE_REQUEST, METAMASK_ERROR_NOT_AUTHORIZED, METAMASK_ERROR_NOT_CONNECTED_TO_CHAIN, METAMASK_ERROR_PROVIDER_DISCONNECTED, METAMASK_ERROR_USER_REJECTED_REQUEST, ERROR_INTERCEPTOR_DISABLED, NEW_BLOCK_ABORT, JSON_RPC_ERROR_CODE_INTERNAL_ERROR } from '../utils/constants.js'
-import { clearWebsiteConnectionIntent, hasAccess as getWebsiteAccessApprovalState, hasAddressAccess as getWebsiteAddressAccessApprovalState, persistWebsiteAccessChange, sendActiveAccountChangeToApprovedWebsitePorts, sendMessageToApprovedWebsitePorts, sendProviderConnectionEventsToPort, updateWebsiteApprovalAccesses, verifyAccess, withSuppressedUnscopedConnectionEventsForSocket } from './accessManagement.js'
+import { clearWebsiteConnectionIntent, hasAccess as getWebsiteAccessApprovalState, hasAddressAccess as getWebsiteAddressAccessApprovalState, persistAddressAccessForApprovedWebsite, persistWebsiteAccessChange, sendActiveAccountChangeToApprovedWebsitePorts, sendMessageToApprovedWebsitePorts, sendProviderConnectionEventsToPort, updateWebsiteApprovalAccesses, verifyAccess, withSuppressedUnscopedConnectionEventsForSocket, withSuppressedUnscopedConnectionEventsForSocketAsync } from './accessManagement.js'
 import { getActiveAddressEntry, identifyAddress } from './metadataUtils.js'
 import { getActiveAddress, sendPopupMessageToOpenWindows } from './backgroundUtils.js'
 import { assertNever } from '../utils/typescript.js'
@@ -595,6 +595,12 @@ export const handleInterceptedRequest = async (port: browser.runtime.Port | unde
 	}
 	const accountConnectionRequest = isAccountConnectionMethod(request.method)
 	const accountIdentityRequest = isAccountOnlyMethod(request.method)
+	const addressAccess = activeAddress === undefined
+		? undefined
+		: getWebsiteAddressAccessApprovalState(settings.websiteAccess, websiteOrigin, activeAddress)
+	const useExistingSiteApproval = request.method === 'eth_requestAccounts'
+		&& getWebsiteAccessApprovalState(settings.websiteAccess, websiteOrigin) === 'hasAccess'
+		&& addressAccess === 'askAccess'
 	const verifyRequestAccess = () => verifyAccess(
 		websiteTabConnections,
 		socket,
@@ -604,7 +610,9 @@ export const handleInterceptedRequest = async (port: browser.runtime.Port | unde
 		settings,
 		accountIdentityRequest,
 	)
-	const access = accountConnectionRequest ? withSuppressedUnscopedConnectionEventsForSocket(socket, verifyRequestAccess) : verifyRequestAccess()
+	const access = useExistingSiteApproval
+		? 'hasAccess'
+		: accountConnectionRequest ? withSuppressedUnscopedConnectionEventsForSocket(socket, verifyRequestAccess) : verifyRequestAccess()
 	if (access === 'interceptorDisabled') return replyToInterceptedRequest(websiteTabConnections, { type: 'result', ...getRequestWithDefinedParams(request), ...ERROR_INTERCEPTOR_DISABLED })
 	if (access === 'hasAccess' && activeAddress === undefined && accountConnectionRequest) {
 		// user has granted access to the site, but not to this account and the application is requesting accounts
@@ -653,7 +661,17 @@ export const handleInterceptedRequest = async (port: browser.runtime.Port | unde
 		case 'noAccess': return refuseAccess(websiteTabConnections, request)
 		case 'hasAccess': {
 			if (activeAddress === undefined) return refuseAccess(websiteTabConnections, request)
-			return await handleContentScriptMessage(ethereum, tokenPriceService, resetSimulationServices, websiteTabConnections, request, await websitePromise, activeAddress?.address, publishRpcConnectionStatus)
+			const website = await websitePromise
+			if (!useExistingSiteApproval) return await handleContentScriptMessage(ethereum, tokenPriceService, resetSimulationServices, websiteTabConnections, request, website, activeAddress.address, publishRpcConnectionStatus)
+			return await withSuppressedUnscopedConnectionEventsForSocketAsync(socket, async () => {
+				const persistedSettings = await persistAddressAccessForApprovedWebsite(ethereum, tokenPriceService, resetSimulationServices, websiteTabConnections, website, activeAddress)
+				if (persistedSettings === undefined) {
+					const currentSiteAccess = getWebsiteAccessApprovalState((await getSettings()).websiteAccess, websiteOrigin)
+					if (currentSiteAccess === 'interceptorDisabled') return replyToInterceptedRequest(websiteTabConnections, { type: 'result', ...getRequestWithDefinedParams(request), ...ERROR_INTERCEPTOR_DISABLED })
+					return refuseAccess(websiteTabConnections, request)
+				}
+				return await handleContentScriptMessage(ethereum, tokenPriceService, resetSimulationServices, websiteTabConnections, request, website, activeAddress.address, publishRpcConnectionStatus)
+			})
 		}
 		default: assertNever(access)
 	}

--- a/app/ts/background/background.ts
+++ b/app/ts/background/background.ts
@@ -7,7 +7,7 @@ import { PASSTHROUGH_STATE, type ResolvedExecutionSimulationState, type Resolved
 import type { WebsiteTabConnections } from '../types/user-interface-types.js'
 import { askForSignerAccountsFromSignerIfNotAvailable, requestAccessFromUser } from './windows/interceptorAccess.js'
 import { METAMASK_ERROR_FAILED_TO_PARSE_REQUEST, METAMASK_ERROR_NOT_AUTHORIZED, METAMASK_ERROR_NOT_CONNECTED_TO_CHAIN, METAMASK_ERROR_PROVIDER_DISCONNECTED, METAMASK_ERROR_USER_REJECTED_REQUEST, ERROR_INTERCEPTOR_DISABLED, NEW_BLOCK_ABORT, JSON_RPC_ERROR_CODE_INTERNAL_ERROR } from '../utils/constants.js'
-import { clearWebsiteConnectionIntent, hasAccess as getWebsiteAccessApprovalState, hasAddressAccess as getWebsiteAddressAccessApprovalState, persistAddressAccessForApprovedWebsite, persistWebsiteAccessChange, sendAccountsChangedToPort, sendActiveAccountChangeToApprovedWebsitePorts, sendMessageToApprovedWebsitePorts, updateWebsiteApprovalAccesses, verifyAccess, withSuppressedUnscopedConnectionEventsForSocket, withSuppressedUnscopedConnectionEventsForSocketAsync } from './accessManagement.js'
+import { clearWebsiteConnectionIntent, finalizeWebsiteAccessChange, hasAccess as getWebsiteAccessApprovalState, hasAddressAccess as getWebsiteAddressAccessApprovalState, persistAddressAccessFromWebsiteApproval, persistWebsiteAccessChange, sendAccountsChangedToPort, sendActiveAccountChangeToApprovedWebsitePorts, sendMessageToApprovedWebsitePorts, updateWebsiteApprovalAccesses, verifyAccess, withSuppressedUnscopedConnectionEventsForSocket, withSuppressedUnscopedConnectionEventsForSocketAsync } from './accessManagement.js'
 import { getActiveAddressEntry, identifyAddress } from './metadataUtils.js'
 import { getActiveAddress, sendPopupMessageToOpenWindows } from './backgroundUtils.js'
 import { assertNever } from '../utils/typescript.js'
@@ -494,8 +494,7 @@ async function revokeWebsitePermissions(
 		}
 	}))
 	clearWebsiteConnectionIntent(websiteTabConnections, websiteOrigin)
-	await updateWebsiteApprovalAccesses(ethereum, tokenPriceService, resetSimulationServices, websiteTabConnections, await getSettings(), false)
-	await sendPopupMessageToOpenWindows({ method: 'popup_websiteAccess_changed' })
+	await finalizeWebsiteAccessChange(ethereum, tokenPriceService, resetSimulationServices, websiteTabConnections, await getSettings(), false)
 	return { type: 'result' as const, method: 'wallet_revokePermissions' as const, result: null }
 }
 
@@ -590,13 +589,7 @@ export const handleInterceptedRequest = async (port: browser.runtime.Port | unde
 	}
 	const accountConnectionRequest = isAccountConnectionMethod(request.method)
 	const accountIdentityRequest = isAccountOnlyMethod(request.method)
-	const addressAccess = activeAddress === undefined
-		? undefined
-		: getWebsiteAddressAccessApprovalState(settings.websiteAccess, websiteOrigin, activeAddress)
 	const requestsAccountPermission = request.method === 'eth_requestAccounts' || RequestPermissions.safeParse(request).success
-	const useExistingSiteApproval = requestsAccountPermission
-		&& getWebsiteAccessApprovalState(settings.websiteAccess, websiteOrigin) === 'hasAccess'
-		&& addressAccess === 'askAccess'
 	const verifyRequestAccess = () => verifyAccess(
 		websiteTabConnections,
 		socket,
@@ -604,11 +597,12 @@ export const handleInterceptedRequest = async (port: browser.runtime.Port | unde
 		websiteOrigin,
 		activeAddress,
 		settings,
-		accountIdentityRequest,
+		{
+			ignoreConnectionApproval: accountIdentityRequest,
+			allowWebsiteApprovalToGrantAddressAccess: requestsAccountPermission,
+		},
 	)
-	const access = useExistingSiteApproval
-		? 'hasAccess'
-		: accountConnectionRequest ? withSuppressedUnscopedConnectionEventsForSocket(socket, verifyRequestAccess) : verifyRequestAccess()
+	const access = accountConnectionRequest ? withSuppressedUnscopedConnectionEventsForSocket(socket, verifyRequestAccess) : verifyRequestAccess()
 	if (access === 'interceptorDisabled') return replyToInterceptedRequest(websiteTabConnections, { type: 'result', ...getRequestWithDefinedParams(request), ...ERROR_INTERCEPTOR_DISABLED })
 	if (access === 'hasAccess' && activeAddress === undefined && accountConnectionRequest) {
 		// user has granted access to the site, but not to this account and the application is requesting accounts
@@ -636,7 +630,7 @@ export const handleInterceptedRequest = async (port: browser.runtime.Port | unde
 			}
 		}
 		if (refreshedActiveAddress === undefined) return replyWithEmptyAccountIdentity(websiteTabConnections, request)
-		const refreshedAccess = verifyAccess(websiteTabConnections, socket, false, websiteOrigin, refreshedActiveAddress, refreshedSettings, true)
+		const refreshedAccess = verifyAccess(websiteTabConnections, socket, false, websiteOrigin, refreshedActiveAddress, refreshedSettings, { ignoreConnectionApproval: true })
 		if (refreshedAccess !== 'hasAccess') return replyWithEmptyAccountIdentity(websiteTabConnections, request)
 		return await handleContentScriptMessage(ethereum, tokenPriceService, resetSimulationServices, websiteTabConnections, request, await websitePromise, refreshedActiveAddress.address, publishRpcConnectionStatus)
 	}
@@ -658,9 +652,13 @@ export const handleInterceptedRequest = async (port: browser.runtime.Port | unde
 		case 'hasAccess': {
 			if (activeAddress === undefined) return refuseAccess(websiteTabConnections, request)
 			const website = await websitePromise
-			if (!useExistingSiteApproval) return await handleContentScriptMessage(ethereum, tokenPriceService, resetSimulationServices, websiteTabConnections, request, website, activeAddress.address, publishRpcConnectionStatus)
+			return await handleContentScriptMessage(ethereum, tokenPriceService, resetSimulationServices, websiteTabConnections, request, website, activeAddress.address, publishRpcConnectionStatus)
+		}
+		case 'websiteApprovalCanGrantAddressAccess': {
+			if (activeAddress === undefined) return refuseAccess(websiteTabConnections, request)
+			const website = await websitePromise
 			return await withSuppressedUnscopedConnectionEventsForSocketAsync(socket, async () => {
-				const persistedSettings = await persistAddressAccessForApprovedWebsite(ethereum, tokenPriceService, resetSimulationServices, websiteTabConnections, website, activeAddress)
+				const persistedSettings = await persistAddressAccessFromWebsiteApproval(ethereum, tokenPriceService, resetSimulationServices, websiteTabConnections, website, activeAddress)
 				if (persistedSettings === undefined) {
 					const currentSiteAccess = getWebsiteAccessApprovalState((await getSettings()).websiteAccess, websiteOrigin)
 					if (currentSiteAccess === 'interceptorDisabled') return replyToInterceptedRequest(websiteTabConnections, { type: 'result', ...getRequestWithDefinedParams(request), ...ERROR_INTERCEPTOR_DISABLED })

--- a/app/ts/background/providerMessageHandlers.ts
+++ b/app/ts/background/providerMessageHandlers.ts
@@ -101,6 +101,7 @@ export async function ethAccountsReply(ethereum: EthereumClientService, tokenPri
 			const changeActiveAddress = async () => await changeActiveAddressAndChain(ethereum, tokenPriceService, resetSimulationServices, websiteTabConnections, {
 				simulationMode: settings.simulationMode,
 				activeAddress: tabStateChange.newState.activeSigningAddress,
+				promptForAccessesIfNeeded: !signerAccountsReply.requestAccounts,
 			})
 			if (signerAccountsReply.requestAccounts) {
 				await withSuppressedUnscopedConnectionEventsForSocketAsync(signerStateToken.socket, changeActiveAddress)

--- a/app/ts/background/windows/interceptorAccess.ts
+++ b/app/ts/background/windows/interceptorAccess.ts
@@ -250,7 +250,7 @@ export async function requestAccessFromUser(
 			website.websiteOrigin,
 			activeAddressEntry,
 			currentSettings,
-			request !== undefined && isAccountConnectionMethod(request.method),
+			{ ignoreConnectionApproval: request !== undefined && isAccountConnectionMethod(request.method) },
 		)
 		if (request === undefined || !isAccountConnectionMethod(request.method)) return verify()
 		return withSuppressedUnscopedConnectionEventsForSocket(request.uniqueRequestIdentifier.requestSocket, verify)

--- a/app/ts/background/windows/interceptorAccess.ts
+++ b/app/ts/background/windows/interceptorAccess.ts
@@ -395,7 +395,7 @@ async function resolve(ethereum: EthereumClientService, tokenPriceService: Token
 	} else {
 		const userRequestedAddressChange = accessReply.requestAccessToAddress !== accessReply.originalRequestAccessToAddress
 		const replyCompletesAccountRequest = request !== undefined && isAccountConnectionMethod(request.method)
-		const shouldPromptForFollowUpAccesses = !(replyCompletesAccountRequest && accessReply.requestAccessToAddress === undefined)
+		const shouldPromptForFollowUpAccesses = !replyCompletesAccountRequest
 		const accountRequestSocket = replyCompletesAccountRequest ? request.uniqueRequestIdentifier.requestSocket : undefined
 		const applyAccessReply = async () => {
 			if (!userRequestedAddressChange) {

--- a/app/ts/types/JsonRpc-types.ts
+++ b/app/ts/types/JsonRpc-types.ts
@@ -308,15 +308,13 @@ export const GetCode = funtypes.ReadonlyObject({
 	params: funtypes.ReadonlyTuple(EthereumAddress, EthereumBlockTag)
 }).asReadonly()
 
-const EmptyPermissionOptions = funtypes.Sealed(funtypes.ReadonlyObject({}))
-const RequestPermissionsParams = funtypes.Sealed(funtypes.ReadonlyObject({ eth_accounts: EmptyPermissionOptions }), { deep: true })
-
-export type RequestPermissions = funtypes.Static<typeof RequestPermissions>
-export const RequestPermissions = funtypes.ReadonlyObject({
+type RequestPermissions = funtypes.Static<typeof RequestPermissions>
+const RequestPermissions = funtypes.ReadonlyObject({
 	method: funtypes.Literal('wallet_requestPermissions'),
-	params: funtypes.ReadonlyTuple(RequestPermissionsParams)
+	params: funtypes.ReadonlyTuple( funtypes.ReadonlyObject({ eth_accounts: funtypes.ReadonlyObject({ }) }) )
 }).asReadonly()
 
+const EmptyPermissionOptions = funtypes.Sealed(funtypes.ReadonlyObject({}))
 const WalletRevokePermissionsParams = funtypes.Sealed(funtypes.ReadonlyObject({ eth_accounts: EmptyPermissionOptions }), { deep: true })
 
 export type WalletRevokePermissions = funtypes.Static<typeof WalletRevokePermissions>

--- a/test/tests/backgroundEthAccounts.test.ts
+++ b/test/tests/backgroundEthAccounts.test.ts
@@ -3511,4 +3511,26 @@ params: [{ signerProviderGeneration: 1, type: 'success', accounts: ['0x333333333
 		assert.equal(hasAccess([], websiteOrigin), 'askAccess')
 		assert.equal(hasAddressAccess([], websiteOrigin, address), 'askAccess')
 	})
+
+	test('verifyAccess exposes website-approved address persistence as a distinct decision', async () => {
+		installBrowserMock()
+		const { getSettings, updateWebsiteAccess, verifyAccess } = await loadModules()
+		const websiteOrigin = 'https://example.test'
+		const website = { websiteOrigin, icon: undefined, title: undefined }
+		const address = { address: 0x1111111111111111111111111111111111111111n, askForAddressAccess: true, type: 'contact', name: 'Test Address' } as const
+		const socket = { tabId: 1, connectionName: 0n }
+		const websiteTabConnections: WebsiteTabConnections = new Map()
+		await updateWebsiteAccess(() => [{ website, access: true, addressAccess: [] }])
+		const settings = await getSettings()
+
+		assert.equal(verifyAccess(websiteTabConnections, socket, true, websiteOrigin, address, settings), 'askAccess')
+		assert.equal(verifyAccess(websiteTabConnections, socket, true, websiteOrigin, address, settings, {
+			allowWebsiteApprovalToGrantAddressAccess: true,
+		}), 'websiteApprovalCanGrantAddressAccess')
+
+		await updateWebsiteAccess(() => [{ website, access: true, addressAccess: [{ address: address.address, access: false }] }])
+		assert.equal(verifyAccess(websiteTabConnections, socket, true, websiteOrigin, address, await getSettings(), {
+			allowWebsiteApprovalToGrantAddressAccess: true,
+		}), 'noAccess')
+	})
 })

--- a/test/tests/backgroundEthAccounts.test.ts
+++ b/test/tests/backgroundEthAccounts.test.ts
@@ -19,6 +19,12 @@ function createDeferredSignal() {
 	return { promise, resolve: () => resolveSignal() }
 }
 
+function createDeferredValue<T>() {
+	let resolveValue = (_value: T) => undefined
+	const promise = new Promise<T>((resolve) => { resolveValue = resolve })
+	return { promise, resolve: (value: T) => resolveValue(value) }
+}
+
 function installBrowserMock({ deferFirstChainChangeRemoval = false } = {}) {
 	const storageState: Record<string, unknown> = {}
 	const chainChangeRemovalStarted = createDeferredSignal()
@@ -2021,7 +2027,7 @@ params: [{ signerProviderGeneration: 1, type: 'success', accounts: ['0x333333333
 		assert.deepEqual(connectedReplies.at(-1)?.result, { metamaskCompatibilityMode: false })
 	})
 
-	test('opens address access dialog after signer account discovery for site-approved eth_requestAccounts', async () => {
+	test('does not open an address access dialog after signer account discovery for site-approved eth_requestAccounts', async () => {
 		installBrowserMock()
 		const {
 			handleInterceptedRequest,
@@ -2030,6 +2036,7 @@ params: [{ signerProviderGeneration: 1, type: 'success', accounts: ['0x333333333
 			setUseSignersAddressAsActiveAddress,
 			updateWebsiteAccess,
 			getPendingAccessRequests,
+			getSettings,
 		} = await loadModules()
 		const websiteOrigin = 'https://example.test'
 		const website = { websiteOrigin, icon: undefined, title: undefined }
@@ -2066,14 +2073,150 @@ params: [{ signerProviderGeneration: 1, type: 'success', accounts: ['0x333333333
 		await handleInterceptedRequest(port, websiteOrigin, website, ethereum, tokenPriceService, resetSimulationServices, socket, request, websiteTabConnections, noopPublishRpcConnectionStatus)
 
 		assert.equal(messages.filter((message) => message.method === 'request_signer_to_eth_requestAccounts').length, 1)
-		assert.equal(messages.some((message) => message.method === 'connect'), false)
-		assert.equal(messages.some((message) => message.method === 'accountsChanged'), false)
-		assert.equal(messages.some((message) => message.method === 'eth_requestAccounts' && message.requestId === 10), false)
-		const pendingRequests = await getPendingAccessRequests()
-		assert.equal(pendingRequests.length, 1)
-		assert.equal(pendingRequests[0]?.request?.method, 'eth_requestAccounts')
-		assert.equal(pendingRequests[0]?.requestAccessToAddress?.address, account)
-		assert.equal(pendingRequests[0]?.originalRequestAccessToAddress?.address, account)
+		assert.deepEqual(messages.filter((message) => message.method === 'connect').map((message) => message.requestId), [10])
+		assert.deepEqual(messages.filter((message) => message.method === 'accountsChanged').map((message) => message.result), [[accountString]])
+		assert.deepEqual(messages.filter((message) => message.method === 'eth_accounts' && message.requestId === 10).map((message) => message.result), [[accountString]])
+		assert.equal((await getPendingAccessRequests()).length, 0)
+		assert.deepEqual((await getSettings()).websiteAccess[0]?.addressAccess, [{ address: account, access: true }])
+	})
+
+	test('does not override an explicitly denied address for site-approved eth_requestAccounts', async () => {
+		installBrowserMock()
+		const {
+			handleInterceptedRequest,
+			websiteSocketToString,
+			changeSimulationMode,
+			setUseSignersAddressAsActiveAddress,
+			updateWebsiteAccess,
+			updateTabState,
+			getPendingAccessRequests,
+		} = await loadModules()
+		const websiteOrigin = 'https://example.test'
+		const website = { websiteOrigin, icon: undefined, title: undefined }
+		const account = 0x5656565656565656565656565656565656565656n
+		await changeSimulationMode({ simulationMode: false, activeSimulationAddress: undefined, activeSigningAddress: account })
+		await setUseSignersAddressAsActiveAddress(false)
+		await updateWebsiteAccess(() => [{ website, access: true, addressAccess: [{ address: account, access: false }] }])
+		await updateTabState(1, (previousState) => ({ ...previousState, signerAccounts: [account], activeSigningAddress: account }))
+
+		const socket = { tabId: 1, connectionName: 0n }
+		const { port, messages } = createPort(socket.tabId)
+		const connectionKey = websiteSocketToString(socket)
+		const websiteTabConnections = new Map([[socket.tabId, { ...confirmedSignerOwnership(socket), connections: {
+			[connectionKey]: { port, socket, websiteOrigin, approved: false, wantsToConnect: true },
+		} }]])
+		const { ethereum, tokenPriceService, resetSimulationServices } = createEthereumWithGetBlockCounter({ count: 0 })
+		const request = {
+			interceptorRequest: true,
+			usingInterceptorWithoutSigner: false,
+			uniqueRequestIdentifier: { requestId: 22, requestSocket: socket },
+			method: 'eth_requestAccounts',
+		}
+
+		await handleInterceptedRequest(port, websiteOrigin, website, ethereum, tokenPriceService, resetSimulationServices, socket, request, websiteTabConnections, noopPublishRpcConnectionStatus)
+
+		assert.equal(messages.some((message) => message.method === 'connect' || message.method === 'accountsChanged'), false)
+		assert.equal(messages.filter((message) => message.method === 'eth_requestAccounts' && message.requestId === 22).at(-1)?.error?.code, 4100)
+		assert.equal((await getPendingAccessRequests()).length, 0)
+	})
+
+	test('does not approve the port before site-approved eth_requestAccounts persists address access', async () => {
+		installBrowserMock()
+		const {
+			handleInterceptedRequest,
+			websiteSocketToString,
+			changeSimulationMode,
+			setUseSignersAddressAsActiveAddress,
+			updateWebsiteAccess,
+			updateTabState,
+			getSettings,
+		} = await loadModules()
+		const websiteOrigin = 'https://example.test'
+		const website = { websiteOrigin, icon: undefined, title: undefined }
+		const pendingWebsite = createDeferredValue<typeof website>()
+		const account = 0x5757575757575757575757575757575757575757n
+		const accountString = '0x5757575757575757575757575757575757575757'
+		await changeSimulationMode({ simulationMode: false, activeSimulationAddress: undefined, activeSigningAddress: account })
+		await setUseSignersAddressAsActiveAddress(false)
+		await updateWebsiteAccess(() => [{ website, access: true, addressAccess: undefined }])
+		await updateTabState(1, (previousState) => ({ ...previousState, signerAccounts: [account], activeSigningAddress: account }))
+
+		const socket = { tabId: 1, connectionName: 0n }
+		const { port, messages } = createPort(socket.tabId)
+		const connection = { port, socket, websiteOrigin, approved: false, wantsToConnect: true }
+		const connectionKey = websiteSocketToString(socket)
+		const websiteTabConnections = new Map([[socket.tabId, { ...confirmedSignerOwnership(socket), connections: {
+			[connectionKey]: connection,
+		} }]])
+		const { ethereum, tokenPriceService, resetSimulationServices } = createEthereumWithGetBlockCounter({ count: 0 })
+		const requestAccountsPromise = handleInterceptedRequest(port, websiteOrigin, pendingWebsite.promise, ethereum, tokenPriceService, resetSimulationServices, socket, {
+			interceptorRequest: true,
+			usingInterceptorWithoutSigner: false,
+			uniqueRequestIdentifier: { requestId: 23, requestSocket: socket },
+			method: 'eth_requestAccounts',
+		}, websiteTabConnections, noopPublishRpcConnectionStatus)
+
+		await handleInterceptedRequest(port, websiteOrigin, website, ethereum, tokenPriceService, resetSimulationServices, socket, {
+			interceptorRequest: true,
+			usingInterceptorWithoutSigner: false,
+			uniqueRequestIdentifier: { requestId: 24, requestSocket: socket },
+			method: 'eth_accounts',
+		}, websiteTabConnections, noopPublishRpcConnectionStatus)
+
+		assert.equal(connection.approved, false)
+		assert.deepEqual(messages.filter((message) => message.method === 'eth_accounts' && message.requestId === 24).map((message) => message.result), [[]])
+		assert.equal((await getSettings()).websiteAccess[0]?.addressAccess, undefined)
+
+		pendingWebsite.resolve(website)
+		await requestAccountsPromise
+
+		assert.equal(connection.approved, true)
+		assert.deepEqual(messages.filter((message) => message.method === 'eth_accounts' && message.requestId === 23).map((message) => message.result), [[accountString]])
+		assert.deepEqual((await getSettings()).websiteAccess[0]?.addressAccess, [{ address: account, access: true }])
+	})
+
+	test('does not overwrite an address denial made while site-approved eth_requestAccounts is pending', async () => {
+		installBrowserMock()
+		const {
+			handleInterceptedRequest,
+			websiteSocketToString,
+			changeSimulationMode,
+			setUseSignersAddressAsActiveAddress,
+			updateWebsiteAccess,
+			updateTabState,
+			getSettings,
+		} = await loadModules()
+		const websiteOrigin = 'https://example.test'
+		const website = { websiteOrigin, icon: undefined, title: undefined }
+		const pendingWebsite = createDeferredValue<typeof website>()
+		const account = 0x5858585858585858585858585858585858585858n
+		await changeSimulationMode({ simulationMode: false, activeSimulationAddress: undefined, activeSigningAddress: account })
+		await setUseSignersAddressAsActiveAddress(false)
+		await updateWebsiteAccess(() => [{ website, access: true, addressAccess: undefined }])
+		await updateTabState(1, (previousState) => ({ ...previousState, signerAccounts: [account], activeSigningAddress: account }))
+
+		const socket = { tabId: 1, connectionName: 0n }
+		const { port, messages } = createPort(socket.tabId)
+		const connection = { port, socket, websiteOrigin, approved: false, wantsToConnect: true }
+		const connectionKey = websiteSocketToString(socket)
+		const websiteTabConnections = new Map([[socket.tabId, { ...confirmedSignerOwnership(socket), connections: {
+			[connectionKey]: connection,
+		} }]])
+		const { ethereum, tokenPriceService, resetSimulationServices } = createEthereumWithGetBlockCounter({ count: 0 })
+		const requestAccountsPromise = handleInterceptedRequest(port, websiteOrigin, pendingWebsite.promise, ethereum, tokenPriceService, resetSimulationServices, socket, {
+			interceptorRequest: true,
+			usingInterceptorWithoutSigner: false,
+			uniqueRequestIdentifier: { requestId: 25, requestSocket: socket },
+			method: 'eth_requestAccounts',
+		}, websiteTabConnections, noopPublishRpcConnectionStatus)
+
+		await updateWebsiteAccess(() => [{ website, access: true, addressAccess: [{ address: account, access: false }] }])
+		pendingWebsite.resolve(website)
+		await requestAccountsPromise
+
+		assert.equal(connection.approved, false)
+		assert.equal(messages.filter((message) => message.method === 'eth_requestAccounts' && message.requestId === 25).at(-1)?.error?.code, 4100)
+		assert.deepEqual((await getSettings()).websiteAccess[0]?.addressAccess, [{ address: account, access: false }])
 	})
 
 	test('uses cached signer account instead of a stale provider-disconnected error when active signing address is missing', async () => {
@@ -2086,7 +2229,7 @@ params: [{ signerProviderGeneration: 1, type: 'success', accounts: ['0x333333333
 			updateWebsiteAccess,
 			updateTabState,
 			getPendingAccessRequests,
-			resolveInterceptorAccess,
+			getSettings,
 		} = await loadModules()
 		const websiteOrigin = 'https://example.test'
 		const website = { websiteOrigin, icon: undefined, title: undefined }
@@ -2118,33 +2261,11 @@ params: [{ signerProviderGeneration: 1, type: 'success', accounts: ['0x333333333
 		await handleInterceptedRequest(port, websiteOrigin, website, ethereum, tokenPriceService, resetSimulationServices, socket, request, websiteTabConnections, noopPublishRpcConnectionStatus)
 
 		assert.equal(messages.some((message) => message.method === 'request_signer_to_eth_requestAccounts'), false)
-		assert.equal(messages.some((message) => message.method === 'connect'), false)
-		assert.equal(messages.some((message) => message.method === 'accountsChanged'), false)
-		assert.equal(messages.some((message) => message.method === 'eth_requestAccounts' && message.requestId === 11), false)
-		const pendingRequests = await getPendingAccessRequests()
-		assert.equal(pendingRequests.length, 1)
-		assert.equal(pendingRequests[0]?.request?.method, 'eth_requestAccounts')
-		assert.equal(pendingRequests[0]?.requestAccessToAddress?.address, account)
-		assert.equal(pendingRequests[0]?.originalRequestAccessToAddress?.address, account)
-		const pendingRequest = pendingRequests[0]
-		if (pendingRequest === undefined) throw new Error('Missing pending request')
-		const siteApprovalResolution = resolveInterceptorAccess(
-			ethereum,
-			tokenPriceService,
-			resetSimulationServices,
-			websiteTabConnections,
-			{
-				userReply: 'Approved',
-				websiteOrigin,
-				requestAccessToAddress: pendingRequest.requestAccessToAddress?.address,
-				originalRequestAccessToAddress: pendingRequest.originalRequestAccessToAddress?.address,
-				accessRequestId: pendingRequest.accessRequestId,
-			},
-			noopPublishRpcConnectionStatus,
-		)
-		await siteApprovalResolution
-		assert.equal(messages.some((message) => message.method === 'accountsChanged' && Array.isArray(message.result) && message.result.length === 0), false)
+		assert.deepEqual(messages.filter((message) => message.method === 'connect').map((message) => message.requestId), [11])
+		assert.deepEqual(messages.filter((message) => message.method === 'accountsChanged').map((message) => message.result), [['0x6666666666666666666666666666666666666666']])
 		assert.deepEqual(messages.filter((message) => message.method === 'eth_accounts' && message.requestId === 11).at(-1)?.result, ['0x6666666666666666666666666666666666666666'])
+		assert.equal((await getPendingAccessRequests()).length, 0)
+		assert.deepEqual((await getSettings()).websiteAccess[0]?.addressAccess, [{ address: account, access: true }])
 	})
 
 	test('reuses a persisted access dialog when the same eth_requestAccounts is replayed after restart', async () => {
@@ -2573,7 +2694,7 @@ params: [{ signerProviderGeneration: 1, type: 'success', accounts: ['0x333333333
 		assert.deepEqual(requestAccountsReplies[0]?.result, [accountString])
 	})
 
-	test('keeps sibling connection events when popup approval resolves eth_requestAccounts', async () => {
+	test('keeps sibling connection events when site approval resolves eth_requestAccounts without a popup', async () => {
 		installBrowserMock()
 		const {
 			handleInterceptedRequest,
@@ -2583,7 +2704,6 @@ params: [{ signerProviderGeneration: 1, type: 'success', accounts: ['0x333333333
 			updateWebsiteAccess,
 			updateTabState,
 			getPendingAccessRequests,
-			resolveInterceptorAccess,
 			getSettings,
 		} = await loadModules()
 		const websiteOrigin = 'https://example.test'
@@ -2615,29 +2735,7 @@ params: [{ signerProviderGeneration: 1, type: 'success', accounts: ['0x333333333
 
 		await handleInterceptedRequest(port, websiteOrigin, website, ethereum, tokenPriceService, resetSimulationServices, socket, request, websiteTabConnections, noopPublishRpcConnectionStatus)
 
-		assert.equal(messages.some((message) => message.method === 'connect'), false)
-		assert.equal(messages.some((message) => message.method === 'accountsChanged'), false)
-		assert.equal(siblingMessages.length, 0)
-		const pendingRequests = await getPendingAccessRequests()
-		assert.equal(pendingRequests.length, 1)
-		const pendingRequest = pendingRequests[0]
-		if (pendingRequest === undefined) throw new Error('Missing pending request')
-		const siteApprovalResolution = resolveInterceptorAccess(
-			ethereum,
-			tokenPriceService,
-			resetSimulationServices,
-			websiteTabConnections,
-			{
-				userReply: 'Approved',
-				websiteOrigin,
-				requestAccessToAddress: pendingRequest.requestAccessToAddress?.address,
-				originalRequestAccessToAddress: pendingRequest.originalRequestAccessToAddress?.address,
-				accessRequestId: pendingRequest.accessRequestId,
-			},
-			noopPublishRpcConnectionStatus,
-		)
-		await siteApprovalResolution
-
+		assert.equal((await getPendingAccessRequests()).length, 0)
 		const requestLifecycleMessages = messages.filter((message) => message.method === 'connect' || message.method === 'accountsChanged' || message.method === 'chainChanged')
 		assert.deepEqual(requestLifecycleMessages.map((message) => message.method), ['connect', 'accountsChanged'])
 		assert.deepEqual(requestLifecycleMessages.map((message) => message.requestId), [18, 18])
@@ -2683,7 +2781,8 @@ params: [{ signerProviderGeneration: 1, type: 'success', accounts: ['0x333333333
 			interceptorRequest: true,
 			usingInterceptorWithoutSigner: false,
 			uniqueRequestIdentifier: { requestId: 21, requestSocket: socket },
-			method: 'eth_requestAccounts',
+			method: 'wallet_requestPermissions',
+			params: [{ eth_accounts: {} }],
 		}
 
 		await handleInterceptedRequest(port, websiteOrigin, website, ethereum, tokenPriceService, resetSimulationServices, socket, request, websiteTabConnections, noopPublishRpcConnectionStatus)

--- a/test/tests/backgroundEthAccounts.test.ts
+++ b/test/tests/backgroundEthAccounts.test.ts
@@ -2036,7 +2036,7 @@ params: [{ signerProviderGeneration: 1, type: 'success', accounts: ['0x333333333
 		assert.deepEqual(connectedReplies.at(-1)?.result, { metamaskCompatibilityMode: false })
 	})
 
-	test('does not open an address access dialog after signer account discovery for site-approved eth_requestAccounts', async () => {
+	test('requires visible address consent after signer discovery for site-approved eth_requestAccounts', async () => {
 		installBrowserMock()
 		const {
 			handleInterceptedRequest,
@@ -2046,6 +2046,7 @@ params: [{ signerProviderGeneration: 1, type: 'success', accounts: ['0x333333333
 			updateWebsiteAccess,
 			getPendingAccessRequests,
 			getSettings,
+			resolveInterceptorAccess,
 		} = await loadModules()
 		const websiteOrigin = 'https://example.test'
 		const website = { websiteOrigin, icon: undefined, title: undefined }
@@ -2083,6 +2084,20 @@ params: [{ signerProviderGeneration: 1, type: 'success', accounts: ['0x333333333
 
 		assert.equal(messages.filter((message) => message.method === 'request_signer_to_eth_requestAccounts').length, 1)
 		assert.equal(messages.some((message) => message.method === 'connect'), false)
+		assert.deepEqual(messages.filter((message) => message.method === 'accountsChanged'), [])
+		assert.deepEqual(messages.filter((message) => message.method === 'eth_accounts' && message.requestId === 10), [])
+		const pendingRequest = (await getPendingAccessRequests())[0]
+		if (pendingRequest === undefined) throw new Error('Missing address access request')
+		assert.equal(pendingRequest.requestAccessToAddress?.address, account)
+		assert.deepEqual((await getSettings()).websiteAccess[0]?.addressAccess, undefined)
+
+		await resolveInterceptorAccess(ethereum, tokenPriceService, resetSimulationServices, websiteTabConnections, {
+			userReply: 'Approved',
+			requestAccessToAddress: account,
+			originalRequestAccessToAddress: account,
+			accessRequestId: pendingRequest.accessRequestId,
+		}, noopPublishRpcConnectionStatus)
+
 		assert.deepEqual(messages.filter((message) => message.method === 'accountsChanged').map((message) => message.result), [[accountString]])
 		assert.deepEqual(messages.filter((message) => message.method === 'eth_accounts' && message.requestId === 10).map((message) => message.result), [[accountString]])
 		assert.equal((await getPendingAccessRequests()).length, 0)
@@ -2129,7 +2144,7 @@ params: [{ signerProviderGeneration: 1, type: 'success', accounts: ['0x333333333
 		assert.equal((await getPendingAccessRequests()).length, 0)
 	})
 
-	test('does not approve the port before site-approved eth_requestAccounts persists address access', async () => {
+	test('does not approve the port before site-approved eth_requestAccounts receives address consent', async () => {
 		installBrowserMock()
 		const {
 			handleInterceptedRequest,
@@ -2138,7 +2153,9 @@ params: [{ signerProviderGeneration: 1, type: 'success', accounts: ['0x333333333
 			setUseSignersAddressAsActiveAddress,
 			updateWebsiteAccess,
 			updateTabState,
+			getPendingAccessRequests,
 			getSettings,
+			resolveInterceptorAccess,
 		} = await loadModules()
 		const websiteOrigin = 'https://example.test'
 		const website = { websiteOrigin, icon: undefined, title: undefined }
@@ -2178,6 +2195,20 @@ params: [{ signerProviderGeneration: 1, type: 'success', accounts: ['0x333333333
 
 		pendingWebsite.resolve(website)
 		await requestAccountsPromise
+
+		const pendingRequest = (await getPendingAccessRequests())[0]
+		if (pendingRequest === undefined) throw new Error('Missing address access request')
+		assert.equal(pendingRequest.requestAccessToAddress?.address, account)
+		assert.equal(connection.approved, false)
+		assert.deepEqual(messages.filter((message) => message.method === 'eth_accounts' && message.requestId === 23), [])
+		assert.equal((await getSettings()).websiteAccess[0]?.addressAccess, undefined)
+
+		await resolveInterceptorAccess(ethereum, tokenPriceService, resetSimulationServices, websiteTabConnections, {
+			userReply: 'Approved',
+			requestAccessToAddress: account,
+			originalRequestAccessToAddress: account,
+			accessRequestId: pendingRequest.accessRequestId,
+		}, noopPublishRpcConnectionStatus)
 
 		assert.equal(connection.approved, true)
 		assert.deepEqual(messages.filter((message) => message.method === 'eth_accounts' && message.requestId === 23).map((message) => message.result), [[accountString]])
@@ -2228,7 +2259,7 @@ params: [{ signerProviderGeneration: 1, type: 'success', accounts: ['0x333333333
 		assert.deepEqual((await getSettings()).websiteAccess[0]?.addressAccess, [{ address: account, access: false }])
 	})
 
-	test('uses cached signer account instead of a stale provider-disconnected error when active signing address is missing', async () => {
+	test('uses a cached signer account for address consent when active signing address is missing', async () => {
 		installBrowserMock()
 		const {
 			handleInterceptedRequest,
@@ -2239,6 +2270,7 @@ params: [{ signerProviderGeneration: 1, type: 'success', accounts: ['0x333333333
 			updateTabState,
 			getPendingAccessRequests,
 			getSettings,
+			resolveInterceptorAccess,
 		} = await loadModules()
 		const websiteOrigin = 'https://example.test'
 		const website = { websiteOrigin, icon: undefined, title: undefined }
@@ -2271,6 +2303,18 @@ params: [{ signerProviderGeneration: 1, type: 'success', accounts: ['0x333333333
 
 		assert.equal(messages.some((message) => message.method === 'request_signer_to_eth_requestAccounts'), false)
 		assert.equal(messages.some((message) => message.method === 'connect'), false)
+		assert.deepEqual(messages.filter((message) => message.method === 'accountsChanged'), [])
+		const pendingRequest = (await getPendingAccessRequests())[0]
+		if (pendingRequest === undefined) throw new Error('Missing address access request')
+		assert.equal(pendingRequest.requestAccessToAddress?.address, account)
+
+		await resolveInterceptorAccess(ethereum, tokenPriceService, resetSimulationServices, websiteTabConnections, {
+			userReply: 'Approved',
+			requestAccessToAddress: account,
+			originalRequestAccessToAddress: account,
+			accessRequestId: pendingRequest.accessRequestId,
+		}, noopPublishRpcConnectionStatus)
+
 		assert.deepEqual(messages.filter((message) => message.method === 'accountsChanged').map((message) => message.result), [['0x6666666666666666666666666666666666666666']])
 		assert.deepEqual(messages.filter((message) => message.method === 'eth_accounts' && message.requestId === 11).at(-1)?.result, ['0x6666666666666666666666666666666666666666'])
 		assert.equal((await getPendingAccessRequests()).length, 0)
@@ -2703,7 +2747,7 @@ params: [{ signerProviderGeneration: 1, type: 'success', accounts: ['0x333333333
 		assert.deepEqual(requestAccountsReplies[0]?.result, [accountString])
 	})
 
-	test('keeps sibling connection events when site approval resolves eth_requestAccounts without a popup', async () => {
+	test('keeps sibling connection events when address consent resolves eth_requestAccounts', async () => {
 		installBrowserMock()
 		const {
 			handleInterceptedRequest,
@@ -2714,6 +2758,7 @@ params: [{ signerProviderGeneration: 1, type: 'success', accounts: ['0x333333333
 			updateTabState,
 			getPendingAccessRequests,
 			getSettings,
+			resolveInterceptorAccess,
 		} = await loadModules()
 		const websiteOrigin = 'https://example.test'
 		const website = { websiteOrigin, icon: undefined, title: undefined }
@@ -2743,6 +2788,19 @@ params: [{ signerProviderGeneration: 1, type: 'success', accounts: ['0x333333333
 		}
 
 		await handleInterceptedRequest(port, websiteOrigin, website, ethereum, tokenPriceService, resetSimulationServices, socket, request, websiteTabConnections, noopPublishRpcConnectionStatus)
+
+		const pendingRequest = (await getPendingAccessRequests())[0]
+		if (pendingRequest === undefined) throw new Error('Missing address access request')
+		assert.equal(pendingRequest.requestAccessToAddress?.address, account)
+		assert.deepEqual(messages.filter((message) => message.method === 'eth_accounts' && message.requestId === 18), [])
+		assert.deepEqual(siblingMessages.filter((message) => message.method === 'connect' || message.method === 'accountsChanged' || message.method === 'chainChanged'), [])
+
+		await resolveInterceptorAccess(ethereum, tokenPriceService, resetSimulationServices, websiteTabConnections, {
+			userReply: 'Approved',
+			requestAccessToAddress: account,
+			originalRequestAccessToAddress: account,
+			accessRequestId: pendingRequest.accessRequestId,
+		}, noopPublishRpcConnectionStatus)
 
 		assert.equal((await getPendingAccessRequests()).length, 0)
 		const requestLifecycleMessages = messages.filter((message) => message.method === 'connect' || message.method === 'accountsChanged' || message.method === 'chainChanged')
@@ -2888,7 +2946,7 @@ params: [{ signerProviderGeneration: 1, type: 'success', accounts: ['0x333333333
 		assert.deepEqual(access?.addressAccess, [{ address: account, access: true }])
 	})
 
-	test('simulation-mode wallet_requestPermissions uses existing site approval without an address prompt', async () => {
+	test('simulation-mode wallet_requestPermissions requires address consent for a site-only approval', async () => {
 		installBrowserMock()
 		const {
 			handleInterceptedRequest,
@@ -2898,6 +2956,7 @@ params: [{ signerProviderGeneration: 1, type: 'success', accounts: ['0x333333333
 			updateWebsiteAccess,
 			getPendingAccessRequests,
 			getSettings,
+			resolveInterceptorAccess,
 		} = await loadModules()
 		const websiteOrigin = 'https://example.test'
 		const website = { websiteOrigin, icon: undefined, title: undefined }
@@ -2923,6 +2982,19 @@ params: [{ signerProviderGeneration: 1, type: 'success', accounts: ['0x333333333
 		}
 
 		await handleInterceptedRequest(port, websiteOrigin, website, ethereum, tokenPriceService, resetSimulationServices, socket, request, websiteTabConnections, noopPublishRpcConnectionStatus)
+
+		const pendingRequest = (await getPendingAccessRequests())[0]
+		if (pendingRequest === undefined) throw new Error('Missing address access request')
+		assert.equal(pendingRequest.requestAccessToAddress?.address, account)
+		assert.deepEqual(messages.filter((message) => message.method === 'accountsChanged'), [])
+		assert.deepEqual(messages.filter((message) => message.method === 'wallet_requestPermissions' && message.requestId === 24), [])
+
+		await resolveInterceptorAccess(ethereum, tokenPriceService, resetSimulationServices, websiteTabConnections, {
+			userReply: 'Approved',
+			requestAccessToAddress: account,
+			originalRequestAccessToAddress: account,
+			accessRequestId: pendingRequest.accessRequestId,
+		}, noopPublishRpcConnectionStatus)
 
 		assert.deepEqual(messages.filter((message) => message.method === 'accountsChanged').map((message) => message.requestId), [24])
 		assert.deepEqual(messages.filter((message) => message.method === 'wallet_requestPermissions' && message.requestId === 24).at(-1)?.result, [{
@@ -2978,7 +3050,7 @@ params: [{ signerProviderGeneration: 1, type: 'success', accounts: ['0x333333333
 		assert.equal((await getSettings()).websiteAccess[0]?.addressAccess, undefined)
 	})
 
-	test('first-time wallet_requestPermissions uses only the site approval dialog', async () => {
+	test('first-time wallet_requestPermissions uses one dialog that identifies the address', async () => {
 		installBrowserMock()
 		const {
 			handleInterceptedRequest,
@@ -3026,8 +3098,8 @@ params: [{ signerProviderGeneration: 1, type: 'success', accounts: ['0x333333333
 		await handleInterceptedRequest(port, websiteOrigin, website, ethereum, tokenPriceService, resetSimulationServices, socket, request, websiteTabConnections, noopPublishRpcConnectionStatus)
 
 		const siteLevelPendingRequest = (await getPendingAccessRequests())[0]
-		if (siteLevelPendingRequest === undefined) throw new Error('Missing site-level pending request')
-		assert.equal(siteLevelPendingRequest.requestAccessToAddress, undefined)
+		if (siteLevelPendingRequest === undefined) throw new Error('Missing combined site and address access request')
+		assert.equal(siteLevelPendingRequest.requestAccessToAddress?.address, account)
 		const siteApprovalResolution = resolveInterceptorAccess(
 			ethereum,
 			tokenPriceService,
@@ -3035,8 +3107,8 @@ params: [{ signerProviderGeneration: 1, type: 'success', accounts: ['0x333333333
 			websiteTabConnections,
 			{
 				userReply: 'Approved',
-				requestAccessToAddress: undefined,
-				originalRequestAccessToAddress: undefined,
+				requestAccessToAddress: account,
+				originalRequestAccessToAddress: account,
 				accessRequestId: siteLevelPendingRequest.accessRequestId,
 			},
 			noopPublishRpcConnectionStatus,
@@ -3044,7 +3116,9 @@ params: [{ signerProviderGeneration: 1, type: 'success', accounts: ['0x333333333
 		await siteApprovalResolution
 
 		assert.equal((await getPendingAccessRequests()).length, 0)
+		await waitForPortMessageCount(messages, 'wallet_requestPermissions', 1)
 		const permissionReply = messages.filter((message) => message.method === 'wallet_requestPermissions' && message.requestId === 23).at(-1)
+		assert.equal(permissionReply?.error, undefined)
 		assert.deepEqual(permissionReply?.result, [{
 			parentCapability: 'eth_accounts',
 			caveats: [{
@@ -3058,7 +3132,7 @@ params: [{ signerProviderGeneration: 1, type: 'success', accounts: ['0x333333333
 		assert.deepEqual(access?.addressAccess, [{ address: account, access: true }])
 	})
 
-	test('site-approved wallet_requestPermissions completes after releasing the popup semaphore', async () => {
+	test('site-approved wallet_requestPermissions opens address consent after releasing the popup semaphore', async () => {
 		installBrowserMock()
 		const {
 			handleInterceptedRequest,
@@ -3069,6 +3143,7 @@ params: [{ signerProviderGeneration: 1, type: 'success', accounts: ['0x333333333
 			updateWebsiteAccess,
 			getPendingAccessRequests,
 			getSettings,
+			resolveInterceptorAccess,
 		} = await loadModules()
 		const websiteOrigin = 'https://example.test'
 		const website = { websiteOrigin, icon: undefined, title: undefined }
@@ -3124,75 +3199,20 @@ params: [{ signerProviderGeneration: 1, type: 'success', accounts: ['0x333333333
 
 		const pendingRequests = await getPendingAccessRequests()
 		assert.equal(messages.some((message) => message.method === 'wallet_requestPermissions' && message.requestId === 73 && message.error?.code === -32002), false)
-		assert.equal(pendingRequests.length, 0)
-		assert.deepEqual(messages.filter((message) => message.method === 'wallet_requestPermissions' && message.requestId === 73).at(-1)?.result, [{
-			parentCapability: 'eth_accounts',
-			caveats: [{
-				type: 'restrictReturnedAccounts',
-				value: [accountString],
-			}],
-			invoker: websiteOrigin,
-		}])
-		assert.deepEqual((await getSettings()).websiteAccess[0]?.addressAccess, [{ address: account, access: true }])
-	})
+		assert.equal(pendingRequests.length, 1)
+		const pendingRequest = pendingRequests[0]
+		if (pendingRequest === undefined) throw new Error('Missing address access request')
+		assert.equal(pendingRequest.requestAccessToAddress?.address, account)
 
-	test('wallet_requestPermissions uses the new site approval when signer state appears before approval', async () => {
-		installBrowserMock()
-		const {
-			handleInterceptedRequest,
-			websiteSocketToString,
-			changeSimulationMode,
-			setUseSignersAddressAsActiveAddress,
-			getPendingAccessRequests,
-			resolveInterceptorAccess,
-			updateTabState,
-			getSettings,
-		} = await loadModules()
-		const websiteOrigin = 'https://example.test'
-		const website = { websiteOrigin, icon: undefined, title: undefined }
-		const account = 0x7272727272727272727272727272727272727272n
-		const accountString = '0x7272727272727272727272727272727272727272'
-		await changeSimulationMode({ simulationMode: false, activeSimulationAddress: undefined, activeSigningAddress: undefined })
-		await setUseSignersAddressAsActiveAddress(false)
-
-		const socket = { tabId: 1, connectionName: 0n }
-		const { port, messages } = createPort(socket.tabId)
-		const connectionKey = websiteSocketToString(socket)
-		const websiteTabConnections = new Map([[socket.tabId, { ...confirmedSignerOwnership(socket), connections: {
-			[connectionKey]: { port, socket, websiteOrigin, approved: false, wantsToConnect: true },
-		} }]])
-		const { ethereum, tokenPriceService, resetSimulationServices } = createEthereumWithGetBlockCounter({ count: 0 })
-		const request = {
-			interceptorRequest: true,
-			usingInterceptorWithoutSigner: false,
-			uniqueRequestIdentifier: { requestId: 25, requestSocket: socket },
-			method: 'wallet_requestPermissions',
-			params: [{ eth_accounts: {} }],
-		}
-
-		await handleInterceptedRequest(port, websiteOrigin, website, ethereum, tokenPriceService, resetSimulationServices, socket, request, websiteTabConnections, noopPublishRpcConnectionStatus)
-
-		const siteLevelPendingRequest = (await getPendingAccessRequests())[0]
-		if (siteLevelPendingRequest === undefined) throw new Error('Missing site-level pending request')
-		await updateTabState(socket.tabId, (previousState) => ({ ...previousState, signerAccounts: [account], activeSigningAddress: account }))
-		const siteApprovalResolution = resolveInterceptorAccess(
-			ethereum,
-			tokenPriceService,
-			resetSimulationServices,
-			websiteTabConnections,
-			{
-				userReply: 'Approved',
-				requestAccessToAddress: undefined,
-				originalRequestAccessToAddress: undefined,
-				accessRequestId: siteLevelPendingRequest.accessRequestId,
-			},
-			noopPublishRpcConnectionStatus,
-		)
-		await siteApprovalResolution
+		await resolveInterceptorAccess(ethereum, tokenPriceService, resetSimulationServices, websiteTabConnections, {
+			userReply: 'Approved',
+			requestAccessToAddress: account,
+			originalRequestAccessToAddress: account,
+			accessRequestId: pendingRequest.accessRequestId,
+		}, noopPublishRpcConnectionStatus)
 
 		assert.equal((await getPendingAccessRequests()).length, 0)
-		const permissionReply = messages.filter((message) => message.method === 'wallet_requestPermissions' && message.requestId === 25).at(-1)
-		assert.deepEqual(permissionReply?.result, [{
+		assert.deepEqual(messages.filter((message) => message.method === 'wallet_requestPermissions' && message.requestId === 73).at(-1)?.result, [{
 			parentCapability: 'eth_accounts',
 			caveats: [{
 				type: 'restrictReturnedAccounts',
@@ -3512,7 +3532,7 @@ params: [{ signerProviderGeneration: 1, type: 'success', accounts: ['0x333333333
 		assert.equal(hasAddressAccess([], websiteOrigin, address), 'askAccess')
 	})
 
-	test('verifyAccess exposes website-approved address persistence as a distinct decision', async () => {
+	test('verifyAccess requires an address decision despite website approval', async () => {
 		installBrowserMock()
 		const { getSettings, updateWebsiteAccess, verifyAccess } = await loadModules()
 		const websiteOrigin = 'https://example.test'
@@ -3524,13 +3544,8 @@ params: [{ signerProviderGeneration: 1, type: 'success', accounts: ['0x333333333
 		const settings = await getSettings()
 
 		assert.equal(verifyAccess(websiteTabConnections, socket, true, websiteOrigin, address, settings), 'askAccess')
-		assert.equal(verifyAccess(websiteTabConnections, socket, true, websiteOrigin, address, settings, {
-			allowWebsiteApprovalToGrantAddressAccess: true,
-		}), 'websiteApprovalCanGrantAddressAccess')
 
 		await updateWebsiteAccess(() => [{ website, access: true, addressAccess: [{ address: address.address, access: false }] }])
-		assert.equal(verifyAccess(websiteTabConnections, socket, true, websiteOrigin, address, await getSettings(), {
-			allowWebsiteApprovalToGrantAddressAccess: true,
-		}), 'noAccess')
+		assert.equal(verifyAccess(websiteTabConnections, socket, true, websiteOrigin, address, await getSettings()), 'noAccess')
 	})
 })


### PR DESCRIPTION
## What this changes

Account connection requests now obtain the active signer address before opening Interceptor access approval. This lets the extension show one dialog that identifies both the requesting site and the wallet address that would be shared.

The behavior applies to `eth_requestAccounts` and `wallet_requestPermissions`:

- first-time connections show one combined site-and-address approval dialog
- a site with website approval but no decision for the active address shows an address-specific approval dialog
- an address that is already approved is returned without another Interceptor dialog
- denied addresses and disabled/denied websites remain blocked
- no account result or request-scoped account event is sent before the displayed address is approved

## Implementation details

- discover signer accounts early enough to populate the request-associated access dialog
- suppress the generic passive access prompt during solicited account discovery, avoiding duplicate dialogs and `request already pending` races
- replay the originating RPC after approval while preserving request-scoped `accountsChanged` ordering
- share website-access refresh and popup notification finalization across approval and revocation paths
- preserve the account-event ordering changes from the merged `main` branch

## Validation

- `bun test test/tests/backgroundEthAccounts.test.ts` — 58 passed
- `bun run test` — 866 passed
- `bun run setup-chrome` — passed
- `bun run typecheck` — passed
- `bun run lint` — passed
- `git diff --check` and `git diff --cached --check` — passed

Project review found no High, Medium, or Low issues (95/100). The Chrome communication benchmark was not run because this change does not alter content-script registration or page/extension transport.