### PR TITLE
Add wallet_getCapabilities support

### DIFF
--- a/app/ts/background/accountRequestMethods.ts
+++ b/app/ts/background/accountRequestMethods.ts
@@ -8,6 +8,7 @@ const ACCOUNT_ONLY_METHODS = new Set<string>([
 	'eth_requestAccounts',
 	'wallet_requestPermissions',
 	'wallet_getPermissions',
+	'wallet_getCapabilities',
 ])
 
 export function isAccountConnectionMethod(method: string) {

--- a/app/ts/background/background.ts
+++ b/app/ts/background/background.ts
@@ -41,6 +41,7 @@ import { getSimulationErrorAbis } from './simulationErrorAbi.js'
 import { dispatchPopupMessage } from './popupMessageDispatcher.js'
 import { getWatchAssetRpcParseFailureReply } from './watchAssetRpc.js'
 import { createMethodHandlerFor, hasOwnKey } from '../utils/methodHandlers.js'
+import { getWalletGetCapabilitiesParseFailureReply } from './walletGetCapabilitiesRpc.js'
 
 if (initializeWatchAssetWindowListeners()) {
 	void processWatchAssetQueue(undefined).catch(async (error: unknown) => {
@@ -49,7 +50,7 @@ if (initializeWatchAssetWindowListeners()) {
 }
 
 const simulationAbortController = new AbortController()
-const RPC_PARSE_FAILURE_HANDLERS = [getWatchAssetRpcParseFailureReply]
+const RPC_PARSE_FAILURE_HANDLERS = [getWatchAssetRpcParseFailureReply, getWalletGetCapabilitiesParseFailureReply]
 const JSON_RPC_METHOD_NOT_FOUND = -32601
 const INTERNAL_PROVIDER_METHODS = [
 	'connected_to_signer',
@@ -262,6 +263,20 @@ async function handleRPCRequest(
 		wallet_watchAsset: rpcRequestHandler('wallet_watchAsset', async (_context, rpcRequest) => await handleWatchAssetRequest(ethereum, websiteTabConnections, request, website, rpcRequest, {}, activeAddress)),
 		wallet_requestPermissions: rpcRequestHandler('wallet_requestPermissions', async () => await requestPermissions(activeAddress, website)),
 		wallet_getPermissions: rpcRequestHandler('wallet_getPermissions', async () => await getPermissions(activeAddress, website)),
+		wallet_getCapabilities: rpcRequestHandler('wallet_getCapabilities', async (_context, rpcRequest) => {
+			if (rpcRequest.params[0] !== activeAddress) {
+				return {
+					type: 'result' as const,
+					method: rpcRequest.method,
+					error: {
+						code: METAMASK_ERROR_NOT_AUTHORIZED,
+						message: 'The requested account has not been authorized by the user.',
+					},
+				}
+			}
+			if (forwardToSigner) return { type: 'forwardToSigner' as const, replyWithSignersReply: true as const, ...request }
+			return { type: 'result' as const, method: rpcRequest.method, result: {} }
+		}),
 		eth_accounts: rpcRequestHandler('eth_accounts', async () => await getAccounts(activeAddress)),
 		eth_requestAccounts: rpcRequestHandler('eth_requestAccounts', async () => await getAccounts(activeAddress)),
 		eth_gasPrice: rpcRequestHandler('eth_gasPrice', async () => await gasPrice(ethereum)),

--- a/app/ts/background/background.ts
+++ b/app/ts/background/background.ts
@@ -416,10 +416,11 @@ function replyWithEmptyPermissions(websiteTabConnections: WebsiteTabConnections,
 	return replyToInterceptedRequest(websiteTabConnections, { type: 'result', method: 'wallet_getPermissions' as const, result: [], uniqueRequestIdentifier: request.uniqueRequestIdentifier })
 }
 
-function replyWithEmptyAccountIdentity(websiteTabConnections: WebsiteTabConnections, request: InterceptedRequest) {
+function replyWithoutActiveAccount(websiteTabConnections: WebsiteTabConnections, request: InterceptedRequest) {
 	switch (request.method) {
 		case 'eth_accounts': return replyWithEmptyAccounts(websiteTabConnections, request)
 		case 'wallet_getPermissions': return replyWithEmptyPermissions(websiteTabConnections, request)
+		case 'wallet_getCapabilities': return refuseAccess(websiteTabConnections, request)
 		default: throw new Error(`Unsupported account identity request method: ${ request.method }`)
 	}
 }
@@ -625,13 +626,16 @@ export const handleInterceptedRequest = async (port: browser.runtime.Port | unde
 		const result: unknown = await handleInterceptedRequest(port, websiteOrigin, websitePromise, ethereum, tokenPriceService, resetSimulationServices, socket, request, websiteTabConnections, publishRpcConnectionStatus)
 		return result
 	}
-	if (access === 'hasAccess' && activeAddress === undefined && (request.method === 'eth_accounts' || request.method === 'wallet_getPermissions') && (!settings.simulationMode || settings.useSignersAddressAsActiveAddress)) {
+	if (access === 'hasAccess' && activeAddress === undefined && (request.method === 'eth_accounts' || request.method === 'wallet_getPermissions' || request.method === 'wallet_getCapabilities') && (!settings.simulationMode || settings.useSignersAddressAsActiveAddress)) {
 		const signerAccountsResult = await askForSignerAccountsFromSignerIfNotAvailable(websiteTabConnections, socket, false)
-		if (isSignerProviderDisconnectedError(signerAccountsResult.error)) return replyWithSignerAccountError(websiteTabConnections, request, signerAccountsResult.error)
+		if (isSignerProviderDisconnectedError(signerAccountsResult.error)) {
+			if (request.method === 'wallet_getCapabilities') return replyWithoutActiveAccount(websiteTabConnections, request)
+			return replyWithSignerAccountError(websiteTabConnections, request, signerAccountsResult.error)
+		}
 		const signerAccounts = signerAccountsResult.accounts
-		if (signerAccounts.length === 0) return replyWithEmptyAccountIdentity(websiteTabConnections, request)
+		if (signerAccounts.length === 0) return replyWithoutActiveAccount(websiteTabConnections, request)
 		const firstSignerAccount = signerAccounts[0]
-		if (firstSignerAccount === undefined) return replyWithEmptyAccountIdentity(websiteTabConnections, request)
+		if (firstSignerAccount === undefined) return replyWithoutActiveAccount(websiteTabConnections, request)
 		const refreshedSettings = await getSettings()
 		let refreshedActiveAddress = await getActiveAddressForRequest(refreshedSettings, websiteTabConnections, socket.tabId)
 		if (refreshedActiveAddress === undefined) {
@@ -641,9 +645,9 @@ export const handleInterceptedRequest = async (port: browser.runtime.Port | unde
 				if (isSignerStateTokenCurrent(websiteTabConnections, signerStateToken)) refreshedActiveAddress = firstSignerAddress
 			}
 		}
-		if (refreshedActiveAddress === undefined) return replyWithEmptyAccountIdentity(websiteTabConnections, request)
+		if (refreshedActiveAddress === undefined) return replyWithoutActiveAccount(websiteTabConnections, request)
 		const refreshedAccess = verifyAccess(websiteTabConnections, socket, false, websiteOrigin, refreshedActiveAddress, refreshedSettings, true)
-		if (refreshedAccess !== 'hasAccess') return replyWithEmptyAccountIdentity(websiteTabConnections, request)
+		if (refreshedAccess !== 'hasAccess') return replyWithoutActiveAccount(websiteTabConnections, request)
 		return await handleContentScriptMessage(ethereum, tokenPriceService, resetSimulationServices, websiteTabConnections, request, await websitePromise, refreshedActiveAddress.address, publishRpcConnectionStatus)
 	}
 

--- a/app/ts/background/walletGetCapabilitiesRpc.ts
+++ b/app/ts/background/walletGetCapabilitiesRpc.ts
@@ -1,0 +1,15 @@
+import type { RPCReply } from '../types/interceptor-messages.js'
+import type { InterceptedRequest } from '../utils/requests.js'
+import { JSON_RPC_ERROR_CODE_INVALID_PARAMS } from '../utils/constants.js'
+
+export function getWalletGetCapabilitiesParseFailureReply(request: InterceptedRequest): RPCReply | undefined {
+	if (request.method !== 'wallet_getCapabilities') return undefined
+	return {
+		type: 'result',
+		method: request.method,
+		error: {
+			code: JSON_RPC_ERROR_CODE_INVALID_PARAMS,
+			message: 'Invalid wallet_getCapabilities parameters.',
+		},
+	}
+}

--- a/app/ts/types/JsonRpc-types.ts
+++ b/app/ts/types/JsonRpc-types.ts
@@ -1,5 +1,5 @@
 import * as funtypes from 'funtypes'
-import { EthereumAddress, EthereumBlockHeader, EthereumBlockHeaderWithTransactionHashes, EthereumBlockTag, EthereumBytes256, EthereumBytes32, EthereumData, EthereumInput, EthereumQuantity, EthereumSignatureParity, LiteralConverterParserFactory } from './wire-types.js'
+import { CanonicalEthereumQuantity, EthereumAddress, EthereumBlockHeader, EthereumBlockHeaderWithTransactionHashes, EthereumBlockTag, EthereumBytes256, EthereumBytes32, EthereumData, EthereumInput, EthereumQuantity, EthereumSignatureParity, LiteralConverterParserFactory } from './wire-types.js'
 import { areEqualUint8Arrays } from '../utils/typed-arrays.js'
 import { EthSimulateV1Params } from './ethSimulate-types.js'
 import { OldSignTypedDataParams, PersonalSignParams, SignTypedDataParams } from './jsonRpc-signing-types.js'
@@ -323,25 +323,12 @@ export const WalletRevokePermissions = funtypes.ReadonlyObject({
 	params: funtypes.ReadonlyTuple(WalletRevokePermissionsParams)
 }).asReadonly()
 
-const CanonicalChainIdParser: funtypes.ParsedValue<funtypes.String, bigint>['config'] = {
-	parse: value => {
-		if (!/^0x(?:0|[1-9a-fA-F][0-9a-fA-F]{0,63})$/.test(value)) return { success: false, message: `${ value } is not a canonical hex chain ID.` }
-		return { success: true, value: BigInt(value) }
-	},
-	serialize: value => {
-		if (typeof value !== 'bigint') return { success: false, message: `${ typeof value } is not a bigint.` }
-		if (value < 0n) return { success: false, message: `${ value } is not a non-negative bigint.` }
-		return { success: true, value: `0x${ value.toString(16) }` }
-	},
-}
-const WalletCapabilitiesChainId = funtypes.String.withParser(CanonicalChainIdParser)
-
 export type WalletGetCapabilities = funtypes.Static<typeof WalletGetCapabilities>
 export const WalletGetCapabilities = funtypes.ReadonlyObject({
 	method: funtypes.Literal('wallet_getCapabilities'),
 	params: funtypes.Union(
 		funtypes.ReadonlyTuple(EthereumAddress),
-		funtypes.ReadonlyTuple(EthereumAddress, funtypes.ReadonlyArray(WalletCapabilitiesChainId)),
+		funtypes.ReadonlyTuple(EthereumAddress, funtypes.ReadonlyArray(CanonicalEthereumQuantity)),
 	),
 }).asReadonly()
 

--- a/app/ts/types/JsonRpc-types.ts
+++ b/app/ts/types/JsonRpc-types.ts
@@ -323,6 +323,28 @@ export const WalletRevokePermissions = funtypes.ReadonlyObject({
 	params: funtypes.ReadonlyTuple(WalletRevokePermissionsParams)
 }).asReadonly()
 
+const CanonicalChainIdParser: funtypes.ParsedValue<funtypes.String, bigint>['config'] = {
+	parse: value => {
+		if (!/^0x(?:0|[1-9a-fA-F][0-9a-fA-F]{0,63})$/.test(value)) return { success: false, message: `${ value } is not a canonical hex chain ID.` }
+		return { success: true, value: BigInt(value) }
+	},
+	serialize: value => {
+		if (typeof value !== 'bigint') return { success: false, message: `${ typeof value } is not a bigint.` }
+		if (value < 0n) return { success: false, message: `${ value } is not a non-negative bigint.` }
+		return { success: true, value: `0x${ value.toString(16) }` }
+	},
+}
+const WalletCapabilitiesChainId = funtypes.String.withParser(CanonicalChainIdParser)
+
+export type WalletGetCapabilities = funtypes.Static<typeof WalletGetCapabilities>
+export const WalletGetCapabilities = funtypes.ReadonlyObject({
+	method: funtypes.Literal('wallet_getCapabilities'),
+	params: funtypes.Union(
+		funtypes.ReadonlyTuple(EthereumAddress),
+		funtypes.ReadonlyTuple(EthereumAddress, funtypes.ReadonlyArray(WalletCapabilitiesChainId)),
+	),
+}).asReadonly()
+
 export type GetTransactionCount = funtypes.Static<typeof GetTransactionCount>
 export const GetTransactionCount = funtypes.ReadonlyObject({
 	method: funtypes.Literal('eth_getTransactionCount'),
@@ -477,6 +499,7 @@ export const EthereumJsonRpcRequest = funtypes.Union(
 	SwitchEthereumChainParams,
 	RequestPermissions,
 	funtypes.ReadonlyObject({ method: funtypes.Literal('wallet_getPermissions') }),
+	WalletGetCapabilities,
 	funtypes.ReadonlyObject({ method: funtypes.Literal('eth_accounts') }),
 	funtypes.ReadonlyObject({ method: funtypes.Literal('eth_requestAccounts') }),
 	funtypes.ReadonlyObject({ method: funtypes.Literal('eth_gasPrice') }),

--- a/app/ts/types/interceptor-messages.ts
+++ b/app/ts/types/interceptor-messages.ts
@@ -101,6 +101,7 @@ const WalletPermission = funtypes.ReadonlyObject({
 	caveats: funtypes.ReadonlyArray(funtypes.Unknown),
 	invoker: funtypes.String,
 })
+const WalletCapabilities = funtypes.ReadonlyRecord(funtypes.String, funtypes.ReadonlyRecord(funtypes.String, funtypes.Unknown))
 const NonForwardingRPCRequestSuccessfullReturnValue = funtypes.Union(
 	funtypes.ReadonlyObject({ method: funtypes.Literal('eth_getBlockByNumber'), result: GetBlockReturn }),
 	funtypes.ReadonlyObject({ method: funtypes.Literal('eth_getBlockByHash'), result: GetBlockReturn }),
@@ -121,6 +122,7 @@ const NonForwardingRPCRequestSuccessfullReturnValue = funtypes.Union(
 	funtypes.ReadonlyObject({ method: funtypes.Literal('eth_accounts'), result: funtypes.ReadonlyArray(EthereumAddress) }),
 	funtypes.ReadonlyObject({ method: funtypes.Literal('wallet_requestPermissions'), result: funtypes.ReadonlyArray(WalletPermission) }),
 	funtypes.ReadonlyObject({ method: funtypes.Literal('wallet_getPermissions'), result: funtypes.ReadonlyArray(WalletPermission) }),
+	funtypes.ReadonlyObject({ method: funtypes.Literal('wallet_getCapabilities'), result: WalletCapabilities }),
 	funtypes.ReadonlyObject({ method: funtypes.Literal('wallet_revokePermissions'), result: funtypes.Null }),
 	funtypes.ReadonlyObject({ method: funtypes.Literal('eth_gasPrice'), result: EthereumQuantity }),
 	funtypes.ReadonlyObject({ method: funtypes.Literal('eth_maxPriorityFeePerGas'), result: EthereumQuantity }),

--- a/app/ts/types/wire-types.ts
+++ b/app/ts/types/wire-types.ts
@@ -14,6 +14,18 @@ const BigIntParser: funtypes.ParsedValue<funtypes.String, bigint>['config'] = {
 	},
 }
 
+const CanonicalBigIntParser: funtypes.ParsedValue<funtypes.String, bigint>['config'] = {
+	parse: value => {
+		if (!/^0x(?:0|[1-9a-fA-F][0-9a-fA-F]{0,63})$/.test(value)) return { success: false, message: `${ value } is not a canonical hex quantity.` }
+		return { success: true, value: BigInt(value) }
+	},
+	serialize: value => {
+		if (typeof value !== 'bigint') return { success: false, message: `${ typeof value } is not a bigint.` }
+		if (value < 0n) return { success: false, message: `${ value } is not a non-negative bigint.` }
+		return { success: true, value: `0x${ value.toString(16) }` }
+	},
+}
+
 const SmallIntParser: funtypes.ParsedValue<funtypes.String, bigint>['config'] = {
 	parse: value => {
 		if (!/^0x([a-fA-F0-9]{1,64})$/.test(value)) return { success: false, message: `${value} is not a hex string encoded number.` }
@@ -177,6 +189,9 @@ export type NonHexBigInt = funtypes.Static<typeof NonHexBigInt>
 
 export const EthereumQuantity = funtypes.String.withParser(BigIntParser)
 export type EthereumQuantity = funtypes.Static<typeof EthereumQuantity>
+
+export const CanonicalEthereumQuantity = funtypes.String.withParser(CanonicalBigIntParser)
+export type CanonicalEthereumQuantity = funtypes.Static<typeof CanonicalEthereumQuantity>
 
 export const EthereumSignatureParity = funtypes.String.withParser(EthereumSignatureParityParser)
 export type EthereumSignatureParity = funtypes.Static<typeof EthereumSignatureParity>

--- a/test/tests/backgroundEthAccounts.test.ts
+++ b/test/tests/backgroundEthAccounts.test.ts
@@ -226,6 +226,76 @@ function createEthereumWithGetBlockCounter(getBlockCalls: { count: number }, ini
 }
 
 describe('background eth_accounts', () => {
+	test('handles wallet_getCapabilities locally and protects capabilities for other accounts', async () => {
+		installBrowserMock()
+		const { handleInterceptedRequest, websiteSocketToString, updateWebsiteAccess, changeSimulationMode, setUseSignersAddressAsActiveAddress, updateTabState } = await loadModules()
+		const websiteOrigin = 'https://example.test'
+		const website = { websiteOrigin, icon: undefined, title: undefined }
+		const account = 0x1111111111111111111111111111111111111111n
+		const accountString = '0x1111111111111111111111111111111111111111'
+		await changeSimulationMode({ simulationMode: true, activeSimulationAddress: account, activeSigningAddress: undefined })
+		await setUseSignersAddressAsActiveAddress(false)
+		await updateWebsiteAccess(() => [{ website, access: true, addressAccess: [{ address: account, access: true }] }])
+
+		const socket = { tabId: 1, connectionName: 0n }
+		const { port, messages } = createPort(socket.tabId)
+		const connectionKey = websiteSocketToString(socket)
+		const websiteTabConnections = new Map([[socket.tabId, { ...confirmedSignerOwnership(socket), connections: {
+			[connectionKey]: { port, socket, websiteOrigin, approved: true, wantsToConnect: true },
+		} }]])
+		const { ethereum, tokenPriceService, resetSimulationServices } = createEthereumWithGetBlockCounter({ count: 0 })
+
+		for (const [requestId, queriedAccount] of [
+			[1, accountString],
+			[2, '0x2222222222222222222222222222222222222222'],
+		] as const) {
+			await handleInterceptedRequest(port, websiteOrigin, website, ethereum, tokenPriceService, resetSimulationServices, socket, {
+				interceptorRequest: true,
+				usingInterceptorWithoutSigner: false,
+				uniqueRequestIdentifier: { requestId, requestSocket: socket },
+				method: 'wallet_getCapabilities',
+				params: [queriedAccount, ['0x1', '0x2105']],
+			}, websiteTabConnections, noopPublishRpcConnectionStatus)
+		}
+
+		assert.deepEqual(messages.find((message) => message.requestId === 1), {
+			interceptorApproved: true,
+			requestId: 1,
+			bridgeRequestSettled: true,
+			type: 'result',
+			method: 'wallet_getCapabilities',
+			result: {},
+		})
+		assert.deepEqual(messages.find((message) => message.requestId === 2), {
+			interceptorApproved: true,
+			requestId: 2,
+			bridgeRequestSettled: true,
+			type: 'result',
+			method: 'wallet_getCapabilities',
+			error: { code: 4100, message: 'The requested account has not been authorized by the user.' },
+		})
+
+		await changeSimulationMode({ simulationMode: false, activeSimulationAddress: account, activeSigningAddress: account })
+		await setUseSignersAddressAsActiveAddress(true)
+		await updateTabState(socket.tabId, (previousState) => ({ ...previousState, signerAccounts: [account], activeSigningAddress: account }))
+		await handleInterceptedRequest(port, websiteOrigin, website, ethereum, tokenPriceService, resetSimulationServices, socket, {
+			interceptorRequest: true,
+			usingInterceptorWithoutSigner: false,
+			uniqueRequestIdentifier: { requestId: 3, requestSocket: socket },
+			method: 'wallet_getCapabilities',
+			params: [accountString, ['0x2105']],
+		}, websiteTabConnections, noopPublishRpcConnectionStatus)
+
+		assert.deepEqual(messages.find((message) => message.requestId === 3), {
+			interceptorApproved: true,
+			requestId: 3,
+			type: 'forwardToSigner',
+			replyWithSignersReply: true,
+			method: 'wallet_getCapabilities',
+			params: [accountString, ['0x2105']],
+		})
+	})
+
 	test('returns invalid params to the webpage for malformed wallet_watchAsset requests', async () => {
 		installBrowserMock()
 		const { handleInterceptedRequest, websiteSocketToString, updateWebsiteAccess, changeSimulationMode, setUseSignersAddressAsActiveAddress } = await loadModules()

--- a/test/tests/backgroundEthAccounts.test.ts
+++ b/test/tests/backgroundEthAccounts.test.ts
@@ -1235,6 +1235,61 @@ params: [{ signerProviderGeneration: 1, type: 'success', accounts: ['0x333333333
 		assert.deepEqual(ethAccountsReplies.at(-1)?.result, ['0x2222222222222222222222222222222222222222'])
 	})
 
+	test('refreshes an approved signer account before forwarding wallet_getCapabilities', async () => {
+		installBrowserMock()
+		const {
+			handleInterceptedRequest,
+			websiteSocketToString,
+			sendInternalWindowMessage,
+			changeSimulationMode,
+			setUseSignersAddressAsActiveAddress,
+			updateWebsiteAccess,
+			updateTabState,
+		} = await loadModules()
+		const websiteOrigin = 'https://example.test'
+		const website = { websiteOrigin, icon: undefined, title: undefined }
+		const account = 0x2323232323232323232323232323232323232323n
+		const accountString = '0x2323232323232323232323232323232323232323'
+		await changeSimulationMode({ simulationMode: false, activeSimulationAddress: undefined, activeSigningAddress: undefined })
+		await setUseSignersAddressAsActiveAddress(false)
+		await updateWebsiteAccess(() => [{ website, access: true, addressAccess: [{ address: account, access: true }] }])
+
+		const socket = { tabId: 1, connectionName: 0n }
+		const { port, messages } = createPort(socket.tabId, (message) => {
+			if (message.method !== 'request_signer_to_eth_accounts') return
+			void (async () => {
+				await updateTabState(socket.tabId, (previousState) => ({ ...previousState, signerAccounts: [account], activeSigningAddress: account }))
+				sendInternalWindowMessage({
+					method: 'window_signer_accounts_changed',
+					data: { socket, signerStateOwnerGeneration: 1, signerProviderGeneration: 1 },
+				})
+			})()
+		})
+		const connectionKey = websiteSocketToString(socket)
+		const websiteTabConnections = new Map([[socket.tabId, { ...confirmedSignerOwnership(socket), connections: {
+			[connectionKey]: { port, socket, websiteOrigin, approved: true, wantsToConnect: true },
+		} }]])
+		const { ethereum, tokenPriceService, resetSimulationServices } = createEthereumWithGetBlockCounter({ count: 0 })
+
+		await handleInterceptedRequest(port, websiteOrigin, website, ethereum, tokenPriceService, resetSimulationServices, socket, {
+			interceptorRequest: true,
+			usingInterceptorWithoutSigner: false,
+			uniqueRequestIdentifier: { requestId: 8, requestSocket: socket },
+			method: 'wallet_getCapabilities',
+			params: [accountString, ['0x2105']],
+		}, websiteTabConnections, noopPublishRpcConnectionStatus)
+
+		assert.equal(messages.filter((message) => message.method === 'request_signer_to_eth_accounts').length, 1)
+		assert.deepEqual(messages.find((message) => message.method === 'wallet_getCapabilities'), {
+			interceptorApproved: true,
+			requestId: 8,
+			type: 'forwardToSigner',
+			replyWithSignersReply: true,
+			method: 'wallet_getCapabilities',
+			params: [accountString, ['0x2105']],
+		})
+	})
+
 	test('routes one tab-wide signer refresh while serializing passive and interactive discovery', async () => {
 		installBrowserMock()
 		const {
@@ -2549,15 +2604,18 @@ params: [{ signerProviderGeneration: 1, type: 'success', accounts: ['0x333333333
 			code: 4900,
 			message: 'No signer wallet is available to this page. Enable your wallet extension for this site, then try again.',
 		}
+		const account = 0x2424242424242424242424242424242424242424n
+		const accountString = '0x2424242424242424242424242424242424242424'
 		const accountRequests = [
 			{ method: 'eth_requestAccounts', signerRequestMethod: 'request_signer_to_eth_requestAccounts', expectedPublicErrorCode: 4001, requestAccounts: true },
 			{ method: 'wallet_requestPermissions', signerRequestMethod: 'request_signer_to_eth_requestAccounts', expectedPublicErrorCode: 4001, requestAccounts: true },
 			{ method: 'eth_accounts', signerRequestMethod: 'request_signer_to_eth_accounts', expectedPublicErrorCode: 4900, requestAccounts: false },
 			{ method: 'wallet_getPermissions', signerRequestMethod: 'request_signer_to_eth_accounts', expectedPublicErrorCode: 4900, requestAccounts: false },
+			{ method: 'wallet_getCapabilities', signerRequestMethod: 'request_signer_to_eth_accounts', expectedPublicErrorCode: 4100, requestAccounts: false },
 		] as const
 		await changeSimulationMode({ simulationMode: false, activeSimulationAddress: undefined, activeSigningAddress: undefined })
 		await setUseSignersAddressAsActiveAddress(false)
-		await updateWebsiteAccess(() => [{ website, access: true, addressAccess: undefined }])
+		await updateWebsiteAccess(() => [{ website, access: true, addressAccess: [{ address: account, access: true }] }])
 
 		const socket = { tabId: 1, connectionName: 0n }
 		let port: browser.runtime.Port
@@ -2589,14 +2647,17 @@ params: [{ signerProviderGeneration: 1, type: 'success', accounts: ['0x333333333
 				usingInterceptorWithoutSigner: true,
 				uniqueRequestIdentifier: { requestId, requestSocket: socket },
 				method: accountRequest.method,
+				...(accountRequest.method === 'wallet_getCapabilities' ? { params: [accountString] } : {}),
 			}, websiteTabConnections, noopPublishRpcConnectionStatus)
 
 			const replies = messages.filter((message) => message.method === accountRequest.method && message.requestId === requestId)
 			assert.equal(replies.length, 1)
-			assert.deepEqual(replies[0]?.error, {
-				...unavailableSignerError,
-				code: accountRequest.expectedPublicErrorCode,
-			})
+			assert.deepEqual(
+				replies[0]?.error,
+				accountRequest.method === 'wallet_getCapabilities'
+					? { code: 4100, message: 'The requested method and/or account has not been authorized by the user.' }
+					: { ...unavailableSignerError, code: accountRequest.expectedPublicErrorCode },
+			)
 			assert.equal(messages.some((message) => (message.method === 'connect' || message.method === 'accountsChanged') && message.requestId === requestId), false)
 		}
 		assert.equal((await getTabState(socket.tabId)).signerAccountError, undefined)

--- a/test/tests/walletGetCapabilities.test.ts
+++ b/test/tests/walletGetCapabilities.test.ts
@@ -1,0 +1,63 @@
+import { describe, expect, test } from 'bun:test'
+import { getWalletGetCapabilitiesParseFailureReply } from '../../app/ts/background/walletGetCapabilitiesRpc.js'
+import { EthereumJsonRpcRequest, WalletGetCapabilities } from '../../app/ts/types/JsonRpc-types.js'
+import { RPCReply } from '../../app/ts/types/interceptor-messages.js'
+
+const account = '0x1111111111111111111111111111111111111111'
+
+describe('wallet_getCapabilities', () => {
+	test('accepts an account with an optional chain ID filter', () => {
+		expect(WalletGetCapabilities.parse({
+			method: 'wallet_getCapabilities',
+			params: [account],
+		})).toEqual({
+			method: 'wallet_getCapabilities',
+			params: [BigInt(account)],
+		})
+		expect(EthereumJsonRpcRequest.parse({
+			method: 'wallet_getCapabilities',
+			params: [account, ['0x1', '0x2105']],
+		})).toEqual({
+			method: 'wallet_getCapabilities',
+			params: [BigInt(account), [1n, 0x2105n]],
+		})
+	})
+
+	test('rejects malformed parameters with an invalid-params response', () => {
+		for (const params of [
+			[],
+			['0x1234'],
+			[account, '0x1'],
+			[account, ['1']],
+			[account, ['0x01']],
+		]) {
+			const request = {
+				interceptorRequest: true,
+				usingInterceptorWithoutSigner: false,
+				uniqueRequestIdentifier: { requestId: 1, requestSocket: { tabId: 1, connectionName: 0n } },
+				method: 'wallet_getCapabilities',
+				params,
+			}
+			expect(EthereumJsonRpcRequest.safeParse(request).success).toBeFalse()
+			expect(getWalletGetCapabilitiesParseFailureReply(request)).toEqual({
+				type: 'result',
+				method: 'wallet_getCapabilities',
+				error: { code: -32602, message: 'Invalid wallet_getCapabilities parameters.' },
+			})
+		}
+	})
+
+	test('serializes capability maps in provider replies', () => {
+		const reply = {
+			type: 'result' as const,
+			method: 'wallet_getCapabilities' as const,
+			result: {
+				'0x2105': {
+					atomic: { supported: 'supported' },
+					paymasterService: { supported: true },
+				},
+			},
+		}
+		expect(RPCReply.parse(reply)).toEqual(reply)
+	})
+})

--- a/test/tests/walletGetCapabilities.test.ts
+++ b/test/tests/walletGetCapabilities.test.ts
@@ -2,10 +2,17 @@ import { describe, expect, test } from 'bun:test'
 import { getWalletGetCapabilitiesParseFailureReply } from '../../app/ts/background/walletGetCapabilitiesRpc.js'
 import { EthereumJsonRpcRequest, WalletGetCapabilities } from '../../app/ts/types/JsonRpc-types.js'
 import { RPCReply } from '../../app/ts/types/interceptor-messages.js'
+import { CanonicalEthereumQuantity, serialize } from '../../app/ts/types/wire-types.js'
 
 const account = '0x1111111111111111111111111111111111111111'
 
 describe('wallet_getCapabilities', () => {
+	test('uses the reusable canonical Ethereum quantity wire type for chain IDs', () => {
+		expect(CanonicalEthereumQuantity.parse('0xA')).toBe(10n)
+		expect(CanonicalEthereumQuantity.safeParse('0x01').success).toBeFalse()
+		expect(serialize(CanonicalEthereumQuantity, 10n)).toBe('0xa')
+	})
+
 	test('accepts an account with an optional chain ID filter', () => {
 		expect(WalletGetCapabilities.parse({
 			method: 'wallet_getCapabilities',


### PR DESCRIPTION
## Summary

- add EIP-5792 wallet_getCapabilities request and response schemas
- validate canonical chain IDs and return invalid-params errors for malformed requests
- enforce account authorization, forward capabilities to the connected signer, and return an empty map in Interceptor-only mode
- add focused schema and background routing tests

## Validation

- bun run test (866 tests, 0 failures)
- bun run setup-chrome
- bun run typecheck
- bun run lint
- git diff --check

The real Chrome communication test was not run because this change reuses the existing generic bridge without changing content-script registration or bridge mechanics.

## Review

- first review: 82/100; canonical leading-zero chain-ID validation finding addressed
- final review: 95/100; no High, Medium, or Low findings