### PR TITLE
Fix ten JSON-RPC and simulation edge cases

### DIFF
--- a/app/ts/AddressBook.tsx
+++ b/app/ts/AddressBook.tsx
@@ -204,7 +204,7 @@ export function AddressBook() {
 	const addressBookEntriesWithFilter = useSignal<AddressBookEntriesWithFilter>({ addressBookEntries: [], activeFilter: 'My Active Addresses' })
 	const addressBookEntries = useComputed(() => addressBookEntriesWithFilter.value.addressBookEntries || [])
 	const activeChain = useSignal<ChainEntry | undefined>(undefined)
-	const activeChainId = useComputed(() => activeChain.value?.chainId || 1n)
+	const activeChainId = useComputed(() => activeChain.value?.chainId ?? 1n)
 	const rpcEntries = useSignal<RpcEntries>([])
 	const viewFilter = useSignal<ViewFilter>({ activeFilter: 'My Active Addresses', searchString: '', chain: undefined })
 	const modalState = useSignal<Modals>({ page: 'noModal' })
@@ -313,7 +313,7 @@ export function AddressBook() {
 				safeVersion: undefined,
 				useAsActiveAddress: filter === 'My Active Addresses' || filter === 'My Safes',
 				declarativeNetRequestBlockMode: undefined,
-				chainId: activeChain.peek()?.chainId || 1n,
+				chainId: activeChain.peek()?.chainId ?? 1n,
 			}
 		}) }
 		return
@@ -329,7 +329,7 @@ export function AddressBook() {
 			data: {
 				address: entry.address,
 				addressBookCategory: viewFilter.value.activeFilter,
-				chainId: entry.chainId || 1n,
+				chainId: entry.chainId ?? 1n,
 			}
 		})
 	}

--- a/app/ts/background/background.ts
+++ b/app/ts/background/background.ts
@@ -190,8 +190,8 @@ async function handleRPCRequest(
 		eth_maxPriorityFeePerGas: rpcRequestHandler('eth_maxPriorityFeePerGas', async () => await maxPriorityFeePerGas(ethereum)),
 		eth_newFilter: rpcRequestHandler('eth_newFilter', async (_context, rpcRequest) => await withSimulationInput((simulationInput) => installNewFilter(socket, rpcRequest, ethereum, simulationInput))),
 		eth_uninstallFilter: rpcRequestHandler('eth_uninstallFilter', async (_context, rpcRequest) => await uninstallNewFilter(socket, rpcRequest)),
-		eth_getFilterChanges: rpcRequestHandler('eth_getFilterChanges', async (_context, rpcRequest) => await withExecutionSimulationState((simulationState) => getFilterChanges(rpcRequest, ethereum, simulationState))),
-		eth_getFilterLogs: rpcRequestHandler('eth_getFilterLogs', async (_context, rpcRequest) => await withExecutionSimulationState((simulationState) => getFilterLogs(rpcRequest, ethereum, simulationState))),
+		eth_getFilterChanges: rpcRequestHandler('eth_getFilterChanges', async (_context, rpcRequest) => await withExecutionSimulationState((simulationState) => getFilterChanges(socket, rpcRequest, ethereum, simulationState))),
+		eth_getFilterLogs: rpcRequestHandler('eth_getFilterLogs', async (_context, rpcRequest) => await withExecutionSimulationState((simulationState) => getFilterLogs(socket, rpcRequest, ethereum, simulationState))),
 		InterceptorError: rpcRequestHandler('InterceptorError', async (_context, rpcRequest) => await handleInterceptorError(rpcRequest)),
 	} as const satisfies Record<ParsedRpcRequest['method'], RpcRequestHandler>
 	return await rpcRequestHandlers[parsedRequest.method](undefined, parsedRequest)

--- a/app/ts/background/metadataUtils.ts
+++ b/app/ts/background/metadataUtils.ts
@@ -58,7 +58,7 @@ async function identifyAddressWithoutNode(address: bigint, rpcEntry: RpcNetwork 
 	if (address === ETHEREUM_LOGS_LOGGER_ADDRESS) return getNativeTokenErc20(rpcEntry)
 
 	if (useLocalStorage) {
-		const userEntry = (await getUserAddressBookEntriesForChainIdMorePreciseFirst(rpcEntry?.chainId || 1n)).find((entry) => entry.address === address)
+		const userEntry = (await getUserAddressBookEntriesForChainIdMorePreciseFirst(rpcEntry?.chainId ?? 1n)).find((entry) => entry.address === address)
 		if (userEntry !== undefined) return userEntry
 	}
 	const addrString = addressString(address)

--- a/app/ts/background/popupMessageHandlers.ts
+++ b/app/ts/background/popupMessageHandlers.ts
@@ -18,7 +18,7 @@ import type { EthereumClientService } from '../simulation/services/EthereumClien
 import { CompleteVisualizedSimulation, InterceptorSimulationExport, type InterceptorStackOperation, InterceptorTransactionStack, type ModifyAddressWindowState } from '../types/visualizer-types.js'
 import { ExportedSettings } from '../types/exportedSettingsTypes.js'
 import { isJSON } from '../utils/json.js'
-import { getConfiguredSafeSigningEntry, getSafeSignerAddresses, isSafeEntryWithSafeSigner, type AddressBookEntry, type IncompleteAddressBookEntry } from '../types/addressBookTypes.js'
+import { doAddressBookChainIdsMatch, getConfiguredSafeSigningEntry, getSafeSignerAddresses, isSafeEntryWithSafeSigner, type AddressBookEntry, type IncompleteAddressBookEntry } from '../types/addressBookTypes.js'
 import { EthereumAddress, serialize } from '../types/wire-types.js'
 import { fetchAbiFromBlockExplorer, isValidAbi } from '../simulation/services/EtherScanAbiFetcher.js'
 import { checksummedAddress, generate256BitRandomBigInt, stringToAddress } from '../utils/bigint.js'
@@ -312,8 +312,8 @@ export async function addOrModifyAddressBookEntry(ethereum: EthereumClientServic
 		}
 	}
 	await updateUserAddressBookEntries((previousContacts) => {
-		if (previousContacts.find((previous) => previous.address === entryToStore.address && (previous.chainId || 1n) === (entryToStore.chainId || 1n)) ) {
-			return previousContacts.map((previous) => previous.address === entryToStore.address && (previous.chainId || 1n) === (entryToStore.chainId || 1n) ? entryToStore : previous)
+		if (previousContacts.find((previous) => previous.address === entryToStore.address && doAddressBookChainIdsMatch(previous.chainId, entryToStore.chainId)) ) {
+			return previousContacts.map((previous) => previous.address === entryToStore.address && doAddressBookChainIdsMatch(previous.chainId, entryToStore.chainId) ? entryToStore : previous)
 		}
 		return previousContacts.concat([entryToStore])
 	})

--- a/app/ts/background/simulationModeHandlers.ts
+++ b/app/ts/background/simulationModeHandlers.ts
@@ -1,6 +1,6 @@
 import type { EthereumClientService } from '../simulation/services/EthereumClientService.js'
 import { createEthereumSubscription, createNewFilter, getEthFilterChanges, getEthFilterLogs, removeEthereumSubscription } from '../simulation/services/EthereumSubscriptionService.js'
-import { getSimulatedBalanceFromInput, getSimulatedBlockByHashFromInput, getSimulatedBlockFromInput, getSimulatedBlockNumberFromInput, getSimulatedCodeFromInput, getSimulatedLogs, getSimulatedStorageAtFromInput, getSimulatedTransactionByHashFromInput, getSimulatedTransactionReceipt, simulatedCallFromInput, simulateEstimateGasFromInput, getInputFieldFromDataOrInput, getSimulatedFeeHistory, getSimulatedTransactionCountFromInput, ethSimulateV1FromInput } from '../simulation/services/SimulationModeEthereumClientService.js'
+import { createSimulationCallParams, getSimulatedBalanceFromInput, getSimulatedBlockByHashFromInput, getSimulatedBlockFromInput, getSimulatedBlockNumberFromInput, getSimulatedCodeFromInput, getSimulatedLogs, getSimulatedStorageAtFromInput, getSimulatedTransactionByHashFromInput, getSimulatedTransactionReceipt, simulatedCallFromInput, simulateEstimateGasFromInput, getSimulatedFeeHistory, getSimulatedTransactionCountFromInput, ethSimulateV1FromInput } from '../simulation/services/SimulationModeEthereumClientService.js'
 import { DEFAULT_CALL_ADDRESS, ERROR_INTERCEPTOR_GET_CODE_FAILED } from '../utils/constants.js'
 import type { WebsiteTabConnections } from '../types/user-interface-types.js'
 import type { ResolvedExecutionSimulationState, ResolvedSimulationInput } from '../types/visualizer-types.js'
@@ -56,22 +56,7 @@ export async function sendTransaction(
 async function singleCallWithFromOverride(ethereumClientService: EthereumClientService, simulationInput: ResolvedSimulationInput, request: EthCallParams, from: bigint) {
 	const callParams = request.params[0]
 	const blockTag = request.params.length > 1 ? request.params[1] : 'latest' as const
-	const gasPrice = callParams.gasPrice !== undefined ? callParams.gasPrice : 0n
-	const value = callParams.value !== undefined ? callParams.value : 0n
-
-	const callTransaction = {
-		type: '1559' as const,
-		from,
-		chainId: ethereumClientService.getChainId(),
-		maxFeePerGas: gasPrice,
-		maxPriorityFeePerGas: 0n,
-		to: callParams.to === undefined ? null : callParams.to,
-		value,
-		input: getInputFieldFromDataOrInput(callParams),
-		accessList: [],
-	}
-
-	return await simulatedCallFromInput(ethereumClientService, undefined, simulationInput, callTransaction, blockTag)
+	return await simulatedCallFromInput(ethereumClientService, undefined, simulationInput, createSimulationCallParams(callParams, from), blockTag)
 }
 
 export async function call(ethereumClientService: EthereumClientService, simulationInput: ResolvedSimulationInput, request: EthCallParams) {
@@ -208,15 +193,15 @@ export async function uninstallNewFilter(socket: WebsiteSocket, request: Uninsta
 	return { type: 'result' as const, method: request.method, result: await removeEthereumSubscription(socket, request.params[0]) }
 }
 
-export async function getFilterChanges(request: GetFilterChanges, ethereumClientService: EthereumClientService, simulationState: ResolvedExecutionSimulationState) {
-	const result = await getEthFilterChanges(request.params[0], ethereumClientService, undefined, simulationState)
+export async function getFilterChanges(socket: WebsiteSocket, request: GetFilterChanges, ethereumClientService: EthereumClientService, simulationState: ResolvedExecutionSimulationState) {
+	const result = await getEthFilterChanges(socket, request.params[0], ethereumClientService, undefined, simulationState)
 	if (result === undefined) return { type: 'result' as const, method: request.method, error: { code: METAMASK_ERROR_BLANKET_ERROR, message: 'No filter found for identifier' } }
 
 	return { type: 'result' as const, method: request.method, result }
 }
 
-export async function getFilterLogs(request: GetFilterLogs, ethereumClientService: EthereumClientService, simulationState: ResolvedExecutionSimulationState) {
-	const result = await getEthFilterLogs(request.params[0], ethereumClientService, undefined, simulationState)
+export async function getFilterLogs(socket: WebsiteSocket, request: GetFilterLogs, ethereumClientService: EthereumClientService, simulationState: ResolvedExecutionSimulationState) {
+	const result = await getEthFilterLogs(socket, request.params[0], ethereumClientService, undefined, simulationState)
 	if (result === undefined) return { type: 'result' as const, method: request.method, error: { code: METAMASK_ERROR_BLANKET_ERROR, message: 'No filter found for identifier' } }
 	return { type: 'result' as const, method: request.method, result }
 }

--- a/app/ts/background/storageVariables.ts
+++ b/app/ts/background/storageVariables.ts
@@ -6,7 +6,7 @@ import { CompleteVisualizedSimulation, type EthereumSubscriptionsAndFilters, Int
 import { browserStorageLocalSafeParseGet } from '../utils/storageUtils.js'
 import { DEFAULT_ACTIVE_ADDRESSES, DEFAULT_RPCS } from '../config/defaults.js'
 import { type UniqueRequestIdentifier, doesUniqueRequestIdentifiersMatch } from '../utils/requests.js'
-import type { AddressBookEntries, AddressBookEntry, ChainIdWithUniversal } from '../types/addressBookTypes.js'
+import { doAddressBookChainIdsMatch, type AddressBookEntries, type AddressBookEntry, type ChainIdWithUniversal } from '../types/addressBookTypes.js'
 import type { SignerName } from '../types/signerTypes.js'
 import type { PendingAccessRequests, PendingTransactionOrSignableMessage } from '../types/accessRequest.js'
 import type { RpcEntries, RpcNetwork } from '../types/rpc.js'
@@ -296,7 +296,7 @@ export async function updateUserAddressBookEntriesV2Old(updateFunc: (prevState: 
 export async function addUserAddressBookEntryIfItDoesNotExist(newEntry: AddressBookEntry) {
 	await userAddressBookEntriesSemaphore.execute(async () => {
 		const entries = await getUserAddressBookEntries()
-		const existingEntry = entries.find((entry) => entry.address === newEntry.address && (entry.chainId || 1n) === (newEntry.chainId || 1n) )
+		const existingEntry = entries.find((entry) => entry.address === newEntry.address && doAddressBookChainIdsMatch(entry.chainId, newEntry.chainId))
 		if (existingEntry !== undefined) return
 		return await browserStorageLocalSet({ userAddressBookEntriesV3: entries.concat(newEntry) })
 	})

--- a/app/ts/background/windows/confirmTransaction.ts
+++ b/app/ts/background/windows/confirmTransaction.ts
@@ -480,7 +480,7 @@ export const formEthSendTransaction = async(ethereumClientService: EthereumClien
 		to: transactionDetails.to === undefined ? null : transactionDetails.to,
 		value,
 		input: getInputFieldFromDataOrInput(transactionDetails),
-		accessList: [],
+		accessList: transactionDetails.accessList ?? [],
 	}
 	const transactionWithoutGas = await createEip1559Or7702Transaction(transactionWithoutGasBase, transactionDetails)
 	const extraParams = {

--- a/app/ts/components/App.tsx
+++ b/app/ts/components/App.tsx
@@ -160,7 +160,7 @@ export function App() {
 				abi: undefined,
 				useAsActiveAddress: true,
 				declarativeNetRequestBlockMode: undefined,
-				chainId: rpcConnectionStatus.peek()?.rpcNetwork.chainId || 1n,
+				chainId: rpcConnectionStatus.peek()?.rpcNetwork.chainId ?? 1n,
 			}
 		} } as const
 		appPage.value = { page: 'AddNewAddress', state: new Signal(newPage.state) }
@@ -190,7 +190,7 @@ export function App() {
 				abi: undefined,
 				useAsActiveAddress: true,
 				declarativeNetRequestBlockMode: undefined,
-				chainId: rpcConnectionStatus.peek()?.rpcNetwork.chainId || 1n,
+				chainId: rpcConnectionStatus.peek()?.rpcNetwork.chainId ?? 1n,
 			} }
 		} as const
 		appPage.value = { page: 'AddNewAddress', state: new Signal(newPage.state) }

--- a/app/ts/components/pages/AddNewAddress.tsx
+++ b/app/ts/components/pages/AddNewAddress.tsx
@@ -188,7 +188,7 @@ function RenderIncompleteAddressBookEntry({ modifyAddressWindowState, rpcEntries
 	}
 	const disableDueToSource = modifyAddressWindowState.value.incompleteAddressBookEntry.entrySource === 'DarkFloristMetadata' || modifyAddressWindowState.value.incompleteAddressBookEntry.entrySource === 'Interceptor'
 	const logoUri = modifyAddressWindowState.value.incompleteAddressBookEntry.addingAddress === false && 'logoUri' in modifyAddressWindowState.value.incompleteAddressBookEntry ? modifyAddressWindowState.value.incompleteAddressBookEntry.logoUri : undefined
-	const selectedChainId = useComputed(() => modifyAddressWindowState.value.incompleteAddressBookEntry.chainId || 1n)
+	const selectedChainId = useComputed(() => modifyAddressWindowState.value.incompleteAddressBookEntry.chainId ?? 1n)
 	const blockExplorerAvailable = useComputed(() => isBlockExplorerAvailableForChain(selectedChainId.value, rpcEntries.value))
 
 	const selectedAddresBookEntryType = useSignal<AddressBookEntryType>(modifyAddressWindowState.value.incompleteAddressBookEntry.type)

--- a/app/ts/components/ui-utils.tsx
+++ b/app/ts/components/ui-utils.tsx
@@ -97,7 +97,7 @@ export const addressEditEntry = (entry: AddressBookEntry) => {
 			abi : undefined,
 			safeVersion: undefined,
 			declarativeNetRequestBlockMode: undefined,
-			chainId: entry.chainId || 1n,
+			chainId: entry.chainId ?? 1n,
 			...entry,
 			address: checksummedAddress(entry.address),
 			safeSignerAddress: entry.type === 'safe' && entry.safeSignerAddress !== undefined

--- a/app/ts/simulation/services/EthereumSubscriptionService.ts
+++ b/app/ts/simulation/services/EthereumSubscriptionService.ts
@@ -7,6 +7,8 @@ import type { WebsiteTabConnections } from '../../types/user-interface-types.js'
 import { getSimulatedBlockFromInput, getSimulatedBlockNumber, getSimulatedBlockNumberFromInput, getSimulatedLogs } from './SimulationModeEthereumClientService.js'
 import { sendSubscriptionReplyOrCallBack } from '../../background/messageSending.js'
 import type { WebsiteSocket } from '../../utils/requests.js'
+import { websiteSocketToString } from '../../background/backgroundUtils.js'
+import { createScopedKeyedSerialExecutor } from '../../utils/semaphore.js'
 
 const dec2hex = (dec: number) => dec.toString(16).padStart(2, '0')
 
@@ -40,6 +42,10 @@ export async function removeEthereumSubscription(socket: WebsiteSocket, subscrip
 	}
 	return false
 }
+
+const isSameWebsiteSocket = (left: WebsiteSocket, right: WebsiteSocket) => left.tabId === right.tabId && left.connectionName === right.connectionName
+const filterChangesScope = {}
+const runFilterChangeSerially = createScopedKeyedSerialExecutor<typeof filterChangesScope, string>()
 
 export async function sendSubscriptionMessagesForNewBlock(
 	blockNumber: bigint,
@@ -77,7 +83,8 @@ export async function sendSubscriptionMessagesForNewBlock(
 		return await simulatedBlocksPromise
 	}
 	for (const subscriptionOrFilter of ethereumSubscriptionsAndFilters) {
-		if (websiteTabConnections.get(subscriptionOrFilter.subscriptionCreatorSocket.tabId) === undefined) { // connection removed
+		const tabConnection = websiteTabConnections.get(subscriptionOrFilter.subscriptionCreatorSocket.tabId)
+		if (tabConnection?.connections[websiteSocketToString(subscriptionOrFilter.subscriptionCreatorSocket)] === undefined) { // connection removed
 			await removeEthereumSubscription(subscriptionOrFilter.subscriptionCreatorSocket, subscriptionOrFilter.subscriptionOrFilterId)
 			continue
 		}
@@ -88,7 +95,7 @@ export async function sendSubscriptionMessagesForNewBlock(
 				sendSubscriptionReplyOrCallBack(websiteTabConnections, subscriptionOrFilter.subscriptionCreatorSocket, {
 					type: 'result',
 					method: 'newHeads' as const,
-					result: { subscription: subscriptionOrFilter.type, result: newBlock } as const,
+					result: { subscription: subscriptionOrFilter.subscriptionOrFilterId, result: newBlock } as const,
 					subscription: subscriptionOrFilter.subscriptionOrFilterId,
 				})
 
@@ -98,7 +105,7 @@ export async function sendSubscriptionMessagesForNewBlock(
 						sendSubscriptionReplyOrCallBack(websiteTabConnections, subscriptionOrFilter.subscriptionCreatorSocket, {
 							type: 'result',
 							method: 'newHeads' as const,
-							result: { subscription: subscriptionOrFilter.type, result: simulatedBlock },
+							result: { subscription: subscriptionOrFilter.subscriptionOrFilterId, result: simulatedBlock },
 							subscription: subscriptionOrFilter.subscriptionOrFilterId,
 						})
 					}
@@ -135,24 +142,31 @@ export async function createNewFilter(params: EthNewFilter, subscriptionCreatorS
 	return subscriptionOrFilterId
 }
 
-export async function getEthFilterChanges(filterId: string, ethereumClientService: EthereumClientService, requestAbortController: AbortController | undefined, simulationState: ResolvedExecutionSimulationState) {
-	const filtersAndSubscriptions = await getEthereumSubscriptionsAndFilters()
-	const filter = filtersAndSubscriptions.find((subscriptionOrfilter) => subscriptionOrfilter.subscriptionOrFilterId === filterId)
-	if (filter === undefined || filter.type !== 'eth_newFilter') return undefined
-	if (filter.params.params[0].blockHash !== undefined) throw new Error('blockHash not supported for this method')
-	const calledInlastBlock = await getSimulatedBlockNumber(ethereumClientService, requestAbortController, simulationState)
-	const logs = calledInlastBlock > filter.calledInlastBlock
-		? await getSimulatedLogs(ethereumClientService, requestAbortController, simulationState, { ...filter.params.params[0], fromBlock: filter.calledInlastBlock + 1n, toBlock: calledInlastBlock })
-		: []
-	await updateEthereumSubscriptionsAndFilters((subscriptionsAndfilters) => {
-		return subscriptionsAndfilters.map((subscriptionOrfilter) => subscriptionOrfilter.subscriptionOrFilterId === filterId ? { ...subscriptionOrfilter, calledInlastBlock } : subscriptionOrfilter)
+export async function getEthFilterChanges(socket: WebsiteSocket, filterId: string, ethereumClientService: EthereumClientService, requestAbortController: AbortController | undefined, simulationState: ResolvedExecutionSimulationState) {
+	return await runFilterChangeSerially(filterChangesScope, `${ websiteSocketToString(socket) }:${ filterId }`, async () => {
+		const filtersAndSubscriptions = await getEthereumSubscriptionsAndFilters()
+		const filter = filtersAndSubscriptions.find((subscriptionOrfilter) => subscriptionOrfilter.subscriptionOrFilterId === filterId && isSameWebsiteSocket(subscriptionOrfilter.subscriptionCreatorSocket, socket))
+		if (filter === undefined || filter.type !== 'eth_newFilter') return undefined
+		if (filter.params.params[0].blockHash !== undefined) throw new Error('blockHash not supported for this method')
+		const calledInlastBlock = await getSimulatedBlockNumber(ethereumClientService, requestAbortController, simulationState)
+		const logs = calledInlastBlock > filter.calledInlastBlock
+			? await getSimulatedLogs(ethereumClientService, requestAbortController, simulationState, { ...filter.params.params[0], fromBlock: filter.calledInlastBlock + 1n, toBlock: calledInlastBlock })
+			: []
+		await updateEthereumSubscriptionsAndFilters((subscriptionsAndfilters) => {
+			return subscriptionsAndfilters.map((subscriptionOrfilter) => subscriptionOrfilter.subscriptionOrFilterId === filterId
+				&& isSameWebsiteSocket(subscriptionOrfilter.subscriptionCreatorSocket, socket)
+				&& subscriptionOrfilter.type === 'eth_newFilter'
+				&& calledInlastBlock > subscriptionOrfilter.calledInlastBlock
+				? { ...subscriptionOrfilter, calledInlastBlock }
+				: subscriptionOrfilter)
+		})
+		return logs
 	})
-	return logs
 }
 
-export async function getEthFilterLogs(filterId: string, ethereumClientService: EthereumClientService, requestAbortController: AbortController | undefined, simulationState: ResolvedExecutionSimulationState) {
+export async function getEthFilterLogs(socket: WebsiteSocket, filterId: string, ethereumClientService: EthereumClientService, requestAbortController: AbortController | undefined, simulationState: ResolvedExecutionSimulationState) {
 	const filtersAndSubscriptions = await getEthereumSubscriptionsAndFilters()
-	const filter = filtersAndSubscriptions.find((filter) => filter.subscriptionOrFilterId === filterId)
+	const filter = filtersAndSubscriptions.find((filter) => filter.subscriptionOrFilterId === filterId && isSameWebsiteSocket(filter.subscriptionCreatorSocket, socket))
 	if (filter === undefined || filter.type !== 'eth_newFilter') return undefined
 	if (filter.params.params[0].blockHash !== undefined) throw new Error('blockHash not supported for this method')
 	return await getSimulatedLogs(ethereumClientService, requestAbortController, simulationState, filter.params.params[0])

--- a/app/ts/simulation/services/SimulationModeEthereumClientService.ts
+++ b/app/ts/simulation/services/SimulationModeEthereumClientService.ts
@@ -335,6 +335,18 @@ export const getSimulatedTransactionCount = async (ethereumClientService: Ethere
 type Simulated1559BlockCall = Pick<IUnsignedTransaction1559, 'type' | 'from' | 'chainId' | 'nonce' | 'maxFeePerGas' | 'maxPriorityFeePerGas' | 'to' | 'value' | 'input'> & Partial<Pick<IUnsignedTransaction1559, 'gasLimit' | 'accessList'>>
 type Simulated7702BlockCall = Pick<IUnsignedTransaction7702, 'type' | 'from' | 'chainId' | 'nonce' | 'maxFeePerGas' | 'maxPriorityFeePerGas' | 'to' | 'value' | 'input' | 'authorizationList'> & Partial<Pick<IUnsignedTransaction7702, 'gasLimit' | 'accessList'>>
 type SimulatedBlockCall = Simulated1559BlockCall | Simulated7702BlockCall
+type SimulatedCallParams = Pick<IUnsignedTransaction1559, 'to' | 'maxFeePerGas' | 'maxPriorityFeePerGas' | 'input' | 'value'> & Partial<Pick<IUnsignedTransaction1559, 'from' | 'gasLimit' | 'accessList'>>
+
+export const createSimulationCallParams = (callParams: PartialEthereumTransaction, from: bigint): SimulatedCallParams => ({
+	from,
+	maxFeePerGas: callParams.gasPrice ?? callParams.maxFeePerGas ?? 0n,
+	maxPriorityFeePerGas: callParams.gasPrice === undefined ? callParams.maxPriorityFeePerGas ?? 0n : 0n,
+	...(callParams.gas === undefined ? {} : { gasLimit: callParams.gas }),
+	to: callParams.to === undefined ? null : callParams.to,
+	value: callParams.value ?? 0n,
+	input: getInputFieldFromDataOrInput(callParams),
+	accessList: callParams.accessList ?? [],
+})
 
 type SimulateBlockCallOptions = {
 	extraOverrides?: StateOverrides
@@ -460,7 +472,7 @@ export const simulateEstimateGas = async (ethereumClientService: EthereumClientS
 		to: data.to === undefined ? null : data.to,
 		value: data.value === undefined ? 0n : data.value,
 		input: getInputFieldFromDataOrInput(data),
-		accessList: []
+		accessList: data.accessList ?? []
 	}
 	const estimateGasTransaction = await createEip1559Or7702Transaction(estimateGasTransactionBase, data)
 	try {
@@ -1347,7 +1359,7 @@ const simulatedCallWithPreparedInputContext = async (
 	ethereumClientService: EthereumClientService,
 	requestAbortController: AbortController | undefined,
 	context: PreparedSimulationExecutionContext | undefined,
-	params: Pick<IUnsignedTransaction1559, 'to' | 'maxFeePerGas' | 'maxPriorityFeePerGas' | 'input' | 'value'> & Partial<Pick<IUnsignedTransaction1559, 'from' | 'gasLimit'>>,
+	params: SimulatedCallParams,
 	blockTag: EthereumBlockTag = 'latest',
 	extraOverrides: StateOverrides = {},
 ) => {
@@ -1389,7 +1401,7 @@ export const simulatedCallFromInput = async (
 	ethereumClientService: EthereumClientService,
 	requestAbortController: AbortController | undefined,
 	simulationStateInput: ResolvedSimulationInput,
-	params: Pick<IUnsignedTransaction1559, 'to' | 'maxFeePerGas' | 'maxPriorityFeePerGas' | 'input' | 'value'> & Partial<Pick<IUnsignedTransaction1559, 'from' | 'gasLimit'>>,
+	params: SimulatedCallParams,
 	blockTag: EthereumBlockTag = 'latest',
 ) => {
 	return await simulatedCallWithPreparedInputContext(
@@ -1556,7 +1568,7 @@ export const simulateEstimateGasFromInput = async (
 		to: data.to === undefined ? null : data.to,
 		value: data.value === undefined ? 0n : data.value,
 		input: getInputFieldFromDataOrInput(data),
-		accessList: []
+		accessList: data.accessList ?? []
 	}
 	const estimateGasTransaction = await createEip1559Or7702Transaction(estimateGasTransactionBase, data)
 	try {
@@ -1664,6 +1676,7 @@ const getLogsOfPreparedSimulatedExecutionBlock = (executionBlock: PreparedSimula
 
 	return events.filter((x) =>
 		(logFilter.address === undefined
+			|| logFilter.address === null
 			|| x.address === logFilter.address
 			|| (Array.isArray(logFilter.address) && logFilter.address.includes(x.address))
 		)
@@ -2095,7 +2108,7 @@ export const getSimulatedFeeHistory = async (ethereumClientService: EthereumClie
 
 				// we can have negative values here, as The Interceptor creates maxFeePerGas = 0 transactions that are intended to have zero base fee, which is not possible in reality
 				const zeroOutNegativeValues = effectivePriorityAndGasWeights.map((point) => modifyObject(point, { dataPoint: max(0n, point.dataPoint) }))
-				return calculateWeightedPercentile(zeroOutNegativeValues, BigInt(percentile))
+				return calculateWeightedPercentile(zeroOutNegativeValues, percentile)
 			})]
 		}
 	}

--- a/app/ts/types/JsonRpc-types.ts
+++ b/app/ts/types/JsonRpc-types.ts
@@ -1,5 +1,5 @@
 import * as funtypes from 'funtypes'
-import { CanonicalEthereumQuantity, EthereumAddress, EthereumBlockHeader, EthereumBlockHeaderWithTransactionHashes, EthereumBlockTag, EthereumBytes256, EthereumBytes32, EthereumData, EthereumInput, EthereumQuantity, EthereumSignatureParity, LiteralConverterParserFactory } from './wire-types.js'
+import { CanonicalEthereumQuantity, EthereumAccessList, EthereumAddress, EthereumBlockHeader, EthereumBlockHeaderWithTransactionHashes, EthereumBlockTag, EthereumBytes256, EthereumBytes32, EthereumData, EthereumInput, EthereumQuantity, EthereumSignatureParity, LiteralConverterParserFactory } from './wire-types.js'
 import { areEqualUint8Arrays } from '../utils/typed-arrays.js'
 import { EthSimulateV1Params } from './ethSimulate-types.js'
 import { OldSignTypedDataParams, PersonalSignParams, SignTypedDataParams } from './jsonRpc-signing-types.js'
@@ -86,6 +86,7 @@ export const PartialEthereumTransaction = funtypes.ReadonlyPartial({
 	maxFeePerGas: funtypes.Union(EthereumQuantity, funtypes.Null), // etherscan sets this field to null, remove this if etherscan fixes this
 	data: EthereumData,
 	input: EthereumData,
+	accessList: EthereumAccessList,
 	authorizationList: funtypes.ReadonlyArray(funtypes.ReadonlyObject({
 		chainId: EthereumQuantity,
 		address: EthereumAddress,
@@ -246,9 +247,9 @@ export const EstimateGasParams = funtypes.ReadonlyObject({
 export type EthCallParams = funtypes.Static<typeof EthCallParams>
 export const EthCallParams = funtypes.ReadonlyObject({
 	method: funtypes.Literal('eth_call'),
-	params: funtypes.ReadonlyTuple(
-		PartialEthereumTransaction,
-		EthereumBlockTag
+	params: funtypes.Union(
+		funtypes.ReadonlyTuple(PartialEthereumTransaction),
+		funtypes.ReadonlyTuple(PartialEthereumTransaction, EthereumBlockTag),
 	)
 }).asReadonly()
 
@@ -433,7 +434,7 @@ export const FeeHistory = funtypes.ReadonlyObject({
 const EthNewFilterOptions = funtypes.ReadonlyPartial({
 	fromBlock: EthereumBlockTag,
 	toBlock: EthereumBlockTag,
-	address: EthereumAddress,
+	address: funtypes.Union(EthereumAddress, funtypes.ReadonlyArray(EthereumAddress), funtypes.Null),
 	topics: funtypes.ReadonlyArray(funtypes.Union(EthereumBytes32, funtypes.ReadonlyArray(EthereumBytes32), funtypes.Null)),
 	blockHash: EthereumBytes32,
 	blockhash: funtypes.Never,

--- a/app/ts/types/addressBookTypes.ts
+++ b/app/ts/types/addressBookTypes.ts
@@ -4,6 +4,8 @@ import { EthereumAddress, EthereumQuantity, LiteralConverterParserFactory } from
 export type ChainIdWithUniversal = funtypes.Static<typeof ChainIdWithUniversal>
 export const ChainIdWithUniversal = funtypes.Union(EthereumQuantity, funtypes.Literal('AllChains'))
 
+export const doAddressBookChainIdsMatch = (left: ChainIdWithUniversal | undefined, right: ChainIdWithUniversal | undefined) => (left ?? 1n) === (right ?? 1n)
+
 export type EntrySource = funtypes.Static<typeof EntrySource>
 export const EntrySource = funtypes.Union(
 	funtypes.Literal('DarkFloristMetadata'),

--- a/app/ts/types/interceptor-messages.ts
+++ b/app/ts/types/interceptor-messages.ts
@@ -155,7 +155,7 @@ type SubscriptionReturnValue = funtypes.Static<typeof SubscriptionReturnValue>
 const SubscriptionReturnValue = funtypes.ReadonlyObject({
 	method: funtypes.Literal('newHeads'),
 	result: funtypes.ReadonlyObject({
-		subscription: funtypes.Literal('newHeads'),
+		subscription: funtypes.String,
 		result: EthereumBlockHeaderWithTransactionHashes
 	})
 })

--- a/app/ts/utils/bigint.ts
+++ b/app/ts/utils/bigint.ts
@@ -109,15 +109,26 @@ export function isHexEncodedNumber(input: string): boolean {
 	return hexNumberRegex.test(input)
 }
 
-export function calculateWeightedPercentile(data: readonly { dataPoint: bigint, weight: bigint }[], percentile: bigint): bigint {
+function positiveDecimalNumberToFraction(value: number) {
+	const [coefficient = '', exponentText] = value.toString().split('e')
+	const [integerPart = '', fractionalPart = ''] = coefficient.split('.')
+	const exponent = exponentText === undefined ? 0 : Number(exponentText)
+	const digits = BigInt(`${ integerPart }${ fractionalPart }`)
+	const decimalPlaces = fractionalPart.length - exponent
+	if (decimalPlaces <= 0) return { numerator: digits * 10n ** BigInt(-decimalPlaces), denominator: 1n }
+	return { numerator: digits, denominator: 10n ** BigInt(decimalPlaces) }
+}
+
+export function calculateWeightedPercentile(data: readonly { dataPoint: bigint, weight: bigint }[], percentile: number): bigint {
 	if (data.length === 0) return 0n
-	if (percentile < 0 || percentile > 100 || data.map((point) => point.weight).some((weight) => weight < 0)) throw new Error('Invalid input')
+	if (!Number.isFinite(percentile) || percentile < 0 || percentile > 100 || data.map((point) => point.weight).some((weight) => weight < 0)) throw new Error('Invalid input')
 	const sortedData = [...data].sort((a, b) => a.dataPoint < b.dataPoint ? -1 : a.dataPoint > b.dataPoint ? 1 : 0)
 	const totalWeight = sortedData.reduce((total, point) => total + point.weight, 0n)
-	const targetWeight = percentile * totalWeight
+	const { numerator, denominator } = positiveDecimalNumberToFraction(percentile)
+	const targetWeight = numerator * totalWeight
 	let cumulativeWeight = 0n
 	for (const point of sortedData) {
-		cumulativeWeight += point.weight * 100n
+		cumulativeWeight += point.weight * 100n * denominator
 		if (cumulativeWeight >= targetWeight) return point.dataPoint
 	}
 	return sortedData[sortedData.length - 1]?.dataPoint ?? 0n

--- a/app/ts/utils/imageToUri.ts
+++ b/app/ts/utils/imageToUri.ts
@@ -98,7 +98,6 @@ export async function imageToUri(url: string, maxSizeInBytes = 1048576, requestI
 		if (!await canDecodeImage(blob)) return imageToUriFailed('image data could not be decoded')
 		const result = await readBlobAsDataUrl(blob)
 		if (result.failureReason !== undefined || result.data === undefined) return result
-		if (result.data.length > maxSizeInBytes) return imageTooLarge(maxSizeInBytes)
 		return result
 	} catch (error) {
 		if (error instanceof Error) return imageToUriFailed(`fetch failed (${ error.message })`)

--- a/test/tests/EthereumSubscriptionService.test.ts
+++ b/test/tests/EthereumSubscriptionService.test.ts
@@ -236,11 +236,11 @@ const blockNumber = 8443561n
 				},
 			]))
 
-			const firstChanges = await getEthFilterChanges('filter-1', ethereum, undefined, toResolvedExecutionSimulationState(simulationState))
+			const firstChanges = await getEthFilterChanges(filterSocket, 'filter-1', ethereum, undefined, toResolvedExecutionSimulationState(simulationState))
 			assert.equal(firstChanges?.length, 1)
 			assert.equal(firstChanges?.[0]?.address, matchingLog.address)
 
-			const secondChanges = await getEthFilterChanges('filter-1', ethereum, undefined, toResolvedExecutionSimulationState(simulationState))
+			const secondChanges = await getEthFilterChanges(filterSocket, 'filter-1', ethereum, undefined, toResolvedExecutionSimulationState(simulationState))
 			assert.deepEqual(secondChanges, [])
 
 			const updated = await getEthereumSubscriptionsAndFilters()
@@ -251,17 +251,17 @@ const blockNumber = 8443561n
 			assert.equal(updated[1]?.subscriptionOrFilterId, 'keep-me')
 		})
 
-		test('eth_getFilterChanges only returns newly simulated logs once', async () => {
+		test('eth_getFilterChanges treats a null address as unrestricted', async () => {
 			installBrowserMock()
 			const { createNewFilter, getEthFilterChanges, getEthereumSubscriptionsAndFilters } = await loadModules()
 			const ethereum = createEthereum()
 			const socket = { tabId: 1, connectionName: 1n } as const
-			const filterId = await createNewFilter({ method: 'eth_newFilter', params: [{}] }, socket, ethereum, undefined, PASSTHROUGH_STATE)
+			const filterId = await createNewFilter({ method: 'eth_newFilter', params: [{ address: null }] }, socket, ethereum, undefined, PASSTHROUGH_STATE)
 			const simulationState = await createExecutionSimulationState(ethereum, undefined, createSimulationInput(21_000n, 0n, 1n))
 			if (simulationState.success === false) throw new Error('simulation unexpectedly failed')
 
-			const firstChanges = await getEthFilterChanges(filterId, ethereum, undefined, toResolvedExecutionSimulationState(simulationState))
-			const secondChanges = await getEthFilterChanges(filterId, ethereum, undefined, toResolvedExecutionSimulationState(simulationState))
+			const firstChanges = await getEthFilterChanges(socket, filterId, ethereum, undefined, toResolvedExecutionSimulationState(simulationState))
+			const secondChanges = await getEthFilterChanges(socket, filterId, ethereum, undefined, toResolvedExecutionSimulationState(simulationState))
 			const storedFilters = await getEthereumSubscriptionsAndFilters()
 			const storedFilter = storedFilters.find((filter) => filter.type === 'eth_newFilter' && filter.subscriptionOrFilterId === filterId)
 			if (storedFilter === undefined || storedFilter.type !== 'eth_newFilter') throw new Error('stored filter missing')
@@ -270,6 +270,57 @@ const blockNumber = 8443561n
 			assert.equal(firstChanges?.[0]?.blockNumber, blockNumber + 1n)
 			assert.deepEqual(secondChanges, [])
 			assert.equal(storedFilter.calledInlastBlock, blockNumber + 1n)
+		})
+
+		test('concurrent eth_getFilterChanges calls do not return the same logs twice', async () => {
+			installBrowserMock()
+			const { createNewFilter, getEthFilterChanges } = await loadModules()
+			const ethereum = createEthereum()
+			const socket = { tabId: 1, connectionName: 1n } as const
+			const filterId = await createNewFilter({ method: 'eth_newFilter', params: [{}] }, socket, ethereum, undefined, PASSTHROUGH_STATE)
+			const simulationState = await createExecutionSimulationState(ethereum, undefined, createSimulationInput(21_000n, 0n, 1n))
+			if (simulationState.success === false) throw new Error('simulation unexpectedly failed')
+			const resolvedSimulationState = toResolvedExecutionSimulationState(simulationState)
+
+			const concurrentChanges = await Promise.all([
+				getEthFilterChanges(socket, filterId, ethereum, undefined, resolvedSimulationState),
+				getEthFilterChanges(socket, filterId, ethereum, undefined, resolvedSimulationState),
+			])
+
+			assert.deepEqual(concurrentChanges.map((logs) => logs?.length).sort(), [0, 1])
+		})
+
+		test('filter reads are restricted to the socket that created the filter', async () => {
+			installBrowserMock()
+			const { createNewFilter, getEthFilterChanges, getEthFilterLogs } = await loadModules()
+			const ethereum = createEthereum()
+			const creatorSocket = { tabId: 1, connectionName: 1n } as const
+			const otherSocketInSameTab = { tabId: 1, connectionName: 2n } as const
+			const filterId = await createNewFilter({ method: 'eth_newFilter', params: [{}] }, creatorSocket, ethereum, undefined, PASSTHROUGH_STATE)
+
+			assert.equal(await getEthFilterChanges(otherSocketInSameTab, filterId, ethereum, undefined, PASSTHROUGH_STATE), undefined)
+			assert.equal(await getEthFilterLogs(otherSocketInSameTab, filterId, ethereum, undefined, PASSTHROUGH_STATE), undefined)
+			assert.deepEqual(await getEthFilterChanges(creatorSocket, filterId, ethereum, undefined, PASSTHROUGH_STATE), [])
+		})
+
+		test('filter cursors do not rewind when the simulated head moves backwards', async () => {
+			installBrowserMock()
+			const { getEthFilterChanges, getEthereumSubscriptionsAndFilters, updateEthereumSubscriptionsAndFilters } = await loadModules()
+			const ethereum = createEthereum()
+			const socket = { tabId: 1, connectionName: 1n } as const
+			const futureCursor = blockNumber + 5n
+			await updateEthereumSubscriptionsAndFilters(() => ([{
+				type: 'eth_newFilter',
+				subscriptionOrFilterId: 'future-filter',
+				params: { method: 'eth_newFilter', params: [{}] },
+				subscriptionCreatorSocket: socket,
+				calledInlastBlock: futureCursor,
+			}]))
+
+			assert.deepEqual(await getEthFilterChanges(socket, 'future-filter', ethereum, undefined, PASSTHROUGH_STATE), [])
+			const [storedFilter] = await getEthereumSubscriptionsAndFilters()
+			if (storedFilter?.type !== 'eth_newFilter') throw new Error('stored filter missing')
+			assert.equal(storedFilter.calledInlastBlock, futureCursor)
 		})
 
 		test('newHeads emits each simulated execution block after a gas split', async () => {
@@ -296,7 +347,7 @@ const blockNumber = 8443561n
 					},
 				}],
 			])
-			await createEthereumSubscription({ method: 'eth_subscribe', params: ['newHeads'] }, socket)
+			const subscriptionId = await createEthereumSubscription({ method: 'eth_subscribe', params: ['newHeads'] }, socket)
 			const splitSimulationInput = [{
 				stateOverrides: {},
 				transactions: [
@@ -336,16 +387,19 @@ const blockNumber = 8443561n
 				if (message.type !== 'result' || !('method' in message) || message.method !== 'newHeads') return []
 				if (!('result' in message) || !('result' in message.result)) throw new Error('wrong subscription payload')
 				if (message.result.result === null) throw new Error('missing simulated block payload')
+				assert.equal(message.subscription, subscriptionId)
+				assert.equal(message.result.subscription, subscriptionId)
 				return [message.result.result.number]
 			})
 			assert.equal(emittedBlockNumbers.length, 3)
 			assert.deepEqual(emittedBlockNumbers, [blockNumber, blockNumber + 1n, blockNumber + 2n])
 		})
 
-		test('newHeads skips stale subscriptions without suppressing later live subscribers', async () => {
+		test('newHeads removes a stale socket while another socket in the same tab remains live', async () => {
 			installBrowserMock()
-			const { createEthereumSubscription, sendSubscriptionMessagesForNewBlock, updateEthereumSubscriptionsAndFilters } = await loadModules()
+			const { createEthereumSubscription, getEthereumSubscriptionsAndFilters, sendSubscriptionMessagesForNewBlock, updateEthereumSubscriptionsAndFilters } = await loadModules()
 			const ethereum = createEthereum()
+			const staleSocket = { tabId: 2, connectionName: 1n } as const
 			const liveSocket = { tabId: 2, connectionName: 2n } as const
 			const postedMessages: InterceptorMessageToInpage[] = []
 			const port = {
@@ -368,8 +422,8 @@ const blockNumber = 8443561n
 			])
 
 			await updateEthereumSubscriptionsAndFilters(() => [])
-			await createEthereumSubscription({ method: 'eth_subscribe', params: ['newHeads'] }, { tabId: 1, connectionName: 1n })
-			await createEthereumSubscription({ method: 'eth_subscribe', params: ['newHeads'] }, liveSocket)
+			const staleSubscriptionId = await createEthereumSubscription({ method: 'eth_subscribe', params: ['newHeads'] }, staleSocket)
+			const liveSubscriptionId = await createEthereumSubscription({ method: 'eth_subscribe', params: ['newHeads'] }, liveSocket)
 
 			await sendSubscriptionMessagesForNewBlock(blockNumber, ethereum, false, websiteTabConnections, async () => PASSTHROUGH_STATE)
 
@@ -381,6 +435,8 @@ const blockNumber = 8443561n
 			})
 
 			assert.deepEqual(emittedBlockNumbers, [blockNumber])
+			assert.deepEqual((await getEthereumSubscriptionsAndFilters()).map((subscription) => subscription.subscriptionOrFilterId), [liveSubscriptionId])
+			assert.notEqual(staleSubscriptionId, liveSubscriptionId)
 		})
 
 		test('newHeads reuses one simulated state computation across multiple live subscribers', async () => {

--- a/test/tests/SimulationModeEthereumClientService.test.ts
+++ b/test/tests/SimulationModeEthereumClientService.test.ts
@@ -6,7 +6,7 @@ import { EthereumClientService } from '../../app/ts/simulation/services/Ethereum
 import { EthereumSignedTransactionToSignedTransaction, EthereumUnsignedTransactionToUnsignedTransaction, serializeSignedTransactionToBytes, serializeUnsignedTransactionToBytes } from '../../app/ts/utils/ethereum.js'
 import { addressString, bytes32String, dataStringWith0xStart, stringToUint8Array } from '../../app/ts/utils/bigint.js'
 import { EthereumAddress, EthereumSignatureParity, EthereumSignedTransaction, EthereumSignedTransaction1559, EthereumSignedTransactionWithBlockData, EthereumUnsignedTransaction, serialize } from '../../app/ts/types/wire-types.js'
-import { createExecutionSimulationState, createSimulationState, ethSimulateV1FromInput, getBaseFeeAdjustedTransactions, getBaseFeeAdjustmentBalances, getSimulatedBalanceFromInput, getSimulatedBlock, getSimulatedBlockByHashFromInput, getSimulatedBlockFromInput, getSimulatedBlockNumberFromInput, getSimulatedCode, getSimulatedCodeFromInput, getSimulatedLogs, getSimulatedStorageAtFromInput, getSimulatedTransactionByHashFromInput, getSimulatedTransactionCount, getSimulatedTransactionCountFromInput, getSimulatedTransactionReceipt, groupEthSimulateV1ResultByInputBlocks, mockSignTransaction, simulateEstimateGas, simulateEstimateGasFromInput, simulatePersonalSign, simulatedCall, simulatedCallFromInput } from '../../app/ts/simulation/services/SimulationModeEthereumClientService.js'
+import { createExecutionSimulationState, createSimulationCallParams, createSimulationState, ethSimulateV1FromInput, getBaseFeeAdjustedTransactions, getBaseFeeAdjustmentBalances, getSimulatedBalanceFromInput, getSimulatedBlock, getSimulatedBlockByHashFromInput, getSimulatedBlockFromInput, getSimulatedBlockNumberFromInput, getSimulatedCode, getSimulatedCodeFromInput, getSimulatedFeeHistory, getSimulatedLogs, getSimulatedStorageAtFromInput, getSimulatedTransactionByHashFromInput, getSimulatedTransactionCount, getSimulatedTransactionCountFromInput, getSimulatedTransactionReceipt, groupEthSimulateV1ResultByInputBlocks, mockSignTransaction, simulateEstimateGas, simulateEstimateGasFromInput, simulatePersonalSign, simulatedCall, simulatedCallFromInput } from '../../app/ts/simulation/services/SimulationModeEthereumClientService.js'
 import { EthTransactionReceiptResponse, EthereumJsonRpcRequest, JsonRpcResponse } from '../../app/ts/types/JsonRpc-types.js'
 import { RPCReply } from '../../app/ts/types/interceptor-messages.js'
 import type { EthSimulateV1BlockTag, EthSimulateV1Params, EthSimulateV1Result } from '../../app/ts/types/ethSimulate-types.js'
@@ -1290,6 +1290,45 @@ describe('SimulationModeEthereumClientService', () => {
 			assert.equal(requestHandler.ethSimulateV1Calls.at(-1)?.lastCallGas, explicitGas)
 		})
 
+		test('eth_call simulation parameters preserve gas, fee, and access-list fields', () => {
+			const accessList = [{ address: 0x2n, storageKeys: [0x42n] }] as const
+			const params = createSimulationCallParams({
+				to: 0x2n,
+				gas: 54_321n,
+				maxFeePerGas: 99n,
+				maxPriorityFeePerGas: 3n,
+				accessList,
+			}, 0x1n)
+
+			assert.equal(params.gasLimit, 54_321n)
+			assert.equal(params.maxFeePerGas, 99n)
+			assert.equal(params.maxPriorityFeePerGas, 3n)
+			assert.deepEqual(params.accessList, accessList)
+		})
+
+		test('gas estimation preserves access lists in both simulation-state paths', async () => {
+			const accessList = [{ address: 0x2n, storageKeys: [0x42n] }] as const
+			const transaction = {
+				from: exampleTransaction.from,
+				to: exampleTransaction.to,
+				value: exampleTransaction.value,
+				input: exampleTransaction.input,
+				accessList,
+			}
+
+			const fromInputEstimate = await simulateEstimateGasFromInput(ethereum, undefined, [], transaction)
+			if ('error' in fromInputEstimate) throw new Error(`estimate gas unexpectedly failed: ${ fromInputEstimate.message }`)
+			const fromInputRequest = requestHandler.ethSimulateV1Requests.at(-1)
+			assert.deepEqual(fromInputRequest?.params[0].blockStateCalls.at(-1)?.calls[0]?.accessList, accessList)
+
+			const simulationState = await createSimulationState(ethereum, undefined, createSimulationStateInput())
+			if (simulationState.success === false) throw new Error('simulation unexpectedly failed')
+			const fromStateEstimate = await simulateEstimateGas(ethereum, undefined, toResolvedSimulationState(simulationState), transaction)
+			if ('error' in fromStateEstimate) throw new Error(`estimate gas unexpectedly failed: ${ fromStateEstimate.message }`)
+			const fromStateRequest = requestHandler.ethSimulateV1Requests.at(-1)
+			assert.deepEqual(fromStateRequest?.params[0].blockStateCalls.at(-1)?.calls[0]?.accessList, accessList)
+		})
+
 		test('simulateEstimateGasFromInput validates and projects signed 7702 authorizations', async () => {
 			requestHandler.ethSimulateV1Calls.length = 0
 			const clearDelegationAuthorization = eip7702Authorization.sign({
@@ -1591,6 +1630,15 @@ describe('SimulationModeEthereumClientService', () => {
 			} finally {
 				requestHandler.maxPriorityFeePerGasResponse = '0x3b9aca00'
 			}
+		})
+
+		test('getSimulatedFeeHistory calculates fractional reward percentiles', async () => {
+			const feeHistory = await getSimulatedFeeHistory(ethereum, undefined, {
+				method: 'eth_feeHistory',
+				params: [1n, 'latest', [0.5, 25.25, 99.999]],
+			})
+
+			assert.equal(feeHistory.reward?.[0]?.length, 3)
 		})
 
 		test('simulateEstimateGasFromInput surfaces RPC errors when omitted gas is rejected', async () => {

--- a/test/tests/addressEditEntry.test.ts
+++ b/test/tests/addressEditEntry.test.ts
@@ -2,8 +2,23 @@ import * as assert from 'assert'
 import { describe, test } from 'bun:test'
 import { addressEditEntry } from '../../app/ts/components/ui-utils.js'
 import { getAddressBookEntryForEdit } from '../../app/ts/components/pages/ConfirmTransaction.js'
+import { doAddressBookChainIdsMatch } from '../../app/ts/types/addressBookTypes.js'
 
 describe('address edit entry state', () => {
+	test('preserves chain ID zero when opening an address for editing', () => {
+		const editState = addressEditEntry({
+			type: 'contact',
+			name: 'Chain zero contact',
+			address: 1n,
+			entrySource: 'User',
+			chainId: 0n,
+		})
+
+		assert.equal(editState.incompleteAddressBookEntry.chainId, 0n)
+		assert.equal(doAddressBookChainIdsMatch(0n, 1n), false)
+		assert.equal(doAddressBookChainIdsMatch(undefined, 1n), true)
+	})
+
 	test('does not reopen with a stale ABI after the current address book entry has removed it', () => {
 		const address = 0xe72ecea44b6d8b2b3cf5171214d9730e86213ca2n
 		const staleClickedEntry = {

--- a/test/tests/eip7702RescueTransactionParsing.test.ts
+++ b/test/tests/eip7702RescueTransactionParsing.test.ts
@@ -423,6 +423,7 @@ describe('EIP-7702 rescue transaction parsing', () => {
 				gas: '0xc350',
 				maxFeePerGas: '0x2',
 				maxPriorityFeePerGas: '0x1',
+				accessList: [{ address: accessListAddress, storageKeys: [accessListStorageKey] }],
 				authorizationList: [signedAuthorizationToRpc(clearDelegationAuthorization)],
 			}],
 		})
@@ -444,6 +445,10 @@ describe('EIP-7702 rescue transaction parsing', () => {
 			if (transaction.success === false) throw new Error('transaction creation unexpectedly failed')
 			assert.equal(transaction.transaction.type, '7702')
 			if (transaction.transaction.type !== '7702') throw new Error('Expected a 7702 transaction')
+			assert.deepEqual(transaction.transaction.accessList, [{
+				address: EthereumAddress.parse(accessListAddress),
+				storageKeys: [EthereumBytes32.parse(accessListStorageKey)],
+			}])
 			const [authorization] = transaction.transaction.authorizationList
 			if (authorization === undefined) throw new Error('Expected authorization to be parsed')
 			assert.equal(authorization.authority, EthereumAddress.parse(victim.address))

--- a/test/tests/imageToUri.test.ts
+++ b/test/tests/imageToUri.test.ts
@@ -158,14 +158,14 @@ describe('imageToUri', () => {
 		assert.equal(result.failureReason, 'image data could not be decoded')
 	})
 
-	test('classifies oversized data uris', async () => {
-		installSuccessfulFileReader('data:image/png;base64,dG9vLWJpZw==')
-		fetchImplementation = async () => new Response(new Blob(['too-big'], { type: 'image/png' }), { status: 200, headers: { 'content-type': 'image/png' } })
+	test('accepts an under-limit image when its encoded data uri is longer than the source bytes', async () => {
+		installSuccessfulFileReader('data:image/png;base64,b2s=')
+		fetchImplementation = async () => new Response(new Blob(['ok'], { type: 'image/png' }), { status: 200, headers: { 'content-type': 'image/png' } })
 
-		const result = await imageToUri('https://example.test/too-big.png', 5)
+		const result = await imageToUri('https://example.test/under-limit.png', 2)
 
-		assert.equal(result.data, undefined)
-		assert.equal(result.failureReason, 'image data exceeded 5 bytes')
+		assert.equal(result.data, 'data:image/png;base64,b2s=')
+		assert.equal(result.failureReason, undefined)
 	})
 
 	test('rejects oversized image responses before decoding them when content-length exceeds the limit', async () => {

--- a/test/tests/jsonRpcRequestCompatibility.test.ts
+++ b/test/tests/jsonRpcRequestCompatibility.test.ts
@@ -1,0 +1,62 @@
+import * as assert from 'assert'
+import { describe, test } from 'bun:test'
+import { EthereumJsonRpcRequest } from '../../app/ts/types/JsonRpc-types.js'
+
+const address = '0x0000000000000000000000000000000000000001'
+const secondAddress = '0x0000000000000000000000000000000000000002'
+const storageKey = `0x${ '42'.padStart(64, '0') }`
+
+describe('JSON-RPC request compatibility', () => {
+	test('accepts eth_call without an explicit block tag', () => {
+		const request = EthereumJsonRpcRequest.parse({
+			method: 'eth_call',
+			params: [{ to: address, data: '0x' }],
+		})
+
+		assert.equal(request.method, 'eth_call')
+		assert.equal(request.params.length, 1)
+	})
+
+	test('preserves transaction access lists at the request boundary', () => {
+		const request = EthereumJsonRpcRequest.parse({
+			method: 'eth_sendTransaction',
+			params: [{
+				from: address,
+				to: secondAddress,
+				accessList: [{ address: secondAddress, storageKeys: [storageKey] }],
+			}],
+		})
+
+		assert.equal(request.method, 'eth_sendTransaction')
+		assert.deepEqual(request.params[0].accessList, [{
+			address: BigInt(secondAddress),
+			storageKeys: [BigInt(storageKey)],
+		}])
+	})
+
+	test('accepts address arrays and null addresses in eth_newFilter', () => {
+		const arrayRequest = EthereumJsonRpcRequest.parse({
+			method: 'eth_newFilter',
+			params: [{ address: [address, secondAddress] }],
+		})
+		const nullRequest = EthereumJsonRpcRequest.parse({
+			method: 'eth_newFilter',
+			params: [{ address: null }],
+		})
+
+		assert.equal(arrayRequest.method, 'eth_newFilter')
+		assert.deepEqual(arrayRequest.params[0].address, [BigInt(address), BigInt(secondAddress)])
+		assert.equal(nullRequest.method, 'eth_newFilter')
+		assert.equal(nullRequest.params[0].address, null)
+	})
+
+	test('accepts fractional eth_feeHistory reward percentiles', () => {
+		const request = EthereumJsonRpcRequest.parse({
+			method: 'eth_feeHistory',
+			params: ['0x1', 'latest', [0.5, 25.25, 99.999]],
+		})
+
+		assert.equal(request.method, 'eth_feeHistory')
+		assert.deepEqual(request.params[2], [0.5, 25.25, 99.999])
+	})
+})

--- a/test/tests/utils.bigint.test.ts
+++ b/test/tests/utils.bigint.test.ts
@@ -14,14 +14,23 @@ describe('utils.bigint', () => {
 	test('display -0.2346 ETH', () => assert.equal(bigintToRoundedPrettyDecimalString(-234567n * 10n ** 12n, 18n, 4), '-0.2346'))
 	test('display -10k ETH', () => assert.equal(bigintToRoundedPrettyDecimalString(-(10n ** 22n), 18n, 4), '-10k'))
 	test('calculates the highest weighted percentile without indexing past the data', () => {
-		assert.equal(calculateWeightedPercentile([{ dataPoint: 10n, weight: 1n }], 100n), 10n)
+		assert.equal(calculateWeightedPercentile([{ dataPoint: 10n, weight: 1n }], 100), 10n)
 		assert.equal(calculateWeightedPercentile([
 			{ dataPoint: 10n, weight: 1n },
 			{ dataPoint: 20n, weight: 3n },
-		], 25n), 10n)
+		], 25), 10n)
 		assert.equal(calculateWeightedPercentile([
 			{ dataPoint: 10n, weight: 1n },
 			{ dataPoint: 20n, weight: 3n },
-		], 26n), 20n)
+		], 26), 20n)
+	})
+
+	test('calculates fractional weighted percentiles without rounding them to integers', () => {
+		const data = [
+			{ dataPoint: 10n, weight: 1n },
+			{ dataPoint: 20n, weight: 199n },
+		] as const
+		assert.equal(calculateWeightedPercentile(data, 0.5), 10n)
+		assert.equal(calculateWeightedPercentile(data, 0.5000000000000001), 20n)
 	})
 })


### PR DESCRIPTION
## Summary

Fixes ten small but user-visible JSON-RPC, subscription, simulation, address-book, and image-handling bugs that remained after #1572.

## Bugs fixed

1. **Wrong `eth_subscription` ID for `newHeads`** — notifications now put the generated subscription ID in both the bridge envelope and the EIP-1193 payload instead of sending the literal string `newHeads`.
2. **Stale subscriptions survived same-tab reconnects** — cleanup now checks the exact tab/connection socket, so a second live socket in the same tab no longer keeps a disconnected socket's subscription alive.
3. **Filter reads were not socket-scoped** — `eth_getFilterChanges` and `eth_getFilterLogs` now require the same socket that created the filter.
4. **Filter cursors could rewind or return duplicate ranges** — cursor advancement is monotonic, and concurrent polls for the same socket/filter are serialized.
5. **Valid one-parameter `eth_call` requests were rejected** — the block parameter is now optional and defaults to `latest`, matching the execution API.
6. **Transaction envelope fields were discarded** — `accessList` is parsed and preserved through send, call, and both gas-estimation paths; `eth_call` also preserves explicit gas and EIP-1559 fee fields.
7. **`eth_newFilter` rejected standard address filters** — address arrays and `null` are accepted, and `null` correctly behaves as no address restriction for simulated logs.
8. **Fractional `eth_feeHistory` percentiles threw** — weighted percentile calculation now handles fractional numbers exactly instead of converting them directly with `BigInt(...)`.
9. **Chain ID `0` was rewritten as mainnet** — truthiness-based `|| 1n` defaults are replaced with nullish defaults, including address-book comparison and UI flows.
10. **Under-limit images were rejected after base64 encoding** — the size limit remains based on downloaded source bytes rather than the longer data-URI character count.

## Tests

Added focused coverage for:

- subscription IDs, exact-socket cleanup, socket-owned filters, monotonic/concurrent filter reads, and `address: null`
- one-parameter `eth_call`, access-list parsing/propagation, gas and fee projection, and filter address arrays
- fractional fee-history percentiles
- chain ID `0`
- source-byte image limits

## Validation

- `bun run test` — 1,019 passed, 0 failed
- `bun run setup-chrome` — passed
- `bun run typecheck` — passed
- `bun run lint` — passed
- `git diff --check origin/main...HEAD` — passed

`bun run test:chrome-communication` was not run because this change does not alter content-script registration, injection, access approval, or bridge lifecycle; the changed subscription serialization and routing are covered by unit tests.

## Review

- Reviewer pass 1: **72/100** — found one Medium issue (`address: null` matching) and one Low issue (concurrent filter polling); both were fixed with regression tests.
- Reviewer pass 2: **94/100** — no High, Medium, or Low findings.
