### PR TITLE
Fix ten RPC, signing, and simulation edge cases

### DIFF
--- a/app/inpage/ts/inpage.ts
+++ b/app/inpage/ts/inpage.ts
@@ -242,7 +242,7 @@ interface ProviderMessage {
 }
 
 type JsonRpcResponse = IJsonRpcSuccess<unknown> | IJsonRpcError
-type LegacyJsonRpcCallback = (error: IJsonRpcError | null, response: JsonRpcResponse | JsonRpcResponse[] | null) => void
+type LegacyJsonRpcCallback = (error: Error | null, response: JsonRpcResponse | JsonRpcResponse[] | null) => void
 
 type SignerAccountsReply =
 	| { readonly type: 'success', readonly accounts: readonly string[], readonly requestAccounts: boolean }
@@ -976,23 +976,18 @@ class InterceptorMessageListener {
 					}
 				}
 			}
-			return {
-				jsonrpc: '2.0',
-				id: param.id,
-				error: { message: 'unknown error', code: METAMASK_ERROR_BLANKET_ERROR }
-			}
+			throw error
 		}
 	}
 
 	private readonly WindowEthereumSendAsync = async (payload: SingleSendAsyncParam | SingleSendAsyncParam[], callback: LegacyJsonRpcCallback) => {
-		if (Array.isArray(payload)) {
-			const responses = await Promise.all(payload.map((param) => this.getWindowEthereumSendAsyncResponse(param)))
-			callback(null, responses)
-			return
-		}
-		const response = await this.getWindowEthereumSendAsyncResponse(payload)
-		if ('error' in response) {
-			callback(response, null)
+		let response: JsonRpcResponse | JsonRpcResponse[]
+		try {
+			response = Array.isArray(payload)
+				? await Promise.all(payload.map((param) => this.getWindowEthereumSendAsyncResponse(param)))
+				: await this.getWindowEthereumSendAsyncResponse(payload)
+		} catch (error: unknown) {
+			callback(error instanceof Error ? error : new Error(`Unexpected sendAsync failure: ${ String(error) }`), null)
 			return
 		}
 		callback(null, response)

--- a/app/ts/background/windows/personalSign.ts
+++ b/app/ts/background/windows/personalSign.ts
@@ -5,7 +5,6 @@ import { assertNever } from '../../utils/typescript.js'
 import { extractEIP712Message, validateEIP712Types } from '../../utils/eip712Parsing.js'
 import { getRpcNetworkForChain, getTabState } from '../storageVariables.js'
 import { getAddressesForSolidityTypes, identifyAddress } from '../metadataUtils.js'
-import type { AddressBookEntry } from '../../types/addressBookTypes.js'
 import type { SignedMessageTransaction } from '../../types/visualizer-types.js'
 import type { RpcNetwork } from '../../types/rpc.js'
 import { getChainName } from '../../utils/constants.js'
@@ -24,6 +23,13 @@ async function addMetadataToOpenSeaOrder(ethereumClientService: EthereumClientSe
 	 }
 }
 
+export function getSigningQuarantineCodes(messageChainId: bigint | undefined, activeChainId: bigint, accountAddress: bigint, activeAddress: bigint, ownerAddress: bigint | undefined): { quarantine: boolean, quarantineReasons: readonly string[] } {
+	const quarantineReasons: string[] = []
+	if (messageChainId !== undefined && messageChainId !== activeChainId) quarantineReasons.push(`The signature request is for a different chain (${ getChainName(messageChainId) }) than what is currently active (${ getChainName(activeChainId) }).`)
+	if (accountAddress !== activeAddress || (ownerAddress !== undefined && accountAddress !== ownerAddress)) quarantineReasons.push('The signature request is for an account that is different from your active address.')
+	return { quarantine: quarantineReasons.length > 0, quarantineReasons }
+}
+
 export async function craftPersonalSignPopupMessage(ethereumClientService: EthereumClientService, requestAbortController: AbortController | undefined, signedMessageTransaction: SignedMessageTransaction, rpcNetwork: RpcNetwork): Promise<VisualizedPersonalSignRequest> {
 	const activeAddressWithMetadata = await identifyAddress(ethereumClientService, requestAbortController, signedMessageTransaction.fakeSignedFor)
 	const signerName = (await getTabState(signedMessageTransaction.request.uniqueRequestIdentifier.requestSocket.tabId)).signerName
@@ -38,22 +44,16 @@ export async function craftPersonalSignPopupMessage(ethereumClientService: Ether
 	const originalParams = signedMessageTransaction
 	const isValid = isValidMessage(signedMessageTransaction.originalRequestParameters)
 
-	const getQuarrantineCodes = async (messageChainId: bigint, account: AddressBookEntry, activeAddress: AddressBookEntry, owner: AddressBookEntry | undefined): Promise<{ quarantine: boolean, quarantineReasons: readonly string[] }> => {
-		const quarantineReasons: string[] = []
-		if (messageChainId !== rpcNetwork.chainId) quarantineReasons.push(`The signature request is for a different chain (${ getChainName(messageChainId) }) than what is currently active (${ getChainName(rpcNetwork.chainId) }).`)
-		if (account.address !== activeAddress.address || (owner !== undefined && account.address !== owner.address)) quarantineReasons.push('The signature request is for an account that is different from your active address.')
-		return { quarantine: quarantineReasons.length > 0, quarantineReasons }
-	}
 	if (originalParams.originalRequestParameters.method === 'eth_signTypedData') {
+		const account = await identifyAddress(ethereumClientService, requestAbortController, originalParams.originalRequestParameters.params[1])
 		return {
 			method: originalParams.originalRequestParameters.method,
 			...basicParams,
 			rpcNetwork,
 			type: 'NotParsed' as const,
 			message: stringifyJSONWithBigInts(originalParams.originalRequestParameters.params[0], 4),
-			account: await identifyAddress(ethereumClientService, requestAbortController, originalParams.originalRequestParameters.params[1]),
-			quarantine: false,
-			quarantineReasons: [],
+			account,
+			...getSigningQuarantineCodes(undefined, rpcNetwork.chainId, account.address, activeAddressWithMetadata.address, undefined),
 			stringifiedMessage: stringifyJSONWithBigInts(originalParams.originalRequestParameters.params[0], 4),
 			rawMessage: stringifyJSONWithBigInts(originalParams.originalRequestParameters.params[0]),
 			isValidMessage: isValid.valid,
@@ -62,15 +62,15 @@ export async function craftPersonalSignPopupMessage(ethereumClientService: Ether
 	}
 
 	if (originalParams.originalRequestParameters.method === 'personal_sign') {
+		const account = await identifyAddress(ethereumClientService, requestAbortController, originalParams.originalRequestParameters.params[1])
 		return {
 			method: originalParams.originalRequestParameters.method,
 			...basicParams,
 			rpcNetwork,
 			type: 'NotParsed' as const,
 			message: originalParams.originalRequestParameters.params[0],
-			account: await identifyAddress(ethereumClientService, requestAbortController, originalParams.originalRequestParameters.params[1]),
-			quarantine: false,
-			quarantineReasons: [],
+			account,
+			...getSigningQuarantineCodes(undefined, rpcNetwork.chainId, account.address, activeAddressWithMetadata.address, undefined),
 			stringifiedMessage: stringifyJSONWithBigInts(originalParams.originalRequestParameters.params[0], 4),
 			rawMessage: originalParams.originalRequestParameters.params[0],
 			isValidMessage: isValid.valid,
@@ -110,7 +110,7 @@ export async function craftPersonalSignPopupMessage(ethereumClientService: Ether
 			type: 'EIP712' as const,
 			message,
 			account,
-			...chainid === undefined ? { quarantine: false, quarantineReasons: [] } : await getQuarrantineCodes(chainid, account, activeAddressWithMetadata, undefined),
+			...getSigningQuarantineCodes(chainid, rpcNetwork.chainId, account.address, activeAddressWithMetadata.address, undefined),
 			stringifiedMessage: stringifyJSONWithBigInts(namedParams.param, 4),
 			rawMessage: stringifyJSONWithBigInts(namedParams.param),
 			isValidMessage: isValid.valid,
@@ -135,7 +135,7 @@ export async function craftPersonalSignPopupMessage(ethereumClientService: Ether
 				owner,
 				spender: await identifyAddress(ethereumClientService, requestAbortController, parsed.message.spender),
 				verifyingContract: token,
-				...await getQuarrantineCodes(BigInt(parsed.domain.chainId), account, activeAddressWithMetadata, owner),
+				...getSigningQuarantineCodes(BigInt(parsed.domain.chainId), rpcNetwork.chainId, account.address, activeAddressWithMetadata.address, owner.address),
 				rawMessage: stringifyJSONWithBigInts(parsed, 4),
 				stringifiedMessage: stringifyJSONWithBigInts(parsed, 4),
 				isValidMessage: isValid.valid,
@@ -156,7 +156,7 @@ export async function craftPersonalSignPopupMessage(ethereumClientService: Ether
 				token: token,
 				spender: await identifyAddress(ethereumClientService, requestAbortController, parsed.message.spender),
 				verifyingContract: await identifyAddress(ethereumClientService, requestAbortController, parsed.domain.verifyingContract),
-				...await getQuarrantineCodes(parsed.domain.chainId, account, activeAddressWithMetadata, undefined),
+				...getSigningQuarantineCodes(parsed.domain.chainId, rpcNetwork.chainId, account.address, activeAddressWithMetadata.address, undefined),
 				stringifiedMessage: stringifyJSONWithBigInts(parsed, 4),
 				rawMessage: stringifyJSONWithBigInts(parsed),
 				isValidMessage: isValid.valid,
@@ -198,7 +198,7 @@ export async function craftPersonalSignPopupMessage(ethereumClientService: Ether
 			rpcNetwork: rpcNetwork.chainId !== parsed.domain.chainId ? await getRpcNetworkForChain(parsed.domain.chainId) : rpcNetwork,
 			message: await addMetadataToOpenSeaOrder(ethereumClientService, requestAbortController, parsed.message),
 			account,
-			...await getQuarrantineCodes(parsed.domain.chainId, account, activeAddressWithMetadata, undefined),
+			...getSigningQuarantineCodes(parsed.domain.chainId, rpcNetwork.chainId, account.address, activeAddressWithMetadata.address, undefined),
 			stringifiedMessage: stringifyJSONWithBigInts(parsed, 4),
 			rawMessage: stringifyJSONWithBigInts(parsed),
 			isValidMessage: isValid.valid,

--- a/app/ts/simulation/services/EthereumClientService.ts
+++ b/app/ts/simulation/services/EthereumClientService.ts
@@ -5,7 +5,7 @@ import { keccak256 } from '../../utils/ethereumPrimitives.js'
 import type { IEthereumJSONRpcRequestHandler } from './EthereumJSONRpcRequestHandler.js'
 import { addressString, bigintSecondsToDate, bytes32String, dataString, dateToBigintSeconds, max } from '../../utils/bigint.js'
 import { type BlockCalls, type BlockOverrides, EthSimulateV1Result, type EthSimulateV1Params } from '../../types/ethSimulate-types.js'
-import { EthGetStorageAtResponse, EthTransactionReceiptResponse, type EthGetLogsRequest, EthGetLogsResponse, type PartialEthereumTransaction } from '../../types/JsonRpc-types.js'
+import { EthGetFeeHistoryResponse, EthGetStorageAtResponse, EthTransactionReceiptResponse, type FeeHistory, type EthGetLogsRequest, EthGetLogsResponse, type PartialEthereumTransaction } from '../../types/JsonRpc-types.js'
 import { getBlockTimeManipulationSeconds, simulatePersonalSign } from './SimulationModeEthereumClientService.js'
 import { DEFAULT_BLOCK_MANIPULATION } from '../../config/defaults.js'
 import { getEcRecoverOverride } from '../../utils/ethereumByteCodes.js'
@@ -280,18 +280,23 @@ export class EthereumClientService {
 		return EthereumSignedTransactionWithBlockData.parse(response)
 	}
 
-	public readonly call = async (transaction: Partial<Pick<IUnsignedTransaction1559, 'to' | 'from' | 'input' | 'value' | 'maxFeePerGas' | 'maxPriorityFeePerGas' | 'gasLimit'>>, blockTag: EthereumBlockTag, requestAbortController: AbortController | undefined) => {
-		if (transaction.to === null) throw new Error('To cannot be null')
+	public readonly call = async (transaction: Partial<Pick<IUnsignedTransaction1559, 'to' | 'from' | 'input' | 'value' | 'maxFeePerGas' | 'maxPriorityFeePerGas' | 'gasLimit' | 'accessList'>>, blockTag: EthereumBlockTag, requestAbortController: AbortController | undefined) => {
 		const params = {
 			...(transaction.to !== undefined ? { to: transaction.to } : {}),
 			...(transaction.from !== undefined ? { from: transaction.from } : {}),
 			...(transaction.input !== undefined ? { data: transaction.input } : {}),
 			...(transaction.value !== undefined ? { value: transaction.value } : {}),
-			...transaction.maxFeePerGas !== undefined && transaction.maxPriorityFeePerGas !== undefined ? { gasPrice: transaction.maxFeePerGas + transaction.maxPriorityFeePerGas } : {},
+			...(transaction.maxFeePerGas !== undefined ? { maxFeePerGas: transaction.maxFeePerGas } : {}),
+			...(transaction.maxPriorityFeePerGas !== undefined ? { maxPriorityFeePerGas: transaction.maxPriorityFeePerGas } : {}),
 			...(transaction.gasLimit !== undefined ? { gas: transaction.gasLimit } : {}),
+			...(transaction.accessList !== undefined ? { accessList: transaction.accessList } : {}),
 		}
 		const response = await this.requestHandler.jsonRpcRequest({ method: 'eth_call', params: [params, blockTag] }, requestAbortController)
 		return EthereumData.parse(response)
+	}
+
+	public readonly getFeeHistory = async (request: FeeHistory, requestAbortController: AbortController | undefined) => {
+		return EthGetFeeHistoryResponse.parse(await this.requestHandler.jsonRpcRequest(request, requestAbortController))
 	}
 
 	public readonly ethSimulateV1 = async (blockStateCalls: readonly BlockCalls[], blockTag: EthereumBlockTag, requestAbortController: AbortController | undefined) => {

--- a/app/ts/simulation/services/SimulationModeEthereumClientService.ts
+++ b/app/ts/simulation/services/SimulationModeEthereumClientService.ts
@@ -1,7 +1,7 @@
 import { type EthereumClientService, getNextBlockTimeStampOverride } from './EthereumClientService.js'
 import type { PreparedEthSimulateV1Input } from './EthereumClientService.js'
-import { type EthereumUnsignedTransaction, type EthereumSignedTransactionWithBlockData, type EthereumBlockTag, EthereumAddress, type EthereumBlockHeader, type EthereumBlockHeaderWithTransactionHashes, EthereumData, EthereumQuantity, EthereumBytes32, type EthereumSendableSignedTransaction, type EthereumBlockHeaderTransaction } from '../../types/wire-types.js'
-import { addressString, bigintSecondsToDate, bigintToUint8Array, bytes32String, calculateWeightedPercentile, dataStringWith0xStart, dateToBigintSeconds, max, min, stringToUint8Array } from '../../utils/bigint.js'
+import { type EthereumUnsignedTransaction, type EthereumSignedTransactionWithBlockData, type EthereumBlockTag, EthereumAddress, type EthereumBlockHeader, type EthereumBlockHeaderWithTransactionHashes, EthereumData, EthereumQuantity, EthereumBytes32, type EthereumSendableSignedTransaction } from '../../types/wire-types.js'
+import { addressString, bigintSecondsToDate, bigintToUint8Array, bytes32String, dataStringWith0xStart, dateToBigintSeconds, max, min, stringToUint8Array } from '../../utils/bigint.js'
 import { CANNOT_SIMULATE_OFF_LEGACY_BLOCK, ERROR_INTERCEPTOR_GAS_ESTIMATION_FAILED, ETHEREUM_LOGS_LOGGER_ADDRESS, ETHEREUM_EIP1559_BASEFEECHANGEDENOMINATOR, ETHEREUM_EIP1559_ELASTICITY_MULTIPLIER, MOCK_ADDRESS, MULTICALL3, Multicall3ABI, DEFAULT_CALL_ADDRESS, GAS_PER_BLOB } from '../../utils/constants.js'
 import type { SimulatedTransaction, SimulationState, TokenBalancesAfter, PreSimulationTransaction, SimulationStateBlock, SimulationStateInput, SimulationStateInputMinimalData, SimulationStateInputMinimalDataBlock, BlockTimeManipulationDeltaUnit, ExecutionSimulatedTransaction, ExecutionSimulationState, ResolvedExecutionSimulationState, ResolvedSimulationInput, ResolvedSimulationState, WebsiteCreatedEthereumTransaction } from '../../types/visualizer-types.js'
 import type { Abi } from '../../utils/ethereumPrimitives.js'
@@ -959,7 +959,7 @@ const canQueryNodeDirectly = async (simulationState: SimulationState, blockTag: 
 }
 
 export const getDeployedContractAddress = (from: EthereumAddress, nonce: EthereumQuantity): EthereumAddress => {
-	return BigInt(`0x${ keccak256(rlpEncode([stripLeadingZeros(bigintToUint8Array(from, 20)), stripLeadingZeros(bigintToUint8Array(nonce, 32))])).slice(26) }`)
+	return BigInt(`0x${ keccak256(rlpEncode([bigintToUint8Array(from, 20), stripLeadingZeros(bigintToUint8Array(nonce, 32))])).slice(26) }`)
 }
 
 export const getSimulatedTransactionReceipt = async (ethereumClientService: EthereumClientService, requestAbortController: AbortController | undefined, simulationState: ResolvedExecutionSimulationState, hash: bigint): Promise<EthTransactionReceiptResponse> => {
@@ -1684,8 +1684,13 @@ const getLogsOfPreparedSimulatedExecutionBlock = (executionBlock: PreparedSimula
 	)
 }
 
-const resolveLogsBlockTag = (blockTag: EthereumBlockTag, latestBlockNumber: bigint) => {
+const resolveLogsBlockTag = async (ethereumClientService: EthereumClientService, requestAbortController: AbortController | undefined, blockTag: EthereumBlockTag, latestBlockNumber: bigint) => {
 	if (blockTag === 'latest' || blockTag === 'pending') return latestBlockNumber
+	if (isNodeOnlyBlockTag(blockTag)) {
+		const block = await ethereumClientService.getBlock(requestAbortController, blockTag, false)
+		if (block === null) throw new Error(`Block '${ blockTag }' was not found`)
+		return block.number
+	}
 	return blockTag
 }
 
@@ -1698,7 +1703,6 @@ export const getSimulatedLogs = async (ethereumClientService: EthereumClientServ
 	const toBlock = 'toBlock' in logFilter && logFilter.toBlock !== undefined ? logFilter.toBlock : 'latest'
 	const fromBlock = 'fromBlock' in logFilter && logFilter.fromBlock !== undefined ? logFilter.fromBlock : 'latest'
 	if (toBlock === 'pending' || fromBlock === 'pending') return await ethereumClientService.getLogs(logFilter, requestAbortController)
-	if (isNodeOnlyBlockTag(toBlock) || isNodeOnlyBlockTag(fromBlock)) return await ethereumClientService.getLogs(logFilter, requestAbortController)
 	if ((fromBlock === 'latest' && toBlock !== 'latest') || (fromBlock !== 'latest' && toBlock !== 'latest' && fromBlock > toBlock )) throw new Error(`From block '${ fromBlock }' is later than to block '${ toBlock }' `)
 
 	const simulatedHead = currentState.blockNumber + BigInt(executionBlocks.length)
@@ -1707,9 +1711,8 @@ export const getSimulatedLogs = async (ethereumClientService: EthereumClientServ
 		if (executionBlock !== undefined) return getLogsOfPreparedSimulatedExecutionBlock(executionBlock, logFilter)
 		return await ethereumClientService.getLogs(logFilter, requestAbortController)
 	}
-	const fromBlockNum = resolveLogsBlockTag(fromBlock, simulatedHead)
-	const toBlockNum = resolveLogsBlockTag(toBlock, simulatedHead)
-	if (typeof fromBlockNum !== 'bigint' || typeof toBlockNum !== 'bigint') return await ethereumClientService.getLogs(logFilter, requestAbortController)
+	const fromBlockNum = await resolveLogsBlockTag(ethereumClientService, requestAbortController, fromBlock, simulatedHead)
+	const toBlockNum = await resolveLogsBlockTag(ethereumClientService, requestAbortController, toBlock, simulatedHead)
 	if (fromBlockNum > toBlockNum) return []
 	const nodeLogs = fromBlockNum <= currentState.blockNumber
 		? await ethereumClientService.getLogs({
@@ -2080,36 +2083,12 @@ const getTokenBalancesAfter = async (
 	}
 }
 
-// takes the most recent block that the application is querying and does the calculation based on that
 export const getSimulatedFeeHistory = async (ethereumClientService: EthereumClientService, requestAbortController: AbortController | undefined, request: FeeHistory): Promise<EthGetFeeHistoryResponse> => {
-	//const numberOfBlocks = Number(request.params[0]) // number of blocks, not used atm as we just return one block
 	const blockTag = request.params[1]
-	const rewardPercentiles = request.params[2]
 	const currentRealBlockNumber = await ethereumClientService.getBlockNumber(requestAbortController)
 	const clampedBlockTag = typeof blockTag === 'bigint' && blockTag > currentRealBlockNumber ? currentRealBlockNumber : blockTag
-	const newestBlock = await ethereumClientService.getBlock(requestAbortController, clampedBlockTag, true)
-	if (newestBlock === null) throw new Error('The latest block is null')
-	const newestBlockBaseFeePerGas = newestBlock.baseFeePerGas
-	if (newestBlockBaseFeePerGas === undefined) throw new Error(`base fee per gas is missing for the block (it's too old)`)
-	return {
-		baseFeePerGas: [newestBlockBaseFeePerGas, getNextBaseFeePerGas(newestBlock.gasUsed, newestBlock.gasLimit, newestBlockBaseFeePerGas)],
-		gasUsedRatio: [Number(newestBlock.gasUsed) / Number(newestBlock.gasLimit)],
-		oldestBlock: newestBlock.number,
-		...rewardPercentiles === undefined ? {} : {
-			reward: [rewardPercentiles.map((percentile) => {
-				// we are using transaction.gas as a weighting factor while this should be `gasUsed`. Getting `gasUsed` requires getting transaction receipts, which we don't want to be doing
-				const getDataPoint = (tx: EthereumBlockHeaderTransaction) => {
-					if ('maxPriorityFeePerGas' in tx && 'maxFeePerGas' in tx && 'gas' in tx) return { dataPoint: min(tx.maxPriorityFeePerGas, tx.maxFeePerGas - (newestBlockBaseFeePerGas ?? 0n)), weight: tx.gas }
-					if ('gasPrice' in tx && 'gas' in tx) return { dataPoint: tx.gasPrice - (newestBlockBaseFeePerGas ?? 0n), weight: tx.gas }
-					return { dataPoint: 0n, weight: 0n }
-				}
-
-				const effectivePriorityAndGasWeights = newestBlock.transactions.map((tx) => getDataPoint(tx))
-
-				// we can have negative values here, as The Interceptor creates maxFeePerGas = 0 transactions that are intended to have zero base fee, which is not possible in reality
-				const zeroOutNegativeValues = effectivePriorityAndGasWeights.map((point) => modifyObject(point, { dataPoint: max(0n, point.dataPoint) }))
-				return calculateWeightedPercentile(zeroOutNegativeValues, percentile)
-			})]
-		}
-	}
+	const clampedRequest: FeeHistory = request.params.length === 2
+		? { ...request, params: [request.params[0], clampedBlockTag] }
+		: { ...request, params: [request.params[0], clampedBlockTag, request.params[2]] }
+	return await ethereumClientService.getFeeHistory(clampedRequest, requestAbortController)
 }

--- a/app/ts/types/JsonRpc-types.ts
+++ b/app/ts/types/JsonRpc-types.ts
@@ -421,13 +421,21 @@ export const EthMaxPriorityFeePerGasParams = funtypes.ReadonlyObject({
 
 //https://docs.infura.io/networks/ethereum/json-rpc-methods/eth_feehistory
 const EthereumQuantityBetween1And1024 = EthereumQuantity.withConstraint((x) => x >= 1n && x <= 1024n)
+const FeeHistoryRewardPercentiles = funtypes.ReadonlyArray(funtypes.Number).withConstraint((percentiles) => {
+	let previousPercentile = 0
+	for (const percentile of percentiles) {
+		if (!Number.isFinite(percentile) || percentile < 0 || percentile > 100 || percentile < previousPercentile) return false
+		previousPercentile = percentile
+	}
+	return true
+})
 
 export type FeeHistory = funtypes.Static<typeof FeeHistory>
 export const FeeHistory = funtypes.ReadonlyObject({
 	method: funtypes.Literal('eth_feeHistory'),
 	params: funtypes.Union(
 		funtypes.ReadonlyTuple(EthereumQuantityBetween1And1024, EthereumBlockTag),
-		funtypes.ReadonlyTuple(EthereumQuantityBetween1And1024, EthereumBlockTag, funtypes.ReadonlyArray(funtypes.Number))
+		funtypes.ReadonlyTuple(EthereumQuantityBetween1And1024, EthereumBlockTag, FeeHistoryRewardPercentiles)
 	)
 })
 

--- a/app/ts/utils/eip712.ts
+++ b/app/ts/utils/eip712.ts
@@ -246,32 +246,6 @@ const simplifyTypesToSolidityTypesOnly = (root: string, nonExtractedTypes: EIP71
 	return { valid: true, tree: extracted }
 }
 
-const isValidEIP712DomainOrder = (expected: readonly string[], test: readonly string[]): boolean => {
-	const matched = test.filter(t => expected.includes(t))
-	const expectedIndex = (field: string) => expected.indexOf(field)
-	const isOrdered = matched.every((field, idx, arr) => {
-		if (idx === 0) return true
-		const previous = arr[idx - 1]
-		if (previous === undefined) throw new Error('array underflow')
-		return expectedIndex(previous) <= expectedIndex(field)
-	})
-	if (!isOrdered) return false
-	// Find the index in test where matched expected fields end
-	const lastMatchedIndex = test.findIndex((t, i) => {
-		if (i === 0) return false
-		const previous = test[i - 1]
-		if (previous === undefined) throw new Error('array underflow')
-		return expected.includes(previous) && !expected.includes(t)
-	})
-	const extras = lastMatchedIndex === -1 ? [] : test.slice(lastMatchedIndex).filter(t => !expected.includes(t))
-	return extras.every((field, i, arr) => {
-		if (i === 0) return true
-		const previous = arr[i - 1]
-		if (previous === undefined) throw new Error('array underflow')
-		return previous <= field
-	})
-}
-
 export const verifyEip712Message = (maybeEip712Message: EIP712Message): { valid: true } | { valid: false, reason: string } => {
 	if (Object.values(maybeEip712Message).length !== 4) return { valid: false, reason: 'EIP712 message should only have 4 fields' }
 
@@ -299,8 +273,6 @@ export const verifyEip712Message = (maybeEip712Message: EIP712Message): { valid:
 	if ('verifyingContract' in maybeEip712Message.domain && !EthereumAddress.safeParse(verifyingContract).success) return { valid: false, reason: 'EIP712Domain.verifyingContract is in wrong type' }
 	if ('name' in maybeEip712Message.domain && !String.safeParse(name).success) return { valid: false, reason: 'EIP712Domain.name is in wrong type' }
 	if ('salt' in maybeEip712Message.domain && !EthereumData.safeParse(salt).success) return { valid: false, reason: 'EIP712Domain.salt is in wrong type' }
-
-	if (!isValidEIP712DomainOrder(validEIP712DomainEntries.map((entry) => entry.name), eip712Domain.map((entry) => entry.name))) return { valid: false, reason: 'EIP712Domain types are in the wrong order' }
 
 	// domain fields exist in valid in types
 	const domainArray = Object.entries(maybeEip712Message.domain)

--- a/app/ts/utils/ethereumNameService.ts
+++ b/app/ts/utils/ethereumNameService.ts
@@ -55,7 +55,7 @@ export const getEthereumNameServiceNameFromTokenId = async (ethereumMainnet: Eth
 	const name = encodeEthereumNameServiceString(nameString)
 	if (name === undefined) return undefined
 	const normalizedName = normalizeEnsNameOrUndefined(name)
-	if (normalizedName === undefined) return name
+	if (normalizedName === undefined) return undefined
 	if (tokenId !== BigInt(namehash(normalizedName))) {
 		console.error(`Querying RPC ${ ethereumMainnet.getRpcEntry().httpsRpc } returned invalid name for hash: ${ tokenId }.`)
 		return undefined

--- a/test/tests/SimulationModeEthereumClientService.test.ts
+++ b/test/tests/SimulationModeEthereumClientService.test.ts
@@ -3,10 +3,10 @@ import * as assert from 'assert'
 import { authorization as eip7702Authorization } from 'micro-eth-signer'
 import { isAbiDataDecodeError, keccak256, recoverAddress } from '../../app/ts/utils/ethereumPrimitives.js'
 import { EthereumClientService } from '../../app/ts/simulation/services/EthereumClientService.js'
-import { EthereumSignedTransactionToSignedTransaction, EthereumUnsignedTransactionToUnsignedTransaction, serializeSignedTransactionToBytes, serializeUnsignedTransactionToBytes } from '../../app/ts/utils/ethereum.js'
-import { addressString, bytes32String, dataStringWith0xStart, stringToUint8Array } from '../../app/ts/utils/bigint.js'
+import { EthereumSignedTransactionToSignedTransaction, EthereumUnsignedTransactionToUnsignedTransaction, rlpEncode, serializeSignedTransactionToBytes, serializeUnsignedTransactionToBytes } from '../../app/ts/utils/ethereum.js'
+import { addressString, bigintToUint8Array, bytes32String, dataStringWith0xStart, stringToUint8Array } from '../../app/ts/utils/bigint.js'
 import { EthereumAddress, EthereumSignatureParity, EthereumSignedTransaction, EthereumSignedTransaction1559, EthereumSignedTransactionWithBlockData, EthereumUnsignedTransaction, serialize } from '../../app/ts/types/wire-types.js'
-import { createExecutionSimulationState, createSimulationCallParams, createSimulationState, ethSimulateV1FromInput, getBaseFeeAdjustedTransactions, getBaseFeeAdjustmentBalances, getSimulatedBalanceFromInput, getSimulatedBlock, getSimulatedBlockByHashFromInput, getSimulatedBlockFromInput, getSimulatedBlockNumberFromInput, getSimulatedCode, getSimulatedCodeFromInput, getSimulatedFeeHistory, getSimulatedLogs, getSimulatedStorageAtFromInput, getSimulatedTransactionByHashFromInput, getSimulatedTransactionCount, getSimulatedTransactionCountFromInput, getSimulatedTransactionReceipt, groupEthSimulateV1ResultByInputBlocks, mockSignTransaction, simulateEstimateGas, simulateEstimateGasFromInput, simulatePersonalSign, simulatedCall, simulatedCallFromInput } from '../../app/ts/simulation/services/SimulationModeEthereumClientService.js'
+import { createExecutionSimulationState, createSimulationCallParams, createSimulationState, ethSimulateV1FromInput, getBaseFeeAdjustedTransactions, getBaseFeeAdjustmentBalances, getDeployedContractAddress, getSimulatedBalanceFromInput, getSimulatedBlock, getSimulatedBlockByHashFromInput, getSimulatedBlockFromInput, getSimulatedBlockNumberFromInput, getSimulatedCode, getSimulatedCodeFromInput, getSimulatedFeeHistory, getSimulatedLogs, getSimulatedStorageAtFromInput, getSimulatedTransactionByHashFromInput, getSimulatedTransactionCount, getSimulatedTransactionCountFromInput, getSimulatedTransactionReceipt, groupEthSimulateV1ResultByInputBlocks, mockSignTransaction, simulateEstimateGas, simulateEstimateGasFromInput, simulatePersonalSign, simulatedCall, simulatedCallFromInput } from '../../app/ts/simulation/services/SimulationModeEthereumClientService.js'
 import { EthTransactionReceiptResponse, EthereumJsonRpcRequest, JsonRpcResponse } from '../../app/ts/types/JsonRpc-types.js'
 import { RPCReply } from '../../app/ts/types/interceptor-messages.js'
 import type { EthSimulateV1BlockTag, EthSimulateV1Params, EthSimulateV1Result } from '../../app/ts/types/ethSimulate-types.js'
@@ -106,6 +106,7 @@ class MockEthereumJSONRpcRequestHandler {
 	public balance = 0n
 	public storageResponse = testBytes32('beef')
 	public maxPriorityFeePerGasResponse = '0x3b9aca00'
+	public ethFeeHistoryCalls: EthereumJsonRpcRequest[] = []
 	public ethGetBalanceCalls: EthereumJsonRpcRequest[] = []
 	public ethGetStorageAtCalls: EthereumJsonRpcRequest[] = []
 	public ethGetBlockByHashErrorsByHash = new Map<bigint, Error>()
@@ -127,6 +128,19 @@ class MockEthereumJSONRpcRequestHandler {
 				this.ethGetStorageAtCalls.push(rpcRequest)
 				return this.storageResponse
 			case 'eth_maxPriorityFeePerGas': return this.maxPriorityFeePerGasResponse
+			case 'eth_feeHistory': {
+				this.ethFeeHistoryCalls.push(rpcRequest)
+				const blockCount = Number(rpcRequest.params[0])
+				const rewardPercentiles = rpcRequest.params[2]
+				return {
+					baseFeePerGas: Array.from({ length: blockCount + 1 }, (_, index) => `0x${ (index + 1).toString(16) }`),
+					gasUsedRatio: Array.from({ length: blockCount }, () => 0.5),
+					oldestBlock: `0x${ (blockNumber - BigInt(blockCount) + 1n).toString(16) }`,
+					...rewardPercentiles === undefined ? {} : {
+						reward: Array.from({ length: blockCount }, () => rewardPercentiles.map((_percentile, index) => `0x${ (index + 1).toString(16) }`)),
+					},
+				}
+			}
 			case 'eth_getBlockByNumber': {
 				if (rpcRequest.params[0] !== blockNumber && rpcRequest.params[0] !== 'latest') throw new Error('Unsupported block number')
 				if (rpcRequest.params[1] === true) return parseRequest(eth_getBlockByNumber_goerli_8443561_true)
@@ -286,6 +300,12 @@ describe('SimulationModeEthereumClientService', () => {
 		authorizationList: [],
 	} as const
 
+	test('preserves the 20-byte sender width when deriving contract addresses', () => {
+		const senderWithLeadingZeroBytes = 1n
+		const expectedAddress = BigInt(`0x${ keccak256(rlpEncode([bigintToUint8Array(senderWithLeadingZeroBytes, 20), new Uint8Array()])).slice(26) }`)
+		assert.equal(getDeployedContractAddress(senderWithLeadingZeroBytes, 0n), expectedAddress)
+	})
+
 	const createSimulationStateInput = () => [{
 		stateOverrides: {},
 		transactions: [{
@@ -401,7 +421,6 @@ describe('SimulationModeEthereumClientService', () => {
 		await getSimulatedTransactionCount(forwardingEthereum, undefined, resolvedState, exampleTransaction.from, 'safe')
 		await getSimulatedCode(forwardingEthereum, undefined, resolvedState, exampleTransaction.to, 'earliest')
 		await getSimulatedBlock(forwardingEthereum, undefined, resolvedState, 'safe', false)
-		await getSimulatedLogs(forwardingEthereum, undefined, toResolvedExecutionSimulationState(simulationState), { fromBlock: 'earliest' })
 		const callParams = {
 			from: exampleTransaction.from,
 			to: exampleTransaction.to,
@@ -417,7 +436,6 @@ describe('SimulationModeEthereumClientService', () => {
 			{ method: 'getTransactionCount', blockTag: 'safe' },
 			{ method: 'getCode', blockTag: 'earliest' },
 			{ method: 'getBlock', blockTag: 'safe' },
-			{ method: 'getLogs', blockTag: 'earliest' },
 			{ method: 'call', blockTag: 'safe' },
 			{ method: 'call', blockTag: 'earliest' },
 		])
@@ -1641,6 +1659,19 @@ describe('SimulationModeEthereumClientService', () => {
 			assert.equal(feeHistory.reward?.[0]?.length, 3)
 		})
 
+		test('getSimulatedFeeHistory returns the requested block range from the node', async () => {
+			requestHandler.ethFeeHistoryCalls.length = 0
+			const feeHistory = await getSimulatedFeeHistory(ethereum, undefined, {
+				method: 'eth_feeHistory',
+				params: [5n, 'latest', [25, 75]],
+			})
+
+			assert.equal(feeHistory.gasUsedRatio.length, 5)
+			assert.equal(feeHistory.baseFeePerGas.length, 6)
+			assert.equal(feeHistory.reward?.length, 5)
+			assert.deepEqual(requestHandler.ethFeeHistoryCalls.at(-1), { method: 'eth_feeHistory', params: [5n, 'latest', [25, 75]] })
+		})
+
 		test('simulateEstimateGasFromInput surfaces RPC errors when omitted gas is rejected', async () => {
 			requestHandler.ethSimulateV1Calls.length = 0
 			requestHandler.rejectOmittedGas = true
@@ -2188,6 +2219,33 @@ describe('SimulationModeEthereumClientService', () => {
 				assert.equal(logs.length, 1)
 				assert.equal(logs[0]?.blockHash, firstBlock.hash)
 				assert.equal(logs[0]?.blockNumber, blockNumber + 1n)
+			})
+
+			test('state-based logs merge simulated events into an earliest-to-latest range', async () => {
+				const simulationState = await createSimulationState(ethereum, undefined, createSimulationStateInput())
+				if (simulationState.success === false) throw new Error('simulation unexpectedly failed')
+				const nodeLogFilters: Parameters<typeof ethereum.getLogs>[0][] = []
+				const overlayEthereum = new Proxy(ethereum, {
+					get(target, property, receiver) {
+						switch (property) {
+							case 'getBlock': return async (requestAbortController: AbortController | undefined, blockTag: Parameters<typeof target.getBlock>[1], fullObjects: boolean) => {
+								if (blockTag === 'earliest') return await target.getBlock(requestAbortController, blockNumber, fullObjects)
+								return await target.getBlock(requestAbortController, blockTag, fullObjects)
+							}
+							case 'getLogs': return async (filter: Parameters<typeof target.getLogs>[0]) => {
+								nodeLogFilters.push(filter)
+								return []
+							}
+							default: return Reflect.get(target, property, receiver)
+						}
+					}
+				})
+
+				const logs = await getSimulatedLogs(overlayEthereum, undefined, toResolvedExecutionSimulationState(simulationState), { fromBlock: 'earliest', toBlock: 'latest' })
+
+				assert.equal(logs.length, 1)
+				assert.equal(logs[0]?.blockNumber, blockNumber + 1n)
+				assert.deepEqual(nodeLogFilters, [{ fromBlock: blockNumber, toBlock: blockNumber }])
 			})
 			test('execution-only simulation skips token balance follow-up simulation', async () => {
 				const simulationStateInput = [{

--- a/test/tests/ethereumClientServiceEthSimulateSerialization.test.ts
+++ b/test/tests/ethereumClientServiceEthSimulateSerialization.test.ts
@@ -1,7 +1,7 @@
 import * as assert from 'assert'
 import { describe, test } from 'bun:test'
 import { EthereumClientService } from '../../app/ts/simulation/services/EthereumClientService.js'
-import { JsonRpcResponse } from '../../app/ts/types/JsonRpc-types.js'
+import { type EthereumJsonRpcRequest, JsonRpcResponse } from '../../app/ts/types/JsonRpc-types.js'
 import { EthSimulateV1Params } from '../../app/ts/types/ethSimulate-types.js'
 import { serialize, type EthereumSendableSignedTransaction } from '../../app/ts/types/wire-types.js'
 import { eth_getBlockByNumber_goerli_8443561_true } from '../RPCResponses.js'
@@ -211,5 +211,49 @@ describe('EthereumClientService eth_simulateV1 serialization', () => {
 			const serialized = JSON.stringify(serializedRequest)
 			assert.doesNotMatch(serialized, /"hash":/, `serialized ${ variant.name } call still contains internal hash`)
 		}
+	})
+})
+
+describe('EthereumClientService eth_call serialization', () => {
+	let capturedRequest: EthereumJsonRpcRequest | undefined
+	const service = new EthereumClientService(
+		{
+			rpcUrl: rpcEntry.httpsRpc,
+			clearCache: () => undefined,
+			async getChainId() { return rpcEntry.chainId },
+			async jsonRpcRequest(request) {
+				capturedRequest = request
+				if (request.method !== 'eth_call') throw new Error(`Unexpected RPC method: ${ request.method }`)
+				return '0x'
+			},
+		},
+		async () => undefined,
+		async () => undefined,
+		rpcEntry,
+	)
+
+	test('forwards null recipients for contract creation calls', async () => {
+		await service.call({ to: null, input: new Uint8Array([0x60, 0x00]) }, 'latest', undefined)
+
+		if (capturedRequest?.method !== 'eth_call') throw new Error('eth_call request was not captured')
+		assert.deepEqual(capturedRequest.params, [{ to: null, data: new Uint8Array([0x60, 0x00]) }, 'latest'])
+	})
+
+	test('preserves EIP-1559 fee fields and access lists', async () => {
+		await service.call({
+			to: toAddress,
+			maxFeePerGas: 100n,
+			maxPriorityFeePerGas: 3n,
+			accessList,
+		}, 'safe', undefined)
+
+		if (capturedRequest?.method !== 'eth_call') throw new Error('eth_call request was not captured')
+		assert.deepEqual(capturedRequest.params, [{
+			to: toAddress,
+			maxFeePerGas: 100n,
+			maxPriorityFeePerGas: 3n,
+			accessList,
+		}, 'safe'])
+		assert.equal('gasPrice' in capturedRequest.params[0], false)
 	})
 })

--- a/test/tests/ethereumNameService.test.ts
+++ b/test/tests/ethereumNameService.test.ts
@@ -1,0 +1,48 @@
+import * as assert from 'assert'
+import { describe, test } from 'bun:test'
+import { EthereumClientService } from '../../app/ts/simulation/services/EthereumClientService.js'
+import { getEthereumNameServiceNameFromTokenId } from '../../app/ts/utils/ethereumNameService.js'
+import { encodeFunctionReturn } from '../../app/ts/utils/abiRuntime.js'
+import { normalizeEnsNameOrUndefined } from '../../app/ts/utils/ens.js'
+
+const rpcEntry = {
+	name: 'Ethereum',
+	chainId: 1n,
+	httpsRpc: 'https://example.invalid',
+	currencyName: 'Ether',
+	currencyTicker: 'ETH',
+	primary: true,
+	minimized: true,
+} as const
+
+const wrappedEnsNamesAbi = [{
+	type: 'function',
+	name: 'names',
+	stateMutability: 'view',
+	inputs: [{ name: 'node', type: 'bytes32' }],
+	outputs: [{ name: 'name', type: 'bytes' }],
+}] as const
+
+describe('wrapped ENS name verification', () => {
+	test('rejects wrapped names that fail ENS normalization', async () => {
+		const invalidEnsName = 'a\u202e.eth'
+		const invalidDnsEncodedName = '0x0461e280ae0365746800'
+		assert.equal(normalizeEnsNameOrUndefined(invalidEnsName), undefined)
+		const service = new EthereumClientService(
+			{
+				rpcUrl: rpcEntry.httpsRpc,
+				clearCache: () => undefined,
+				async getChainId() { return rpcEntry.chainId },
+				async jsonRpcRequest(request) {
+					if (request.method !== 'eth_call') throw new Error(`Unexpected RPC method: ${ request.method }`)
+					return encodeFunctionReturn(wrappedEnsNamesAbi, 'names', [invalidDnsEncodedName])
+				},
+			},
+			async () => undefined,
+			async () => undefined,
+			rpcEntry,
+		)
+
+		assert.equal(await getEthereumNameServiceNameFromTokenId(service, undefined, 1n), undefined)
+	})
+})

--- a/test/tests/inpageSignerBridge.test.ts
+++ b/test/tests/inpageSignerBridge.test.ts
@@ -286,6 +286,94 @@ async function withFakeInpageWindow<T>(fakeWindow: ReturnType<typeof createFakeW
 }
 
 describe('inpage signer bridge', () => {
+	test('returns JSON-RPC failures through the sendAsync response argument', async () => {
+		const { fakeWindow } = createFakeWindow({
+			handleRequest: (request, sendBackgroundMessage) => {
+				if (request.method !== 'eth_chainId' || request.internal === true) return false
+				sendBackgroundMessage({
+					interceptorApproved: true,
+					requestId: request.requestId,
+					type: 'result',
+					method: request.method,
+					error: { code: -32000, message: 'RPC failed' },
+				})
+				return true
+			},
+		})
+
+		await withFakeInpageWindow(fakeWindow, '../../app/inpage/ts/inpage.js?send-async-json-rpc-error', async () => {
+			const sendAsync = Reflect.get(fakeWindow.ethereum, 'sendAsync')
+			if (typeof sendAsync !== 'function') throw new Error('sendAsync is unavailable')
+			const callbackArguments = await new Promise<readonly [unknown, unknown]>((resolve) => {
+				void sendAsync({ id: 71, method: 'eth_chainId', params: [] }, (error: unknown, response: unknown) => resolve([error, response]))
+			})
+
+			assert.equal(callbackArguments[0], null)
+			const response = callbackArguments[1]
+			if (!isRecord(response) || !isRecord(response.error)) throw new Error('Malformed JSON-RPC error response')
+			assert.equal(response.id, 71)
+			assert.equal(response.error.code, -32000)
+			assert.equal(response.error.message, 'RPC failed')
+		})
+	})
+
+	test('returns bridge transport failures through the sendAsync error argument', async () => {
+		const { fakeWindow, signerRequests } = createFakeWindow()
+
+		await withFakeInpageWindow(fakeWindow, '../../app/inpage/ts/inpage.js?send-async-transport-error', async () => {
+			await waitFor(() => signerRequests.includes('eth_chainId'))
+			await new Promise((resolve) => setTimeout(resolve, 0))
+			const sendAsync = Reflect.get(fakeWindow.ethereum, 'sendAsync')
+			if (typeof sendAsync !== 'function') throw new Error('sendAsync is unavailable')
+			const postMessageDescriptor = Object.getOwnPropertyDescriptor(MessagePort.prototype, 'postMessage')
+			if (postMessageDescriptor === undefined) throw new Error('MessagePort.postMessage descriptor is unavailable')
+			Object.defineProperty(MessagePort.prototype, 'postMessage', {
+				...postMessageDescriptor,
+				value: () => { throw new Error('bridge transport failed') },
+			})
+			let callbackArguments: readonly [unknown, unknown]
+			try {
+				callbackArguments = await new Promise<readonly [unknown, unknown]>((resolve) => {
+					void sendAsync({ id: 72, method: 'eth_chainId', params: [] }, (error: unknown, response: unknown) => resolve([error, response]))
+				})
+			} finally {
+				Object.defineProperty(MessagePort.prototype, 'postMessage', postMessageDescriptor)
+			}
+
+			assert.equal(callbackArguments[0] instanceof Error, true)
+			if (!(callbackArguments[0] instanceof Error)) throw new Error('Expected a transport Error')
+			assert.equal(callbackArguments[0].message, 'bridge transport failed')
+			assert.equal(callbackArguments[1], null)
+		})
+	})
+
+	test('does not invoke a sendAsync callback twice when the dapp callback throws', async () => {
+		const { fakeWindow } = createFakeWindow({
+			handleRequest: (request, sendBackgroundMessage) => {
+				if (request.method !== 'eth_chainId' || request.internal === true) return false
+				sendBackgroundMessage({
+					interceptorApproved: true,
+					requestId: request.requestId,
+					type: 'result',
+					method: request.method,
+					error: { code: -32000, message: 'RPC failed' },
+				})
+				return true
+			},
+		})
+
+		await withFakeInpageWindow(fakeWindow, '../../app/inpage/ts/inpage.js?send-async-callback-error', async () => {
+			const sendAsync = Reflect.get(fakeWindow.ethereum, 'sendAsync')
+			if (typeof sendAsync !== 'function') throw new Error('sendAsync is unavailable')
+			let callbackCount = 0
+			await assert.rejects(async () => await sendAsync({ id: 73, method: 'eth_chainId', params: [] }, () => {
+				callbackCount += 1
+				throw new Error('dapp callback failed')
+			}), /dapp callback failed/)
+			assert.equal(callbackCount, 1)
+		})
+	})
+
 	test('annotates only public eth_requestAccounts requests for replay after disconnect', async () => {
 		const bridgeRequests: InpageRequest[] = []
 		const account = '0x1111111111111111111111111111111111111111'

--- a/test/tests/jsonRpcBoundaryValidation.test.ts
+++ b/test/tests/jsonRpcBoundaryValidation.test.ts
@@ -1,6 +1,6 @@
 import * as assert from 'assert'
 import { describe, test } from 'bun:test'
-import { EthereumJsonRpcRequest, EthGetLogsRequest, EthNewFilter } from '../../app/ts/types/JsonRpc-types.js'
+import { EthereumJsonRpcRequest, FeeHistory, EthGetLogsRequest, EthNewFilter } from '../../app/ts/types/JsonRpc-types.js'
 import { EthereumAddress, EthereumBlockTag, EthereumBytes16, EthereumBytes256, EthereumBytes32, serialize } from '../../app/ts/types/wire-types.js'
 
 const blockHash = `0x${ '12'.repeat(32) }`
@@ -42,5 +42,15 @@ describe('JSON-RPC boundary validation', () => {
 		assert.equal(serialize(EthereumBytes32, (1n << 256n) - 1n).length, 66)
 		assert.equal(serialize(EthereumBytes256, (1n << 2048n) - 1n).length, 514)
 		assert.equal(serialize(EthereumBytes16, (1n << 64n) - 1n).length, 18)
+	})
+
+	test('accepts valid fee history reward percentiles', () => {
+		assert.equal(FeeHistory.safeParse({ method: 'eth_feeHistory', params: ['0x5', 'latest', [0, 25.5, 25.5, 100]] }).success, true)
+	})
+
+	test('rejects out-of-range and decreasing fee history reward percentiles', () => {
+		assert.equal(FeeHistory.safeParse({ method: 'eth_feeHistory', params: ['0x5', 'latest', [-1]] }).success, false)
+		assert.equal(FeeHistory.safeParse({ method: 'eth_feeHistory', params: ['0x5', 'latest', [101]] }).success, false)
+		assert.equal(FeeHistory.safeParse({ method: 'eth_feeHistory', params: ['0x5', 'latest', [75, 25]] }).success, false)
 	})
 })

--- a/test/tests/personalSignQuarantine.test.ts
+++ b/test/tests/personalSignQuarantine.test.ts
@@ -1,0 +1,19 @@
+import * as assert from 'assert'
+import { describe, test } from 'bun:test'
+import { getSigningQuarantineCodes } from '../../app/ts/background/windows/personalSign.js'
+
+describe('personal sign quarantine checks', () => {
+	test('quarantines an account mismatch when the signed message has no chain ID', () => {
+		assert.deepEqual(getSigningQuarantineCodes(undefined, 1n, 0x1n, 0x2n, undefined), {
+			quarantine: true,
+			quarantineReasons: ['The signature request is for an account that is different from your active address.'],
+		})
+	})
+
+	test('does not quarantine a matching account solely because the message has no chain ID', () => {
+		assert.deepEqual(getSigningQuarantineCodes(undefined, 1n, 0x1n, 0x1n, undefined), {
+			quarantine: false,
+			quarantineReasons: [],
+		})
+	})
+})

--- a/test/tests/signTypedData.test.ts
+++ b/test/tests/signTypedData.test.ts
@@ -166,12 +166,12 @@ describe('EIP712', () => {
 		delete parsed.message.contents
 		assert.equal(verifyEip712Message(parsed).valid, false)
 	})
-	test('reports invalid domain field order as a validation failure', () => {
+	test('accepts domain fields in the order declared by the EIP712Domain type', () => {
 		const parsed = JSON.parse(hasFixedArray)
 		const firstDomainField = parsed.types.EIP712Domain[0]
 		parsed.types.EIP712Domain[0] = parsed.types.EIP712Domain[1]
 		parsed.types.EIP712Domain[1] = firstDomainField
-		assert.deepEqual(verifyEip712Message(parsed), { valid: false, reason: 'EIP712Domain types are in the wrong order' })
+		assert.deepEqual(verifyEip712Message(parsed), { valid: true })
 	})
 	test('can validate safeTx message', () => {
 		const parsed = EIP712Message.parse(safeTx)


### PR DESCRIPTION
## Summary

This PR fixes ten small but user-visible correctness and compatibility bugs found after auditing the code merged in #1573. Each fix includes focused regression coverage.

## Issues and fixes

1. **`eth_feeHistory` ignored `blockCount`**
   - Issue: the simulation handler always reconstructed a one-block response regardless of the requested range.
   - Fix: delegate the clamped request to the upstream node through a typed `EthereumClientService.getFeeHistory` method, preserving the requested count and node-calculated rewards.
   - Coverage: verifies five requested blocks produce five gas ratios, six base fees, and five reward rows.

2. **Invalid fee-history reward percentiles were accepted**
   - Issue: negative, greater-than-100, and decreasing percentile lists crossed the JSON-RPC boundary.
   - Fix: constrain percentiles to finite values from 0 through 100 in nondecreasing order.
   - Coverage: accepts fractional and repeated valid values and rejects out-of-range or decreasing lists.

3. **CREATE addresses were wrong for senders with leading-zero bytes**
   - Issue: contract-address derivation stripped leading zeros from the creator before RLP encoding, changing the required 20-byte sender representation.
   - Fix: retain the full 20-byte sender and continue minimally encoding only the nonce.
   - Coverage: derives an address for a sender with leading-zero bytes and compares it with the width-preserving RLP formula.

4. **Contract-creation `eth_call` requests were rejected**
   - Issue: `EthereumClientService.call` threw when `to` was `null`, although `null` represents contract creation.
   - Fix: forward `to: null` to the node.
   - Coverage: asserts the serialized request retains the null recipient and creation bytecode.

5. **EIP-1559 call fees were converted to an incorrect legacy gas price**
   - Issue: `maxFeePerGas + maxPriorityFeePerGas` was emitted as `gasPrice`, overcounting the priority fee and changing transaction semantics.
   - Fix: forward `maxFeePerGas` and `maxPriorityFeePerGas` independently; the same path now also preserves access lists.
   - Coverage: verifies both fee fields and the access list survive while `gasPrice` is absent.

6. **`eth_getLogs` from `earliest` omitted simulated logs**
   - Issue: a node-only endpoint caused the complete range to bypass the simulation overlay.
   - Fix: resolve `earliest`, `safe`, and `finalized` to concrete node block numbers, then use the existing node-plus-simulation merge.
   - Coverage: verifies an `earliest`-to-`latest` request queries the real range and includes the simulated event.

7. **Valid EIP-712 domain field ordering was rejected**
   - Issue: validation required canonical domain field order even though EIP-712 tells user agents to accept the order declared by `EIP712Domain`.
   - Fix: remove the nonstandard ordering rejection while retaining field-name and field-type validation.
   - Coverage: verifies a valid reordered domain declaration is accepted.

8. **No-chain signing requests skipped account mismatch quarantine**
   - Issue: `personal_sign`, legacy typed data, and generic typed data without `domain.chainId` could request another account without a quarantine warning.
   - Fix: separate account validation from optional chain validation and apply it consistently across signing paths.
   - Coverage: verifies no-chain messages quarantine mismatched accounts without quarantining a matching account.

9. **Non-normalizable wrapped ENS names were returned as verified**
   - Issue: normalization failure returned the raw name and skipped namehash verification.
   - Fix: reject the wrapped name when ENS normalization fails.
   - Coverage: uses a DNS-encoded bidirectional-control name, confirms normalization fails, and verifies wrapped-name resolution returns `undefined`.

10. **Legacy `sendAsync` mixed JSON-RPC, transport, and callback errors**
    - Issue: JSON-RPC failures were supplied as callback transport errors; the initial correction also needed to preserve real bridge failures and avoid double-calling callbacks that throw.
    - Fix: return coded provider failures as JSON-RPC error responses, report uncoded bridge failures through the callback error argument, and invoke dapp callbacks outside the transport catch.
    - Coverage: checks JSON-RPC error placement, forced `MessagePort.postMessage` transport failure placement, and once-only callback behavior when the dapp callback throws.

## Validation

- `bun run test` — passed, 1,032 tests and 0 failures
- `bun run setup-chrome` — passed
- `bun run typecheck` — passed
- `bun run lint` — passed
- `test:chrome-communication` — not run because this change does not modify MV3 registration, access-popup approval, or content-script connection setup; the existing inpage harness directly covers the changed provider callback behavior

## Review

The required project reviewer completed three passes. The first two passes identified transport callback semantics, an incorrect ENS fixture, and callback double-invocation coverage; all findings were addressed. The final pass reported no High, Medium, or Low findings and scored the diff 95/100.
