### PR TITLE
Fix access dialog address selection routing

### DIFF
--- a/app/inpage/ts/inpage.ts
+++ b/app/inpage/ts/inpage.ts
@@ -104,8 +104,7 @@ const INTERCEPTOR_BRIDGE_REQUEST_MESSAGE = 'interceptor_bridge_request'
 const REQUEST_SCOPED_PROVIDER_EVENT_METHODS = new Set(['accountsChanged', 'connect', 'disconnect', 'chainChanged'])
 
 export function normalizeSignerChainId(chainId: string) {
-	// Coinbase historically emitted decimal chain IDs. Only normalize the entire
-	// value so malformed IDs are not silently truncated by Number.parseInt.
+	// Coinbase historically emitted decimal chain IDs. Only normalize the entire value so malformed IDs are not silently truncated by Number.parseInt.
 	return /^[0-9]+$/.test(chainId) ? `0x${ BigInt(chainId).toString(16) }` : chainId
 }
 

--- a/app/ts/components/pages/InterceptorAccess.tsx
+++ b/app/ts/components/pages/InterceptorAccess.tsx
@@ -353,7 +353,7 @@ export function InterceptorAccess() {
 			<div class = { `modal ${ isModalActive ? 'is-active' : ''}` }>
 				{ (appPage.value.page === 'AddNewAddress' || appPage.value.page === 'ModifyAddress') && selectedPendingAccessRequest !== undefined
 					? <AddNewAddress
-						setActiveAddressAndInformAboutIt = { (address: bigint | 'signer') => setActiveAddressAndInformAboutIt(appPage.value.accessRequestId, address) }
+						setActiveAddressAndInformAboutIt = { (address: bigint | 'signer') => setActiveAddressAndInformAboutIt(selectedPendingAccessRequest.accessRequestId, address) }
 						modifyAddressWindowState = { appPage.value.state }
 						close = { () => { appPage.value = { page: 'Home', accessRequestId: '' } } }
 						activeAddress = { selectedPendingAccessRequest.requestAccessToAddress?.address }
@@ -364,7 +364,7 @@ export function InterceptorAccess() {
 
 				{ appPage.value.page === 'ChangeActiveAddress' && selectedPendingAccessRequest !== undefined
 					? <ChangeActiveAddress
-						setActiveAddressAndInformAboutIt = { (address: bigint | 'signer') => setActiveAddressAndInformAboutIt(appPage.value.accessRequestId, address) }
+						setActiveAddressAndInformAboutIt = { (address: bigint | 'signer') => setActiveAddressAndInformAboutIt(selectedPendingAccessRequest.accessRequestId, address) }
 						signerAccounts = { selectedPendingAccessRequest.signerAccounts }
 						close = { () => { appPage.value = { page: 'Home', accessRequestId: '' } } }
 						activeAddresses = { activeAddresses }

--- a/test/tests/popupAsyncActionUi.test.tsx
+++ b/test/tests/popupAsyncActionUi.test.tsx
@@ -3,7 +3,7 @@ import { afterEach, describe, test } from 'bun:test'
 import { signal } from '@preact/signals'
 import { h, render } from 'preact'
 import { act } from 'preact/test-utils'
-import { type GovernanceVoteInputParameters, SimulateExecutionReply } from '../../app/ts/types/interceptor-messages.js'
+import { type GovernanceVoteInputParameters, MessageToPopup, PopupMessage, SimulateExecutionReply } from '../../app/ts/types/interceptor-messages.js'
 import { PopupRequestsReplies } from '../../app/ts/types/interceptor-reply-messages.js'
 import type { VisualizedPersonalSignRequestSafeTx } from '../../app/ts/types/personal-message-definitions.js'
 import type { SimulatedAndVisualizedTransaction } from '../../app/ts/types/visualizer-types.js'
@@ -475,6 +475,87 @@ describe('popup async action UI', () => {
 
 		deferredReply.resolve()
 		await deferredReply.promise
+		render(null, dom.document.body)
+		dom.restore()
+	})
+
+	test('keeps the access request id when selecting an address closes the modal', async () => {
+		const modules = await modulesPromise
+		const dom = installDomMock()
+		const currentAddress = 0x1111111111111111111111111111111111111111n
+		const selectedAddress = 0x2222222222222222222222222222222222222222n
+		const request = {
+			...createAccessRequestFixture(),
+			requestAccessToAddress: {
+				type: 'contact' as const,
+				name: 'Current address',
+				address: currentAddress,
+				askForAddressAccess: true,
+				useAsActiveAddress: true,
+				entrySource: 'User' as const,
+			},
+			originalRequestAccessToAddress: {
+				type: 'contact' as const,
+				name: 'Current address',
+				address: currentAddress,
+				askForAddressAccess: true,
+				useAsActiveAddress: true,
+				entrySource: 'User' as const,
+			},
+			simulationMode: true,
+		}
+		const selectedAddressEntry = {
+			type: 'contact' as const,
+			name: 'Selected address',
+			address: selectedAddress,
+			askForAddressAccess: true,
+			useAsActiveAddress: true,
+			entrySource: 'User' as const,
+		}
+		let addressChangeMessage: unknown = undefined
+		runtimeSendMessage = async (message) => {
+			if (getRuntimeMethod(message) === 'popup_interceptorAccessChangeAddress') addressChangeMessage = message
+			return undefined
+		}
+
+		await act(async () => {
+			render(h(modules.InterceptorAccess, {}), dom.document.body)
+			await settleAsyncUpdates()
+		})
+		await act(async () => {
+			await emitRuntimeMessage(MessageToPopup.serialize({
+				role: 'all',
+				method: 'popup_interceptorAccessDialog',
+				data: { activeAddresses: [selectedAddressEntry], pendingAccessRequests: [request] },
+			}))
+		})
+
+		const changeButton = collectElements(dom.document.body, 'button').find((button) => button.textContent?.trim() === 'Change')
+		if (changeButton === undefined) throw new Error('Expected the change-address button to render')
+		await act(async () => { await clickElement(changeButton) })
+
+		const selectedAddressCard = collectElements(dom.document.body, 'div').find((element) =>
+			element.attributes?.class?.split(/\s+/).includes('card') === true
+			&& element.textContent?.includes('Selected address') === true
+		)
+		if (selectedAddressCard === undefined) throw new Error('Expected the selected address card to render')
+		await act(async () => {
+			await clickElement(selectedAddressCard)
+			await settleAsyncUpdates()
+		})
+
+		const parsedAddressChangeMessage = PopupMessage.parse(addressChangeMessage)
+		assert.deepEqual(parsedAddressChangeMessage, {
+			method: 'popup_interceptorAccessChangeAddress',
+			data: {
+				socket: request.socket,
+				website: request.website,
+				requestAccessToAddress: currentAddress,
+				newActiveAddress: selectedAddress,
+				accessRequestId: request.accessRequestId,
+			},
+		})
+
 		render(null, dom.document.body)
 		dom.restore()
 	})


### PR DESCRIPTION
## Summary

- Route address changes using the selected pending access request ID.
- Add regression coverage for access dialog address selection and modal closure.
- Keep the inpage signer chain ID comment within the prose line-length limit.

## Testing

- Not run