### PR TITLE
Fix address book save missing replies

### DIFF
--- a/app/ts/background/accessManagement.ts
+++ b/app/ts/background/accessManagement.ts
@@ -355,7 +355,6 @@ export async function updateDeclarativeNetRequestBlocks(websiteTabConnections: W
 		// check if the rules would change, if not, just bail out
 		const decralativeNetRequestBlockIdentifier = `${ tabIdsToBlock.join('|') }|a|${ sitesToBlock.join('|') }`
 		if (decralativeNetRequestBlockIdentifier === previousDecralativeNetRequestBlockIdentifier) return
-		previousDecralativeNetRequestBlockIdentifier = decralativeNetRequestBlockIdentifier
 
 		if (browser.runtime.getManifest().manifest_version === 3) {
 			const dynamicRuleIds = (await browser.declarativeNetRequest.getDynamicRules()).map((rule) => rule.id)
@@ -389,6 +388,7 @@ export async function updateDeclarativeNetRequestBlocks(websiteTabConnections: W
 			// enable `declarativeNetRequestFeedback` permission to manifest and uncomment to enable debugging
 			// const a = (data: any) => { console.log(data) }
 			// (browser.declarativeNetRequest as any).onRuleMatchedDebug.addListener(a)
+			previousDecralativeNetRequestBlockIdentifier = decralativeNetRequestBlockIdentifier
 		} else {
 			browser.webRequest.onBeforeRequest.removeListener(webRequestListener)
 			webRequestListener = (details: browser.webRequest._OnBeforeRequestDetails) => {
@@ -401,8 +401,12 @@ export async function updateDeclarativeNetRequestBlocks(websiteTabConnections: W
 				if (sitesToBlock.find((blockUrl) => blockUrl === websiteOrigin) !== undefined) return { cancel: true }
 				return {}
 			}
-			if (sitesToBlock.length === 0 && tabIdsToBlock.length === 0) return
+			if (sitesToBlock.length === 0 && tabIdsToBlock.length === 0) {
+				previousDecralativeNetRequestBlockIdentifier = decralativeNetRequestBlockIdentifier
+				return
+			}
 			browser.webRequest.onBeforeRequest.addListener(webRequestListener, { urls: ['<all_urls>'] }, ['blocking'])
+			previousDecralativeNetRequestBlockIdentifier = decralativeNetRequestBlockIdentifier
 		}
 	})
 }
@@ -421,6 +425,7 @@ export async function updateWebsiteApprovalAccesses(
 	websiteTabConnections: WebsiteTabConnections,
 	settings: Settings,
 	promptForAccessesIfNeeded: boolean,
+	throwOnError = false,
 ): Promise<number> {
 	const popupRefreshGeneration = bumpPopupRefreshGeneration()
 	const allTabStates = await getAllTabStates()
@@ -429,6 +434,7 @@ export async function updateWebsiteApprovalAccesses(
 	try {
 		await updateDeclarativeNetRequestBlocks(websiteTabConnections)
 	} catch (error) {
+		if (throwOnError) throw error
 		await reportUnexpectedError(error)
 	}
 	// update port connections and disconnect from ports that should not have access anymore
@@ -444,6 +450,7 @@ export async function updateWebsiteApprovalAccesses(
 	try {
 		await Promise.all(updatePromises)
 	} catch (error) {
+		if (throwOnError) throw error
 		await reportUnexpectedError(error)
 	}
 	const iconRefreshPromises = [...iconRefreshTargets.values()].map(({ tabId, websiteOrigin }) =>
@@ -452,6 +459,7 @@ export async function updateWebsiteApprovalAccesses(
 	try {
 		await Promise.all(iconRefreshPromises)
 	} catch (error) {
+		if (throwOnError) throw error
 		await reportUnexpectedError(error)
 	}
 	return popupRefreshGeneration

--- a/app/ts/background/popupMessageHandlers.ts
+++ b/app/ts/background/popupMessageHandlers.ts
@@ -266,39 +266,52 @@ export async function removeAddressBookEntry(ethereum: EthereumClientService, to
 }
 
 export async function addOrModifyAddressBookEntry(ethereum: EthereumClientService, tokenPriceService: TokenPriceService, resetSimulationServices: ResetSimulationServices, websiteTabConnections: WebsiteTabConnections, entry: AddOrEditAddressBookEntry) {
-	let entryToStore: AddressBookEntry = entry.data
-	if (entry.data.type === 'safe') {
-		try {
-			if (entry.data.chainId !== ethereum.getChainId()) {
+	try {
+		let entryToStore: AddressBookEntry = entry.data
+		if (entry.data.type === 'safe') {
+			try {
+				if (entry.data.chainId !== ethereum.getChainId()) {
+					return {
+						type: 'AddOrModifyAddressBookEntryReply' as const,
+						ok: false as const,
+						message: `Switch Interceptor to chain ${ entry.data.chainId.toString() } before validating this Gnosis Safe.`,
+					}
+				}
+				const { blockNumber, state: safeState } = await getSafeContractSnapshot(ethereum, entry.data.address)
+				const ownerValidator = createSafeOwnerValidator(ethereum, entry.data.address, { blockNumber, state: safeState })
+				await Promise.all(getSafeSignerAddresses(entry.data).map(async (safeSignerAddress) =>
+					await ownerValidator.assertEoaOwner(safeSignerAddress)
+				))
+				entryToStore = { ...entry.data, safeVersion: safeState.version }
+			} catch(error) {
 				return {
 					type: 'AddOrModifyAddressBookEntryReply' as const,
 					ok: false as const,
-					message: `Switch Interceptor to chain ${ entry.data.chainId.toString() } before validating this Gnosis Safe.`,
+					message: getErrorMessage(error) ?? 'Failed to validate Gnosis Safe address.',
 				}
 			}
-			const { blockNumber, state: safeState } = await getSafeContractSnapshot(ethereum, entry.data.address)
-			const ownerValidator = createSafeOwnerValidator(ethereum, entry.data.address, { blockNumber, state: safeState })
-			await Promise.all(getSafeSignerAddresses(entry.data).map(async (safeSignerAddress) =>
-				await ownerValidator.assertEoaOwner(safeSignerAddress)
-			))
-			entryToStore = { ...entry.data, safeVersion: safeState.version }
-		} catch(error) {
-			return {
-				type: 'AddOrModifyAddressBookEntryReply' as const,
-				ok: false as const,
-				message: getErrorMessage(error) ?? 'Failed to validate Gnosis Safe address.',
+		}
+		await updateUserAddressBookEntries((previousContacts) => {
+			if (previousContacts.find((previous) => previous.address === entryToStore.address && doAddressBookChainIdsMatch(previous.chainId, entryToStore.chainId)) ) {
+				return previousContacts.map((previous) => previous.address === entryToStore.address && doAddressBookChainIdsMatch(previous.chainId, entryToStore.chainId) ? entryToStore : previous)
 			}
+			return previousContacts.concat([entryToStore])
+		})
+		if (entryToStore.useAsActiveAddress) await updateWebsiteApprovalAccesses(ethereum, tokenPriceService, resetSimulationServices, websiteTabConnections, await getSettings(), true, true)
+		await sendPopupMessageToOpenWindows({ method: 'popup_addressBookEntriesChanged' })
+		return { type: 'AddOrModifyAddressBookEntryReply' as const, ok: true as const }
+	} catch(error) {
+		if (!isExpectedInfrastructureError(error)) await reportUnexpectedError(error, {
+			source: 'address_book_save',
+			code: 'address_book_save_failed',
+			displayMessage: 'Failed to save address-book entry.',
+		})
+		return {
+			type: 'AddOrModifyAddressBookEntryReply' as const,
+			ok: false as const,
+			message: getErrorMessage(error) ?? 'Failed to save address-book entry.',
 		}
 	}
-	await updateUserAddressBookEntries((previousContacts) => {
-		if (previousContacts.find((previous) => previous.address === entryToStore.address && doAddressBookChainIdsMatch(previous.chainId, entryToStore.chainId)) ) {
-			return previousContacts.map((previous) => previous.address === entryToStore.address && doAddressBookChainIdsMatch(previous.chainId, entryToStore.chainId) ? entryToStore : previous)
-		}
-		return previousContacts.concat([entryToStore])
-	})
-	if (entryToStore.useAsActiveAddress) await updateWebsiteApprovalAccesses(ethereum, tokenPriceService, resetSimulationServices, websiteTabConnections, await getSettings(), true)
-	await sendPopupMessageToOpenWindows({ method: 'popup_addressBookEntriesChanged' })
-	return { type: 'AddOrModifyAddressBookEntryReply' as const, ok: true as const }
 }
 
 export async function setActiveSafeSigner(

--- a/test/tests/popupMessageDispatcher.test.ts
+++ b/test/tests/popupMessageDispatcher.test.ts
@@ -9,6 +9,8 @@ const storageState: Record<string, unknown> = {}
 const sentMessages: unknown[] = []
 const dynamicRuleUpdates: unknown[] = []
 const dispatcherEvents: ({ type: 'message', message: unknown } | { type: 'dynamicRuleUpdate' })[] = []
+let storageSetError: Error | undefined
+let dynamicRuleUpdateError: Error | undefined
 
 Reflect.set(globalThis, 'chrome', { runtime: { id: 'test-extension' } })
 Reflect.set(globalThis, 'browser', {
@@ -32,6 +34,7 @@ Reflect.set(globalThis, 'browser', {
 				return Object.fromEntries(Object.entries(keys).map(([key, defaultValue]) => [key, key in storageState ? storageState[key] : defaultValue]))
 			},
 			async set(items: Record<string, unknown>) {
+				if (storageSetError !== undefined) throw storageSetError
 				Object.assign(storageState, items)
 			},
 			async remove(keys: string | string[]) {
@@ -66,6 +69,7 @@ Reflect.set(globalThis, 'browser', {
 		getDynamicRules: async () => [],
 		getSessionRules: async () => [],
 		updateDynamicRules: async (update: unknown) => {
+			if (dynamicRuleUpdateError !== undefined) throw dynamicRuleUpdateError
 			dynamicRuleUpdates.push(update)
 			dispatcherEvents.push({ type: 'dynamicRuleUpdate' })
 			return undefined
@@ -76,11 +80,13 @@ Reflect.set(globalThis, 'browser', {
 
 const [
 	{ dispatchPopupMessage },
+	{ getLatestUnexpectedError },
 	{ EthereumClientService: EthereumClientServiceConstructor },
 	{ TokenPriceService: TokenPriceServiceConstructor },
 	{ MessageToPopup },
 ] = await Promise.all([
 	import('../../app/ts/background/popupMessageDispatcher.js'),
+	import('../../app/ts/background/storageVariables.js'),
 	import('../../app/ts/simulation/services/EthereumClientService.js'),
 	import('../../app/ts/simulation/services/priceEstimator.js'),
 	import('../../app/ts/types/interceptor-messages.js'),
@@ -121,6 +127,8 @@ function createDispatcherContext(resetSimulationState: () => Promise<void>): Pop
 }
 
 beforeEach(() => {
+	storageSetError = undefined
+	dynamicRuleUpdateError = undefined
 	for (const key of Object.keys(storageState)) delete storageState[key]
 	sentMessages.splice(0, sentMessages.length)
 	dynamicRuleUpdates.splice(0, dynamicRuleUpdates.length)
@@ -128,6 +136,78 @@ beforeEach(() => {
 })
 
 describe('popup message dispatcher seams', () => {
+	test('returns a save failure when address-book persistence fails', async () => {
+		storageSetError = new Error('Address-book storage unavailable.')
+
+		const result = await dispatchPopupMessage(createDispatcherContext(async () => undefined), {
+			method: 'popup_addOrModifyAddressBookEntry',
+			data: {
+				type: 'contact',
+				name: 'Alice',
+				address: 1n,
+				entrySource: 'User',
+			},
+		})
+
+		assert.deepEqual(result, {
+			type: 'AddOrModifyAddressBookEntryReply',
+			ok: false,
+			message: 'Address-book storage unavailable.',
+		})
+	})
+
+	test('returns and records a failure when active-address access refresh fails', async () => {
+		storageState.websiteAccess = [{
+			website: {
+				websiteOrigin: 'address-book-refresh-failure.test',
+				icon: undefined,
+				title: 'Address-book refresh failure',
+			},
+			addressAccess: [],
+			access: true,
+			declarativeNetRequestBlockMode: 'block-all',
+		}]
+		dynamicRuleUpdateError = new Error('Access refresh unavailable.')
+
+		const result = await dispatchPopupMessage(createDispatcherContext(async () => undefined), {
+			method: 'popup_addOrModifyAddressBookEntry',
+			data: {
+				type: 'contact',
+				name: 'Alice',
+				address: 1n,
+				entrySource: 'User',
+				useAsActiveAddress: true,
+			},
+		})
+		const latestUnexpectedError = await getLatestUnexpectedError()
+
+		assert.deepEqual(result, {
+			type: 'AddOrModifyAddressBookEntryReply',
+			ok: false,
+			message: 'Access refresh unavailable.',
+		})
+		assert.equal(latestUnexpectedError?.data.source, 'address_book_save')
+		assert.equal(latestUnexpectedError?.data.code, 'address_book_save_failed')
+
+		dynamicRuleUpdateError = undefined
+		const retryResult = await dispatchPopupMessage(createDispatcherContext(async () => undefined), {
+			method: 'popup_addOrModifyAddressBookEntry',
+			data: {
+				type: 'contact',
+				name: 'Alice',
+				address: 1n,
+				entrySource: 'User',
+				useAsActiveAddress: true,
+			},
+		})
+
+		assert.deepEqual(retryResult, {
+			type: 'AddOrModifyAddressBookEntryReply',
+			ok: true,
+		})
+		assert.equal(dynamicRuleUpdates.length, 1)
+	})
+
 	test('delegates simulation reset through the injected lifecycle callback', async () => {
 		let resetCount = 0
 		const result = await dispatchPopupMessage(createDispatcherContext(async () => {


### PR DESCRIPTION
## Summary

- Return structured failures when address-book persistence or active-address access refresh fails.
- Preserve specific Gnosis Safe validation errors.
- Record unexpected address-book save failures with dedicated diagnostics.
- Commit DNR block-state cache only after browser updates succeed, so retries are reliable.
- Add regression coverage for persistence failures, refresh failures, diagnostics, and retry behavior.

## Validation

- `bun run test` — 1,091 passed, 0 failed
- `bun run setup-chrome` — passed
- `bun run typecheck` — passed
- `bun run lint` — blocked by the pre-existing prose-comment violation at `app/inpage/ts/inpage.ts:108`

Final reviewer pass: no High, Medium, or Low findings.
