### PR TITLE
Fix content script refresh and chain ID precision

### DIFF
--- a/app/inpage/ts/inpage.ts
+++ b/app/inpage/ts/inpage.ts
@@ -104,9 +104,12 @@ const INTERCEPTOR_BRIDGE_REQUEST_MESSAGE = 'interceptor_bridge_request'
 const REQUEST_SCOPED_PROVIDER_EVENT_METHODS = new Set(['accountsChanged', 'connect', 'disconnect', 'chainChanged'])
 
 export function normalizeSignerChainId(chainId: string) {
-	// Coinbase historically emitted decimal chain IDs. Only normalize the entire
-	// value so malformed IDs are not silently truncated by Number.parseInt.
+	// Coinbase historically emitted decimal chain IDs. Only normalize the entire value so malformed IDs are not silently truncated by Number.parseInt.
 	return /^[0-9]+$/.test(chainId) ? `0x${ BigInt(chainId).toString(16) }` : chainId
+}
+
+function chainIdToNetworkVersion(chainId: string) {
+	return BigInt(chainId).toString(10)
 }
 
 type InterceptorApprovedMessageCandidate = {
@@ -1371,7 +1374,7 @@ class InterceptorMessageListener {
 					this.activeChainId = reply
 					if (this.metamaskCompatibilityMode && this.signerWindowEthereumRequest === undefined && inpageWindow.ethereum !== undefined) {
 						setCompatibilityProperty(inpageWindow.ethereum, 'chainId', reply, 'window.ethereum.chainId')
-						setCompatibilityProperty(inpageWindow.ethereum, 'networkVersion', Number(reply).toString(10), 'window.ethereum.networkVersion')
+						setCompatibilityProperty(inpageWindow.ethereum, 'networkVersion', chainIdToNetworkVersion(reply), 'window.ethereum.networkVersion')
 					}
 					for (const callback of this.onChainChangedCallBacks) {
 						callback(reply)
@@ -1475,9 +1478,9 @@ class InterceptorMessageListener {
 						}
 						case 'eth_chainId': {
 							if (typeof forwardRequest.result !== 'string') throw new Error('wrong type')
-							const chainId = forwardRequest.result as string
+							const chainId = forwardRequest.result
 							setCompatibilityProperty(inpageWindow.ethereum, 'chainId', chainId, 'window.ethereum.chainId')
-							setCompatibilityProperty(inpageWindow.ethereum, 'networkVersion', Number(chainId).toString(10), 'window.ethereum.networkVersion')
+							setCompatibilityProperty(inpageWindow.ethereum, 'networkVersion', chainIdToNetworkVersion(chainId), 'window.ethereum.networkVersion')
 							this.activeChainId = chainId
 							break
 						}

--- a/app/ts/utils/contentScriptsUpdating.ts
+++ b/app/ts/utils/contentScriptsUpdating.ts
@@ -64,10 +64,13 @@ export const updateContentScriptInjectionStrategyManifestV3 = async () => {
 		}]
 		const registeredContentScripts = await browser.scripting.getRegisteredContentScripts()
 		const registeredContentScriptIds = new Set(registeredContentScripts.map(({ id }) => id))
+		const desiredContentScriptIds = new Set(contentScripts.map(({ id }) => id))
 		const missingContentScripts = contentScripts.filter(({ id }) => !registeredContentScriptIds.has(id))
 		const existingContentScripts = contentScripts.filter(({ id }) => registeredContentScriptIds.has(id))
+		const obsoleteContentScriptIds = registeredContentScripts.map(({ id }) => id).filter((id) => !desiredContentScriptIds.has(id))
 		if (missingContentScripts.length > 0) await browser.scripting.registerContentScripts(missingContentScripts)
 		if (existingContentScripts.length > 0) await browser.scripting.updateContentScripts(existingContentScripts)
+		if (obsoleteContentScriptIds.length > 0) await browser.scripting.unregisterContentScripts({ ids: obsoleteContentScriptIds })
 	} catch (error: unknown) {
 		await reportUnexpectedError(error, { code: 'content_script_registration_failed' })
 	}

--- a/app/ts/utils/contentScriptsUpdating.ts
+++ b/app/ts/utils/contentScriptsUpdating.ts
@@ -10,15 +10,41 @@ const extensionGalleryInjectionTargetErrorMessage = 'The extensions gallery cann
 const isInjectableSite = (url: string) => injectableSitesRegexp.some((regexpPattern) => regexpPattern.test(url)) && !extensionGallerySitesRegexp.some((regexpPattern) => regexpPattern.test(url))
 const isExpectedManifestV2InjectionTargetError = (error: unknown) => error instanceof Error && (error.message === otherExtensionInjectionTargetErrorMessage || error.message === extensionGalleryInjectionTargetErrorMessage)
 
+function getManifestV3ExcludeMatchesForOrigin(origin: string) {
+	if (origin === '') return ['file:///*']
+	try {
+		const hasExplicitScheme = origin.includes('://')
+		const url = new URL(hasExplicitScheme ? origin : `http://${ origin }`)
+		if (url.protocol === 'file:') return url.hostname === '' ? ['file:///*'] : []
+		if (url.protocol !== 'http:' && url.protocol !== 'https:') return []
+		if (url.username !== '' || url.password !== '' || url.pathname !== '/' || url.search !== '' || url.hash !== '') return []
+		const hostname = url.hostname
+		if (hostname === '') return []
+		const isIpAddressOrLocalhost = hostname === 'localhost' || hostname.startsWith('[') || /^\d+(?:\.\d+){3}$/.test(hostname)
+		const hostPattern = isIpAddressOrLocalhost ? url.host : `*.${ url.host }`
+		if (hasExplicitScheme) return [`${ url.protocol.slice(0, -1) }://${ hostPattern }/*`]
+		if (url.port === '') return [`*://${ hostPattern }/*`]
+		return [`http://${ hostPattern }/*`, `https://${ hostPattern }/*`]
+	} catch {
+		return []
+	}
+}
+
+export function getManifestV3ExcludeMatches(origins: readonly string[]) {
+	const patterns = new Set<string>()
+	for (const origin of origins) {
+		for (const pattern of getManifestV3ExcludeMatchesForOrigin(origin)) patterns.add(pattern)
+	}
+	return [...patterns]
+}
+
 export const updateContentScriptInjectionStrategyManifestV3 = async () => {
-	const excludeMatches = getInterceptorDisabledSites(await getSettings()).map((origin) => `*://*.${ origin }/*`)
+	const excludeMatches = getManifestV3ExcludeMatches(getInterceptorDisabledSites(await getSettings()))
 	try {
 		type RegisteredContentScript = Parameters<typeof browser.scripting.registerContentScripts>[0][0]
-		// 'MAIN'` is not supported in `browser.` but its in `chrome.`. This code is only going to be run in manifest v3 environment (chrome) so this should be fine, just ugly
-		type FixedRegisterContentScripts = (scripts: (RegisteredContentScript & { world?: 'MAIN' | 'ISOLATED', matchOriginAsFallback: boolean })[]) => Promise<void>
-		const fixedRegisterContentScripts = ((browser.scripting.registerContentScripts as unknown) as FixedRegisterContentScripts)
-		await browser.scripting.unregisterContentScripts()
-		await fixedRegisterContentScripts([{
+		// The browser polyfill types do not expose Chrome's MAIN world or matchOriginAsFallback options.
+		type FixedContentScript = RegisteredContentScript & { world?: 'MAIN' | 'ISOLATED', matchOriginAsFallback: boolean }
+		const contentScripts: FixedContentScript[] = [{
 			id: 'inpage2',
 			allFrames: true,
 			matches: injectableSitesWildcard,
@@ -35,7 +61,13 @@ export const updateContentScriptInjectionStrategyManifestV3 = async () => {
 			runAt: 'document_start',
 			world: 'MAIN',
 			matchOriginAsFallback: true
-		}])
+		}]
+		const registeredContentScripts = await browser.scripting.getRegisteredContentScripts()
+		const registeredContentScriptIds = new Set(registeredContentScripts.map(({ id }) => id))
+		const missingContentScripts = contentScripts.filter(({ id }) => !registeredContentScriptIds.has(id))
+		const existingContentScripts = contentScripts.filter(({ id }) => registeredContentScriptIds.has(id))
+		if (missingContentScripts.length > 0) await browser.scripting.registerContentScripts(missingContentScripts)
+		if (existingContentScripts.length > 0) await browser.scripting.updateContentScripts(existingContentScripts)
 	} catch (error: unknown) {
 		await reportUnexpectedError(error, { code: 'content_script_registration_failed' })
 	}

--- a/test/tests/contentScriptsUpdating.test.ts
+++ b/test/tests/contentScriptsUpdating.test.ts
@@ -29,7 +29,8 @@ function installBrowserMock({ registerError, updateError, executeScriptError, ta
 	const executedScriptFiles: string[] = []
 	const registeredContentScripts = new Map(registeredContentScriptIds.map((id) => [id, { id }]))
 	let executeScriptCalls = 0
-	let unregisterContentScriptCalls = 0
+	const scriptingOperations: string[] = []
+	const unregisteredContentScriptIdBatches: string[][] = []
 	let currentTabUrl = tabUrl
 	let committedListener: ((details: browser.webNavigation._OnCommittedDetails) => unknown) | undefined
 	const getStorageItems = (keys?: string | string[] | Record<string, unknown> | null) => {
@@ -67,16 +68,20 @@ function installBrowserMock({ registerError, updateError, executeScriptError, ta
 				},
 			},
 			scripting: {
-				async unregisterContentScripts() {
-					unregisterContentScriptCalls++
-					registeredContentScripts.clear()
+				async unregisterContentScripts(filter?: { readonly ids?: readonly string[] }) {
+					scriptingOperations.push('unregister')
+					const ids = filter?.ids === undefined ? [...registeredContentScripts.keys()] : [...filter.ids]
+					unregisteredContentScriptIdBatches.push(ids)
+					for (const id of ids) registeredContentScripts.delete(id)
 				},
 				async getRegisteredContentScripts() { return [...registeredContentScripts.values()] },
 				async registerContentScripts(scripts: readonly RegisteredContentScript[]) {
+					scriptingOperations.push('register')
 					if (registerError !== undefined) throw registerError
 					for (const script of scripts) registeredContentScripts.set(script.id, script)
 				},
 				async updateContentScripts(scripts: readonly RegisteredContentScript[]) {
+					scriptingOperations.push('update')
 					if (updateError !== undefined) throw updateError
 					for (const script of scripts) registeredContentScripts.set(script.id, script)
 				},
@@ -125,7 +130,8 @@ function installBrowserMock({ registerError, updateError, executeScriptError, ta
 	return {
 		sentMessages,
 		getRegisteredContentScripts() { return [...registeredContentScripts.values()] },
-		getUnregisterContentScriptCalls() { return unregisterContentScriptCalls },
+		getScriptingOperations() { return [...scriptingOperations] },
+		getUnregisteredContentScriptIdBatches() { return unregisteredContentScriptIdBatches.map((ids) => [...ids]) },
 		getExecuteScriptCalls() { return executeScriptCalls },
 		getExecutedScriptFiles() { return [...executedScriptFiles] },
 		getCommittedListener() {
@@ -220,28 +226,30 @@ describe('content script injection strategy', () => {
 		assert.equal(sentMessages.at(-1)?.method, 'popup_UnexpectedErrorOccured')
 	})
 
-	test('registers missing manifest v3 scripts and updates existing definitions without unregistering', async () => {
-		const { getRegisteredContentScripts, getUnregisterContentScriptCalls } = installBrowserMock({ registeredContentScriptIds: ['inpage'] })
+	test('registers missing scripts, updates existing definitions, and then prunes obsolete registrations', async () => {
+		const { getRegisteredContentScripts, getScriptingOperations, getUnregisteredContentScriptIdBatches } = installBrowserMock({ registeredContentScriptIds: ['inpage', 'obsolete-inpage'] })
 		const { updateContentScriptInjectionStrategyManifestV3 } = await loadModules()
 
 		await updateContentScriptInjectionStrategyManifestV3()
 
-		assert.equal(getUnregisterContentScriptCalls(), 0)
 		assert.deepEqual(getRegisteredContentScripts().map(({ id }) => id).sort(), ['inpage', 'inpage2'])
 		assert.equal(getRegisteredContentScripts().every(({ excludeMatches }) => excludeMatches?.length === 0), true)
+		assert.deepEqual(getScriptingOperations(), ['register', 'update', 'unregister'])
+		assert.deepEqual(getUnregisteredContentScriptIdBatches(), [['obsolete-inpage']])
 	})
 
-	test('keeps existing manifest v3 content scripts registered when an update fails', async () => {
-		const { getRegisteredContentScripts, getUnregisterContentScriptCalls } = installBrowserMock({
-			registeredContentScriptIds: ['inpage', 'inpage2'],
+	test('keeps existing and obsolete manifest v3 content scripts registered when an update fails', async () => {
+		const { getRegisteredContentScripts, getScriptingOperations, getUnregisteredContentScriptIdBatches } = installBrowserMock({
+			registeredContentScriptIds: ['inpage', 'inpage2', 'obsolete-inpage'],
 			updateError: new Error('update failed'),
 		})
 		const { updateContentScriptInjectionStrategyManifestV3 } = await loadModules()
 
 		await withSilencedConsole(async () => await updateContentScriptInjectionStrategyManifestV3())
 
-		assert.equal(getUnregisterContentScriptCalls(), 0)
-		assert.deepEqual(getRegisteredContentScripts().map(({ id }) => id).sort(), ['inpage', 'inpage2'])
+		assert.deepEqual(getScriptingOperations(), ['update'])
+		assert.deepEqual(getUnregisteredContentScriptIdBatches(), [])
+		assert.deepEqual(getRegisteredContentScripts().map(({ id }) => id).sort(), ['inpage', 'inpage2', 'obsolete-inpage'])
 	})
 
 	test('keeps missing-tab manifest v2 injection failures ignored', async () => {

--- a/test/tests/contentScriptsUpdating.test.ts
+++ b/test/tests/contentScriptsUpdating.test.ts
@@ -10,17 +10,26 @@ type RuntimeMessage = {
 
 type BrowserMockOptions = {
 	readonly registerError?: Error
+	readonly updateError?: Error
 	readonly executeScriptError?: Error
 	readonly tabUrl?: string
 	readonly hasVisibleTabUrl?: boolean
 	readonly tabUrlAfterStorageRead?: string
+	readonly registeredContentScriptIds?: readonly string[]
 }
 
-function installBrowserMock({ registerError, executeScriptError, tabUrl = 'https://example.com/', hasVisibleTabUrl = true, tabUrlAfterStorageRead }: BrowserMockOptions = {}) {
+type RegisteredContentScript = {
+	readonly id: string
+	readonly excludeMatches?: readonly string[]
+}
+
+function installBrowserMock({ registerError, updateError, executeScriptError, tabUrl = 'https://example.com/', hasVisibleTabUrl = true, tabUrlAfterStorageRead, registeredContentScriptIds = [] }: BrowserMockOptions = {}) {
 	const storageState: Record<string, unknown> = {}
 	const sentMessages: RuntimeMessage[] = []
 	const executedScriptFiles: string[] = []
+	const registeredContentScripts = new Map(registeredContentScriptIds.map((id) => [id, { id }]))
 	let executeScriptCalls = 0
+	let unregisterContentScriptCalls = 0
 	let currentTabUrl = tabUrl
 	let committedListener: ((details: browser.webNavigation._OnCommittedDetails) => unknown) | undefined
 	const getStorageItems = (keys?: string | string[] | Record<string, unknown> | null) => {
@@ -58,10 +67,18 @@ function installBrowserMock({ registerError, executeScriptError, tabUrl = 'https
 				},
 			},
 			scripting: {
-				async unregisterContentScripts() { return undefined },
-				async registerContentScripts() {
+				async unregisterContentScripts() {
+					unregisterContentScriptCalls++
+					registeredContentScripts.clear()
+				},
+				async getRegisteredContentScripts() { return [...registeredContentScripts.values()] },
+				async registerContentScripts(scripts: readonly RegisteredContentScript[]) {
 					if (registerError !== undefined) throw registerError
-					return undefined
+					for (const script of scripts) registeredContentScripts.set(script.id, script)
+				},
+				async updateContentScripts(scripts: readonly RegisteredContentScript[]) {
+					if (updateError !== undefined) throw updateError
+					for (const script of scripts) registeredContentScripts.set(script.id, script)
 				},
 			},
 			tabs: {
@@ -107,6 +124,8 @@ function installBrowserMock({ registerError, executeScriptError, tabUrl = 'https
 
 	return {
 		sentMessages,
+		getRegisteredContentScripts() { return [...registeredContentScripts.values()] },
+		getUnregisterContentScriptCalls() { return unregisterContentScriptCalls },
 		getExecuteScriptCalls() { return executeScriptCalls },
 		getExecutedScriptFiles() { return [...executedScriptFiles] },
 		getCommittedListener() {
@@ -143,6 +162,33 @@ function getManifestV2WebAccessibleResources() {
 }
 
 describe('content script injection strategy', () => {
+	test('creates valid manifest v3 exclusions without admitting malformed stored origins', async () => {
+		installBrowserMock()
+		const { getManifestV3ExcludeMatches } = await loadModules()
+
+		assert.deepEqual(getManifestV3ExcludeMatches([
+			'',
+			'example.com',
+			'localhost:3000',
+			'127.0.0.1:8545',
+			'[::1]:8545',
+			'https://secure.example',
+			'https://localhost:4443',
+			'https://invalid.example/path',
+		]), [
+			'file:///*',
+			'*://*.example.com/*',
+			'http://localhost:3000/*',
+			'https://localhost:3000/*',
+			'http://127.0.0.1:8545/*',
+			'https://127.0.0.1:8545/*',
+			'http://[::1]:8545/*',
+			'https://[::1]:8545/*',
+			'https://*.secure.example/*',
+			'https://localhost:4443/*',
+		])
+	})
+
 	test('exposes every manifest v2 injected file to Firefox', async () => {
 		const { getCommittedListener, getExecutedScriptFiles } = installBrowserMock()
 		const { updateContentScriptInjectionStrategyManifestV2 } = await loadModules()
@@ -172,6 +218,30 @@ describe('content script injection strategy', () => {
 		assert.equal(latestUnexpectedError?.data.message, 'registration failed')
 		assert.equal(latestUnexpectedError?.data.code, 'content_script_registration_failed')
 		assert.equal(sentMessages.at(-1)?.method, 'popup_UnexpectedErrorOccured')
+	})
+
+	test('registers missing manifest v3 scripts and updates existing definitions without unregistering', async () => {
+		const { getRegisteredContentScripts, getUnregisterContentScriptCalls } = installBrowserMock({ registeredContentScriptIds: ['inpage'] })
+		const { updateContentScriptInjectionStrategyManifestV3 } = await loadModules()
+
+		await updateContentScriptInjectionStrategyManifestV3()
+
+		assert.equal(getUnregisterContentScriptCalls(), 0)
+		assert.deepEqual(getRegisteredContentScripts().map(({ id }) => id).sort(), ['inpage', 'inpage2'])
+		assert.equal(getRegisteredContentScripts().every(({ excludeMatches }) => excludeMatches?.length === 0), true)
+	})
+
+	test('keeps existing manifest v3 content scripts registered when an update fails', async () => {
+		const { getRegisteredContentScripts, getUnregisterContentScriptCalls } = installBrowserMock({
+			registeredContentScriptIds: ['inpage', 'inpage2'],
+			updateError: new Error('update failed'),
+		})
+		const { updateContentScriptInjectionStrategyManifestV3 } = await loadModules()
+
+		await withSilencedConsole(async () => await updateContentScriptInjectionStrategyManifestV3())
+
+		assert.equal(getUnregisterContentScriptCalls(), 0)
+		assert.deepEqual(getRegisteredContentScripts().map(({ id }) => id).sort(), ['inpage', 'inpage2'])
 	})
 
 	test('keeps missing-tab manifest v2 injection failures ignored', async () => {

--- a/test/tests/inpageSignerBridge.test.ts
+++ b/test/tests/inpageSignerBridge.test.ts
@@ -640,6 +640,41 @@ describe('inpage signer bridge', () => {
 		assert.deepEqual(connectedToSignerParams, [[false, 'NoSigner', 1]])
 	})
 
+	test('preserves large chain IDs in the legacy networkVersion compatibility property', async () => {
+		const largeChainId = '0x20000000000001'
+		const { fakeWindow } = createFakeWindow({
+			handleRequest: (request, sendBackgroundReply) => {
+				if (request.method === 'connected_to_signer') {
+					sendBackgroundReply({
+						interceptorApproved: true,
+						requestId: request.requestId,
+						type: 'result',
+						method: request.method,
+						result: { metamaskCompatibilityMode: true },
+					})
+					return true
+				}
+				if (request.method !== 'eth_chainId') return false
+				sendBackgroundReply({
+					interceptorApproved: true,
+					requestId: request.requestId,
+					type: 'result',
+					method: request.method,
+					result: largeChainId,
+				})
+				return true
+			},
+		})
+		Reflect.deleteProperty(fakeWindow, 'ethereum')
+
+		await withFakeInpageWindow(fakeWindow, '../../app/inpage/ts/inpage.js?large-network-version', async () => {
+			const provider = Reflect.get(fakeWindow, 'ethereum')
+			if (!isRecord(provider) || typeof provider.request !== 'function') throw new Error('Interceptor provider was not installed')
+			assert.equal(await provider.request({ method: 'eth_chainId' }), largeChainId)
+			assert.equal(provider.networkVersion, '9007199254740993')
+		})
+	})
+
 	test('reports a fresh signer epoch when the background requests reconnect status', async () => {
 		const connectedToSignerParams: unknown[][] = []
 		const { fakeWindow, sendBackgroundMessage } = createFakeWindow({


### PR DESCRIPTION
## Summary

- validate and normalize Manifest V3 disabled-site match patterns, including file URLs and port-bearing localhost/IP origins
- preserve registered content scripts when a refresh fails by registering missing definitions and updating existing ones without unregistering first
- preserve exact legacy networkVersion values for chain IDs above Number.MAX_SAFE_INTEGER
- fix the split prose comment lint failure and add regression coverage

## Validation

- bun run test: 1,095 passed, 0 failed
- bun run setup-chrome: passed
- bun run typecheck: passed
- bun run lint: passed
- git diff --check: passed

The optional Chrome communication harness remains blocked by a pre-existing generated classic-script export error outside this diff.

## Review

- first review: 40/100; fixed the High finding for Chromium-invalid wildcard-scheme patterns with ports
- final review: 91/100; no High, Medium, or Low findings