### PR TITLE
Fix UI and JSON-RPC boundary bugs

### DIFF
--- a/app/ts/background/settings.ts
+++ b/app/ts/background/settings.ts
@@ -222,9 +222,10 @@ export async function exportSettingsAndAddressBook(): Promise<ExportedSettings> 
 }
 
 export async function importSettingsAndAddressBook(exportedSetings: ExportedSettings) {
-	if (exportedSetings.version === '1.3') {
+	if (exportedSetings.version === '1.3' || exportedSetings.version === '1.4') {
 		await setPage(exportedSetings.settings.openedPage)
-	} else if (exportedSetings.version === '1.0') {
+	}
+	if (exportedSetings.version === '1.0') {
 		await changeSimulationMode({
 			simulationMode: exportedSetings.settings.simulationMode,
 			rpcNetwork: defaultRpcs[0],

--- a/app/ts/components/subcomponents/ChainSelector.tsx
+++ b/app/ts/components/subcomponents/ChainSelector.tsx
@@ -29,13 +29,17 @@ interface ChainSelectorParams {
 	buttonClassses: string
 }
 
+export function findChainEntryByName(chains: readonly ChainEntry[], chainName: string) {
+	return chains.find((chainEntry) => chainEntry.name === chainName)
+}
+
 export function ChainSelector(params: ChainSelectorParams) {
 	const chains = useComputed(() => rpcEntriesToChainEntriesWithAllChainsEntry(params.rpcEntries.value))
 	const options = useComputed(() => chains.value.map((entry) => entry.name))
 	const selected = useComputed(() => chains.value.find((chainEntry) => chainEntry.chainId === params.chainId.value)?.name || 'No Chain Selected')
-	const onChangedCallBack = (rpcName: string) => {
-		const newEntry = params.rpcEntries.value.find((rpcEntry) => rpcEntry.name === rpcName)
-		if (newEntry === undefined) throw new Error(`Tried to change chain that does not exist: ${ rpcName }`)
+	const onChangedCallBack = (chainName: string) => {
+		const newEntry = findChainEntryByName(chains.value, chainName)
+		if (newEntry === undefined) throw new Error(`Tried to change chain that does not exist: ${ chainName }`)
 		params.changeChain(newEntry)
 	}
 	return <DropDownMenu selected = { selected } dropDownOptions = { options } onChangedCallBack = { onChangedCallBack } buttonClassses = { params.buttonClassses }/>

--- a/app/ts/components/subcomponents/ConfigureRpcConnection.tsx
+++ b/app/ts/components/subcomponents/ConfigureRpcConnection.tsx
@@ -3,7 +3,7 @@ import { useComputed, useSignal, useSignalEffect } from '@preact/signals'
 import { useContext, useRef } from 'preact/hooks'
 import { useAsyncState } from '../../utils/preact-utilities.js'
 import { TextInput } from './TextField.js'
-import { RpcEntry } from '../../types/rpc.js'
+import type { RpcEntry } from '../../types/rpc.js'
 import { sendPopupMessageToBackgroundPage } from '../../background/backgroundUtils.js'
 import { getSettings } from '../../background/settings.js'
 import { getChainName } from '../../utils/constants.js'
@@ -14,6 +14,7 @@ import { JsonRpcResponseError } from '../../utils/errors.js'
 import { EthereumQuantity } from '../../types/wire-types.js'
 import { isBrowserFetchTransportError } from '../../utils/caughtErrors.js'
 import { AsyncStatusIcon } from './AsyncAction.js'
+import { parseRpcFormData } from '../../utils/rpcFormData.js'
 
 type RpcProbeResult = {
 	chainId: bigint
@@ -198,24 +199,6 @@ const ConfigureRpcForm = ({ defaultValues, onCancel, onSave, onRemove }: Configu
 					}
 			}
 		}
-	}
-
-	const parseRpcFormData = (formData: FormData) => {
-		const chainIdFromForm = formData.get('chainId')?.toString().trim()
-		const blockExplorerUrlForm = formData.get('blockExplorerUrl')?.toString().trim()
-		const blockExplorerApiKeyForm = formData.get('blockExplorerApiKey')?.toString().trim()
-		const isBlockExplorerDefined = blockExplorerUrlForm !== undefined && blockExplorerApiKeyForm !== undefined && blockExplorerUrlForm.length > 0 && blockExplorerApiKeyForm.length > 0
-		const newRpcEntry = {
-			name: formData.get('name')?.toString().trim() || '',
-			chainId: chainIdFromForm ? `0x${ BigInt(chainIdFromForm).toString(16) }` : '',
-			httpsRpc: formData.get('httpsRpc')?.toString().trim() || '',
-			currencyName: formData.get('currencyName')?.toString().trim() || '',
-			currencyTicker: formData.get('currencyTicker')?.toString().trim() || '',
-			...isBlockExplorerDefined ? { blockExplorer: { apiUrl: blockExplorerUrlForm || '', apiKey: blockExplorerApiKeyForm } } : {},
-			minimized: true,
-			primary: false,
-		}
-		return RpcEntry.safeParse(newRpcEntry)
 	}
 
 	const chainIdDefault = useComputed(() => {

--- a/app/ts/components/subcomponents/DropDownMenu.tsx
+++ b/app/ts/components/subcomponents/DropDownMenu.tsx
@@ -36,14 +36,14 @@ export const DropDownMenu = <OptionType extends string,>({ selected, dropDownOpt
 
 	return <div ref = { ref } class = { `dropdown ${ isOpen.value ? 'is-active' : '' }` }>
 		<div class = 'dropdown-trigger' style = { { maxWidth: '100%' } }>
-			<button class = { buttonClassses } disabled = { disabled } aria-haspopup = 'true' aria-controls = 'dropdown-menu' onClick = { toggle } title = { selected.value } style = { { width: '100%' } }>
+			<button type = 'button' class = { buttonClassses } disabled = { disabled } aria-haspopup = 'true' aria-controls = 'dropdown-menu' onClick = { toggle } title = { selected.value } style = { { width: '100%' } }>
 				<DropDownMenuButtonContent label = { selected.value }/>
 			</button>
 		</div>
 		<div class = 'dropdown-menu' id = 'dropdown-menu' role = 'menu' style = { { right: '0' } }>
 			<div class = 'dropdown-content' style = { { right: '0' } }> {
 				dropDownOptions.value.map((option) => <>
-					<button type = { buttonClassses } class = { `dropdown-item ${ option === selected.value ? 'is-active' : '' }` } onClick = { () => onChanged(option) } >
+					<button type = 'button' class = { `dropdown-item ${ option === selected.value ? 'is-active' : '' }` } onClick = { () => onChanged(option) } >
 						{ option }
 					</button>
 				</>)

--- a/app/ts/components/subcomponents/InlineCard.tsx
+++ b/app/ts/components/subcomponents/InlineCard.tsx
@@ -36,7 +36,7 @@ export const InlineCard = (props: InlineCardProps) => {
 
 	return (
 		<span class = 'inline-card' role = 'figure' style = { props.style } title = { props.label }>
-			{ props.warningMessage ? <WarningSign /> : <></> }
+			{ props.warningMessage ? <WarningSign message = { props.warningMessage } /> : <></> }
 			<span role = 'img'><Icon /></span>
 			<data class = 'truncate text-legible' style = { props.style } value = { props.label }>{ props.label }</data>
 			<span role = 'menu' aria-hidden = { props.nonInteractive } aria-label = { props.noExpandButtons || props.nonInteractive ? undefined : 'Spell-out actions' }>
@@ -79,7 +79,7 @@ export const InlineCard = (props: InlineCardProps) => {
 					</button>
 				) : <></> }
 			</span>
-			{ props.warningMessage ? <WarningSign /> : <></> }
+			{ props.warningMessage ? <WarningSign message = { props.warningMessage } /> : <></> }
 			<Tooltip config = { tooltip } />
 		</span>
 	)

--- a/app/ts/components/subcomponents/TimePicker.tsx
+++ b/app/ts/components/subcomponents/TimePicker.tsx
@@ -11,6 +11,8 @@ const timePickerDeltaOptions = ['Seconds', 'Minutes', 'Hours', 'Days', 'Weeks', 
 export type DeltaUnit = typeof timePickerDeltaOptions[number]
 export type TimePickerMode = typeof timePickerModeDownOptions[number]
 
+export const parseTimePickerDeltaValue = (value: string) => /^[0-9]+$/.test(value) ? BigInt(value) : undefined
+
 export const getTimeManipulatorFromSignals = (timeSelectorMode: TimePickerMode, timeSelectorAbsoluteTime: Date | undefined, timeSelectorDeltaValue: bigint, timeSelectorDeltaUnit: DeltaUnit) => {
 	switch(timeSelectorMode) {
 		case 'No Delay': return { type: 'No Delay' } as const
@@ -49,7 +51,7 @@ const TimePickerModeViews = ({ mode, absoluteTime, timePickerDeltaOptionsSignal,
 		case 'No Delay': return <></>
 		case 'Until': return <input type = 'datetime-local' disabled = { disabled } class = 'timepicker-datetime-local' value = { formatDateToLocalDateTimeValue(absoluteTime.value) } onInput = { absoluteTimeChanged } />
 		case 'For': return <div>
-			<input class = 'input' disabled = { disabled } style = 'width: 50px; margin-right: 10px; vertical-align: unset; text-align: center;' type = 'number' value = { Number(deltaValue.value) } onInput = { changeDeltaValue } />
+			<input class = 'input' disabled = { disabled } style = 'width: 50px; margin-right: 10px; vertical-align: unset; text-align: center;' type = 'number' value = { deltaValue.value?.toString() ?? '' } onInput = { changeDeltaValue } />
 			<DropDownMenu selected = { deltaUnit } dropDownOptions = { timePickerDeltaOptionsSignal } onChangedCallBack = { changeDeltaUnit } buttonClassses = { 'btn btn--outline is-small' } disabled = { disabled }/>
 		</div>
 		default: assertNever(mode.value)
@@ -110,14 +112,14 @@ export const TimePicker = ({ mode, absoluteTime, deltaValue, deltaUnit, onChange
 	const changeDeltaValue = (event: JSX.TargetedInputEvent<HTMLInputElement>) => {
 		if (disabled) return
 		event.preventDefault()
-		const sanitized = event.currentTarget.value.replace(/[^0-9.]/g, '')
-		if (sanitized.length === 0 || Number.isNaN(parseInt(sanitized))) {
+		const parsedValue = parseTimePickerDeltaValue(event.currentTarget.value)
+		if (parsedValue === undefined) {
 			temporaryDeltaValue.value = undefined
 			event.currentTarget.value = ''
 			return
 		}
-		temporaryDeltaValue.value = BigInt(parseInt(sanitized))
-		event.currentTarget.value = temporaryDeltaValue.value.toString()
+		temporaryDeltaValue.value = parsedValue
+		event.currentTarget.value = parsedValue.toString()
 	}
 
 	const hasValuesChanged = useComputed(() => {

--- a/app/ts/simulation/services/EthereumSubscriptionService.ts
+++ b/app/ts/simulation/services/EthereumSubscriptionService.ts
@@ -139,7 +139,7 @@ export async function getEthFilterChanges(filterId: string, ethereumClientServic
 	const filtersAndSubscriptions = await getEthereumSubscriptionsAndFilters()
 	const filter = filtersAndSubscriptions.find((subscriptionOrfilter) => subscriptionOrfilter.subscriptionOrFilterId === filterId)
 	if (filter === undefined || filter.type !== 'eth_newFilter') return undefined
-	if (filter.params.params[0].blockhash !== undefined) throw new Error('blockhash not supported for this method')
+	if (filter.params.params[0].blockHash !== undefined) throw new Error('blockHash not supported for this method')
 	const calledInlastBlock = await getSimulatedBlockNumber(ethereumClientService, requestAbortController, simulationState)
 	const logs = calledInlastBlock > filter.calledInlastBlock
 		? await getSimulatedLogs(ethereumClientService, requestAbortController, simulationState, { ...filter.params.params[0], fromBlock: filter.calledInlastBlock + 1n, toBlock: calledInlastBlock })
@@ -154,6 +154,6 @@ export async function getEthFilterLogs(filterId: string, ethereumClientService: 
 	const filtersAndSubscriptions = await getEthereumSubscriptionsAndFilters()
 	const filter = filtersAndSubscriptions.find((filter) => filter.subscriptionOrFilterId === filterId)
 	if (filter === undefined || filter.type !== 'eth_newFilter') return undefined
-	if (filter.params.params[0].blockhash !== undefined) throw new Error('blockhash not supported for this method')
+	if (filter.params.params[0].blockHash !== undefined) throw new Error('blockHash not supported for this method')
 	return await getSimulatedLogs(ethereumClientService, requestAbortController, simulationState, filter.params.params[0])
 }

--- a/app/ts/simulation/services/SimulationModeEthereumClientService.ts
+++ b/app/ts/simulation/services/SimulationModeEthereumClientService.ts
@@ -257,12 +257,14 @@ const resolveSimulationBlockTag = (
 	return blockTag
 }
 
+const isNodeOnlyBlockTag = (blockTag: EthereumBlockTag): blockTag is 'earliest' | 'safe' | 'finalized' => blockTag === 'earliest' || blockTag === 'safe' || blockTag === 'finalized'
+
 const canQueryNodeDirectlyFromInput = (
 	baseBlockNumber: bigint,
 	executionBlockCount: number,
 	blockTag: EthereumBlockTag = 'latest',
 ) => {
-	if (blockTag === 'finalized') return true
+	if (isNodeOnlyBlockTag(blockTag)) return true
 	if (executionBlockCount === 0) return true
 	if (typeof blockTag === 'bigint' && blockTag <= baseBlockNumber) return true
 	return false
@@ -306,7 +308,7 @@ export function getInputFieldFromDataOrInput(request: { input?: Uint8Array} | { 
 }
 
 export const getSimulatedTransactionCount = async (ethereumClientService: EthereumClientService, requestAbortController: AbortController | undefined, simulationState: ResolvedSimulationState, address: bigint, blockTag: EthereumBlockTag = 'latest') => {
-	if (blockTag === 'finalized' || simulationState.kind === 'passthrough') return await ethereumClientService.getTransactionCount(address, blockTag, requestAbortController)
+	if (isNodeOnlyBlockTag(blockTag) || simulationState.kind === 'passthrough') return await ethereumClientService.getTransactionCount(address, blockTag, requestAbortController)
 	const currentState = simulationState.value
 	if (currentState.success === false) throw new JsonRpcResponseError(currentState.jsonRpcError)
 	const blockNumToUseForSim = blockTag === 'latest' || blockTag === 'pending' ? currentState.blockNumber + BigInt(currentState.simulatedBlocks.length) : blockTag
@@ -935,7 +937,7 @@ export const getBaseFeeAdjustedTransactions = (
 }
 
 const canQueryNodeDirectly = async (simulationState: SimulationState, blockTag: EthereumBlockTag = 'latest') => {
-	if (blockTag === 'finalized'
+	if (isNodeOnlyBlockTag(blockTag)
 		|| (simulationState.success && simulationState.simulatedBlocks.length === 0)
 		|| (simulationState.success && typeof blockTag === 'bigint' && blockTag <= simulationState.blockNumber)
 	){
@@ -1349,9 +1351,9 @@ const simulatedCallWithPreparedInputContext = async (
 	blockTag: EthereumBlockTag = 'latest',
 	extraOverrides: StateOverrides = {},
 ) => {
-	if (blockTag === 'finalized') {
+	if (isNodeOnlyBlockTag(blockTag)) {
 		try {
-			return { result: await ethereumClientService.call(params, 'finalized', requestAbortController) }
+			return { result: await ethereumClientService.call(params, blockTag, requestAbortController) }
 		} catch(error: unknown) {
 			if (error instanceof JsonRpcResponseError) {
 				const safeParsedData = EthereumData.safeParse(error.data)
@@ -1618,7 +1620,7 @@ export async function getSimulatedBlock(ethereumClientService: EthereumClientSer
 export async function getSimulatedBlock(ethereumClientService: EthereumClientService, requestAbortController: AbortController | undefined, simulationState: ResolvedSimulationState, blockTag: EthereumBlockTag, fullObjects: boolean): Promise<EthereumBlockHeader | EthereumBlockHeaderWithTransactionHashes>
 export async function getSimulatedBlock(ethereumClientService: EthereumClientService, requestAbortController: AbortController | undefined, simulationState: ResolvedSimulationState, blockTag: EthereumBlockTag, fullObjects: false): Promise<EthereumBlockHeaderWithTransactionHashes>
 export async function getSimulatedBlock(ethereumClientService: EthereumClientService, requestAbortController: AbortController | undefined, simulationState: ResolvedSimulationState, blockTag: EthereumBlockTag = 'latest', fullObjects = true): Promise<EthereumBlockHeader | EthereumBlockHeaderWithTransactionHashes>  {
-	if (simulationState.kind === 'passthrough' || blockTag === 'finalized' || await canQueryNodeDirectly(simulationState.value, blockTag)) {
+	if (simulationState.kind === 'passthrough' || isNodeOnlyBlockTag(blockTag) || await canQueryNodeDirectly(simulationState.value, blockTag)) {
 		return await ethereumClientService.getBlock(requestAbortController, blockTag, fullObjects)
 	}
 	const currentState = simulationState.value
@@ -1683,9 +1685,9 @@ export const getSimulatedLogs = async (ethereumClientService: EthereumClientServ
 	const toBlock = 'toBlock' in logFilter && logFilter.toBlock !== undefined ? logFilter.toBlock : 'latest'
 	const fromBlock = 'fromBlock' in logFilter && logFilter.fromBlock !== undefined ? logFilter.fromBlock : 'latest'
 	if (toBlock === 'pending' || fromBlock === 'pending') return await ethereumClientService.getLogs(logFilter, requestAbortController)
+	if (isNodeOnlyBlockTag(toBlock) || isNodeOnlyBlockTag(fromBlock)) return await ethereumClientService.getLogs(logFilter, requestAbortController)
 	if ((fromBlock === 'latest' && toBlock !== 'latest') || (fromBlock !== 'latest' && toBlock !== 'latest' && fromBlock > toBlock )) throw new Error(`From block '${ fromBlock }' is later than to block '${ toBlock }' `)
 
-	if (toBlock === 'finalized' || fromBlock === 'finalized') return await ethereumClientService.getLogs(logFilter, requestAbortController)
 	const simulatedHead = currentState.blockNumber + BigInt(executionBlocks.length)
 	if ('blockHash' in logFilter) {
 		const executionBlock = executionBlocks.find((block) => logFilter.blockHash === block.blockHash)
@@ -1757,10 +1759,10 @@ export const getSimulatedTransactionByHash = async (ethereumClientService: Ether
 	return await ethereumClientService.getTransactionByHash(hash, requestAbortController)
 }
 
-const simulatedCall = async (ethereumClientService: EthereumClientService, requestAbortController: AbortController | undefined, simulationState: ResolvedSimulationState, params: Pick<IUnsignedTransaction1559, 'to' | 'maxFeePerGas' | 'maxPriorityFeePerGas' | 'input' | 'value'> & Partial<Pick<IUnsignedTransaction1559, 'from' | 'gasLimit'>>, blockTag: EthereumBlockTag = 'latest', extraOverrides: StateOverrides = {}) => {
-	if (blockTag === 'finalized') {
+export const simulatedCall = async (ethereumClientService: EthereumClientService, requestAbortController: AbortController | undefined, simulationState: ResolvedSimulationState, params: Pick<IUnsignedTransaction1559, 'to' | 'maxFeePerGas' | 'maxPriorityFeePerGas' | 'input' | 'value'> & Partial<Pick<IUnsignedTransaction1559, 'from' | 'gasLimit'>>, blockTag: EthereumBlockTag = 'latest', extraOverrides: StateOverrides = {}) => {
+	if (isNodeOnlyBlockTag(blockTag)) {
 		try {
-			return { result: await ethereumClientService.call(params, 'finalized', requestAbortController) }
+			return { result: await ethereumClientService.call(params, blockTag, requestAbortController) }
 		} catch(error: unknown) {
 			if (error instanceof JsonRpcResponseError) {
 				const safeParsedData = EthereumData.safeParse(error.data)

--- a/app/ts/types/JsonRpc-types.ts
+++ b/app/ts/types/JsonRpc-types.ts
@@ -23,16 +23,14 @@ export const EthGetStorageAtResponse = funtypes.Union(
 )
 
 export type EthGetLogsRequest = funtypes.Static<typeof EthGetLogsRequest>
-export const EthGetLogsRequest = funtypes.Intersect(
-	funtypes.Union(
-		funtypes.ReadonlyObject({ blockHash: EthereumBytes32 }).asReadonly(),
-		funtypes.Partial({ fromBlock: EthereumBlockTag, toBlock: EthereumBlockTag }).asReadonly(),
-	),
-	funtypes.Partial({
-		address: funtypes.Union(EthereumAddress, funtypes.ReadonlyArray(EthereumAddress), funtypes.Null),
-		topics: funtypes.ReadonlyArray(funtypes.Union(EthereumBytes32, funtypes.ReadonlyArray(EthereumBytes32), funtypes.Null)),
-	}).asReadonly()
-)
+export const EthGetLogsRequest = funtypes.ReadonlyPartial({
+	blockHash: EthereumBytes32,
+	blockhash: funtypes.Never,
+	fromBlock: EthereumBlockTag,
+	toBlock: EthereumBlockTag,
+	address: funtypes.Union(EthereumAddress, funtypes.ReadonlyArray(EthereumAddress), funtypes.Null),
+	topics: funtypes.ReadonlyArray(funtypes.Union(EthereumBytes32, funtypes.ReadonlyArray(EthereumBytes32), funtypes.Null)),
+}).withConstraint((logFilter) => logFilter.blockHash === undefined || (logFilter.fromBlock === undefined && logFilter.toBlock === undefined))
 
 export type EthGetLogsResponse = funtypes.Static<typeof EthGetLogsResponse>
 export const EthGetLogsResponse = funtypes.ReadonlyArray(
@@ -432,16 +430,19 @@ export const FeeHistory = funtypes.ReadonlyObject({
 	)
 })
 
+const EthNewFilterOptions = funtypes.ReadonlyPartial({
+	fromBlock: EthereumBlockTag,
+	toBlock: EthereumBlockTag,
+	address: EthereumAddress,
+	topics: funtypes.ReadonlyArray(funtypes.Union(EthereumBytes32, funtypes.ReadonlyArray(EthereumBytes32), funtypes.Null)),
+	blockHash: EthereumBytes32,
+	blockhash: funtypes.Never,
+}).withConstraint((logFilter) => logFilter.blockHash === undefined || (logFilter.fromBlock === undefined && logFilter.toBlock === undefined))
+
 export type EthNewFilter = funtypes.Static<typeof EthNewFilter>
 export const EthNewFilter = funtypes.ReadonlyObject({
 	method: funtypes.Literal('eth_newFilter'),
-	params: funtypes.ReadonlyTuple(funtypes.ReadonlyPartial({
-		fromBlock: EthereumBlockTag,
-		toBlock: EthereumBlockTag,
-		address: EthereumAddress,
-		topics: funtypes.ReadonlyArray(funtypes.Union(EthereumBytes32, funtypes.ReadonlyArray(EthereumBytes32), funtypes.Null)),
-		blockhash: EthereumBytes32,
-	}))
+	params: funtypes.ReadonlyTuple(EthNewFilterOptions)
 })
 
 export type UninstallFilter = funtypes.Static<typeof UninstallFilter>

--- a/app/ts/types/wire-types.ts
+++ b/app/ts/types/wire-types.ts
@@ -40,16 +40,19 @@ const SmallIntParser: funtypes.ParsedValue<funtypes.String, bigint>['config'] = 
 	},
 }
 
+function serializeFixedWidthBigInt(value: unknown, hexadecimalDigits: number, typeName: string) {
+	if (typeof value !== 'bigint') return { success: false as const, message: `${ typeof value } is not a bigint.` }
+	if (value < 0n) return { success: false as const, message: `${ value } is not a non-negative bigint.` }
+	if (value >= 1n << BigInt(hexadecimalDigits * 4)) return { success: false as const, message: `${ value } does not fit in ${ typeName }.` }
+	return { success: true as const, value: `0x${ value.toString(16).padStart(hexadecimalDigits, '0') }` }
+}
+
 const AddressParser: funtypes.ParsedValue<funtypes.String, bigint>['config'] = {
 	parse: value => {
 		if (!/^0x([a-fA-F0-9]{40})$/.test(value)) return { success: false, message: `${value} is not a hex string encoded address.` }
 		return { success: true, value: BigInt(value) }
 	},
-	serialize: value => {
-		if (typeof value !== 'bigint') return { success: false, message: `${typeof value} is not a bigint.`}
-		if (value < 0n) return { success: false, message: `${typeof value} is not a non negative bigint.`}
-		return { success: true, value: `0x${value.toString(16).padStart(40, '0')}` }
-	},
+	serialize: value => serializeFixedWidthBigInt(value, 40, 'an Ethereum address'),
 }
 
 const Bytes32Parser: funtypes.ParsedValue<funtypes.String, bigint>['config'] = {
@@ -57,11 +60,7 @@ const Bytes32Parser: funtypes.ParsedValue<funtypes.String, bigint>['config'] = {
 		if (!/^0x([a-fA-F0-9]{64})$/.test(value)) return { success: false, message: `${value} is not a hex string encoded 32 byte value.` }
 		return { success: true, value: BigInt(value) }
 	},
-	serialize: value => {
-		if (typeof value !== 'bigint') return { success: false, message: `${typeof value} is not a bigint.`}
-		if (value < 0n) return { success: false, message: `${typeof value} is not a non negative bigint.`}
-		return { success: true, value: `0x${value.toString(16).padStart(64, '0')}` }
-	},
+	serialize: value => serializeFixedWidthBigInt(value, 64, 'a 32-byte value'),
 }
 
 const Bytes256Parser: funtypes.ParsedValue<funtypes.String, bigint>['config'] = {
@@ -69,22 +68,14 @@ const Bytes256Parser: funtypes.ParsedValue<funtypes.String, bigint>['config'] = 
 		if (!/^0x([a-fA-F0-9]{512})$/.test(value)) return { success: false, message: `${value} is not a hex string encoded 256 byte value.` }
 		return { success: true, value: BigInt(value) }
 	},
-	serialize: value => {
-		if (typeof value !== 'bigint') return { success: false, message: `${typeof value} is not a bigint.`}
-		if (value < 0n) return { success: false, message: `${typeof value} is not a non negative bigint.`}
-		return { success: true, value: `0x${value.toString(16).padStart(512, '0')}` }
-	},
+	serialize: value => serializeFixedWidthBigInt(value, 512, 'a 256-byte value'),
 }
 const Bytes16Parser: funtypes.ParsedValue<funtypes.String, bigint>['config'] = {
 	parse: value => {
 		if (!/^0x([a-fA-F0-9]{16})$/.test(value)) return { success: false, message: `${value} is not a hex string encoded 256 byte value.` }
 		return { success: true, value: BigInt(value) }
 	},
-	serialize: value => {
-		if (typeof value !== 'bigint') return { success: false, message: `${typeof value} is not a bigint.`}
-		if (value < 0n) return { success: false, message: `${typeof value} is not a non negative bigint.`}
-		return { success: true, value: `0x${value.toString(16).padStart(16, '0')}` }
-	},
+	serialize: value => serializeFixedWidthBigInt(value, 16, 'an 8-byte value'),
 }
 
 export const BytesParser: funtypes.ParsedValue<funtypes.String, Uint8Array>['config'] = {
@@ -225,7 +216,7 @@ export type EthereumBytes16 = funtypes.Static<typeof EthereumBytes16>
 export const EthereumTimestamp = funtypes.String.withParser(TimestampParser)
 export type EthereumTimestamp = funtypes.Static<typeof EthereumTimestamp>
 
-export const EthereumBlockTag = funtypes.Union(EthereumQuantitySmall, EthereumBytes32, funtypes.Literal('latest'), funtypes.Literal('pending'), funtypes.Literal('finalized'))
+export const EthereumBlockTag = funtypes.Union(EthereumQuantitySmall, EthereumBytes32, funtypes.Literal('earliest'), funtypes.Literal('safe'), funtypes.Literal('latest'), funtypes.Literal('pending'), funtypes.Literal('finalized'))
 export type EthereumBlockTag = funtypes.Static<typeof EthereumBlockTag>
 
 export const EthereumInput = funtypes.Union(funtypes.String, funtypes.Undefined).withParser(OptionalBytesParser)

--- a/app/ts/utils/rpcFormData.ts
+++ b/app/ts/utils/rpcFormData.ts
@@ -1,0 +1,19 @@
+import { RpcEntry } from '../types/rpc.js'
+
+export function parseRpcFormData(formData: FormData) {
+	const chainIdFromForm = formData.get('chainId')?.toString().trim()
+	const blockExplorerUrlForm = formData.get('blockExplorerUrl')?.toString().trim()
+	const blockExplorerApiKeyForm = formData.get('blockExplorerApiKey')?.toString().trim()
+	const hasBlockExplorerUrl = blockExplorerUrlForm !== undefined && blockExplorerUrlForm.length > 0
+	const newRpcEntry = {
+		name: formData.get('name')?.toString().trim() || '',
+		chainId: chainIdFromForm ? `0x${ BigInt(chainIdFromForm).toString(16) }` : '',
+		httpsRpc: formData.get('httpsRpc')?.toString().trim() || '',
+		currencyName: formData.get('currencyName')?.toString().trim() || '',
+		currencyTicker: formData.get('currencyTicker')?.toString().trim() || '',
+		...hasBlockExplorerUrl ? { blockExplorer: { apiUrl: blockExplorerUrlForm, apiKey: blockExplorerApiKeyForm ?? '' } } : {},
+		minimized: true,
+		primary: false,
+	}
+	return RpcEntry.safeParse(newRpcEntry)
+}

--- a/test/tests/SimulationModeEthereumClientService.test.ts
+++ b/test/tests/SimulationModeEthereumClientService.test.ts
@@ -6,7 +6,7 @@ import { EthereumClientService } from '../../app/ts/simulation/services/Ethereum
 import { EthereumSignedTransactionToSignedTransaction, EthereumUnsignedTransactionToUnsignedTransaction, serializeSignedTransactionToBytes, serializeUnsignedTransactionToBytes } from '../../app/ts/utils/ethereum.js'
 import { addressString, bytes32String, dataStringWith0xStart, stringToUint8Array } from '../../app/ts/utils/bigint.js'
 import { EthereumAddress, EthereumSignatureParity, EthereumSignedTransaction, EthereumSignedTransaction1559, EthereumSignedTransactionWithBlockData, EthereumUnsignedTransaction, serialize } from '../../app/ts/types/wire-types.js'
-import { createExecutionSimulationState, createSimulationState, ethSimulateV1FromInput, getBaseFeeAdjustedTransactions, getBaseFeeAdjustmentBalances, getSimulatedBalanceFromInput, getSimulatedBlockByHashFromInput, getSimulatedBlockFromInput, getSimulatedBlockNumberFromInput, getSimulatedCode, getSimulatedCodeFromInput, getSimulatedLogs, getSimulatedStorageAtFromInput, getSimulatedTransactionByHashFromInput, getSimulatedTransactionCount, getSimulatedTransactionCountFromInput, getSimulatedTransactionReceipt, groupEthSimulateV1ResultByInputBlocks, mockSignTransaction, simulateEstimateGas, simulateEstimateGasFromInput, simulatePersonalSign, simulatedCallFromInput } from '../../app/ts/simulation/services/SimulationModeEthereumClientService.js'
+import { createExecutionSimulationState, createSimulationState, ethSimulateV1FromInput, getBaseFeeAdjustedTransactions, getBaseFeeAdjustmentBalances, getSimulatedBalanceFromInput, getSimulatedBlock, getSimulatedBlockByHashFromInput, getSimulatedBlockFromInput, getSimulatedBlockNumberFromInput, getSimulatedCode, getSimulatedCodeFromInput, getSimulatedLogs, getSimulatedStorageAtFromInput, getSimulatedTransactionByHashFromInput, getSimulatedTransactionCount, getSimulatedTransactionCountFromInput, getSimulatedTransactionReceipt, groupEthSimulateV1ResultByInputBlocks, mockSignTransaction, simulateEstimateGas, simulateEstimateGasFromInput, simulatePersonalSign, simulatedCall, simulatedCallFromInput } from '../../app/ts/simulation/services/SimulationModeEthereumClientService.js'
 import { EthTransactionReceiptResponse, EthereumJsonRpcRequest, JsonRpcResponse } from '../../app/ts/types/JsonRpc-types.js'
 import { RPCReply } from '../../app/ts/types/interceptor-messages.js'
 import type { EthSimulateV1BlockTag, EthSimulateV1Params, EthSimulateV1Result } from '../../app/ts/types/ethSimulate-types.js'
@@ -360,6 +360,67 @@ describe('SimulationModeEthereumClientService', () => {
 	const createDappEthSimulateV1Request = (blockTag: EthSimulateV1BlockTag | undefined = 'latest', validation = false): EthSimulateV1Params => ({
 		method: 'eth_simulateV1',
 		params: blockTag === undefined ? [createDappEthSimulateV1Payload(validation)] : [createDappEthSimulateV1Payload(validation), blockTag],
+	})
+
+	test('forwards safe and earliest block tags instead of applying the simulation overlay', async () => {
+		const simulationState = await createSimulationState(ethereum, undefined, createSimulationStateInput())
+		if (simulationState.success === false) throw new Error('simulation unexpectedly failed')
+		const forwardedTags: { method: string, blockTag: unknown }[] = []
+		const forwardingEthereum = new Proxy(ethereum, {
+			get(target, property, receiver) {
+				switch(property) {
+					case 'getTransactionCount': return async (_address: bigint, blockTag: unknown) => {
+						forwardedTags.push({ method: property, blockTag })
+						return 0n
+					}
+					case 'getCode': return async (_address: bigint, blockTag: unknown) => {
+						forwardedTags.push({ method: property, blockTag })
+						return new Uint8Array()
+					}
+					case 'getBlock': return async (requestAbortController: AbortController | undefined, blockTag: Parameters<typeof target.getBlock>[1], fullObjects: boolean) => {
+						if (blockTag === 'safe' || blockTag === 'earliest') {
+							forwardedTags.push({ method: property, blockTag })
+							return null
+						}
+						return await target.getBlock(requestAbortController, blockTag, fullObjects)
+					}
+					case 'getLogs': return async (filter: { fromBlock?: unknown }) => {
+						forwardedTags.push({ method: property, blockTag: filter.fromBlock })
+						return []
+					}
+					case 'call': return async (_transaction: unknown, blockTag: unknown) => {
+						forwardedTags.push({ method: property, blockTag })
+						return new Uint8Array()
+					}
+					default: return Reflect.get(target, property, receiver)
+				}
+			}
+		})
+		const resolvedState = toResolvedSimulationState(simulationState)
+
+		await getSimulatedTransactionCount(forwardingEthereum, undefined, resolvedState, exampleTransaction.from, 'safe')
+		await getSimulatedCode(forwardingEthereum, undefined, resolvedState, exampleTransaction.to, 'earliest')
+		await getSimulatedBlock(forwardingEthereum, undefined, resolvedState, 'safe', false)
+		await getSimulatedLogs(forwardingEthereum, undefined, toResolvedExecutionSimulationState(simulationState), { fromBlock: 'earliest' })
+		const callParams = {
+			from: exampleTransaction.from,
+			to: exampleTransaction.to,
+			value: exampleTransaction.value,
+			input: exampleTransaction.input,
+			maxFeePerGas: exampleTransaction.maxFeePerGas,
+			maxPriorityFeePerGas: exampleTransaction.maxPriorityFeePerGas,
+		}
+		await simulatedCallFromInput(forwardingEthereum, undefined, toResolvedSimulationInput(createSimulationStateInput()), callParams, 'safe')
+		await simulatedCall(forwardingEthereum, undefined, resolvedState, callParams, 'earliest')
+
+		assert.deepEqual(forwardedTags, [
+			{ method: 'getTransactionCount', blockTag: 'safe' },
+			{ method: 'getCode', blockTag: 'earliest' },
+			{ method: 'getBlock', blockTag: 'safe' },
+			{ method: 'getLogs', blockTag: 'earliest' },
+			{ method: 'call', blockTag: 'safe' },
+			{ method: 'call', blockTag: 'earliest' },
+		])
 	})
 
 		test('prepareEthSimulateV1Input strips the local transaction hash from RPC calls', async () => {

--- a/test/tests/jsonRpcBoundaryValidation.test.ts
+++ b/test/tests/jsonRpcBoundaryValidation.test.ts
@@ -1,0 +1,46 @@
+import * as assert from 'assert'
+import { describe, test } from 'bun:test'
+import { EthereumJsonRpcRequest, EthGetLogsRequest, EthNewFilter } from '../../app/ts/types/JsonRpc-types.js'
+import { EthereumAddress, EthereumBlockTag, EthereumBytes16, EthereumBytes256, EthereumBytes32, serialize } from '../../app/ts/types/wire-types.js'
+
+const blockHash = `0x${ '12'.repeat(32) }`
+
+describe('JSON-RPC boundary validation', () => {
+	test('accepts safe and earliest block tags', () => {
+		assert.equal(EthereumBlockTag.parse('safe'), 'safe')
+		assert.equal(EthereumBlockTag.parse('earliest'), 'earliest')
+	})
+
+	test('preserves the standard blockHash field on new filters', () => {
+		const parsed = EthNewFilter.safeParse({ method: 'eth_newFilter', params: [{ blockHash }] })
+
+		assert.equal(parsed.success, true)
+		if (!parsed.success) throw new Error(parsed.message)
+		assert.equal(parsed.value.params[0].blockHash, BigInt(blockHash))
+	})
+
+	test('rejects the non-standard lowercase blockhash field instead of stripping it', () => {
+		assert.equal(EthereumJsonRpcRequest.safeParse({ method: 'eth_getLogs', params: [{ blockhash: blockHash }] }).success, false)
+		assert.equal(EthereumJsonRpcRequest.safeParse({ method: 'eth_newFilter', params: [{ blockhash: blockHash }] }).success, false)
+	})
+
+	test('rejects blockHash combined with block range fields', () => {
+		assert.equal(EthGetLogsRequest.safeParse({ blockHash, fromBlock: 'latest' }).success, false)
+		assert.equal(EthGetLogsRequest.safeParse({ blockHash, toBlock: 'latest' }).success, false)
+		assert.equal(EthNewFilter.safeParse({ method: 'eth_newFilter', params: [{ blockHash, fromBlock: 'latest' }] }).success, false)
+	})
+
+	test('rejects values that exceed fixed-width wire types', () => {
+		assert.throws(() => serialize(EthereumAddress, 1n << 160n))
+		assert.throws(() => serialize(EthereumBytes32, 1n << 256n))
+		assert.throws(() => serialize(EthereumBytes256, 1n << 2048n))
+		assert.throws(() => serialize(EthereumBytes16, 1n << 64n))
+	})
+
+	test('continues to serialize the largest fixed-width values', () => {
+		assert.equal(serialize(EthereumAddress, (1n << 160n) - 1n).length, 42)
+		assert.equal(serialize(EthereumBytes32, (1n << 256n) - 1n).length, 66)
+		assert.equal(serialize(EthereumBytes256, (1n << 2048n) - 1n).length, 514)
+		assert.equal(serialize(EthereumBytes16, (1n << 64n) - 1n).length, 18)
+	})
+})

--- a/test/tests/settingsImport.test.ts
+++ b/test/tests/settingsImport.test.ts
@@ -89,6 +89,24 @@ const buildVersion12Import = (useTabsInsteadOfPopup: boolean, metamaskCompatibil
 	},
 })
 
+const buildVersion13Import = (): ExportedSettings => ({
+	name: 'InterceptorSettingsAndAddressBook',
+	version: '1.3',
+	exportedDate: '2026-05-21',
+	settings: {
+		activeSimulationAddress: 0x3333333333333333333333333333333333333333n,
+		rpcNetwork: testRpcNetwork,
+		openedPage: { page: 'Settings' },
+		useSignersAddressAsActiveAddress: false,
+		websiteAccess: [],
+		simulationMode: false,
+		addressInfos: [],
+		contacts: undefined,
+		useTabsInsteadOfPopup: false,
+		metamaskCompatibilityMode: false,
+	},
+})
+
 const buildVersion14Import = (useTabsInsteadOfPopup: boolean, metamaskCompatibilityMode: boolean, websiteAccess: ExportedSettings['settings']['websiteAccess'] = []): ExportedSettings => ({
 	name: 'InterceptorSettingsAndAddressBook',
 	version: '1.4',
@@ -96,7 +114,7 @@ const buildVersion14Import = (useTabsInsteadOfPopup: boolean, metamaskCompatibil
 	settings: {
 		activeSimulationAddress: 0x2222222222222222222222222222222222222222n,
 		rpcNetwork: testRpcNetwork,
-		openedPage: { page: 'Home' },
+		openedPage: { page: 'Settings' },
 		useSignersAddressAsActiveAddress: false,
 		websiteAccess,
 		simulationMode: true,
@@ -109,6 +127,26 @@ const buildVersion14Import = (useTabsInsteadOfPopup: boolean, metamaskCompatibil
 describe('settings import', () => {
 	beforeEach(() => {
 		browserMock.reset()
+	})
+
+	test('restores simulation settings and the opened page from version 1.3 exports', async () => {
+		const { getPage, getSettings, importSettingsAndAddressBook } = await settingsModulePromise
+
+		await importSettingsAndAddressBook(buildVersion13Import())
+
+		const settings = await getSettings()
+		assert.equal(settings.simulationMode, false)
+		assert.equal(settings.activeSimulationAddress, 0x3333333333333333333333333333333333333333n)
+		assert.deepEqual(settings.activeRpcNetwork, testRpcNetwork)
+		assert.deepEqual(await getPage(), { page: 'Settings' })
+	})
+
+	test('restores the opened page from version 1.4 exports', async () => {
+		const { getPage, importSettingsAndAddressBook } = await settingsModulePromise
+
+		await importSettingsAndAddressBook(buildVersion14Import(false, false))
+
+		assert.deepEqual(await getPage(), { page: 'Settings' })
 	})
 
 	test('restores metamask compatibility mode from version 1.4 exports', async () => {

--- a/test/tests/uiBoundaryFixes.test.tsx
+++ b/test/tests/uiBoundaryFixes.test.tsx
@@ -1,0 +1,112 @@
+import * as assert from 'assert'
+import { describe, test } from 'bun:test'
+import { signal } from '@preact/signals'
+import { render } from 'preact'
+import { act } from 'preact/test-utils'
+import { findChainEntryByName } from '../../app/ts/components/subcomponents/ChainSelector.js'
+import { DropDownMenu } from '../../app/ts/components/subcomponents/DropDownMenu.js'
+import { InlineCard } from '../../app/ts/components/subcomponents/InlineCard.js'
+import { parseTimePickerDeltaValue, TimePicker } from '../../app/ts/components/subcomponents/TimePicker.js'
+import { rpcEntriesToChainEntriesWithAllChainsEntry } from '../../app/ts/components/ui-utils.js'
+import { parseRpcFormData } from '../../app/ts/utils/rpcFormData.js'
+import { installDomMock } from './domMock.js'
+
+type TestNode = {
+	readonly childNodes?: readonly TestNode[]
+	readonly getAttribute?: (name: string) => string | null
+	readonly tagName?: string
+}
+
+function collectElements(node: TestNode | undefined, tagName: string, results: TestNode[] = []) {
+	if (node?.tagName === tagName.toUpperCase()) results.push(node)
+	for (const child of node?.childNodes ?? []) collectElements(child, tagName, results)
+	return results
+}
+
+function createRpcFormData(apiKey: string) {
+	const formData = new FormData()
+	formData.set('name', 'Test RPC')
+	formData.set('chainId', '1')
+	formData.set('httpsRpc', 'https://rpc.example')
+	formData.set('currencyName', 'Ether')
+	formData.set('currencyTicker', 'ETH')
+	formData.set('blockExplorerUrl', 'https://explorer.example/api')
+	formData.set('blockExplorerApiKey', apiKey)
+	return formData
+}
+
+describe('UI boundary fixes', () => {
+	test('selects normalized and synthetic chain entries by their displayed names', () => {
+		const chains = rpcEntriesToChainEntriesWithAllChainsEntry([{
+			name: 'Custom Ethereum Name',
+			chainId: 1n,
+			httpsRpc: 'https://rpc.example',
+			currencyName: 'Ether',
+			currencyTicker: 'ETH',
+			primary: false,
+			minimized: true,
+		}])
+
+		assert.equal(findChainEntryByName(chains, 'Ethereum Mainnet')?.chainId, 1n)
+		assert.equal(findChainEntryByName(chains, 'All Chains')?.chainId, 'AllChains')
+	})
+
+	test('keeps dropdown controls from submitting surrounding forms', async () => {
+		const dom = installDomMock()
+		try {
+			await act(() => {
+				render(<form><DropDownMenu selected = { signal('One') } dropDownOptions = { signal<readonly string[]>(['One', 'Two']) } onChangedCallBack = { () => undefined } buttonClassses = 'button-class' /></form>, dom.document.body)
+			})
+
+			const buttons = collectElements(dom.document.body, 'button')
+			assert.equal(buttons.length, 3)
+			assert.equal(buttons.every((button) => button.getAttribute?.('type') === 'button'), true)
+		} finally {
+			render(null, dom.document.body)
+			dom.restore()
+		}
+	})
+
+	test('renders warning details supplied by InlineCard callers', async () => {
+		const dom = installDomMock()
+		try {
+			await act(() => {
+				render(<InlineCard icon = { () => <span>Token</span> } label = 'TKN' warningMessage = 'Untrusted address' noCopy noExpandButtons />, dom.document.body)
+			})
+
+			const warningSigns = collectElements(dom.document.body, 'span').filter((element) => element.getAttribute?.('role') === 'alert')
+			assert.equal(warningSigns.length, 2)
+			assert.equal(warningSigns.every((warningSign) => warningSign.getAttribute?.('title') === 'Untrusted address'), true)
+		} finally {
+			render(null, dom.document.body)
+			dom.restore()
+		}
+	})
+
+	test('parses and renders bigint delays without Number precision loss', async () => {
+		const largeDelay = 9_007_199_254_740_993n
+		assert.equal(parseTimePickerDeltaValue(largeDelay.toString()), largeDelay)
+		assert.equal(parseTimePickerDeltaValue('1.5'), undefined)
+
+		const dom = installDomMock()
+		try {
+			await act(() => {
+				render(<TimePicker mode = { signal('For') } absoluteTime = { signal(undefined) } deltaValue = { signal(largeDelay) } deltaUnit = { signal('Seconds') } onChangedCallBack = { () => undefined } startText = 'Delay' removeNoDelayOption = { false } />, dom.document.body)
+			})
+
+			const numberInput = collectElements(dom.document.body, 'input').find((input) => input.getAttribute?.('type') === 'number')
+			assert.equal(numberInput?.getAttribute?.('value'), largeDelay.toString())
+		} finally {
+			render(null, dom.document.body)
+			dom.restore()
+		}
+	})
+
+	test('keeps a block explorer URL when its API key is empty', () => {
+		const parsed = parseRpcFormData(createRpcFormData(''))
+
+		assert.equal(parsed.success, true)
+		if (!parsed.success) throw new Error(parsed.message)
+		assert.deepEqual(parsed.value.blockExplorer, { apiUrl: 'https://explorer.example/api', apiKey: '' })
+	})
+})


### PR DESCRIPTION
## Ten bugs fixed

1. **Settings imports dropped version-specific state.** Version 1.3 restored the opened page but skipped simulation mode, RPC, and active-address settings, while version 1.4 restored simulation settings but skipped the opened page. Page restoration is now independent of simulation-setting restoration.
2. **Chain selection failed for displayed and synthetic names.** The selector displayed normalized chain names and `All Chains` but looked up selections in raw RPC entries, causing custom-named chains and `All Chains` to throw. Selection now uses the displayed chain entries.
3. **Dropdown controls submitted surrounding forms.** The trigger omitted its button type and option buttons used a CSS class as their type. Both controls now use `type="button"`.
4. **TimePicker corrupted large bigint delays.** Delay values were converted through JavaScript `Number` and `parseInt`, losing precision above `Number.MAX_SAFE_INTEGER`. Values now remain decimal strings until parsed directly as `bigint`.
5. **InlineCard discarded warning details.** Callers supplied messages such as `Untrusted address`, but the warning icon always used its generic default title. Both warning icons now receive the supplied message.
6. **RPC configuration dropped keyless block explorers.** A block explorer URL was discarded unless its optional API-key field was also non-empty. URLs are now retained with an empty key when no key is required.
7. **`eth_newFilter` used the wrong `blockHash` casing.** The schema and consumers used `blockhash`, causing the standard `blockHash` field to be stripped. The standard field is now preserved, and the lowercase spelling is explicitly rejected.
8. **Log filters accepted mutually exclusive selectors.** `eth_getLogs` and `eth_newFilter` could accept `blockHash` together with `fromBlock` or `toBlock`, then silently discard one selector. These invalid combinations are now rejected.
9. **Valid `safe` and `earliest` block tags were rejected.** Both standard tags are now accepted and forwarded directly to the backing node across transaction-count, code, block, log, and call paths instead of reaching simulation bigint arithmetic.
10. **Fixed-width serializers emitted oversized values.** Address, bytes32, bytes256, and 8-byte nonce serializers padded short values but did not reject overflow. They now enforce their upper bounds while preserving valid maximum values.

These fixes are separate from the validation and UI boundary work in #1571.

## Regression coverage

Focused tests cover settings migration, normalized and synthetic chain selection, non-submitting dropdowns, warning text, large bigint delays, keyless explorers, log-filter validation, fixed-width serialization bounds, and node-only block-tag forwarding.

## Validation

- `bun run test` — 987 tests passed across 132 files
- `bun run setup-chrome` — passed
- `bun run typecheck` — passed
- `bun run lint` — passed

`bun run test:chrome-communication` was not run because this diff does not affect content-script registration, provider injection, access approval, or page-to-extension messaging.

## Review

The project reviewer gate completed in three passes. Findings from the first two passes were addressed by rebasing onto current main, preserving the #1570 startup lifecycle fixes, rejecting lowercase `blockhash`, and expanding node-only block-tag forwarding coverage. The final pass reported no High, Medium, or Low findings and scored the diff 94/100.