### PR TITLE
Route Safe storage reads through the simulation overlay

### DIFF
--- a/app/ts/background/background.ts
+++ b/app/ts/background/background.ts
@@ -178,7 +178,7 @@ async function handleRPCRequest(
 			return { type: 'result' as const, method: rpcRequest.method, error: { code: 10000, message: 'wallet_addEthereumChain not implemented' } }
 		}),
 		eth_getStorageAt: rpcRequestHandler('eth_getStorageAt', async (_context, rpcRequest) => {
-			if (forwardToSigner) return getForwardingMessage(rpcRequest)
+			if (forwardToSigner && !simulationOverlayEnabled) return getForwardingMessage(rpcRequest)
 			return await withSimulationInput((simulationInput) => getStorageAt(ethereum, simulationInput, rpcRequest))
 		}),
 		eth_getLogs: rpcRequestHandler('eth_getLogs', async (_context, rpcRequest) => await withExecutionSimulationState((simulationState) => getLogs(ethereum, simulationState, rpcRequest))),

--- a/app/ts/background/simulationUpdating.ts
+++ b/app/ts/background/simulationUpdating.ts
@@ -433,7 +433,10 @@ export const updateSimulationMetadata = async (ethereum: EthereumClientService, 
 }
 
 export const prepareSimulationInputForRpc = async (simulationInput: SimulationStateInput, ethereum: EthereumClientService) => {
-	if (simulationInput.length === 0) return simulationInput
+	// Base-fee and nonce repair only rewrite transactions. Signed-message and state-
+	// override blocks must still reach the RPC handler, but inspecting them here would
+	// run an extra eth_simulateV1 request without any transaction nonce to repair.
+	if (simulationInput.every((block) => block.transactions.length === 0)) return simulationInput
 	const parentBlock = await ethereum.getBlock(undefined)
 	const getBaseFeeFixedInputStateBlocks = async () => {
 		if (parentBlock === undefined) return simulationInput

--- a/app/ts/background/simulationUpdating.ts
+++ b/app/ts/background/simulationUpdating.ts
@@ -433,6 +433,7 @@ export const updateSimulationMetadata = async (ethereum: EthereumClientService, 
 }
 
 export const prepareSimulationInputForRpc = async (simulationInput: SimulationStateInput, ethereum: EthereumClientService) => {
+	if (simulationInput.length === 0) return simulationInput
 	const parentBlock = await ethereum.getBlock(undefined)
 	const getBaseFeeFixedInputStateBlocks = async () => {
 		if (parentBlock === undefined) return simulationInput

--- a/scripts/capture-safe-ui-screenshots.mts
+++ b/scripts/capture-safe-ui-screenshots.mts
@@ -6,7 +6,7 @@ import { PendingTransactionOrSignableMessage } from '../app/ts/types/accessReque
 import { serialize } from '../app/ts/types/wire-types.js'
 import { getSafeTxHash } from '../app/ts/utils/eip712.js'
 import { privateKeyToAccount } from '../app/ts/utils/ethereumPrimitives.js'
-import { connectTarget, createTargetPage, launchChromeSession, waitForAnyExtensionServiceWorker, waitForTargetByUrl } from '../test/benchmarks/chromeHarness.js'
+import { connectTarget, createTargetPage, launchChromeSession, waitForInterceptorExtensionServiceWorker, waitForTargetByUrl } from '../test/benchmarks/chromeHarness.js'
 
 const outputDirectory = path.resolve(process.env.SAFE_UI_SCREENSHOT_OUTPUT_DIRECTORY ?? path.join(tmpdir(), 'interceptor-safe-wallet-screenshots'))
 
@@ -46,7 +46,7 @@ console.info('Launching Chromium')
 const session = await launchChromeSession()
 try {
 	console.info('Waiting for extension worker')
-	const workerTarget = await waitForAnyExtensionServiceWorker(session.browserDebugPort)
+	const workerTarget = await waitForInterceptorExtensionServiceWorker(session.browserDebugPort)
 	const extensionId = new URL(workerTarget.url).host
 
 	const addressBookUrl = `chrome-extension://${ extensionId }/html3/addressBookV3.html`

--- a/test/benchmarks/chromeCommunication.ts
+++ b/test/benchmarks/chromeCommunication.ts
@@ -1,4 +1,4 @@
-import { closeTarget, connectTarget, createTargetPage, launchChromeSession, waitForAnyExtensionServiceWorker, waitForPerformanceMarks, waitForRegisteredContentScripts, waitForTargetByUrl } from './chromeHarness.js'
+import { closeTarget, connectTarget, createTargetPage, launchChromeSession, waitForInterceptorExtensionServiceWorker, waitForPerformanceMarks, waitForRegisteredContentScripts, waitForTargetByUrl } from './chromeHarness.js'
 import { startChromeCommunicationPageServer } from './chromeCommunicationPageServer.js'
 import type { CdpConnection } from './chromeHarness.js'
 import { authorization as eip7702Authorization, Transaction } from 'micro-eth-signer'
@@ -104,7 +104,7 @@ async function main() {
 	let accessTargetId: string | undefined
 	let confirmTargetId: string | undefined
 	try {
-		const workerTarget = await waitForAnyExtensionServiceWorker(chrome.browserDebugPort, 30_000)
+		const workerTarget = await waitForInterceptorExtensionServiceWorker(chrome.browserDebugPort, 30_000)
 		const extensionId = extractExtensionId(workerTarget.url)
 		const workerConnection = await connectTarget(chrome.browserDebugPort, workerTarget.id)
 		try {

--- a/test/benchmarks/chromeHarness.ts
+++ b/test/benchmarks/chromeHarness.ts
@@ -316,8 +316,15 @@ export async function connectTarget(browserDebugPort: number, targetId: string) 
 	return connection
 }
 
-export async function waitForAnyExtensionServiceWorker(browserDebugPort: number, timeoutMs = 15_000) {
-	return await waitForTarget(browserDebugPort, (target) => target.type === 'service_worker' && target.url.startsWith('chrome-extension://'), timeoutMs, 'extension service worker')
+export async function waitForInterceptorExtensionServiceWorker(browserDebugPort: number, timeoutMs = 15_000) {
+	return await waitForTarget(
+		browserDebugPort,
+		(target) => target.type === 'service_worker'
+			&& target.url.startsWith('chrome-extension://')
+			&& target.url.endsWith('/js/backgroundServiceWorker.js'),
+		timeoutMs,
+		'Interceptor extension service worker',
+	)
 }
 
 export async function waitForTargetByUrl(browserDebugPort: number, urlPrefix: string, timeoutMs = 15_000) {

--- a/test/benchmarks/chromeSafeCoSigningCommunication.ts
+++ b/test/benchmarks/chromeSafeCoSigningCommunication.ts
@@ -6,18 +6,29 @@ import { SAFE_ABI, createSafeTx, safeTxToTypedDataJson } from '../../app/ts/safe
 import { EIP712Message } from '../../app/ts/types/eip721.js'
 import { EthSimulateV1Result } from '../../app/ts/types/ethSimulate-types.js'
 import { SafeStackExport, SafeTransactionStacks } from '../../app/ts/types/safeTypes.js'
+import { InterceptorTransactionStack } from '../../app/ts/types/visualizer-types.js'
 import { EthereumBlockHeader, EthereumQuantity, serialize } from '../../app/ts/types/wire-types.js'
 import { encodeFunctionCall, encodeFunctionReturn } from '../../app/ts/utils/abiRuntime.js'
-import { addressString, bytes32String } from '../../app/ts/utils/bigint.js'
+import { addressString, bytes32String, dataStringWith0xStart } from '../../app/ts/utils/bigint.js'
 import { getSafeTxHash } from '../../app/ts/utils/eip712.js'
 import { privateKeyToAccount } from '../../app/ts/utils/ethereumPrimitives.js'
-import { closeTarget, connectTarget, createTargetPage, launchChromeSession, readExtensionLargeStateValue, waitForAnyExtensionServiceWorker, waitForPerformanceMarks, waitForRegisteredContentScripts, waitForTargetByUrl, waitForTargetGone } from './chromeHarness.js'
+import { encodeStorageReaderCall, STORAGE_READER_ABI } from '../../app/ts/simulation/storageReader.js'
+import { closeTarget, connectTarget, createTargetPage, launchChromeSession, readExtensionLargeStateValue, waitForInterceptorExtensionServiceWorker, waitForPerformanceMarks, waitForRegisteredContentScripts, waitForTargetByUrl, waitForTargetGone } from './chromeHarness.js'
 import type { CdpConnection } from './chromeHarness.js'
 
 const ACCESS_APPROVE_BUTTON_SELECTOR = 'nav.popup-button-row button.is-primary:not(.is-danger)'
 const CONFIRM_APPROVE_BUTTON_SELECTOR = 'nav.popup-button-row button.dialog-action-button.is-primary:not(.is-danger)'
 const SAFE_ADDRESS = 0x1234567890123456789012345678901234567890n
+const SAFE_SINGLETON_ADDRESS = 0x41675c099f32341bf84bfc5382af534df5c7461an
 const DESTINATION_ADDRESS = 0x9876543210987654321098765432109876543210n
+const GET_CODE_CONTRACT = 0x1ce438391307f908756fefe0fe220c0f0d51508an
+const GET_CODE_ABI = [{
+	type: 'function',
+	name: 'at',
+	stateMutability: 'view',
+	inputs: [{ name: 'target', type: 'address' }],
+	outputs: [{ name: 'code', type: 'bytes' }],
+}] as const
 const OWNER_ACCOUNT = privateKeyToAccount('0xabcdefabcdefabcdefabcdefabcdefabcdefabcdefabcdefabcdefabcdefabcd')
 const OWNER_ADDRESS = BigInt(OWNER_ACCOUNT.address)
 const SAFE_TX = createSafeTx(1n, SAFE_ADDRESS, {
@@ -49,6 +60,28 @@ const UNSIGNED_STACK_EXPORT = {
 	stacks: [UNSIGNED_STACK],
 }
 const UNSIGNED_STACK_JSON = JSON.stringify(SafeStackExport.serialize(UNSIGNED_STACK_EXPORT), undefined, '\t')
+const SIGNED_MESSAGE_STACK = {
+	operations: [{
+		type: 'Message' as const,
+		signedMessageTransaction: {
+			website: { websiteOrigin: 'https://signed-message.example', icon: undefined, title: 'Signed message' },
+			created: new Date('2026-07-28T00:00:00.000Z'),
+			fakeSignedFor: SAFE_ADDRESS,
+			originalRequestParameters: { method: 'personal_sign' as const, params: ['0x68656c6c6f', SAFE_ADDRESS] },
+			request: {
+				interceptorRequest: true,
+				usingInterceptorWithoutSigner: false,
+				uniqueRequestIdentifier: { requestId: 999, requestSocket: { tabId: 1, connectionName: 0n } },
+				method: 'personal_sign' as const,
+				params: ['0x68656c6c6f', addressString(SAFE_ADDRESS)],
+			},
+			simulationMode: true,
+			messageIdentifier: 999n,
+		},
+	}],
+}
+const STORAGE_READER_CALL = dataStringWith0xStart(encodeStorageReaderCall(0n))
+const STORAGE_READER_RESULT = encodeFunctionReturn(STORAGE_READER_ABI, 'readSlot', [bytes32String(SAFE_SINGLETON_ADDRESS)])
 
 function sleep(ms: number) {
 	return new Promise<void>((resolve) => setTimeout(resolve, ms))
@@ -153,7 +186,11 @@ function makeFakeEthSimulateResult(calls: readonly unknown[]) {
 		calls: calls.map((call) => {
 			const input = isRecord(call) && typeof call.input === 'string' ? call.input : undefined
 			const to = isRecord(call) && typeof call.to === 'string' ? call.to : undefined
-			const safeResult = input !== undefined && to !== undefined && BigInt(to) === SAFE_ADDRESS
+			const safeResult = to !== undefined && BigInt(to) === GET_CODE_CONTRACT
+				? encodeFunctionReturn(GET_CODE_ABI, 'at', ['0x01'])
+				: input === STORAGE_READER_CALL && to !== undefined && BigInt(to) === SAFE_ADDRESS
+				? STORAGE_READER_RESULT
+				: input !== undefined && to !== undefined && BigInt(to) === SAFE_ADDRESS
 				? safeCallResults.get(input)
 				: undefined
 			const returnData = safeResult ?? aggregate3Result
@@ -212,8 +249,8 @@ async function handleRpcRequest(request: JsonRpcRequest) {
 		case 'eth_maxPriorityFeePerGas': return serialize(EthereumQuantity, 0n)
 		case 'eth_getCode': {
 			const [address] = request.params ?? []
-			const isSafeAddress = typeof address === 'string' && BigInt(address) === SAFE_ADDRESS
-			return isSafeAddress ? '0x01' : '0x'
+			const isSafeContract = typeof address === 'string' && (BigInt(address) === SAFE_ADDRESS || BigInt(address) === SAFE_SINGLETON_ADDRESS)
+			return isSafeContract ? '0x01' : '0x'
 		}
 		case 'eth_call': {
 			const [call] = request.params ?? []
@@ -236,6 +273,8 @@ const communicationPageHtml = await readFile(new URL('./chromeCommunicationPage.
 const sealwortFixtureDirectory = path.resolve('test/fixtures/sealwort')
 const sealwortExpectedSafeState = {
 	chainId: '0x1',
+	singletonAddress: addressString(SAFE_SINGLETON_ADDRESS),
+	singletonStorage: bytes32String(SAFE_SINGLETON_ADDRESS),
 	calls: safeStateReadCalls.map((data) => {
 		const result = safeCallResults.get(data)
 		if (result === undefined) throw new Error(`Missing Safe test response for ${ data }`)
@@ -345,7 +384,7 @@ async function main() {
 	let accessTargetId: string | undefined
 	let confirmTargetId: string | undefined
 	try {
-		const workerTarget = await waitForAnyExtensionServiceWorker(chrome.browserDebugPort, 30_000)
+		const workerTarget = await waitForInterceptorExtensionServiceWorker(chrome.browserDebugPort, 30_000)
 		const extensionId = extractExtensionId(workerTarget.url)
 		const workerConnection = await connectTarget(chrome.browserDebugPort, workerTarget.id)
 		try {
@@ -492,6 +531,7 @@ async function main() {
 			try {
 				await stackSeedConnection.evaluate(`browser.storage.local.set({
 					safeTransactionStacks: ${ JSON.stringify(serialize(SafeTransactionStacks, [UNSIGNED_STACK])) },
+					interceptorTransactionStack: ${ JSON.stringify(serialize(InterceptorTransactionStack, SIGNED_MESSAGE_STACK)) },
 				})`)
 			} finally {
 				stackSeedConnection.close()
@@ -509,9 +549,11 @@ async function main() {
 				10_000,
 				'Safe co-signer fixture API',
 			)
+			const sealwortInspectionRpcStart = rpcRequests.length
 			await pageConnection.evaluate('globalThis.__sealwortFixture.connect()')
 			try {
 				await waitForText(pageConnection, addressString(SAFE_ADDRESS))
+				await waitForText(pageConnection, 'Safe account inspection complete.')
 			} catch (error) {
 				const fixtureDiagnostics = await pageConnection.evaluate(`(async () => ({
 					text: document.body.textContent,
@@ -520,8 +562,27 @@ async function main() {
 					resources: performance.getEntriesByType('resource').map(({ name }) => name),
 					script: await fetch('./main.js').then(async (response) => ({ status: response.status, type: response.headers.get('content-type'), text: await response.text() })),
 				}))()`)
-				throw new Error(`Safe co-signer fixture did not connect. Page: ${ JSON.stringify(fixtureDiagnostics) }`, { cause: error })
+				const failureDiagnosticsConnection = await connectTarget(chrome.browserDebugPort, workerTarget.id)
+				const extensionDiagnostics = await failureDiagnosticsConnection.evaluate(`browser.storage.local.get(['latestUnexpectedError', 'interceptorErrorDiagnostics'])`)
+				failureDiagnosticsConnection.close()
+				throw new Error(`Safe co-signer fixture did not connect. Page: ${ JSON.stringify(fixtureDiagnostics) }. Extension: ${ JSON.stringify(extensionDiagnostics) }. RPC: ${ JSON.stringify(rpcRequests.slice(sealwortInspectionRpcStart)) }`, { cause: error })
 			}
+			const sealwortInspectionRpcRequests = rpcRequests.slice(sealwortInspectionRpcStart)
+			const sealwortSimulationRequests = sealwortInspectionRpcRequests.filter((rpcRequest) => rpcRequest.method === 'eth_simulateV1')
+			const hasTransactionPreparationSimulation = sealwortSimulationRequests.some((rpcRequest) => {
+				const [payload] = rpcRequest.params ?? []
+				if (!isRecord(payload) || !Array.isArray(payload.blockStateCalls)) return false
+				return payload.blockStateCalls.every((blockStateCall) => isRecord(blockStateCall) && Array.isArray(blockStateCall.calls) && blockStateCall.calls.length === 0)
+			})
+			if (hasTransactionPreparationSimulation) throw new Error('Sealwort Safe inspection ran transaction preparation for a transaction-free overlay')
+			const simulatedStorageLookup = sealwortSimulationRequests.some((rpcRequest) => {
+				const [payload] = rpcRequest.params ?? []
+				if (!isRecord(payload) || !Array.isArray(payload.blockStateCalls)) return false
+				return payload.blockStateCalls.some((blockStateCall) => isRecord(blockStateCall)
+					&& Array.isArray(blockStateCall.calls)
+					&& blockStateCall.calls.some((call) => isRecord(call) && call.input === STORAGE_READER_CALL))
+			})
+			if (!simulatedStorageLookup) throw new Error('Sealwort Safe inspection bypassed the simulated storage overlay')
 			const sealwortSignerStateConnection = await connectTarget(chrome.browserDebugPort, workerTarget.id)
 			try {
 				await sealwortSignerStateConnection.evaluate(`(async () => {

--- a/test/benchmarks/chromeSigningCommunication.ts
+++ b/test/benchmarks/chromeSigningCommunication.ts
@@ -1,4 +1,4 @@
-import { closeTarget, connectTarget, createTargetPage, launchChromeSession, waitForAnyExtensionServiceWorker, waitForPerformanceMarks, waitForRegisteredContentScripts, waitForTargetByUrl, waitForTargetGone } from './chromeHarness.js'
+import { closeTarget, connectTarget, createTargetPage, launchChromeSession, waitForInterceptorExtensionServiceWorker, waitForPerformanceMarks, waitForRegisteredContentScripts, waitForTargetByUrl, waitForTargetGone } from './chromeHarness.js'
 import { startChromeCommunicationPageServer } from './chromeCommunicationPageServer.js'
 import type { CdpConnection } from './chromeHarness.js'
 
@@ -98,7 +98,7 @@ async function main() {
 	let accessTargetId: string | undefined
 	let confirmTargetId: string | undefined
 	try {
-		const workerTarget = await waitForAnyExtensionServiceWorker(chrome.browserDebugPort, 30_000)
+		const workerTarget = await waitForInterceptorExtensionServiceWorker(chrome.browserDebugPort, 30_000)
 		const extensionId = extractExtensionId(workerTarget.url)
 		const workerConnection = await connectTarget(chrome.browserDebugPort, workerTarget.id)
 		try {

--- a/test/benchmarks/dispatchEventReloadComparison.ts
+++ b/test/benchmarks/dispatchEventReloadComparison.ts
@@ -1,5 +1,5 @@
 import { mkdir } from 'node:fs/promises'
-import { closeTarget, connectTarget, createTargetPage, launchChromeSession, waitForAnyExtensionServiceWorker, waitForPerformanceMarks, waitForRegisteredContentScripts } from './chromeHarness.js'
+import { closeTarget, connectTarget, createTargetPage, launchChromeSession, waitForInterceptorExtensionServiceWorker, waitForPerformanceMarks, waitForRegisteredContentScripts } from './chromeHarness.js'
 import { startDispatchEventReloadPageServer } from './dispatchEventReloadPageServer.js'
 import type { CdpConnection } from './chromeHarness.js'
 
@@ -57,7 +57,7 @@ async function ensureNoopExtension() {
 }
 
 async function waitForInterceptorReadiness(browserDebugPort: number) {
-	const workerTarget = await waitForAnyExtensionServiceWorker(browserDebugPort, 30_000)
+	const workerTarget = await waitForInterceptorExtensionServiceWorker(browserDebugPort, 30_000)
 	const workerConnection = await connectTarget(browserDebugPort, workerTarget.id)
 	try {
 		await waitForPerformanceMarks(workerConnection, ['interceptor:background:loaded'], 30_000)

--- a/test/benchmarks/popupLifecycleChrome.ts
+++ b/test/benchmarks/popupLifecycleChrome.ts
@@ -1,7 +1,7 @@
 import { performance } from 'perf_hooks'
 import { BENCHMARK_RPC_REQUESTS_GLOBAL } from '../../app/ts/utils/benchmarking.js'
 import { POPUP_PERFORMANCE_MARKS } from '../../app/ts/utils/popupPerformance.js'
-import { launchChromeSession, waitForAnyExtensionServiceWorker, waitForServiceWorker, createTargetPage, connectTarget, closeTarget, waitForPerformanceMark, waitForPerformanceMarks, waitForRegisteredContentScripts, readExtensionLargeStateValue, getPerformanceSnapshot, roundToTwoDecimals, absoluteTime, waitForPopupTarget, waitForTargetByUrl, waitForTargetGone, waitForBrowserTargets } from './chromeHarness.js'
+import { launchChromeSession, waitForInterceptorExtensionServiceWorker, waitForServiceWorker, createTargetPage, connectTarget, closeTarget, waitForPerformanceMark, waitForPerformanceMarks, waitForRegisteredContentScripts, readExtensionLargeStateValue, getPerformanceSnapshot, roundToTwoDecimals, absoluteTime, waitForPopupTarget, waitForTargetByUrl, waitForTargetGone, waitForBrowserTargets } from './chromeHarness.js'
 import { startTransactionStackPageServer } from './transactionStackPageServer.js'
 import type { CdpConnection, ChromeSession, PerformanceMarkSnapshot } from './chromeHarness.js'
 import type { BenchmarkRpcRequestSample } from '../../app/ts/utils/benchmarking.js'
@@ -300,7 +300,7 @@ async function ensureAnchorTarget(context: BenchmarkContext) {
 async function prepareBenchmarkContext(): Promise<BenchmarkContext> {
 	const chrome = await launchChromeSession()
 	try {
-		const initialWorkerTarget = await waitForAnyExtensionServiceWorker(chrome.browserDebugPort, 30_000)
+		const initialWorkerTarget = await waitForInterceptorExtensionServiceWorker(chrome.browserDebugPort, 30_000)
 		const extensionId = extractExtensionId(initialWorkerTarget.url)
 		const anchorTargetId = await createTargetPage(chrome.browserConnection, 'about:blank')
 		const workerConnection = await connectTarget(chrome.browserDebugPort, initialWorkerTarget.id)

--- a/test/fixtures/sealwort/main.js
+++ b/test/fixtures/sealwort/main.js
@@ -41,6 +41,25 @@ async function connect() {
 	try {
 		const [account] = await globalThis.ethereum.request({ method: 'eth_requestAccounts' })
 		accountOutput.textContent = account
+		const expectedState = await fetch('./expected-safe-state.json').then((response) => response.json())
+		const chainId = await globalThis.ethereum.request({ method: 'eth_chainId' })
+		await globalThis.ethereum.request({ method: 'wallet_getCapabilities', params: [account, [chainId]] })
+		const code = await globalThis.ethereum.request({ method: 'eth_getCode', params: [account, 'latest'] })
+		if (code === '0x') throw new Error('The connected account is not a contract')
+		const [singletonStorage, ...safeCallResults] = await Promise.all([
+			globalThis.ethereum.request({ method: 'eth_getStorageAt', params: [account, '0x0', 'latest'] }),
+			...expectedState.calls.map(({ data }) => globalThis.ethereum.request({
+				method: 'eth_call',
+				params: [{ to: account, data }, 'latest'],
+			})),
+		])
+		if (singletonStorage !== expectedState.singletonStorage) throw new Error('Unexpected Safe singleton storage')
+		for (const [index, result] of safeCallResults.entries()) {
+			if (result !== expectedState.calls[index]?.result) throw new Error('Unexpected Safe state response')
+		}
+		const singletonCode = await globalThis.ethereum.request({ method: 'eth_getCode', params: [expectedState.singletonAddress, 'latest'] })
+		if (singletonCode === '0x') throw new Error('The Safe singleton has no code')
+		statusOutput.textContent = 'Safe account inspection complete.'
 	} catch (error) {
 		statusOutput.textContent = error instanceof Error ? error.message : String(error)
 	}

--- a/test/tests/backgroundEthAccountsTestHarness.ts
+++ b/test/tests/backgroundEthAccountsTestHarness.ts
@@ -176,7 +176,10 @@ export async function waitForPortMessageCount(messages: readonly PortMessage[], 
 	}
 }
 
-export function createEthereumWithGetBlockCounter(getBlockCalls: { count: number }, initialBlockPolling = true) {
+export function createEthereumWithGetBlockCounter(
+	getBlockCalls: { count: number },
+	{ initialBlockPolling = true, getCodeResult }: { readonly initialBlockPolling?: boolean, readonly getCodeResult?: Uint8Array } = {},
+) {
 	const rpcEntry: RpcEntry = {
 		name: 'Test RPC',
 		chainId: 1n,
@@ -206,6 +209,7 @@ export function createEthereumWithGetBlockCounter(getBlockCalls: { count: number
 						return null
 					}
 				}
+				if (property === 'getCode' && getCodeResult !== undefined) return async () => getCodeResult
 				return Reflect.get(target, property, receiver)
 			},
 		},

--- a/test/tests/backgroundEthAccountsTestHarness.ts
+++ b/test/tests/backgroundEthAccountsTestHarness.ts
@@ -178,7 +178,15 @@ export async function waitForPortMessageCount(messages: readonly PortMessage[], 
 
 export function createEthereumWithGetBlockCounter(
 	getBlockCalls: { count: number },
-	{ initialBlockPolling = true, getCodeResult }: { readonly initialBlockPolling?: boolean, readonly getCodeResult?: Uint8Array } = {},
+	{
+		initialBlockPolling = true,
+		getCodeResult,
+		getStorageAtResult,
+	}: {
+		readonly initialBlockPolling?: boolean
+		readonly getCodeResult?: Uint8Array
+		readonly getStorageAtResult?: bigint
+	} = {},
 ) {
 	const rpcEntry: RpcEntry = {
 		name: 'Test RPC',
@@ -210,6 +218,7 @@ export function createEthereumWithGetBlockCounter(
 					}
 				}
 				if (property === 'getCode' && getCodeResult !== undefined) return async () => getCodeResult
+				if (property === 'getStorageAt' && getStorageAtResult !== undefined) return async () => getStorageAtResult
 				return Reflect.get(target, property, receiver)
 			},
 		},

--- a/test/tests/backgroundProviderRouting.test.ts
+++ b/test/tests/backgroundProviderRouting.test.ts
@@ -1,5 +1,6 @@
 import * as assert from 'assert'
 import { describe, test } from 'bun:test'
+import type { SimulationStateInput } from '../../app/ts/types/visualizer-types.js'
 import { addressString, confirmedSignerOwnership, createEthereumWithGetBlockCounter, createPort, createSafeTx, EthereumJsonRpcRequest, installBrowserMock, loadModules, noopPublishRpcConnectionStatus, safeTxToTypedDataJson, } from './backgroundEthAccountsTestHarness.js'
 
 describe('background eth_accounts', () => {
@@ -73,7 +74,7 @@ describe('background eth_accounts', () => {
 		})
 	})
 
-	test('answers Sealwort Safe account inspection without preparing an empty simulation overlay', async () => {
+	test('answers Sealwort Safe code and storage inspection without forwarding storage to the signer', async () => {
 		installBrowserMock()
 		const {
 			handleInterceptedRequest,
@@ -108,7 +109,11 @@ describe('background eth_accounts', () => {
 			[connectionKey]: { port, socket, websiteOrigin, approved: true, wantsToConnect: true },
 		} }]])
 		const getBlockCalls = { count: 0 }
-		const { ethereum, tokenPriceService, resetSimulationServices } = createEthereumWithGetBlockCounter(getBlockCalls, { getCodeResult: new Uint8Array([0x60]) })
+		const singletonAddress = 0x41675c099f32341bf84bfc5382af534df5c7461an
+		const { ethereum, tokenPriceService, resetSimulationServices } = createEthereumWithGetBlockCounter(getBlockCalls, {
+			getCodeResult: new Uint8Array([0x60]),
+			getStorageAtResult: singletonAddress,
+		})
 
 		await handleInterceptedRequest(port, websiteOrigin, website, ethereum, tokenPriceService, resetSimulationServices, socket, {
 			interceptorRequest: true,
@@ -127,6 +132,63 @@ describe('background eth_accounts', () => {
 			method: 'eth_getCode',
 			result: '0x60',
 		})
+
+		await handleInterceptedRequest(port, websiteOrigin, website, ethereum, tokenPriceService, resetSimulationServices, socket, {
+			interceptorRequest: true,
+			usingInterceptorWithoutSigner: false,
+			uniqueRequestIdentifier: { requestId: 2, requestSocket: socket },
+			method: 'eth_getStorageAt',
+			params: [addressString(safeAddress), '0x0', 'latest'],
+		}, websiteTabConnections, noopPublishRpcConnectionStatus)
+
+		assert.equal(getBlockCalls.count, 0)
+		assert.deepEqual(messages.at(-1), {
+			interceptorApproved: true,
+			requestId: 2,
+			bridgeRequestSettled: true,
+			type: 'result',
+			method: 'eth_getStorageAt',
+			result: `0x${ singletonAddress.toString(16).padStart(64, '0') }`,
+		})
+	})
+
+	test('preserves transaction-free overlays without running transaction preparation', async () => {
+		installBrowserMock()
+		const { prepareSimulationInputForRpc } = await import('../../app/ts/background/simulationUpdating.js')
+		const address = 0x1111111111111111111111111111111111111111n
+		const socket = { tabId: 1, connectionName: 0n }
+		const website = { websiteOrigin: 'https://sealwort.example', icon: undefined, title: 'Sealwort' }
+		const originalRequestParameters = { method: 'personal_sign' as const, params: ['0x68656c6c6f', address] }
+		const simulationInput = [{
+			stateOverrides: { [addressString(address)]: { balance: 123n } },
+			transactions: [],
+			signedMessages: [{
+				website,
+				created: new Date('2026-08-03T00:00:00.000Z'),
+				fakeSignedFor: address,
+				originalRequestParameters,
+				request: {
+					...originalRequestParameters,
+					interceptorRequest: true,
+					usingInterceptorWithoutSigner: false,
+					uniqueRequestIdentifier: { requestId: 1, requestSocket: socket },
+				},
+				simulationMode: true,
+				messageIdentifier: 1n,
+			}],
+			blockTimeManipulation: { type: 'AddToTimestamp' as const, deltaToAdd: 30n, deltaUnit: 'Seconds' as const },
+			simulateWithZeroBaseFee: true,
+		}] satisfies SimulationStateInput
+		const getBlockCalls = { count: 0 }
+		const { ethereum } = createEthereumWithGetBlockCounter(getBlockCalls)
+
+		const prepared = await prepareSimulationInputForRpc(simulationInput, ethereum)
+
+		assert.strictEqual(prepared, simulationInput)
+		assert.equal(getBlockCalls.count, 0)
+		assert.deepEqual(prepared[0]?.signedMessages, simulationInput[0].signedMessages)
+		assert.deepEqual(prepared[0]?.stateOverrides, simulationInput[0].stateOverrides)
+		assert.deepEqual(prepared[0]?.blockTimeManipulation, simulationInput[0].blockTimeManipulation)
 	})
 
 	test('returns invalid params to the webpage for malformed wallet_watchAsset requests', async () => {

--- a/test/tests/backgroundProviderRouting.test.ts
+++ b/test/tests/backgroundProviderRouting.test.ts
@@ -73,6 +73,62 @@ describe('background eth_accounts', () => {
 		})
 	})
 
+	test('answers Sealwort Safe account inspection without preparing an empty simulation overlay', async () => {
+		installBrowserMock()
+		const {
+			handleInterceptedRequest,
+			websiteSocketToString,
+			updateWebsiteAccess,
+			changeSimulationMode,
+			setUseSignersAddressAsActiveAddress,
+			updateUserAddressBookEntries,
+		} = await loadModules()
+		const websiteOrigin = 'https://darkflorist.github.io'
+		const website = { websiteOrigin, icon: undefined, title: 'Sealwort' }
+		const safeAddress = 0x1111111111111111111111111111111111111111n
+		const safeSignerAddress = 0x2222222222222222222222222222222222222222n
+		await changeSimulationMode({ simulationMode: false, activeSimulationAddress: safeAddress, activeSigningAddress: safeSignerAddress })
+		await setUseSignersAddressAsActiveAddress(false)
+		await updateUserAddressBookEntries(() => [{
+			type: 'safe',
+			name: 'Treasury Safe',
+			address: safeAddress,
+			chainId: 1n,
+			entrySource: 'User',
+			useAsActiveAddress: true,
+			safeSignerAddress,
+			safeVersion: '1.4.1',
+		}])
+		await updateWebsiteAccess(() => [{ website, access: true, addressAccess: [{ address: safeAddress, access: true }] }])
+
+		const socket = { tabId: 1, connectionName: 0n }
+		const { port, messages } = createPort(socket.tabId)
+		const connectionKey = websiteSocketToString(socket)
+		const websiteTabConnections = new Map([[socket.tabId, { ...confirmedSignerOwnership(socket), connections: {
+			[connectionKey]: { port, socket, websiteOrigin, approved: true, wantsToConnect: true },
+		} }]])
+		const getBlockCalls = { count: 0 }
+		const { ethereum, tokenPriceService, resetSimulationServices } = createEthereumWithGetBlockCounter(getBlockCalls, { getCodeResult: new Uint8Array([0x60]) })
+
+		await handleInterceptedRequest(port, websiteOrigin, website, ethereum, tokenPriceService, resetSimulationServices, socket, {
+			interceptorRequest: true,
+			usingInterceptorWithoutSigner: false,
+			uniqueRequestIdentifier: { requestId: 1, requestSocket: socket },
+			method: 'eth_getCode',
+			params: [addressString(safeAddress), 'latest'],
+		}, websiteTabConnections, noopPublishRpcConnectionStatus)
+
+		assert.equal(getBlockCalls.count, 0)
+		assert.deepEqual(messages.at(-1), {
+			interceptorApproved: true,
+			requestId: 1,
+			bridgeRequestSettled: true,
+			type: 'result',
+			method: 'eth_getCode',
+			result: '0x60',
+		})
+	})
+
 	test('returns invalid params to the webpage for malformed wallet_watchAsset requests', async () => {
 		installBrowserMock()
 		const { defaultActiveAddresses, handleInterceptedRequest, websiteSocketToString, updateWebsiteAccess, changeSimulationMode, setUseSignersAddressAsActiveAddress } = await loadModules()

--- a/test/tests/backgroundSignerLifecycle.test.ts
+++ b/test/tests/backgroundSignerLifecycle.test.ts
@@ -19,7 +19,7 @@ describe('background eth_accounts', () => {
 		const websiteTabConnections = new Map([[socket.tabId, { ...confirmedSignerOwnership(socket), connections: {
 			[connectionKey]: { port, socket, websiteOrigin, approved: true, wantsToConnect: true },
 		} }]])
-		const { ethereum, tokenPriceService, resetSimulationServices } = createEthereumWithGetBlockCounter({ count: 0 }, false)
+		const { ethereum, tokenPriceService, resetSimulationServices } = createEthereumWithGetBlockCounter({ count: 0 }, { initialBlockPolling: false })
 		const rpcNetwork = ethereum.getRpcEntry()
 		await setRpcConnectionStatus({
 			isConnected: false,
@@ -65,7 +65,7 @@ describe('background eth_accounts', () => {
 		const websiteTabConnections = new Map([[socket.tabId, { ...confirmedSignerOwnership(socket), connections: {
 			[connectionKey]: { port, socket, websiteOrigin, approved: true, wantsToConnect: true },
 		} }]])
-		const { ethereum, tokenPriceService, resetSimulationServices } = createEthereumWithGetBlockCounter({ count: 0 }, false)
+		const { ethereum, tokenPriceService, resetSimulationServices } = createEthereumWithGetBlockCounter({ count: 0 }, { initialBlockPolling: false })
 		await setRpcConnectionStatus({
 			isConnected: false,
 			lastConnnectionAttempt: new Date('2024-01-01T00:00:00.000Z'),


### PR DESCRIPTION
## What changed

- route eth_getStorageAt through Interceptor’s simulation overlay when a configured Safe is active
- continue forwarding eth_getStorageAt to the signer for ordinary EOA signing mode
- skip base-fee and nonce repair for transaction-free overlays while preserving signed messages, state overrides, block timing, and the downstream simulation
- expand the Chrome Sealwort fixture to cover its real Safe account-inspection requests
- make Chrome workflows select Interceptor’s service worker when other extension workers are installed

## Why

Sealwort reads storage slot 0 to identify the singleton behind a Safe proxy. In Safe signing mode, Interceptor incorrectly forwarded eth_getStorageAt to the backing EOA wallet even though a simulation overlay was active. The signer did not answer that request, so Sealwort waited until its 15-second timeout and reported that the connected contract was not a supported Safe.

Safe storage reads now follow the same overlay-aware path as other Safe state reads. Nonempty overlays are never bypassed: the slot lookup is still performed through the simulated storage-reader call.

Transaction-free overlays previously ran an extra eth_simulateV1 pass for base-fee and nonce repair even though that preparation can only rewrite transactions. Those inputs now skip only the transaction-repair pass and remain intact for the actual simulated read.

## Regression coverage

The Chrome Safe co-signing workflow now seeds a signed-message overlay and runs Sealwort’s startup sequence:

- wallet_getCapabilities
- eth_getCode
- slot-0 eth_getStorageAt
- concurrent Safe eth_call reads
- singleton eth_getCode

The test asserts that storage is read through the simulation overlay and that no transaction-repair-only simulation is performed. Unit tests cover Safe storage routing and preservation of transaction-free overlay data.

## Validation

- bun run test
- bun run setup-chrome
- bun run typecheck
- bun run lint
- CHROME_BIN=/usr/local/bin/chromium bun run test:chrome-communication
- CHROME_BIN=/usr/local/bin/chromium bun run test:chrome-safe-cosigning-communication
- CHROME_BIN=/usr/local/bin/chromium SAFE_UI_SCREENSHOT_OUTPUT_DIRECTORY=/tmp/interceptor-safe-ui-review bun ./scripts/capture-safe-ui-screenshots.mts
