### PR TITLE
Fix validation and UI boundary bugs

### DIFF
--- a/app/ts/components/pages/PersonalSign.tsx
+++ b/app/ts/components/pages/PersonalSign.tsx
@@ -190,23 +190,30 @@ type EIP712Entry = {
 }
 
 function EIP712Table({ enrichedEIP712Message, renameAddressCallBack, isSubTable }: EIP712Table) {
-	function EIP712Entry({ name, entry }: EIP712Entry) {
-		if (entry === undefined) return <></>
+	function EIP712Value({ entry }: { entry: TypeEnrichedEIP712MessageRecord }) {
+		if (entry.type === 'nestedArray') {
+			return <span style = 'display: inline-flex; flex-wrap: wrap;'>
+				[{
+					entry.value.map((nestedEntry, index) => <span key = { index } style = 'display: inline-flex;'>
+						{ index === 0 ? '' : ', ' }
+						<EIP712Value entry = { nestedEntry }/>
+					</span>)
+				}]
+			</span>
+		}
 		if (entry.type === 'record[]') {
-			return <>
-				<CellElement text = { `${ name }: ` }/>
-				<CellElement text = { entry.value.map((value, index) => <EIP712Table key = { index } enrichedEIP712Message = { value } renameAddressCallBack = { renameAddressCallBack } isSubTable = { true }/>) } />
-			</>
+			return <>{ entry.value.map((value, index) => <EIP712Table key = { index } enrichedEIP712Message = { value } renameAddressCallBack = { renameAddressCallBack } isSubTable = { true }/>) }</>
 		}
 		if (entry.type === 'record') {
-			return <>
-				<CellElement text = { `${ name }: ` }/>
-				<CellElement text = { <EIP712Table enrichedEIP712Message = { entry.value } renameAddressCallBack = { renameAddressCallBack } isSubTable = { true }/> }/>
-			</>
+			return <EIP712Table enrichedEIP712Message = { entry.value } renameAddressCallBack = { renameAddressCallBack } isSubTable = { true }/>
 		}
+		return <EnrichedSolidityTypeComponent valueType = { entry } renameAddressCallBack = { renameAddressCallBack }/>
+	}
+	function EIP712Entry({ name, entry }: EIP712Entry) {
+		if (entry === undefined) return <></>
 		return <>
 			<CellElement text = { `${ name }: ` }/>
-			<CellElement text = { <EnrichedSolidityTypeComponent valueType = { entry } renameAddressCallBack = { renameAddressCallBack }/> }/>
+			<CellElement text = { <EIP712Value entry = { entry }/> }/>
 		</>
 	}
 	return <span class = 'eip-712-table' style = { isSubTable ? 'justify-content: space-between;' : '' }>

--- a/app/ts/components/subcomponents/DynamicScroller.tsx
+++ b/app/ts/components/subcomponents/DynamicScroller.tsx
@@ -7,6 +7,13 @@ interface DynamicScrollerProps<T extends {}> {
 	renderItem: (item: T) => ComponentChild
 }
 
+export const getDynamicScrollOffset = (startIndex: number, itemHeight: number, itemCount: number, maximumVisibleItems: number) => {
+	if (itemHeight <= 0 || !Number.isFinite(itemHeight) || !Number.isFinite(maximumVisibleItems)) return 0
+	const requestedOffset = startIndex * itemHeight
+	const maximumOffset = Math.max(0, (itemCount - maximumVisibleItems) * itemHeight)
+	return Math.min(requestedOffset, maximumOffset)
+}
+
 export const DynamicScroller = <T extends {}>({ items, renderItem, }: DynamicScrollerProps<T>) => {
 	const startIndex = useSignal(0)
 	const maxItems = useSignal(0)
@@ -16,13 +23,13 @@ export const DynamicScroller = <T extends {}>({ items, renderItem, }: DynamicScr
 
 	const recalculateStartIndex = (event: Event) => {
 		if (!(event.currentTarget instanceof HTMLDivElement)) return
+		if (itemHeight.value <= 0) return
 		startIndex.value = Math.floor(event.currentTarget.scrollTop / itemHeight.value)
 	}
 
-	const scrollViewHeight = useComputed(() => itemHeight.value * maxItems.value)
 	const scrollAreaHeight = useComputed(() => items.value.length * itemHeight.value)
 	const visibleItems = useComputed(() => items.value.slice(startIndex.value, startIndex.value + maxItems.value + 1))
-	const scrollOffset = useComputed(() => Math.min(startIndex.value * itemHeight.value, scrollAreaHeight.value - scrollViewHeight.value))
+	const scrollOffset = useComputed(() => getDynamicScrollOffset(startIndex.value, itemHeight.value, items.value.length, maxItems.value))
 
 	// calculate item height
 	useSignalEffect(() => {
@@ -35,7 +42,7 @@ export const DynamicScroller = <T extends {}>({ items, renderItem, }: DynamicScr
 	useSignalEffect(() => {
 		if (!scrollViewRef.current) return
 		const containerObserver = new ResizeObserver(([entry]) => {
-			maxItems.value = Math.ceil(entry!.contentRect.height / itemHeight.value)
+			maxItems.value = itemHeight.value <= 0 ? 0 : Math.ceil(entry!.contentRect.height / itemHeight.value)
 		})
 		containerObserver.observe(scrollViewRef.current)
 		return () => { containerObserver.disconnect() }

--- a/app/ts/components/subcomponents/Tooltip.tsx
+++ b/app/ts/components/subcomponents/Tooltip.tsx
@@ -8,17 +8,32 @@ export type TooltipConfig = {
 	duration?: number
 }
 
+type TooltipTimer = ReturnType<typeof globalThis.setTimeout>
+
+export function scheduleTooltipDismissal(
+	config: Signal<TooltipConfig | undefined>,
+	activeConfig: TooltipConfig,
+	schedule: (callback: () => void, duration: number) => TooltipTimer = globalThis.setTimeout,
+	cancel: (timer: TooltipTimer) => void = globalThis.clearTimeout,
+) {
+	const timer = schedule(() => {
+		if (config.peek() === activeConfig) config.value = undefined
+	}, activeConfig.duration ?? 1500)
+	return () => cancel(timer)
+}
+
 export function Tooltip({ config }: { config: Signal<TooltipConfig | undefined> }) {
 	const popoverRef = useRef<HTMLDivElement>(null)
 
 	useSignalEffect(() => {
-		if (!config.value) {
+		const activeConfig = config.value
+		if (activeConfig === undefined) {
 			popoverRef.current?.hidePopover()
 			return
 		}
 
 		popoverRef.current?.showPopover()
-		setTimeout(() => { config.value = undefined }, config.value.duration || 1500)
+		return scheduleTooltipDismissal(config, activeConfig)
 	})
 
 	return (

--- a/app/ts/types/eip721.ts
+++ b/app/ts/types/eip721.ts
@@ -30,12 +30,16 @@ const EIP712MessageParser: funtypes.ParsedValue<funtypes.String, EIP712MessageUn
 export type EIP712Message = funtypes.Static<typeof EIP712Message>
 export const EIP712Message = funtypes.String.withParser(EIP712MessageParser)
 
-export type TypeEnrichedEIP712MessageRecord = EnrichedGroupedSolidityType | { type: 'record', value: { [x: string]: TypeEnrichedEIP712MessageRecord | undefined } } | { type: 'record[]', value: ReadonlyArray<{ [x: string]: TypeEnrichedEIP712MessageRecord | undefined }> }
+export type TypeEnrichedEIP712MessageRecord = EnrichedGroupedSolidityType
+	| { type: 'record', value: { [x: string]: TypeEnrichedEIP712MessageRecord | undefined } }
+	| { type: 'record[]', value: ReadonlyArray<{ [x: string]: TypeEnrichedEIP712MessageRecord | undefined }> }
+	| { type: 'nestedArray', value: readonly TypeEnrichedEIP712MessageRecord[] }
 export type EnrichedEIP712MessageRecord = funtypes.Static<typeof EnrichedEIP712MessageRecord>
 export const EnrichedEIP712MessageRecord: funtypes.Runtype<TypeEnrichedEIP712MessageRecord> = funtypes.Lazy(() => funtypes.Union(
 	EnrichedGroupedSolidityType,
 	funtypes.ReadonlyObject({ type: funtypes.Literal('record'), value: funtypes.ReadonlyRecord(funtypes.String, EnrichedEIP712MessageRecord) }),
 	funtypes.ReadonlyObject({ type: funtypes.Literal('record[]'), value: funtypes.ReadonlyArray(funtypes.ReadonlyRecord(funtypes.String, EnrichedEIP712MessageRecord)) }),
+	funtypes.ReadonlyObject({ type: funtypes.Literal('nestedArray'), value: funtypes.ReadonlyArray(EnrichedEIP712MessageRecord) }),
 ))
 
 export type EnrichedEIP712Message = funtypes.Static<typeof EnrichedEIP712Message>

--- a/app/ts/types/wire-types.ts
+++ b/app/ts/types/wire-types.ts
@@ -114,12 +114,16 @@ export const BytesParser: funtypes.ParsedValue<funtypes.String, Uint8Array>['con
 
 const TimestampParser: funtypes.ParsedValue<funtypes.String, Date>['config'] = {
 	parse: value => {
-		if (!/^0x([a-fA-F0-9]*)$/.test(value)) return { success: false, message: `${value} is not a hex string encoded timestamp.` }
-		return { success: true, value: new Date(Number.parseInt(value, 16) * 1000) }
+		if (!/^0x[a-fA-F0-9]+$/.test(value)) return { success: false, message: `${ value } is not a hex string encoded timestamp.` }
+		const seconds = BigInt(value)
+		if (seconds > 8_640_000_000_000n) return { success: false, message: `${ value } is outside the supported timestamp range.` }
+		return { success: true, value: new Date(Number(seconds) * 1000) }
 	},
 	serialize: value => {
-		if (!(value instanceof Date)) return { success: false, message: `${typeof value} is not a Date.`}
-		return { success: true, value: `0x${Math.floor(value.valueOf() / 1000).toString(16)}` }
+		if (!(value instanceof Date) || !Number.isFinite(value.valueOf())) return { success: false, message: `${ typeof value } is not a valid Date.`}
+		const seconds = Math.floor(value.valueOf() / 1000)
+		if (seconds < 0) return { success: false, message: `${ value.toISOString() } is before the Unix epoch.` }
+		return { success: true, value: `0x${ seconds.toString(16) }` }
 	},
 }
 

--- a/app/ts/utils/bigint.ts
+++ b/app/ts/utils/bigint.ts
@@ -113,29 +113,14 @@ export function calculateWeightedPercentile(data: readonly { dataPoint: bigint, 
 	if (data.length === 0) return 0n
 	if (percentile < 0 || percentile > 100 || data.map((point) => point.weight).some((weight) => weight < 0)) throw new Error('Invalid input')
 	const sortedData = [...data].sort((a, b) => a.dataPoint < b.dataPoint ? -1 : a.dataPoint > b.dataPoint ? 1 : 0)
-	const cumulativeWeights = sortedData.map((point) => point.weight).reduce((acc, w, i) => [...acc, (acc[i] ?? 0n) + w], [0n])
-	const totalWeight = cumulativeWeights[cumulativeWeights.length - 1]
-	if (totalWeight === undefined) throw new Error('Invalid input')
-
-	const targetIndex = percentile * totalWeight / 100n
-
-	const index = cumulativeWeights.findIndex(w => w >= targetIndex)
-
-	if (index === -1) throw new Error('Invalid input')
-
-	const lowerIndex = index === 0 ? 0 : index - 1
-	const upperIndex = index
-
-	const lowerValue = sortedData[lowerIndex]
-	const upperValue = sortedData[upperIndex]
-	const lowerWeight = cumulativeWeights[lowerIndex]
-	const upperWeight = cumulativeWeights[upperIndex]
-
-	if (lowerWeight === undefined || upperWeight === undefined || lowerValue === undefined || upperValue === undefined) throw new Error('weights were undefined')
-	if (lowerIndex === upperIndex) return lowerValue.dataPoint
-
-	const interpolation = (targetIndex - lowerWeight) / (upperWeight - lowerWeight)
-	return lowerValue.dataPoint + (upperValue.dataPoint - lowerValue.dataPoint) * interpolation
+	const totalWeight = sortedData.reduce((total, point) => total + point.weight, 0n)
+	const targetWeight = percentile * totalWeight
+	let cumulativeWeight = 0n
+	for (const point of sortedData) {
+		cumulativeWeight += point.weight * 100n
+		if (cumulativeWeight >= targetWeight) return point.dataPoint
+	}
+	return sortedData[sortedData.length - 1]?.dataPoint ?? 0n
 }
 
 export const bigintSecondsToDate = (seconds: bigint) => {

--- a/app/ts/utils/eip712.ts
+++ b/app/ts/utils/eip712.ts
@@ -90,22 +90,15 @@ const validateTypeValue = (typeStr: string, value: typeJSONEncodeable, solidityT
 	if (typeStr.startsWith('tuple(')) return { valid: false, reason: 'tuples are not supported'}
 
 	// Check for array types (non-tuple arrays)
-	const arrayMatch = typeStr.match(/^([^\[]+)(\[(?!0\])[0-9]*\](\[(?!0\])[0-9]*\])*)$/)
+	const arrayMatch = typeStr.match(/^(.*)\[(\d*)\]$/)
 	if (arrayMatch) {
-		const base = arrayMatch[1] // "array"
-		const brackets = arrayMatch[2] // "[][][]"
-		if (base === undefined || brackets === undefined) return { valid: false, reason: 'base or brackets were undefined'}
-		const remaining = brackets.replace(/^(\[(?!0\])[0-9]*\])/, '')
-		const innerType = base + remaining
-		const arrayLength = (brackets: string | undefined) => {
-			if (brackets === undefined) return undefined
-			const lengthMatch = brackets.match(/\[(\d*)\]$/)
-			return lengthMatch && lengthMatch[1] !== '' && lengthMatch[1] !== undefined ? parseInt(lengthMatch[1]) : undefined
-		}
-		const expectedLength = arrayLength(arrayMatch[2])
+		const innerType = arrayMatch[1]
+		const lengthText = arrayMatch[2]
+		if (innerType === undefined || lengthText === undefined) return { valid: false, reason: 'array type was incomplete'}
+		const expectedLength = lengthText === '' ? undefined : Number.parseInt(lengthText, 10)
 		if (!Array.isArray(value)) return { valid: false, reason: `invalid array: ${ JSON.stringify(value) }` }
 
-		if (expectedLength !== undefined && value.length > expectedLength) return { valid: false, reason: `expected array of length ${ expectedLength }, got ${ value.length }` }
+		if (expectedLength !== undefined && value.length !== expectedLength) return { valid: false, reason: `expected array of length ${ expectedLength }, got ${ value.length }` }
 		for (const elem of value) {
 			const valid = validateTypeValue(innerType, elem, solidityTypeTree)
 			if (valid.valid === false) return valid
@@ -182,6 +175,8 @@ const validatePrimitiveOrStruct = (typeStr: string, value: typeJSONEncodeable, s
 	if (typeTree !== undefined) {
 		if (typeof value === 'object' && value !== null && !Array.isArray(value)) {
 			const entries = Object.entries(value)
+			const missingTypeDefinition = typeTree.find((typeDefinition) => !Object.prototype.hasOwnProperty.call(value, typeDefinition.name))
+			if (missingTypeDefinition !== undefined) return { valid: false, reason: `missing value for: ${ missingTypeDefinition.name }` }
 			for (const [entryName, entryValue] of entries) {
 				if (entryValue === undefined) return { valid: false, reason: 'entry is invalid' }
 				const typeDefinition = typeTree.find((leaf) => leaf.name === entryName)
@@ -305,7 +300,7 @@ export const verifyEip712Message = (maybeEip712Message: EIP712Message): { valid:
 	if ('name' in maybeEip712Message.domain && !String.safeParse(name).success) return { valid: false, reason: 'EIP712Domain.name is in wrong type' }
 	if ('salt' in maybeEip712Message.domain && !EthereumData.safeParse(salt).success) return { valid: false, reason: 'EIP712Domain.salt is in wrong type' }
 
-	if (!isValidEIP712DomainOrder(validEIP712DomainEntries.map((entry) => entry.name), eip712Domain.map((entry) => entry.name))) throw new Error('domain types are in wrong order')
+	if (!isValidEIP712DomainOrder(validEIP712DomainEntries.map((entry) => entry.name), eip712Domain.map((entry) => entry.name))) return { valid: false, reason: 'EIP712Domain types are in the wrong order' }
 
 	// domain fields exist in valid in types
 	const domainArray = Object.entries(maybeEip712Message.domain)
@@ -316,6 +311,8 @@ export const verifyEip712Message = (maybeEip712Message: EIP712Message): { valid:
 		if (extractedTypes.valid === false) return extractedTypes
 		const extractedPrimary = extractedTypes.tree[primaryType]
 		if (extractedPrimary === undefined) return { valid: false, reason: 'Failed to extract primary type' }
+		const missingTypeDefinition = extractedPrimary.find((typeDefinition) => !Object.prototype.hasOwnProperty.call(message, typeDefinition.name))
+		if (missingTypeDefinition !== undefined) return { valid: false, reason: `Missing value for ${ missingTypeDefinition.name }` }
 		const fieldsArray = Object.entries(message)
 		for (const field of fieldsArray) {
 			if (field[0] === undefined) return { valid: false, reason: 'Field was invalid' }

--- a/app/ts/utils/eip712Parsing.ts
+++ b/app/ts/utils/eip712Parsing.ts
@@ -1,5 +1,5 @@
 import type { EthereumClientService } from '../simulation/services/EthereumClientService.js'
-import { JSONEncodeableObject, JSONEncodeableObjectArray } from '../utils/json.js'
+import { JSONEncodeableObject } from '../utils/json.js'
 import type { EIP712Message, EnrichedEIP712, EnrichedEIP712Message, EnrichedEIP712MessageRecord } from '../types/eip721.js'
 import { parseSolidityValueByTypeEnriched } from './solidityTypes.js'
 import { SolidityType } from '../types/solidityType.js'
@@ -9,13 +9,38 @@ function findType(name: string, types: readonly { readonly name: string, readonl
 	return types.find((x) => x.name === name)?.type
 }
 
-function separateArraySuffix(typeWithMaybeArraySuffix: string) {
-	const arrayMatch = /^(.*)\[(\d*)\]$/.exec(typeWithMaybeArraySuffix)
-	if (arrayMatch === null) return { arraylessType: typeWithMaybeArraySuffix, isArray: false, expectedLength: undefined }
-	const arraylessType = arrayMatch[1]
-	const lengthText = arrayMatch[2]
-	if (arraylessType === undefined || lengthText === undefined) return { arraylessType: typeWithMaybeArraySuffix, isArray: false, expectedLength: undefined }
-	return { arraylessType, isArray: true, expectedLength: lengthText === '' ? undefined : Number.parseInt(lengthText, 10) }
+type ParsedEIP712Type = {
+	readonly baseType: string
+	readonly arrayDimensions: readonly (number | undefined)[]
+	readonly valid: boolean
+}
+
+function parseEIP712Type(typeWithMaybeArraySuffix: string): ParsedEIP712Type {
+	let baseType = typeWithMaybeArraySuffix
+	const arrayDimensions: (number | undefined)[] = []
+	while (true) {
+		const arrayMatch = /^(.*)\[(\d*)\]$/.exec(baseType)
+		if (arrayMatch === null) return { baseType, arrayDimensions, valid: baseType.length !== 0 && !/[\[\]]/.test(baseType) }
+		const nextBaseType = arrayMatch[1]
+		const lengthText = arrayMatch[2]
+		if (nextBaseType === undefined || lengthText === undefined || (lengthText !== '' && !/^[1-9][0-9]*$/.test(lengthText))) return { baseType, arrayDimensions, valid: false }
+		baseType = nextBaseType
+		arrayDimensions.push(lengthText === '' ? undefined : Number.parseInt(lengthText, 10))
+	}
+}
+
+function validateEIP712Value(depth: number, value: unknown, parsedType: ParsedEIP712Type, types: { [x: string]: readonly { readonly name: string, readonly type: string}[] | undefined }): boolean {
+	if (!parsedType.valid) return false
+	if (parsedType.arrayDimensions.length !== 0) {
+		if (!Array.isArray(value)) return false
+		const expectedLength = parsedType.arrayDimensions[0]
+		if (expectedLength !== undefined && value.length !== expectedLength) return false
+		const nestedType = { baseType: parsedType.baseType, arrayDimensions: parsedType.arrayDimensions.slice(1), valid: true }
+		return value.every((nestedValue) => validateEIP712Value(depth, nestedValue, nestedType, types))
+	}
+	if (SolidityType.test(parsedType.baseType)) return !Array.isArray(value)
+	if (!JSONEncodeableObject.test(value)) return false
+	return validateEIP712TypesSubset(depth + 1, value, parsedType.baseType, types)
 }
 
 function validateEIP712TypesSubset(depth: number, message: JSONEncodeableObject, currentType: string, types: { [x: string]: readonly { readonly name: string, readonly type: string}[] | undefined }): boolean {
@@ -28,27 +53,41 @@ function validateEIP712TypesSubset(depth: number, message: JSONEncodeableObject,
 		if (fullType === undefined) return false
 		const subMessage = message[key]
 		if (subMessage === undefined) return false
-		const arraylessType = separateArraySuffix(fullType)
-		if (arraylessType.isArray !== Array.isArray(subMessage)) return false
-		if (Array.isArray(subMessage) && arraylessType.expectedLength !== undefined && subMessage.length !== arraylessType.expectedLength) return false
-		const currentType = arraylessType.arraylessType
-		if (SolidityType.test(currentType)) continue
-		if (currentType === undefined) return false
-		const jsonEncodeableArray = JSONEncodeableObjectArray.safeParse(subMessage)
-		if (jsonEncodeableArray.success) {
-			if (jsonEncodeableArray.value.map((arrayElement) => JSONEncodeableObject.test(arrayElement) ? validateEIP712TypesSubset(depth, arrayElement, currentType, types) : false).every((v) => v === true) === false) {
-				return false
-			}
-		} else {
-			if (!JSONEncodeableObject.test(subMessage)) return false
-			if (validateEIP712TypesSubset(depth + 1, subMessage, currentType, types) === false) return false
-		}
+		if (!validateEIP712Value(depth, subMessage, parseEIP712Type(fullType), types)) return false
 	}
 	return true
 }
 
 export function validateEIP712Types(message: EIP712Message) {
 	return validateEIP712TypesSubset(0, message.message, message.primaryType, message.types) && validateEIP712TypesSubset(0, message.domain, 'EIP712Domain', message.types)
+}
+
+function parseEIP712Array(value: unknown, expectedLength: number | undefined): readonly unknown[] {
+	if (!Array.isArray(value)) throw new Error(`Type was defined to be an array but it was not: ${ value }`)
+	if (expectedLength !== undefined && value.length !== expectedLength) throw new Error(`Array length was ${ value.length }, expected ${ expectedLength }`)
+	return value
+}
+
+async function extractEIP712Value(ethereumClientService: EthereumClientService, requestAbortController: AbortController | undefined, depth: number, value: unknown, parsedType: ParsedEIP712Type, types: { [x: string]: readonly { readonly name: string, readonly type: string}[] | undefined }, useLocalStorage: boolean): Promise<EnrichedEIP712MessageRecord> {
+	if (!parsedType.valid) throw new Error('EIP712 type contained an invalid array dimension')
+	if (parsedType.arrayDimensions.length > 1) {
+		const arrayValue = parseEIP712Array(value, parsedType.arrayDimensions[0])
+		const nestedType = { baseType: parsedType.baseType, arrayDimensions: parsedType.arrayDimensions.slice(1), valid: true }
+		return { type: 'nestedArray', value: await promiseAllMapAbortSafe(arrayValue, (nestedValue) => extractEIP712Value(ethereumClientService, requestAbortController, depth, nestedValue, nestedType, types, useLocalStorage)) }
+	}
+	if (SolidityType.test(parsedType.baseType)) {
+		if (parsedType.arrayDimensions.length === 1) parseEIP712Array(value, parsedType.arrayDimensions[0])
+		return parseSolidityValueByTypeEnriched(ethereumClientService, requestAbortController, parsedType.baseType, value, parsedType.arrayDimensions.length === 1, useLocalStorage)
+	}
+	if (parsedType.arrayDimensions.length === 1) {
+		const arrayValue = parseEIP712Array(value, parsedType.arrayDimensions[0])
+		return { type: 'record[]', value: await promiseAllMapAbortSafe(arrayValue, (nestedValue) => {
+			if (!JSONEncodeableObject.test(nestedValue)) throw new Error('EIP712 record array contained a non-record value')
+			return extractEIP712MessageSubset(ethereumClientService, requestAbortController, depth + 1, nestedValue, parsedType.baseType, types, useLocalStorage)
+		}) }
+	}
+	if (!JSONEncodeableObject.test(value)) throw new Error(`Not a JSON record: ${ value }`)
+	return { type: 'record', value: await extractEIP712MessageSubset(ethereumClientService, requestAbortController, depth + 1, value, parsedType.baseType, types, useLocalStorage) }
 }
 
 async function extractEIP712MessageSubset(ethereumClientService: EthereumClientService, requestAbortController: AbortController | undefined, depth: number, message: JSONEncodeableObject, currentType: string, types: { [x: string]: readonly { readonly name: string, readonly type: string}[] | undefined }, useLocalStorage = true): Promise<EnrichedEIP712Message> {
@@ -60,22 +99,7 @@ async function extractEIP712MessageSubset(ethereumClientService: EthereumClientS
 		if (messageEntry === undefined) throw new Error(`Subtype not found: ${ key }`)
 		const fullType = findType(key, currentTypes)
 		if (fullType === undefined) throw new Error(`Type not found for key: ${ key }`)
-		const arraylessType = separateArraySuffix(fullType)
-		if (SolidityType.test(arraylessType.arraylessType)) {
-			return [key, await parseSolidityValueByTypeEnriched(ethereumClientService, requestAbortController, SolidityType.parse(arraylessType.arraylessType), messageEntry, arraylessType.isArray, useLocalStorage)]
-		}
-		if (arraylessType.isArray) {
-			const jsonEncodeableArray = JSONEncodeableObjectArray.safeParse(messageEntry)
-			if (!jsonEncodeableArray.success) throw new Error(`Type was defined to be an array but it was not: ${ messageEntry }`)
-			const currentType = arraylessType.arraylessType
-			if (currentType === undefined) throw new Error(`array's type is missing`)
-			return [key, { type: 'record[]', value: await promiseAllMapAbortSafe(jsonEncodeableArray.value, (subSubMessage) => {
-				if (JSONEncodeableObject.test(subSubMessage)) return extractEIP712MessageSubset(ethereumClientService, requestAbortController, depth + 1, subSubMessage, currentType, types, useLocalStorage)
-				throw new Error('Too deep EIP712 message (object)')
-			}) }]
-		}
-		if (!JSONEncodeableObject.test(messageEntry)) throw new Error(`Not a JSON type: ${ messageEntry }`)
-		return [key, { type: 'record', value: await extractEIP712MessageSubset(ethereumClientService, requestAbortController, depth + 1, messageEntry, fullType, types, useLocalStorage) }]
+		return [key, await extractEIP712Value(ethereumClientService, requestAbortController, depth, messageEntry, parseEIP712Type(fullType), types, useLocalStorage)]
 	})
 	return pairArray.reduce((accumulator, [key, value]) => ({ ...accumulator, [key]: value }), {} as Promise<EnrichedEIP712Message>)
 }

--- a/app/ts/utils/eip712Parsing.ts
+++ b/app/ts/utils/eip712Parsing.ts
@@ -10,9 +10,12 @@ function findType(name: string, types: readonly { readonly name: string, readonl
 }
 
 function separateArraySuffix(typeWithMaybeArraySuffix: string) {
-	const splitted = typeWithMaybeArraySuffix.split('[]')
-	if (splitted.length === 1) return { arraylessType: typeWithMaybeArraySuffix, isArray: false }
-	return { arraylessType: splitted[0], isArray: true }
+	const arrayMatch = /^(.*)\[(\d*)\]$/.exec(typeWithMaybeArraySuffix)
+	if (arrayMatch === null) return { arraylessType: typeWithMaybeArraySuffix, isArray: false, expectedLength: undefined }
+	const arraylessType = arrayMatch[1]
+	const lengthText = arrayMatch[2]
+	if (arraylessType === undefined || lengthText === undefined) return { arraylessType: typeWithMaybeArraySuffix, isArray: false, expectedLength: undefined }
+	return { arraylessType, isArray: true, expectedLength: lengthText === '' ? undefined : Number.parseInt(lengthText, 10) }
 }
 
 function validateEIP712TypesSubset(depth: number, message: JSONEncodeableObject, currentType: string, types: { [x: string]: readonly { readonly name: string, readonly type: string}[] | undefined }): boolean {
@@ -27,6 +30,7 @@ function validateEIP712TypesSubset(depth: number, message: JSONEncodeableObject,
 		if (subMessage === undefined) return false
 		const arraylessType = separateArraySuffix(fullType)
 		if (arraylessType.isArray !== Array.isArray(subMessage)) return false
+		if (Array.isArray(subMessage) && arraylessType.expectedLength !== undefined && subMessage.length !== arraylessType.expectedLength) return false
 		const currentType = arraylessType.arraylessType
 		if (SolidityType.test(currentType)) continue
 		if (currentType === undefined) return false

--- a/app/ts/utils/websiteData.ts
+++ b/app/ts/utils/websiteData.ts
@@ -37,7 +37,7 @@ const websiteMetaData: WebsiteMetaData = {
 		name: 'Octant',
 		externalRpc: true,
 	},
-	'app.aave.com/': {
+	'app.aave.com': {
 		name: 'Aave',
 		externalRpc: true,
 	},

--- a/test/tests/signTypedData.test.ts
+++ b/test/tests/signTypedData.test.ts
@@ -85,9 +85,9 @@ describe('EIP712', () => {
 		const verification = verifyEip712Message(JSON.parse(extraType))
 		assert.equal(verification.valid, true)
 	})
-	test('can verify missingChainId message', () => {
+	test('rejects a domain missing a field declared in its type', () => {
 		const verification = verifyEip712Message(JSON.parse(missingChainId))
-		assert.equal(verification.valid, true)
+		assert.equal(verification.valid, false)
 	})
 	test('can verify hasArray message', () => {
 		const verification = verifyEip712Message(JSON.parse(hasArray))
@@ -105,9 +105,9 @@ describe('EIP712', () => {
 		const verification = verifyEip712Message(JSON.parse(chainIdOverFlow))
 		assert.deepEqual(verification, { valid: false, reason: 'EIP712Domain.chainId is in wrong type' })
 	})
-	test('can not verify hasTooLongFixedArray message', () => {
+	test('rejects fixed arrays that are shorter than their declared length', () => {
 		const verification = verifyEip712Message(JSON.parse(hasTooLongFixedArray))
-		assert.equal(verification.valid, true)
+		assert.equal(verification.valid, false)
 	})
 	test('can not verify fixedArrayOverload message', () => {
 		const verification = verifyEip712Message(JSON.parse(fixedArrayOverload))
@@ -141,13 +141,36 @@ describe('EIP712', () => {
 		const parsed = EIP712Message.parse(d2Array)
 		assert.deepEqual(verifyEip712Message(parsed), { valid: true })
 	})
-	test('can verify d2ArrayFixed message', () => {
+	test('rejects multidimensional fixed arrays with undersized inner arrays', () => {
 		const parsed = EIP712Message.parse(d2ArrayFixed)
-		assert.deepEqual(verifyEip712Message(parsed), { valid: true })
+		assert.equal(verifyEip712Message(parsed).valid, false)
 	})
 	test('can verify d3ArrayFixed message', () => {
 		const parsed = EIP712Message.parse(d3ArrayFixed)
 		assert.deepEqual(verifyEip712Message(parsed), { valid: true })
+	})
+	test('validates multidimensional fixed arrays from the outermost dimension', () => {
+		const parsed = JSON.parse(hasFixedArray)
+		parsed.types.Mail[2].type = 'string[2][1]'
+		parsed.message.contents = [['first', 'second']]
+		assert.deepEqual(verifyEip712Message(parsed), { valid: true })
+	})
+	test('rejects messages missing a required nested field', () => {
+		const parsed = JSON.parse(hasFixedArray)
+		delete parsed.message.from.wallet
+		assert.equal(verifyEip712Message(parsed).valid, false)
+	})
+	test('rejects messages missing a required top-level field', () => {
+		const parsed = JSON.parse(hasFixedArray)
+		delete parsed.message.contents
+		assert.equal(verifyEip712Message(parsed).valid, false)
+	})
+	test('reports invalid domain field order as a validation failure', () => {
+		const parsed = JSON.parse(hasFixedArray)
+		const firstDomainField = parsed.types.EIP712Domain[0]
+		parsed.types.EIP712Domain[0] = parsed.types.EIP712Domain[1]
+		parsed.types.EIP712Domain[1] = firstDomainField
+		assert.deepEqual(verifyEip712Message(parsed), { valid: false, reason: 'EIP712Domain types are in the wrong order' })
 	})
 	test('can validate safeTx message', () => {
 		const parsed = EIP712Message.parse(safeTx)
@@ -159,6 +182,10 @@ describe('EIP712', () => {
 	})
 	test('can validate openSea message', () => {
 		const parsed = EIP712Message.parse(openSeaWithTotalOriginalConsiderationItems)
+		assert.equal(validateEIP712Types(parsed), true)
+	})
+	test('can validate a fixed-size primitive array for visualization', () => {
+		const parsed = EIP712Message.parse(hasFixedArray)
 		assert.equal(validateEIP712Types(parsed), true)
 	})
 

--- a/test/tests/signTypedData.test.ts
+++ b/test/tests/signTypedData.test.ts
@@ -5,7 +5,8 @@ import * as assert from 'assert'
 import { stringifyJSONWithBigInts } from '../../app/ts/utils/bigint.js'
 import { MockRequestHandler } from '../MockRequestHandler.js'
 import { EthereumClientService } from '../../app/ts/simulation/services/EthereumClientService.js'
-import { EIP712Message } from '../../app/ts/types/eip721.js'
+import { EIP712Message, EnrichedEIP712 } from '../../app/ts/types/eip721.js'
+import { serialize } from '../../app/ts/types/wire-types.js'
 import { getMessageAndDomainHash, verifyEip712Message } from '../../app/ts/utils/eip712.js'
 import { canVerifyStructArray, chainIdIsNotDefined, chainIdOverFlow, d2Array, d2ArrayFixed, d3ArrayFixed, duplicateType, eip712Example, eip721DomainMissing, extraType, fixedArrayOverload, hasArray, hasFixedArray, hasTooLongFixedArray, missingChainId, openSeaWithTotalOriginalConsiderationItems, permit2Message, permit2MessageHexChainId, permit2MessageNumberChainId, primarytypeIsWrong, safeTx, smallOverFlow, structNotDefined, tupleSupport, typeMissmatch, unknownExtraField, unknownExtraField2 } from './data/eip712Data.js'
 import { jsonParserWithNumbersAsStringsConverter } from '../../app/ts/utils/json.js'
@@ -188,6 +189,36 @@ describe('EIP712', () => {
 		const parsed = EIP712Message.parse(hasFixedArray)
 		assert.equal(validateEIP712Types(parsed), true)
 	})
+	test('can validate a multidimensional dynamic array for visualization', () => {
+		const parsed = EIP712Message.parse(d2Array)
+		assert.equal(validateEIP712Types(parsed), true)
+	})
+	test('validates every dimension of a multidimensional fixed array for visualization', () => {
+		assert.equal(validateEIP712Types(EIP712Message.parse(d2ArrayFixed)), false)
+		assert.equal(validateEIP712Types(EIP712Message.parse(d3ArrayFixed)), true)
+	})
+	test('rejects malformed fixed array dimensions for visualization', () => {
+		const parsed = JSON.parse(d2Array)
+		parsed.message.contents = []
+		for (const invalidType of ['string[0]', 'string[00]', 'string[01]', 'string[1][0]', 'string[1][00]', 'string[1][01]']) {
+			parsed.types.Mail[2].type = invalidType
+			assert.equal(validateEIP712Types(EIP712Message.parse(JSON.stringify(parsed))), false)
+		}
+
+		parsed.types.Mail[2].type = 'string[]'
+		assert.equal(validateEIP712Types(EIP712Message.parse(JSON.stringify(parsed))), true)
+	})
+	test('does not treat malformed array suffixes as struct names for visualization', () => {
+		const parsed = JSON.parse(d2Array)
+		parsed.types['Person[abc]'] = parsed.types.Person
+		parsed.message.contents = parsed.message.from
+		parsed.types.Mail[2].type = 'Person[abc]'
+		assert.equal(validateEIP712Types(EIP712Message.parse(JSON.stringify(parsed))), false)
+
+		parsed.message.contents = [parsed.message.from]
+		parsed.types.Mail[2].type = 'Person[abc][]'
+		assert.equal(validateEIP712Types(EIP712Message.parse(JSON.stringify(parsed))), false)
+	})
 
 	test('can extract safeTx message', async () => {
 		const parsed = EIP712Message.parse(safeTx)
@@ -210,6 +241,19 @@ describe('EIP712', () => {
 		const parsed = EIP712Message.parse(permit2MessageNumberChainId)
 		const enrichedMessage = stringifyJSONWithBigInts(await extractEIP712Message(ethereum, undefined, parsed, false))
 		assert.equal(enrichedMessage, expectedPermit2)
+	})
+	test('can extract a multidimensional dynamic array', async () => {
+		const parsed = EIP712Message.parse(d2Array)
+		const enrichedMessage = await extractEIP712Message(ethereum, undefined, parsed, false)
+		const serializedMessage = serialize(EnrichedEIP712, enrichedMessage)
+		assert.deepEqual(EnrichedEIP712.parse(serializedMessage), enrichedMessage)
+		assert.deepEqual(enrichedMessage.message.contents, {
+			type: 'nestedArray',
+			value: [
+				{ type: 'string[]', value: ['Hello, Bob!'] },
+				{ type: 'string[]', value: ['Hello'] },
+			],
+		})
 	})
 	test('can extract openSea message', async () => {
 		const parsed = EIP712Message.parse(openSeaWithTotalOriginalConsiderationItems)

--- a/test/tests/tooltipAndDynamicScroller.test.ts
+++ b/test/tests/tooltipAndDynamicScroller.test.ts
@@ -1,0 +1,55 @@
+import * as assert from 'assert'
+import { signal } from '@preact/signals'
+import { describe, test } from 'bun:test'
+import { getDynamicScrollOffset } from '../../app/ts/components/subcomponents/DynamicScroller.js'
+import { scheduleTooltipDismissal, type TooltipConfig } from '../../app/ts/components/subcomponents/Tooltip.js'
+
+describe('tooltip dismissal', () => {
+	test('does not let an older timer dismiss newer tooltip content', () => {
+		const firstConfig: TooltipConfig = { message: 'first', x: 0, y: 0 }
+		const secondConfig: TooltipConfig = { message: 'second', x: 0, y: 0 }
+		const config = signal<TooltipConfig | undefined>(firstConfig)
+		let scheduledCallback: (() => void) | undefined
+		let cancelledTimer: number | undefined
+		const cleanup = scheduleTooltipDismissal(
+			config,
+			firstConfig,
+			(callback) => {
+				scheduledCallback = callback
+				return 7
+			},
+			(timer) => { cancelledTimer = timer },
+		)
+
+		config.value = secondConfig
+		scheduledCallback?.()
+		assert.equal(config.value, secondConfig)
+		cleanup()
+		assert.equal(cancelledTimer, 7)
+	})
+
+	test('honors an explicit zero duration', () => {
+		const activeConfig: TooltipConfig = { message: 'brief', x: 0, y: 0, duration: 0 }
+		const config = signal<TooltipConfig | undefined>(activeConfig)
+		let scheduledDuration: number | undefined
+		scheduleTooltipDismissal(config, activeConfig, (_callback, duration) => {
+			scheduledDuration = duration
+			return 1
+		})
+		assert.equal(scheduledDuration, 0)
+	})
+})
+
+describe('dynamic scrolling offset', () => {
+	test('does not translate a short list above the viewport', () => {
+		assert.equal(getDynamicScrollOffset(0, 40, 2, 10), 0)
+	})
+
+	test('keeps the offset stable before item measurements are available', () => {
+		assert.equal(getDynamicScrollOffset(0, 0, 2, Number.POSITIVE_INFINITY), 0)
+	})
+
+	test('clamps the requested offset to the final full viewport', () => {
+		assert.equal(getDynamicScrollOffset(8, 40, 10, 4), 240)
+	})
+})

--- a/test/tests/utils.bigint.test.ts
+++ b/test/tests/utils.bigint.test.ts
@@ -1,4 +1,4 @@
-import { bigintToRoundedPrettyDecimalString } from '../../app/ts/utils/bigint.js'
+import { bigintToRoundedPrettyDecimalString, calculateWeightedPercentile } from '../../app/ts/utils/bigint.js'
 import { describe, test } from 'bun:test'
 import * as assert from 'assert'
 
@@ -13,4 +13,15 @@ describe('utils.bigint', () => {
 	test('display -2345.67 ETH', () => assert.equal(bigintToRoundedPrettyDecimalString(-234567n * 10n ** 16n, 18n, 4), '-2345.67'))
 	test('display -0.2346 ETH', () => assert.equal(bigintToRoundedPrettyDecimalString(-234567n * 10n ** 12n, 18n, 4), '-0.2346'))
 	test('display -10k ETH', () => assert.equal(bigintToRoundedPrettyDecimalString(-(10n ** 22n), 18n, 4), '-10k'))
+	test('calculates the highest weighted percentile without indexing past the data', () => {
+		assert.equal(calculateWeightedPercentile([{ dataPoint: 10n, weight: 1n }], 100n), 10n)
+		assert.equal(calculateWeightedPercentile([
+			{ dataPoint: 10n, weight: 1n },
+			{ dataPoint: 20n, weight: 3n },
+		], 25n), 10n)
+		assert.equal(calculateWeightedPercentile([
+			{ dataPoint: 10n, weight: 1n },
+			{ dataPoint: 20n, weight: 3n },
+		], 26n), 20n)
+	})
 })

--- a/test/tests/websiteData.test.ts
+++ b/test/tests/websiteData.test.ts
@@ -1,0 +1,12 @@
+import * as assert from 'assert'
+import { describe, test } from 'bun:test'
+import { getWebsiteWarningMessage } from '../../app/ts/utils/websiteData.js'
+
+describe('website warning metadata', () => {
+	test('finds the Aave warning by its hostname origin', () => {
+		assert.deepEqual(getWebsiteWarningMessage('app.aave.com', true), {
+			message: 'Aave relies on a centralized RPC connection which causes The Interceptor\'s Simulation Mode to not work properly with this site.',
+			suggestedAlternative: undefined,
+		})
+	})
+})

--- a/test/tests/wireTypesTimestamp.test.ts
+++ b/test/tests/wireTypesTimestamp.test.ts
@@ -1,0 +1,20 @@
+import * as assert from 'assert'
+import { describe, test } from 'bun:test'
+import { EthereumTimestamp } from '../../app/ts/types/wire-types.js'
+
+describe('EthereumTimestamp', () => {
+	test('rejects empty and out-of-range hexadecimal timestamps', () => {
+		assert.equal(EthereumTimestamp.safeParse('0x').success, false)
+		assert.equal(EthereumTimestamp.safeParse('0xffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff').success, false)
+	})
+
+	test('rejects invalid and pre-epoch dates during serialization', () => {
+		assert.throws(() => EthereumTimestamp.serialize(new Date(Number.NaN)))
+		assert.throws(() => EthereumTimestamp.serialize(new Date(-1)))
+	})
+
+	test('round trips valid timestamps', () => {
+		const date = new Date('2024-01-01T00:00:00.000Z')
+		assert.deepEqual(EthereumTimestamp.parse(EthereumTimestamp.serialize(date)), date)
+	})
+})


### PR DESCRIPTION
## Summary

This PR fixes the ten boundary and validation bugs found during the codebase audit:

1. **EIP-712 fixed-array lengths:** Rejects arrays that are shorter or longer than their declared fixed length instead of accepting undersized values.
2. **EIP-712 required fields:** Rejects primary, domain, and nested struct values when fields declared by their type are missing.
3. **EIP-712 multidimensional arrays:** Descends through dimensions from the correct outermost, rightmost suffix so unequal dimensions are validated in the proper order.
4. **EIP-712 visualization compatibility:** Recognizes one-dimensional fixed-array suffixes during typed-data visualization instead of accepting them at verification and rejecting them later.
5. **EIP-712 domain ordering:** Returns a normal validation failure for incorrectly ordered domain fields instead of throwing an internal exception.
6. **Weighted percentiles:** Replaces shifted cumulative-weight indexing with weighted bucket selection so the 100th percentile cannot index past the dataset.
7. **Ethereum timestamps:** Rejects empty and out-of-range hexadecimal timestamps, invalid `Date` values, and dates before the Unix epoch.
8. **Aave warning metadata:** Corrects the stored key from `app.aave.com/` to the hostname origin `app.aave.com`, allowing its simulation-mode warning to appear.
9. **Tooltip timer races:** Cancels obsolete dismissal timers, prevents an older timer from clearing newer tooltip content, and honors an explicit zero duration.
10. **Dynamic scrolling offsets:** Clamps short-list offsets to zero and guards the unmeasured state so address-book entries are not translated above the viewport or assigned invalid offsets.

Focused regression tests cover every corrected behavior, including malformed and valid EIP-712 cases, percentile boundaries, timestamp codecs, website metadata lookup, tooltip scheduling, and virtual scrolling calculations.

## Review follow-up

The multidimensional EIP-712 review finding is addressed end to end:

- Parses every array suffix in outer-to-inner order, including mixed dynamic and fixed dimensions.
- Recursively validates all dimensions and rejects zero, leading-zero, and malformed bracket suffixes.
- Recursively extracts multidimensional primitive and struct arrays without flattening their shape or treating inner arrays as structs.
- Adds a recursive `nestedArray` enriched-message variant, wire-codec support, and PersonalSign rendering.
- Adds regressions for `string[][]`, valid and invalid multidimensional fixed arrays, malformed dimension syntax, malicious struct-name collisions, extraction shape, and codec round trips.

## Validation

- `bun run test` — passed, including 49 EIP-712 tests
- `bun run setup-chrome` — passed
- `bun run typecheck` — passed
- `bun run lint` — passed

`bun run test:chrome-communication` was not run because these changes do not affect extension messaging or content-script registration.

## Review

The project reviewer’s final pass scored the diff **95/100** and reported no High, Medium, or Low findings. Earlier passes identified an isolated codec-test mismatch and malformed array-dimension edge cases; all were fixed and re-reviewed.
