### PR TITLE
Fix non-responsive address and ENS edit controls across extension views

### DIFF
--- a/app/ts/components/pages/ConfirmTransaction.tsx
+++ b/app/ts/components/pages/ConfirmTransaction.tsx
@@ -242,6 +242,7 @@ function FailedTransactionPreviewDetails({
 	simulationConductedTimestamp,
 	rpcConnectionStatus,
 	currentBlockNumber,
+	renameAddressCallBack,
 }: {
 	website: Website
 	transactionIdentifier: bigint
@@ -254,6 +255,7 @@ function FailedTransactionPreviewDetails({
 	simulationConductedTimestamp: Date
 	rpcConnectionStatus: Signal<RpcConnectionStatus>
 	currentBlockNumber: Signal<bigint | undefined>
+	renameAddressCallBack: RenameAddressCallBack
 }) {
 	const request = originalRequestParameters.method === 'eth_sendTransaction' ? originalRequestParameters.params[0] : undefined
 	const rawRequest = originalRequestParameters.method === 'eth_sendRawTransaction' ? originalRequestParameters.params[0] : undefined
@@ -281,9 +283,9 @@ function FailedTransactionPreviewDetails({
 					<dt>Transaction type</dt>
 					<dd>{ originalRequestParameters.method }</dd>
 					<dt>From</dt>
-					<dd>{ from === undefined ? 'Unknown' : <SmallAddress addressBookEntry = { from } renameAddressCallBack = { () => undefined } /> }</dd>
+					<dd>{ from === undefined ? 'Unknown' : <SmallAddress addressBookEntry = { from } renameAddressCallBack = { renameAddressCallBack } /> }</dd>
 					<dt>To</dt>
-					<dd>{ to === undefined ? 'No receiving Address' : <SmallAddress addressBookEntry = { to } renameAddressCallBack = { () => undefined } /> }</dd>
+					<dd>{ to === undefined ? 'No receiving Address' : <SmallAddress addressBookEntry = { to } renameAddressCallBack = { renameAddressCallBack } /> }</dd>
 					<dt>Value</dt>
 					<dd>{ request === undefined ? 'Unknown' : `${ bigintToDecimalString(request.value ?? 0n, 18n) } ether` }</dd>
 					<dt>Gas limit </dt>
@@ -295,7 +297,7 @@ function FailedTransactionPreviewDetails({
 			<div style = 'margin-top: 10px;'>
 				<p class = 'paragraph' style = 'color: var(--subtitle-text-color)'>Transaction Input</p>
 				{ rawRequest === undefined
-					? <TransactionInput parsedInputData = { undefined } input = { input } to = { to } addressMetaData = { addressMetaData } renameAddressCallBack = { () => undefined } />
+					? <TransactionInput parsedInputData = { undefined } input = { input } to = { to } addressMetaData = { addressMetaData } renameAddressCallBack = { renameAddressCallBack } />
 					: <div class = 'textbox'><pre>{ dataStringWith0xStart(rawRequest) }</pre></div>
 				}
 			</div>
@@ -375,6 +377,7 @@ function TransactionCardContent(param: TransactionCardContentParams) {
 				simulationConductedTimestamp = { popupVisualisation.data.simulationState.simulationConductedTimestamp }
 				rpcConnectionStatus = { param.rpcConnectionStatus }
 				currentBlockNumber = { param.currentBlockNumber }
+				renameAddressCallBack = { param.renameAddressCallBack }
 			/>
 		</>
 	}

--- a/app/ts/components/pages/FetchSimulationStack.tsx
+++ b/app/ts/components/pages/FetchSimulationStack.tsx
@@ -3,9 +3,9 @@ import { MessageToPopup } from '../../types/interceptor-messages.js'
 import { requestPopupCompleteVisualizedSimulation, requestPopupSimulationMetadata, sendPopupMessageToBackgroundPage, sendPopupReadyAndListening } from '../../background/backgroundUtils.js'
 import { addressEditEntry, tryFocusingTabOrWindow } from '../ui-utils.js'
 import type { PendingFetchSimulationStackRequestPromise } from '../../types/user-interface-types.js'
-import { Signal, useComputed, useSignal } from '@preact/signals'
+import { type ReadonlySignal, Signal, useComputed, useSignal } from '@preact/signals'
 import { noReplyExpectingBrowserRuntimeOnMessageListener } from '../../utils/browser.js'
-import { type CompleteVisualizedSimulation, type ModifyAddressWindowState, type SimulationAndVisualisationResults, createPassthroughCompleteVisualizedSimulation } from '../../types/visualizer-types.js'
+import { type CompleteVisualizedSimulation, type EditEnsNamedHashWindowState, type ModifyAddressWindowState, type SimulationAndVisualisationResults, createPassthroughCompleteVisualizedSimulation } from '../../types/visualizer-types.js'
 import type { AddressBookEntry } from '../../types/addressBookTypes.js'
 import { SmallAddress } from '../subcomponents/address.js'
 import { AddNewAddress } from './AddNewAddress.js'
@@ -18,14 +18,70 @@ import { SimulationStackRows } from '../simulationExplaining/Transactions.js'
 import { sanitizeStoredWebsiteIcon } from '../../utils/websiteIcons.js'
 import { useAsyncState } from '../../utils/preact-utilities.js'
 import { AsyncActionButton } from '../subcomponents/AsyncAction.js'
+import { EditEnsLabelHash } from './EditEnsLabelHash.js'
+import type { EthereumBytes32 } from '../../types/wire-types.js'
 
-type ModalState =
+export type FetchSimulationStackModalState =
 	{ page: 'modifyAddress', state: Signal<ModifyAddressWindowState> } |
+	{ page: 'editEnsNamedHash', state: EditEnsNamedHashWindowState } |
 	{ page: 'noModal' }
+
+export function FetchSimulationStackModal({ modalState, rpcEntries }: {
+	modalState: Signal<FetchSimulationStackModalState>
+	rpcEntries: Signal<RpcEntries>
+}) {
+	const close = () => {
+		modalState.value = { page: 'noModal' }
+	}
+	return <div class = { `modal ${ modalState.value.page !== 'noModal' ? 'is-active' : '' }` }>
+		{ modalState.value.page === 'modifyAddress' ?
+			<AddNewAddress
+				setActiveAddressAndInformAboutIt = { undefined }
+				modifyAddressWindowState = { modalState.value.state }
+				close = { close }
+				activeAddress = { undefined }
+				rpcEntries = { rpcEntries }
+			/>
+		: <></> }
+		{ modalState.value.page === 'editEnsNamedHash' ?
+			<EditEnsLabelHash
+				close = { close }
+				editEnsNamedHashWindowState = { modalState.value.state }
+			/>
+		: <></> }
+	</div>
+}
+
+export function FetchSimulationStackRows({
+	simulationAndVisualisationResults,
+	activeAddress,
+	addressMetaData,
+	renameAddressCallBack,
+	modalState,
+}: {
+	simulationAndVisualisationResults: ReadonlySignal<SimulationAndVisualisationResults | undefined>
+	activeAddress: ReadonlySignal<bigint | undefined>
+	addressMetaData: ReadonlySignal<readonly AddressBookEntry[]>
+	renameAddressCallBack: (entry: AddressBookEntry) => void
+	modalState: Signal<FetchSimulationStackModalState>
+}) {
+	const editEnsNamedHashCallBack = (type: 'nameHash' | 'labelHash', nameHash: EthereumBytes32, name: string | undefined) => {
+		modalState.value = { page: 'editEnsNamedHash', state: { type, nameHash, name } }
+	}
+	return <SimulationStackRows
+		simulationAndVisualisationResults = { simulationAndVisualisationResults }
+		removeTransactionOrSignedMessage = { undefined }
+		activeAddress = { activeAddress }
+		renameAddressCallBack = { renameAddressCallBack }
+		editEnsNamedHashCallBack = { editEnsNamedHashCallBack }
+		addressMetaData = { addressMetaData }
+		showTimePicker = { false }
+	/>
+}
 
 export function FetchSimulationStack() {
 	const changeRequest = useSignal<PendingFetchSimulationStackRequestPromise | undefined>(undefined)
-	const modalState = useSignal<ModalState>({ page: 'noModal' })
+	const modalState = useSignal<FetchSimulationStackModalState>({ page: 'noModal' })
 
 	const completeVisualizedSimulation = useSignal<CompleteVisualizedSimulation>(createPassthroughCompleteVisualizedSimulation())
 	const simulationMetadata = useSignal<SimulationMetadata | undefined>(undefined)
@@ -132,17 +188,7 @@ export function FetchSimulationStack() {
 	return (
 		<main>
 			<Hint>
-				<div class = { `modal ${ modalState.value.page !== 'noModal' ? 'is-active' : ''}` }>
-					{ modalState.value.page === 'modifyAddress' ?
-						<AddNewAddress
-							setActiveAddressAndInformAboutIt = { undefined }
-							modifyAddressWindowState = { modalState.value.state }
-							close = { () => { modalState.value = { page: 'noModal' } } }
-							activeAddress = { undefined }
-							rpcEntries = { rpcEntries }
-						/>
-					: <></> }
-				</div>
+				<FetchSimulationStackModal modalState = { modalState } rpcEntries = { rpcEntries } />
 				<div class = 'block' style = 'margin-bottom: 0px; margin: 10px'>
 					<header class = 'card-header window-header'>
 						<div class = 'card-header-icon unset-cursor'>
@@ -188,14 +234,12 @@ export function FetchSimulationStack() {
 										<p class = 'paragraph'> Simulation stack:</p>
 										<div class = 'sub-importance-box'>
 											{ !isThereSimulationStack.value ? <p class = 'paragraph'> No simulation stack</p> : <>
-												<SimulationStackRows
+												<FetchSimulationStackRows
 													simulationAndVisualisationResults = { simulationStackResults }
-													removeTransactionOrSignedMessage = { undefined }
 													activeAddress = { activeAddress }
 													renameAddressCallBack = { renameAddressCallBack }
-													editEnsNamedHashCallBack = { () => undefined }
 													addressMetaData = { addressMetaData }
-													showTimePicker = { false }
+													modalState = { modalState }
 												/>
 											</> }
 										</div>

--- a/app/ts/components/pages/WebsiteAccess.tsx
+++ b/app/ts/components/pages/WebsiteAccess.tsx
@@ -403,13 +403,13 @@ const AddressAccessCard = ({ website, addressAccess, renameAddressCallBack }: { 
 	return (
 		<div style = { { display: 'grid', gridTemplateColumns: 'minmax(0,1fr) min-content min-content', columnGap: '1rem', alignItems: 'center' } }>
 			<BigAddress addressBookEntry = { addressBookEntry.deepValue } noEditAddress = { true } renameAddressCallBack = { renameAddressCallBack } />
-			<RemoveAddressConfirmation website = { website } addressBookEntry = { addressBookEntry.deepValue } />
+			<RemoveAddressConfirmation website = { website } addressBookEntry = { addressBookEntry.deepValue } renameAddressCallBack = { renameAddressCallBack } />
 			<Switch checked = { addressAccess.access } onChange = { setAddressAccess } />
 		</div>
 	)
 }
 
-const RemoveAddressConfirmation = ({ website, addressBookEntry }: { addressBookEntry: AddressBookEntry, website: ReadonlySignal<Website | undefined> }) => {
+const RemoveAddressConfirmation = ({ website, addressBookEntry, renameAddressCallBack }: { addressBookEntry: AddressBookEntry, website: ReadonlySignal<Website | undefined>, renameAddressCallBack: RenameAddressCallBack }) => {
 	const removeAddressAccessForWebsite = async () => {
 		if (!addressBookEntry) return
 		const currentWebsite = website.value
@@ -427,7 +427,7 @@ const RemoveAddressConfirmation = ({ website, addressBookEntry }: { addressBookE
 			<Modal.Open class = 'btn btn--ghost'><TrashIcon /></Modal.Open>
 			<Modal.Dialog class = 'dialog' style = { { textAlign: 'center', color: 'var(--disabled-text-color)' } } onModalClose = { confirmOrRejectRemoval }>
 				<h2 style = { { fontWeight: 600, fontSize: '1.125rem', color: 'var(--text-color)', marginBlock: '1rem' } }>Removing Address</h2>
-				<div style = { { marginBlock: '0.5rem' } }>This will prevent <WebsiteCard website = { website.value } /> from accessing or using <SmallAddress addressBookEntry = { addressBookEntry } renameAddressCallBack = { () => undefined } />
+				<div style = { { marginBlock: '0.5rem' } }>This will prevent <WebsiteCard website = { website.value } /> from accessing or using <SmallAddress addressBookEntry = { addressBookEntry } renameAddressCallBack = { renameAddressCallBack } />
 				</div>
 				<p style = { { marginBlock: '1rem' } }>Remove the website's access to this address anyway?</p>
 				<div style = { { display: 'flex', flexWrap: 'wrap', columnGap: '1rem', justifyContent: 'center', marginBlock: '1rem' } }>

--- a/app/ts/components/pages/WebsiteAccess.tsx
+++ b/app/ts/components/pages/WebsiteAccess.tsx
@@ -410,6 +410,7 @@ const AddressAccessCard = ({ website, addressAccess, renameAddressCallBack }: { 
 }
 
 const RemoveAddressConfirmation = ({ website, addressBookEntry, renameAddressCallBack }: { addressBookEntry: AddressBookEntry, website: ReadonlySignal<Website | undefined>, renameAddressCallBack: RenameAddressCallBack }) => {
+	const dialogRef = useRef<HTMLDialogElement>(null)
 	const removeAddressAccessForWebsite = async () => {
 		if (!addressBookEntry) return
 		const currentWebsite = website.value
@@ -422,12 +423,17 @@ const RemoveAddressConfirmation = ({ website, addressBookEntry, renameAddressCal
 		removeAddressAccessForWebsite()
 	}
 
+	const editAddress = (entry: AddressBookEntry) => {
+		dialogRef.current?.close('reject')
+		renameAddressCallBack(entry)
+	}
+
 	return (
-		<Modal>
+		<Modal dialogRef = { dialogRef }>
 			<Modal.Open class = 'btn btn--ghost'><TrashIcon /></Modal.Open>
 			<Modal.Dialog class = 'dialog' style = { { textAlign: 'center', color: 'var(--disabled-text-color)' } } onModalClose = { confirmOrRejectRemoval }>
 				<h2 style = { { fontWeight: 600, fontSize: '1.125rem', color: 'var(--text-color)', marginBlock: '1rem' } }>Removing Address</h2>
-				<div style = { { marginBlock: '0.5rem' } }>This will prevent <WebsiteCard website = { website.value } /> from accessing or using <SmallAddress addressBookEntry = { addressBookEntry } renameAddressCallBack = { renameAddressCallBack } />
+				<div style = { { marginBlock: '0.5rem' } }>This will prevent <WebsiteCard website = { website.value } /> from accessing or using <SmallAddress addressBookEntry = { addressBookEntry } renameAddressCallBack = { editAddress } />
 				</div>
 				<p style = { { marginBlock: '1rem' } }>Remove the website's access to this address anyway?</p>
 				<div style = { { display: 'flex', flexWrap: 'wrap', columnGap: '1rem', justifyContent: 'center', marginBlock: '1rem' } }>

--- a/app/ts/components/subcomponents/Modal.tsx
+++ b/app/ts/components/subcomponents/Modal.tsx
@@ -25,8 +25,9 @@ import { useContext, useEffect, useRef } from 'preact/hooks'
  * }
  * ```
  */
-export const Modal = ({ children }: { children: ComponentChildren }) => {
-	const dialogRef = useRef<HTMLDialogElement>(null)
+export const Modal = ({ children, dialogRef: providedDialogRef }: { children: ComponentChildren, dialogRef?: RefObject<HTMLDialogElement> }) => {
+	const internalDialogRef = useRef<HTMLDialogElement>(null)
+	const dialogRef = providedDialogRef ?? internalDialogRef
 	return <ModalContext.Provider value = { { dialogRef } }>{ children }</ModalContext.Provider>
 }
 

--- a/test/tests/confirmTransactionRpcStatus.test.ts
+++ b/test/tests/confirmTransactionRpcStatus.test.ts
@@ -6,6 +6,26 @@ import { installDomMock } from './domMock.js'
 
 type RuntimeMessageListener = (message: unknown) => unknown
 
+type TestDomNode = {
+	readonly tagName?: string
+	readonly parentNode?: TestDomNode | null
+	readonly childNodes?: readonly TestDomNode[]
+	readonly textContent?: string | null
+	readonly l?: Record<string, (event: unknown) => unknown>
+}
+
+function collectElements(node: TestDomNode | undefined, tagName: string, results: TestDomNode[] = []) {
+	if (node?.tagName === tagName.toUpperCase()) results.push(node)
+	for (const child of node?.childNodes ?? []) collectElements(child, tagName, results)
+	return results
+}
+
+async function clickElement(element: TestDomNode) {
+	const clickHandler = element.l === undefined ? undefined : Object.entries(element.l).find(([key]) => key.startsWith('Click'))?.[1]
+	if (clickHandler === undefined) throw new Error('Expected click handler')
+	await clickHandler({ currentTarget: element })
+}
+
 function installBrowserMock(sendMessageOverride?: (message: unknown, sentMessages: unknown[]) => unknown) {
 	const listeners: RuntimeMessageListener[] = []
 	const storageState: Record<string, unknown> = {}
@@ -448,6 +468,50 @@ describe('confirm transaction rpc status bootstrap', () => {
 		assert.equal(dom.document.body.textContent?.includes('Failed to decode ABI data'), true)
 		assert.equal(dom.document.body.textContent?.includes('Simulating...'), false)
 		assert.equal(dom.document.body.textContent?.includes('Initializing...'), false)
+		await unmountConfirmTransaction(dom)
+		dom.restore()
+	})
+
+	test('opens address editing from an execution error preview', async () => {
+		const dom = installDomMock()
+		installBrowserMock((message) => {
+			if (typeof message !== 'object' || message === null || !('method' in message)) return undefined
+			const typedMessage = message as { method?: string }
+			if (typedMessage.method === 'popup_readyAndListening') return undefined
+			if (typedMessage.method === 'popup_requestSettings') return undefined
+			return undefined
+		})
+		const [
+			{ browserStorageLocalSet2 },
+			{ ConfirmTransaction },
+		] = await Promise.all([
+			import('../../app/ts/utils/storageUtils.js'),
+			import('../../app/ts/components/pages/ConfirmTransaction.js'),
+		])
+
+		await browserStorageLocalSet2({
+			pendingTransactionsAndMessages: [makeUnexpectedSimulationFailurePendingTransaction('execution reverted')],
+		})
+
+		await act(() => {
+			render(h(ConfirmTransaction, {}), dom.document.body)
+		})
+		await new Promise((resolve) => setTimeout(resolve, 25))
+
+		assert.equal(dom.document.body.textContent?.includes('Execution error'), true)
+		const toLabel = collectElements(dom.document.body, 'dt').find((term) => term.textContent?.trim() === 'To')
+		if (toLabel === undefined || toLabel.parentNode === null || toLabel.parentNode === undefined) throw new Error('Expected the receiving address row')
+		const toLabelIndex = toLabel.parentNode.childNodes?.indexOf(toLabel) ?? -1
+		const receivingAddress = toLabel.parentNode.childNodes?.[toLabelIndex + 1]
+		if (receivingAddress === undefined) throw new Error('Expected the receiving address details')
+		const editAbiButton = collectElements(receivingAddress, 'button').find((button) => button.textContent?.trim() === 'edit')
+		if (editAbiButton === undefined) throw new Error('Expected the receiving address edit button')
+
+		await act(async () => {
+			await clickElement(editAbiButton)
+		})
+
+		assert.equal(dom.document.body.textContent?.includes('Abi:'), true)
 		await unmountConfirmTransaction(dom)
 		dom.restore()
 	})

--- a/test/tests/domMock.test.ts
+++ b/test/tests/domMock.test.ts
@@ -8,12 +8,14 @@ test('installDomMock restore keeps newer interleaved mock globals active', () =>
 	const firstClearInterval = globalThis.clearInterval
 	const firstRequestAnimationFrame = globalThis.requestAnimationFrame
 	const firstCancelAnimationFrame = globalThis.cancelAnimationFrame
+	const firstHtmlDialogElement = globalThis.HTMLDialogElement
 
 	const second = installDomMock()
 	const secondSetInterval = globalThis.setInterval
 	const secondClearInterval = globalThis.clearInterval
 	const secondRequestAnimationFrame = globalThis.requestAnimationFrame
 	const secondCancelAnimationFrame = globalThis.cancelAnimationFrame
+	const secondHtmlDialogElement = globalThis.HTMLDialogElement
 
 	first.restore()
 
@@ -23,6 +25,7 @@ test('installDomMock restore keeps newer interleaved mock globals active', () =>
 	assert.equal(globalThis.clearInterval, secondClearInterval)
 	assert.equal(globalThis.requestAnimationFrame, secondRequestAnimationFrame)
 	assert.equal(globalThis.cancelAnimationFrame, secondCancelAnimationFrame)
+	assert.equal(globalThis.HTMLDialogElement, secondHtmlDialogElement)
 
 	second.restore()
 
@@ -38,4 +41,6 @@ test('installDomMock restore keeps newer interleaved mock globals active', () =>
 	assert.notEqual(globalThis.requestAnimationFrame, secondRequestAnimationFrame)
 	assert.notEqual(globalThis.cancelAnimationFrame, firstCancelAnimationFrame)
 	assert.notEqual(globalThis.cancelAnimationFrame, secondCancelAnimationFrame)
+	assert.notEqual(globalThis.HTMLDialogElement, firstHtmlDialogElement)
+	assert.notEqual(globalThis.HTMLDialogElement, secondHtmlDialogElement)
 })

--- a/test/tests/domMock.ts
+++ b/test/tests/domMock.ts
@@ -145,6 +145,32 @@ class TestElement extends TestNode {
 	}
 }
 
+class TestDialogElement extends TestElement {
+	open = false
+	returnValue = ''
+	readonly eventListeners = new Map<string, Set<(event: { currentTarget: TestDialogElement }) => void>>()
+
+	override addEventListener(type: string, listener: (event: { currentTarget: TestDialogElement }) => void) {
+		const listeners = this.eventListeners.get(type) ?? new Set()
+		listeners.add(listener)
+		this.eventListeners.set(type, listeners)
+	}
+
+	override removeEventListener(type: string, listener: (event: { currentTarget: TestDialogElement }) => void) {
+		this.eventListeners.get(type)?.delete(listener)
+	}
+
+	showModal() {
+		this.open = true
+	}
+
+	close(returnValue = '') {
+		this.open = false
+		this.returnValue = returnValue
+		for (const listener of this.eventListeners.get('close') ?? []) listener({ currentTarget: this })
+	}
+}
+
 class TestDocument {
 	body: TestElement
 
@@ -156,6 +182,7 @@ class TestDocument {
 	removeEventListener() { return undefined }
 
 	createElement(tagName: string) {
+		if (tagName.toLowerCase() === 'dialog') return new TestDialogElement(this, tagName)
 		return new TestElement(this, tagName)
 	}
 
@@ -227,6 +254,7 @@ export function installDomMock() {
 	const previousClearInterval = globalThis.clearInterval
 	const previousRequestAnimationFrame = globalThis.requestAnimationFrame
 	const previousCancelAnimationFrame = globalThis.cancelAnimationFrame
+	const previousHtmlDialogElement = globalThis.HTMLDialogElement
 	const state: DomMockState = {
 		restored: false,
 		previousDocument,
@@ -244,6 +272,7 @@ export function installDomMock() {
 	defineGlobalValue('clearInterval', clearIntervalMock)
 	defineGlobalValue('requestAnimationFrame', requestAnimationFrameMock)
 	defineGlobalValue('cancelAnimationFrame', cancelAnimationFrameMock)
+	defineGlobalValue('HTMLDialogElement', TestDialogElement)
 
 	return {
 		document,
@@ -257,6 +286,7 @@ export function installDomMock() {
 			restoreOwnedGlobal('clearInterval', globalThis.clearInterval === clearIntervalMock, previousClearInterval, undefined, (owner) => owner.previousClearInterval)
 			restoreOwnedGlobal('requestAnimationFrame', globalThis.requestAnimationFrame === requestAnimationFrameMock, previousRequestAnimationFrame, undefined, (owner) => owner.previousRequestAnimationFrame)
 			restoreOwnedGlobal('cancelAnimationFrame', globalThis.cancelAnimationFrame === cancelAnimationFrameMock, previousCancelAnimationFrame, undefined, (owner) => owner.previousCancelAnimationFrame)
+			if (globalThis.HTMLDialogElement === TestDialogElement && previousHtmlDialogElement !== undefined) defineGlobalValue('HTMLDialogElement', previousHtmlDialogElement)
 		},
 	}
 }

--- a/test/tests/domMock.ts
+++ b/test/tests/domMock.ts
@@ -173,8 +173,10 @@ class TestDialogElement extends TestElement {
 
 class TestDocument {
 	body: TestElement
+	readonly dialogElementConstructor: typeof TestDialogElement
 
-	constructor() {
+	constructor(dialogElementConstructor: typeof TestDialogElement = TestDialogElement) {
+		this.dialogElementConstructor = dialogElementConstructor
 		this.body = new TestElement(this, 'body')
 	}
 
@@ -182,7 +184,7 @@ class TestDocument {
 	removeEventListener() { return undefined }
 
 	createElement(tagName: string) {
-		if (tagName.toLowerCase() === 'dialog') return new TestDialogElement(this, tagName)
+		if (tagName.toLowerCase() === 'dialog') return new this.dialogElementConstructor(this, tagName)
 		return new TestElement(this, tagName)
 	}
 
@@ -209,6 +211,7 @@ type DomMockState = {
 	previousClearInterval: unknown
 	previousRequestAnimationFrame: unknown
 	previousCancelAnimationFrame: unknown
+	previousHtmlDialogElement: unknown
 }
 
 const fallbackDocument = new TestDocument()
@@ -235,7 +238,8 @@ function restoreOwnedGlobal(name: string, isOwnedByThisMock: boolean, previousVa
 }
 
 export function installDomMock() {
-	const document = new TestDocument()
+	class OwnedTestDialogElement extends TestDialogElement {}
+	const document = new TestDocument(OwnedTestDialogElement)
 	const window: TestWindow = {
 		document,
 		addEventListener() { return undefined },
@@ -263,8 +267,9 @@ export function installDomMock() {
 		previousClearInterval,
 		previousRequestAnimationFrame,
 		previousCancelAnimationFrame,
+		previousHtmlDialogElement,
 	}
-	for (const ownedValue of [document, window, setIntervalMock, clearIntervalMock, requestAnimationFrameMock, cancelAnimationFrameMock]) domMockOwners.set(ownedValue, state)
+	for (const ownedValue of [document, window, setIntervalMock, clearIntervalMock, requestAnimationFrameMock, cancelAnimationFrameMock, OwnedTestDialogElement]) domMockOwners.set(ownedValue, state)
 
 	defineGlobalValue('document', document)
 	defineGlobalValue('window', window)
@@ -272,7 +277,7 @@ export function installDomMock() {
 	defineGlobalValue('clearInterval', clearIntervalMock)
 	defineGlobalValue('requestAnimationFrame', requestAnimationFrameMock)
 	defineGlobalValue('cancelAnimationFrame', cancelAnimationFrameMock)
-	defineGlobalValue('HTMLDialogElement', TestDialogElement)
+	defineGlobalValue('HTMLDialogElement', OwnedTestDialogElement)
 
 	return {
 		document,
@@ -286,7 +291,7 @@ export function installDomMock() {
 			restoreOwnedGlobal('clearInterval', globalThis.clearInterval === clearIntervalMock, previousClearInterval, undefined, (owner) => owner.previousClearInterval)
 			restoreOwnedGlobal('requestAnimationFrame', globalThis.requestAnimationFrame === requestAnimationFrameMock, previousRequestAnimationFrame, undefined, (owner) => owner.previousRequestAnimationFrame)
 			restoreOwnedGlobal('cancelAnimationFrame', globalThis.cancelAnimationFrame === cancelAnimationFrameMock, previousCancelAnimationFrame, undefined, (owner) => owner.previousCancelAnimationFrame)
-			if (globalThis.HTMLDialogElement === TestDialogElement && previousHtmlDialogElement !== undefined) defineGlobalValue('HTMLDialogElement', previousHtmlDialogElement)
+			restoreOwnedGlobal('HTMLDialogElement', globalThis.HTMLDialogElement === OwnedTestDialogElement, previousHtmlDialogElement, undefined, (owner) => owner.previousHtmlDialogElement)
 		},
 	}
 }

--- a/test/tests/fetchSimulationStackEditing.test.tsx
+++ b/test/tests/fetchSimulationStackEditing.test.tsx
@@ -1,0 +1,220 @@
+import * as assert from 'assert'
+import { Signal } from '@preact/signals'
+import { h, render } from 'preact'
+import { act } from 'preact/test-utils'
+import { describe, test } from 'bun:test'
+import { FetchSimulationStackModal, FetchSimulationStackRows, type FetchSimulationStackModalState } from '../../app/ts/components/pages/FetchSimulationStack.js'
+import { getNativeTokenErc20 } from '../../app/ts/background/metadataUtils.js'
+import { mockSignTransaction } from '../../app/ts/simulation/services/SimulationModeEthereumClientService.js'
+import type { AddressBookEntry } from '../../app/ts/types/addressBookTypes.js'
+import type { EnsEvent } from '../../app/ts/types/EnrichedEthereumData.js'
+import type { SimulationAndVisualisationResults, SimulatedAndVisualizedTransaction } from '../../app/ts/types/visualizer-types.js'
+import { installDomMock } from './domMock.js'
+
+type TestDomNode = {
+	readonly tagName?: string
+	readonly childNodes?: readonly TestDomNode[]
+	readonly getAttribute?: (name: string) => string | null
+	readonly l?: Record<string, (event: unknown) => unknown>
+}
+
+function collectElements(node: TestDomNode | undefined, tagName: string, results: TestDomNode[] = []) {
+	if (node?.tagName === tagName.toUpperCase()) results.push(node)
+	for (const child of node?.childNodes ?? []) collectElements(child, tagName, results)
+	return results
+}
+
+async function clickElement(element: TestDomNode) {
+	const clickHandler = element.l === undefined ? undefined : Object.entries(element.l).find(([key]) => key.startsWith('Click'))?.[1]
+	if (clickHandler === undefined) throw new Error('Expected click handler')
+	await clickHandler({ currentTarget: element })
+}
+
+const signerAddress = 0x1111111111111111111111111111111111111111n
+const contractAddress = 0x2222222222222222222222222222222222222222n
+const nameHash = 0x1234n
+const rpcNetwork = {
+	name: 'Ethereum',
+	chainId: 1n,
+	httpsRpc: 'https://example.invalid',
+	currencyName: 'Ether',
+	currencyTicker: 'ETH',
+	primary: true,
+	minimized: false,
+}
+const signerEntry: AddressBookEntry = {
+	type: 'contact',
+	name: 'Signer',
+	address: signerAddress,
+	entrySource: 'User',
+	askForAddressAccess: true,
+	useAsActiveAddress: true,
+	chainId: 1n,
+}
+const contractEntry: AddressBookEntry = {
+	type: 'contract',
+	name: 'ENS Contract',
+	address: contractAddress,
+	entrySource: 'User',
+	chainId: 1n,
+}
+const nativeTokenEntry = getNativeTokenErc20(rpcNetwork)
+const originalRequestParameters = {
+	method: 'eth_sendTransaction' as const,
+	params: [{
+		from: signerAddress,
+		to: contractAddress,
+		value: 0n,
+		input: new Uint8Array(),
+	}],
+}
+const transactionIdentifier = 1n
+const created = new Date('2024-01-01T00:00:00.000Z')
+const transaction = {
+	type: '1559' as const,
+	from: signerAddress,
+	nonce: 0n,
+	maxFeePerGas: 1n,
+	maxPriorityFeePerGas: 1n,
+	gas: 21_000n,
+	to: contractAddress,
+	value: 0n,
+	input: new Uint8Array(),
+	chainId: 1n,
+	accessList: [],
+}
+const preSimulationTransaction = {
+	signedTransaction: mockSignTransaction(transaction),
+	website: { websiteOrigin: 'https://example.com', icon: undefined, title: 'Example' },
+	created,
+	originalRequestParameters,
+	transactionIdentifier,
+}
+const ensEvent: EnsEvent = {
+	type: 'ENS',
+	subType: 'ENSTextChangedKeyValue',
+	isParsed: 'Parsed',
+	name: 'TextChanged',
+	signature: 'TextChanged(bytes32,string,string)',
+	args: [],
+	address: contractAddress,
+	loggersAddressBookEntry: contractEntry,
+	data: new Uint8Array(),
+	topics: [],
+	logInformation: {
+		node: {
+			nameHash,
+			name: 'example.eth',
+		},
+		indexedKey: new Uint8Array([1]),
+		key: 'avatar',
+		value: 'ipfs://avatar',
+	},
+}
+const simulatedTransaction: SimulatedAndVisualizedTransaction = {
+	website: preSimulationTransaction.website,
+	created,
+	parsedInputData: { type: 'NonParsed', input: new Uint8Array() },
+	transactionIdentifier,
+	originalRequestParameters,
+	tokenBalancesAfter: [],
+	tokenPriceEstimates: [],
+	tokenPriceQuoteToken: undefined,
+	gasSpent: 21_000n,
+	realizedGasPrice: 1n,
+	quarantine: false,
+	quarantineReasons: [],
+	transactionStatus: 'Transaction Succeeded',
+	transaction: {
+		from: signerEntry,
+		to: contractEntry,
+		rpcNetwork,
+		type: '1559',
+		nonce: 0n,
+		maxFeePerGas: 1n,
+		maxPriorityFeePerGas: 1n,
+		gas: 21_000n,
+		value: 0n,
+		input: new Uint8Array(),
+		hash: 1n,
+	},
+	events: [ensEvent],
+}
+const blockTimeManipulation = { type: 'No Delay' as const }
+const simulationResults: SimulationAndVisualisationResults = {
+	blockNumber: 100n,
+	blockTimestamp: created,
+	simulationConductedTimestamp: created,
+	simulationStateInput: [{
+		stateOverrides: {},
+		transactions: [preSimulationTransaction],
+		signedMessages: [],
+		blockTimeManipulation,
+		simulateWithZeroBaseFee: false,
+	}],
+	addressBookEntries: [signerEntry, contractEntry, nativeTokenEntry],
+	visualizedSimulationState: {
+		success: true,
+		visualizedBlocks: [{
+			simulatedAndVisualizedTransactions: [simulatedTransaction],
+			visualizedPersonalSignRequests: [],
+			blockTimeManipulation,
+		}],
+	},
+	rpcNetwork,
+	tokenPriceEstimates: [],
+	namedTokenIds: [],
+}
+
+describe('FetchSimulationStack editing', () => {
+	test('opens the ENS hash editor from a simulation stack event', async () => {
+		const dom = installDomMock()
+		const modalState = new Signal<FetchSimulationStackModalState>({ page: 'noModal' })
+
+		await act(() => {
+			render(h('div', {},
+				h(FetchSimulationStackRows, {
+					simulationAndVisualisationResults: new Signal(simulationResults),
+					activeAddress: new Signal<bigint | undefined>(signerAddress),
+					addressMetaData: new Signal([signerEntry, contractEntry, nativeTokenEntry]),
+					renameAddressCallBack: () => undefined,
+					modalState,
+				}),
+				h(FetchSimulationStackModal, {
+					modalState,
+					rpcEntries: new Signal([rpcNetwork]),
+				}),
+			), dom.document.body)
+		})
+
+		const renameEnsButton = collectElements(dom.document.body, 'button').find((button) => button.getAttribute?.('class')?.split(/\s+/).includes('rename-address-button'))
+		if (renameEnsButton === undefined) throw new Error('Expected ENS rename button')
+
+		await act(async () => {
+			await clickElement(renameEnsButton)
+		})
+
+		assert.deepEqual(modalState.value, {
+			page: 'editEnsNamedHash',
+			state: {
+				type: 'nameHash',
+				nameHash,
+				name: 'example.eth',
+			},
+		})
+		assert.equal(dom.document.body.textContent.includes('What is the correct ENS name for this hash?'), true)
+		const closeEditorButton = collectElements(dom.document.body, 'button').find((button) => button.textContent?.trim() === 'Ok')
+		if (closeEditorButton === undefined) throw new Error('Expected ENS editor close button')
+
+		await act(async () => {
+			await clickElement(closeEditorButton)
+		})
+
+		assert.deepEqual(modalState.value, { page: 'noModal' })
+		assert.equal(dom.document.body.textContent.includes('What is the correct ENS name for this hash?'), false)
+		await act(() => {
+			render(null, dom.document.body)
+		})
+		dom.restore()
+	})
+})

--- a/test/tests/fetchSimulationStackEditing.test.tsx
+++ b/test/tests/fetchSimulationStackEditing.test.tsx
@@ -33,6 +33,7 @@ async function clickElement(element: TestDomNode) {
 const signerAddress = 0x1111111111111111111111111111111111111111n
 const contractAddress = 0x2222222222222222222222222222222222222222n
 const nameHash = 0x1234n
+const labelHash = 0x5678n
 const rpcNetwork = {
 	name: 'Ethereum',
 	chainId: 1n,
@@ -111,6 +112,26 @@ const ensEvent: EnsEvent = {
 		value: 'ipfs://avatar',
 	},
 }
+const ensLabelEvent: EnsEvent = {
+	type: 'ENS',
+	subType: 'ENSBaseRegistrarNameRegistered',
+	isParsed: 'Parsed',
+	name: 'NameRegistered',
+	signature: 'NameRegistered(uint256,address,uint256)',
+	args: [],
+	address: contractAddress,
+	loggersAddressBookEntry: contractEntry,
+	data: new Uint8Array(),
+	topics: [],
+	logInformation: {
+		labelHash: {
+			labelHash,
+			label: 'example',
+		},
+		owner: signerEntry,
+		expires: 2_000_000_000n,
+	},
+}
 const simulatedTransaction: SimulatedAndVisualizedTransaction = {
 	website: preSimulationTransaction.website,
 	created,
@@ -166,33 +187,68 @@ const simulationResults: SimulationAndVisualisationResults = {
 	namedTokenIds: [],
 }
 
+function replaceEnsEvent(event: EnsEvent): SimulationAndVisualisationResults {
+	return {
+		...simulationResults,
+		visualizedSimulationState: {
+			success: true,
+			visualizedBlocks: [{
+				simulatedAndVisualizedTransactions: [{ ...simulatedTransaction, events: [event] }],
+				visualizedPersonalSignRequests: [],
+				blockTimeManipulation,
+			}],
+		},
+	}
+}
+
+async function renderAndOpenEnsEditor(event: EnsEvent) {
+	const dom = installDomMock()
+	const modalState = new Signal<FetchSimulationStackModalState>({ page: 'noModal' })
+
+	await act(() => {
+		render(h('div', {},
+			h(FetchSimulationStackRows, {
+				simulationAndVisualisationResults: new Signal(replaceEnsEvent(event)),
+				activeAddress: new Signal<bigint | undefined>(signerAddress),
+				addressMetaData: new Signal([signerEntry, contractEntry, nativeTokenEntry]),
+				renameAddressCallBack: () => undefined,
+				modalState,
+			}),
+			h(FetchSimulationStackModal, {
+				modalState,
+				rpcEntries: new Signal([rpcNetwork]),
+			}),
+		), dom.document.body)
+	})
+
+	const renameEnsButton = collectElements(dom.document.body, 'button').find((button) => button.getAttribute?.('class')?.split(/\s+/).includes('rename-address-button'))
+	if (renameEnsButton === undefined) throw new Error('Expected ENS rename button')
+
+	await act(async () => {
+		await clickElement(renameEnsButton)
+	})
+
+	return { dom, modalState }
+}
+
+async function closeEnsEditor(dom: ReturnType<typeof installDomMock>, modalState: Signal<FetchSimulationStackModalState>) {
+	const closeEditorButton = collectElements(dom.document.body, 'button').find((button) => button.textContent?.trim() === 'Ok')
+	if (closeEditorButton === undefined) throw new Error('Expected ENS editor close button')
+
+	await act(async () => {
+		await clickElement(closeEditorButton)
+	})
+
+	assert.deepEqual(modalState.value, { page: 'noModal' })
+	await act(() => {
+		render(null, dom.document.body)
+	})
+	dom.restore()
+}
+
 describe('FetchSimulationStack editing', () => {
 	test('opens the ENS hash editor from a simulation stack event', async () => {
-		const dom = installDomMock()
-		const modalState = new Signal<FetchSimulationStackModalState>({ page: 'noModal' })
-
-		await act(() => {
-			render(h('div', {},
-				h(FetchSimulationStackRows, {
-					simulationAndVisualisationResults: new Signal(simulationResults),
-					activeAddress: new Signal<bigint | undefined>(signerAddress),
-					addressMetaData: new Signal([signerEntry, contractEntry, nativeTokenEntry]),
-					renameAddressCallBack: () => undefined,
-					modalState,
-				}),
-				h(FetchSimulationStackModal, {
-					modalState,
-					rpcEntries: new Signal([rpcNetwork]),
-				}),
-			), dom.document.body)
-		})
-
-		const renameEnsButton = collectElements(dom.document.body, 'button').find((button) => button.getAttribute?.('class')?.split(/\s+/).includes('rename-address-button'))
-		if (renameEnsButton === undefined) throw new Error('Expected ENS rename button')
-
-		await act(async () => {
-			await clickElement(renameEnsButton)
-		})
+		const { dom, modalState } = await renderAndOpenEnsEditor(ensEvent)
 
 		assert.deepEqual(modalState.value, {
 			page: 'editEnsNamedHash',
@@ -203,18 +259,23 @@ describe('FetchSimulationStack editing', () => {
 			},
 		})
 		assert.equal(dom.document.body.textContent.includes('What is the correct ENS name for this hash?'), true)
-		const closeEditorButton = collectElements(dom.document.body, 'button').find((button) => button.textContent?.trim() === 'Ok')
-		if (closeEditorButton === undefined) throw new Error('Expected ENS editor close button')
-
-		await act(async () => {
-			await clickElement(closeEditorButton)
-		})
-
-		assert.deepEqual(modalState.value, { page: 'noModal' })
+		await closeEnsEditor(dom, modalState)
 		assert.equal(dom.document.body.textContent.includes('What is the correct ENS name for this hash?'), false)
-		await act(() => {
-			render(null, dom.document.body)
+	})
+
+	test('opens the ENS label editor from a simulation stack event', async () => {
+		const { dom, modalState } = await renderAndOpenEnsEditor(ensLabelEvent)
+
+		assert.deepEqual(modalState.value, {
+			page: 'editEnsNamedHash',
+			state: {
+				type: 'labelHash',
+				nameHash: labelHash,
+				name: 'example',
+			},
 		})
-		dom.restore()
+		assert.equal(dom.document.body.textContent.includes('What is the correct ENS label for this hash?'), true)
+		await closeEnsEditor(dom, modalState)
+		assert.equal(dom.document.body.textContent.includes('What is the correct ENS label for this hash?'), false)
 	})
 })

--- a/test/tests/websiteAccessSelection.test.ts
+++ b/test/tests/websiteAccessSelection.test.ts
@@ -15,10 +15,12 @@ type RuntimeMessage = {
 type DomElement = {
 	tagName?: string
 	childNodes?: readonly DomElement[]
+	textContent?: string | null
 	type?: string
 	value?: string
 	checked?: boolean
 	attributes?: Record<string, string | undefined>
+	l?: Record<string, (event: unknown) => unknown>
 }
 
 function createBrowserMock() {
@@ -165,6 +167,12 @@ function isChecked(element: DomElement) {
 	return element.checked === true || element.attributes?.checked !== undefined
 }
 
+async function clickElement(element: DomElement) {
+	const clickHandler = element.l === undefined ? undefined : Object.entries(element.l).find(([key]) => key.startsWith('Click'))?.[1]
+	if (clickHandler === undefined) throw new Error('Expected click handler')
+	await clickHandler({ currentTarget: element })
+}
+
 const websiteAccessEntries: readonly WebsiteAccess[] = [
 	{
 		website: { websiteOrigin: 'alpha.example', icon: 'alpha.png', title: 'Alpha' },
@@ -303,6 +311,17 @@ describe('WebsiteAccessView selection', () => {
 
 		assert.equal(dom.document.body.textContent.includes('app.sablier.com'), true)
 		assert.equal(dom.document.body.textContent.includes('Primary'), true)
+
+		const removeAddressDialog = collectElements(dom.document.body, 'dialog').filter((dialog) => dialog.textContent?.includes('Removing Address')).at(-1)
+		if (removeAddressDialog === undefined) throw new Error('Expected remove address dialog')
+		const editAddressButton = collectElements(removeAddressDialog, 'button').find((button) => button.textContent?.trim() === 'edit')
+		if (editAddressButton === undefined) throw new Error('Expected address edit button in remove dialog')
+
+		await act(async () => {
+			await clickElement(editAddressButton)
+		})
+
+		assert.equal(dom.document.body.textContent.includes('Abi:'), true)
 		dom.restore()
 	})
 

--- a/test/tests/websiteAccessSelection.test.ts
+++ b/test/tests/websiteAccessSelection.test.ts
@@ -15,12 +15,14 @@ type RuntimeMessage = {
 type DomElement = {
 	tagName?: string
 	childNodes?: readonly DomElement[]
+	parentNode?: DomElement | null
 	textContent?: string | null
 	type?: string
 	value?: string
 	checked?: boolean
 	attributes?: Record<string, string | undefined>
 	l?: Record<string, (event: unknown) => unknown>
+	open?: boolean
 }
 
 function createBrowserMock() {
@@ -314,6 +316,15 @@ describe('WebsiteAccessView selection', () => {
 
 		const removeAddressDialog = collectElements(dom.document.body, 'dialog').filter((dialog) => dialog.textContent?.includes('Removing Address')).at(-1)
 		if (removeAddressDialog === undefined) throw new Error('Expected remove address dialog')
+		const dialogSiblings = removeAddressDialog.parentNode?.childNodes ?? []
+		const removeAddressButton = dialogSiblings[dialogSiblings.indexOf(removeAddressDialog) - 1]
+		if (removeAddressButton === undefined) throw new Error('Expected remove address button')
+
+		await act(async () => {
+			await clickElement(removeAddressButton)
+		})
+		assert.equal(removeAddressDialog.open, true)
+
 		const editAddressButton = collectElements(removeAddressDialog, 'button').find((button) => button.textContent?.trim() === 'edit')
 		if (editAddressButton === undefined) throw new Error('Expected address edit button in remove dialog')
 
@@ -321,6 +332,7 @@ describe('WebsiteAccessView selection', () => {
 			await clickElement(editAddressButton)
 		})
 
+		assert.equal(removeAddressDialog.open, false)
 		assert.equal(dom.document.body.textContent.includes('Abi:'), true)
 		dom.restore()
 	})


### PR DESCRIPTION
## Problem

Several edit controls were rendered but did nothing because their views passed no-op callbacks:

- address/ABI editing in failed or rejected Confirm Transaction execution-error previews
- address/ABI editing inside the Website Access removal confirmation
- ENS name-hash and label-hash editing in Fetch Simulation Stack

Website Access also required dismissing its native removal dialog before opening the address editor; otherwise the confirmation remained in the browser top layer and blocked the editor.

## Changes

- thread the existing address-edit callback through Confirm Transaction execution-error details
- forward the Website Access address-edit callback and close the removal confirmation with reject semantics before opening the editor
- allow `Modal` callers to provide a dialog ref for coordinated dismissal
- add ENS editor modal state to Fetch Simulation Stack and connect both name-hash and label-hash actions
- extend the test DOM mock with ownership-safe native dialog behavior
- add regression tests that click the actual controls and verify editor open/close transitions

## Validation

- `bun run test` — 876 passed, 0 failed
- `bun run setup-chrome` — passed
- `bun run typecheck` — passed
- `bun run lint` — passed
- final project reviewer — no findings, 98/100

`bun run test:chrome-communication` was not run because these changes are confined to local Preact UI callback and modal behavior; they do not alter content-script registration, injected-provider communication, access approval, or page-to-extension messaging.