### PR TITLE
Fix validation and UI lifecycle edge cases

### DIFF
--- a/app/inpage/ts/inpage.ts
+++ b/app/inpage/ts/inpage.ts
@@ -1363,7 +1363,7 @@ class InterceptorMessageListener {
 					if (!this.connected) return
 					this.connected = false
 					for (const callback of this.onDisconnectCallBacks) {
-						callback({ name: 'disconnect', code: METAMASK_ERROR_USER_REJECTED_REQUEST, message: 'User refused access to the wallet' })
+						callback({ name: 'disconnect', code: METAMASK_ERROR_PROVIDER_DISCONNECTED, message: 'Provider disconnected from all chains.' })
 					}
 					return
 				}

--- a/app/ts/components/subcomponents/CopyToClipboard.tsx
+++ b/app/ts/components/subcomponents/CopyToClipboard.tsx
@@ -1,8 +1,21 @@
 import type { ComponentChildren, JSX } from 'preact'
 import type { Signal } from '@preact/signals'
 import { clipboardCopy } from './clipboardcopy.js'
+import { showHint } from './Hint.js'
 
 type CopySource = { content: string } | { copyFunction: () => Promise<string | undefined> }
+
+export const copyToClipboard = async (source: CopySource, copy = clipboardCopy) => {
+	if ('content' in source) {
+		await copy(source.content)
+		return true
+	}
+
+	const resolvedText = await source.copyFunction()
+	if (resolvedText === undefined) return false
+	await copy(resolvedText)
+	return true
+}
 
 type CopyToClipboardProps = CopySource & {
 	children: ComponentChildren
@@ -13,21 +26,25 @@ type CopyToClipboardProps = CopySource & {
 }
 
 export function CopyToClipboard(props: CopyToClipboardProps) {
-	const performCopy = async () => {
-		if ('content' in props) {
-			await clipboardCopy(props.content)
+	const performCopy = async (event: JSX.TargetedMouseEvent<HTMLDivElement>) => {
+		const target = event.currentTarget
+		const position = { x: event.clientX, y: event.clientY }
+		const text = 'content' in props ? props.content : await props.copyFunction()
+		if (text === undefined) return
+		try {
+			await clipboardCopy(text)
+		} catch (error: unknown) {
+			if (!(error instanceof DOMException)) throw error
+			showHint(target, { content: 'Could not copy to clipboard.', delay: 1500, ...position })
 			return
 		}
-
-		const resolvedText = await props.copyFunction()
-		if (resolvedText === undefined) return
-		await clipboardCopy(resolvedText)
+		showHint(target, { content: props.copyMessage ?? 'Copied to clipboard!', delay: 1500, ...position })
 	}
 
 	const tooltipContent = 'content' in props ? (props.contentDisplayOverride ?? props.content) : props.contentDisplayOverride
 
 	return <div onClick = { performCopy } class = { props.classNames } style = { props.style ?? 'display: inherit; overflow: inherit;' }>
-		<div data-hint-clickable-hide-timer-ms = { 1500 } data-hint = { props.copyMessage ?? 'Copied to clipboard!' } data-tooltip = { tooltipContent } style = 'display: inherit; overflow: inherit; width: 100%;'>
+		<div data-tooltip = { tooltipContent } style = 'display: inherit; overflow: inherit; width: 100%;'>
 			{ props.children }
 		</div>
 	</div>

--- a/app/ts/components/subcomponents/DynamicScroller.tsx
+++ b/app/ts/components/subcomponents/DynamicScroller.tsx
@@ -9,9 +9,15 @@ interface DynamicScrollerProps<T extends {}> {
 
 export const getDynamicScrollOffset = (startIndex: number, itemHeight: number, itemCount: number, maximumVisibleItems: number) => {
 	if (itemHeight <= 0 || !Number.isFinite(itemHeight) || !Number.isFinite(maximumVisibleItems)) return 0
-	const requestedOffset = startIndex * itemHeight
+	const requestedOffset = getClampedDynamicScrollStartIndex(startIndex, itemCount, maximumVisibleItems) * itemHeight
 	const maximumOffset = Math.max(0, (itemCount - maximumVisibleItems) * itemHeight)
 	return Math.min(requestedOffset, maximumOffset)
+}
+
+export const getClampedDynamicScrollStartIndex = (startIndex: number, itemCount: number, maximumVisibleItems: number) => {
+	if (!Number.isFinite(startIndex) || !Number.isFinite(itemCount) || !Number.isFinite(maximumVisibleItems)) return 0
+	const maximumStartIndex = Math.max(0, Math.floor(itemCount) - Math.max(1, Math.floor(maximumVisibleItems)))
+	return Math.min(Math.max(0, Math.floor(startIndex)), maximumStartIndex)
 }
 
 export const DynamicScroller = <T extends {}>({ items, renderItem, }: DynamicScrollerProps<T>) => {
@@ -28,8 +34,16 @@ export const DynamicScroller = <T extends {}>({ items, renderItem, }: DynamicScr
 	}
 
 	const scrollAreaHeight = useComputed(() => items.value.length * itemHeight.value)
-	const visibleItems = useComputed(() => items.value.slice(startIndex.value, startIndex.value + maxItems.value + 1))
-	const scrollOffset = useComputed(() => getDynamicScrollOffset(startIndex.value, itemHeight.value, items.value.length, maxItems.value))
+	const clampedStartIndex = useComputed(() => getClampedDynamicScrollStartIndex(startIndex.value, items.value.length, maxItems.value))
+	const visibleItems = useComputed(() => items.value.slice(clampedStartIndex.value, clampedStartIndex.value + maxItems.value + 1))
+	const scrollOffset = useComputed(() => getDynamicScrollOffset(clampedStartIndex.value, itemHeight.value, items.value.length, maxItems.value))
+
+	useSignalEffect(() => {
+		const synchronizedStartIndex = clampedStartIndex.value
+		if (startIndex.value === synchronizedStartIndex) return
+		startIndex.value = synchronizedStartIndex
+		if (scrollViewRef.current !== null) scrollViewRef.current.scrollTop = getDynamicScrollOffset(synchronizedStartIndex, itemHeight.value, items.value.length, maxItems.value)
+	})
 
 	// calculate item height
 	useSignalEffect(() => {
@@ -52,7 +66,7 @@ export const DynamicScroller = <T extends {}>({ items, renderItem, }: DynamicScr
 		<div ref = { scrollViewRef } style = { { overflowY: 'scroll', maxHeight: '100%' } } onScroll = { recalculateStartIndex }>
 			<div style = { { height: `${ scrollAreaHeight }px`, '--virtual-scroll-offset': `${ scrollOffset }px` } }>
 				{ visibleItems.value.map((item, index) => (
-					<div key = { startIndex.value + index } ref = { itemRef } style = { {  contain: 'layout', transform: 'translateY(var(--virtual-scroll-offset))' } }>
+					<div key = { clampedStartIndex.value + index } ref = { itemRef } style = { {  contain: 'layout', transform: 'translateY(var(--virtual-scroll-offset))' } }>
 						{ renderItem(item) }
 					</div>
 				)) }

--- a/app/ts/components/subcomponents/Hint.tsx
+++ b/app/ts/components/subcomponents/Hint.tsx
@@ -9,6 +9,22 @@ interface Props {
 }
 
 const timerAttribute = 'data-hint-clickable-hide-timer-ms'
+const showHintEventName = 'interceptor:show-hint'
+
+type ShowHintEventDetail = {
+	content: string
+	delay: number
+	x: number
+	y: number
+}
+
+export const showHint = (target: HTMLElement, detail: ShowHintEventDetail) => {
+	target.dispatchEvent(new CustomEvent(showHintEventName, { bubbles: true, detail }))
+}
+
+export const clearHintTimeouts = (timeoutIds: readonly (ReturnType<typeof setTimeout> | null)[], clearTimeoutFunction = clearTimeout) => {
+	for (const timeoutId of timeoutIds) clearTimeoutFunction(timeoutId ?? undefined)
+}
 
 export default function Container(props: Props) {
 	const copyAttribute = props.attribute || 'data-hint'
@@ -65,6 +81,27 @@ export default function Container(props: Props) {
 			}, parseInt(delayValue))
 		}
 
+		const show = (event: Event) => {
+			if (!(event instanceof CustomEvent)) return
+			if (!(event.target instanceof Element) || !containerElement.contains(event.target)) return
+			const detail: unknown = event.detail
+			if (typeof detail !== 'object' || detail === null) return
+			if (!('content' in detail) || typeof detail.content !== 'string') return
+			if (!('delay' in detail) || typeof detail.delay !== 'number' || !Number.isFinite(detail.delay) || detail.delay < 0) return
+			if (!('x' in detail) || typeof detail.x !== 'number' || !('y' in detail) || typeof detail.y !== 'number') return
+
+			clearHintTimeouts([copyMessageTimeoutIdRef.current, toolTipTimeoutIdRef.current])
+			copyMessageTimeoutIdRef.current = null
+			toolTipTimeoutIdRef.current = null
+			content.value = detail.content
+			clickPosition.value = { x: detail.x, y: detail.y }
+			copyMessageTimeoutIdRef.current = setTimeout(() => {
+				content.value = ''
+				clickPosition.value = null
+				copyMessageTimeoutIdRef.current = null
+			}, detail.delay)
+		}
+
 		const mouseover = (event: MouseEvent) => {
 			const targetElement = getHintElement(event.target, toolTipAttribute) ?? getHintElement(event.target, timerAttribute)
 			if (targetElement === undefined) return
@@ -80,12 +117,17 @@ export default function Container(props: Props) {
 		containerElement.addEventListener('mouseover', mouseover)
 		containerElement.addEventListener('mouseout', hide)
 		containerElement.addEventListener('focusout', hide)
+		containerElement.addEventListener(showHintEventName, show)
 
 		return () => {
+			clearHintTimeouts([copyMessageTimeoutIdRef.current, toolTipTimeoutIdRef.current])
+			copyMessageTimeoutIdRef.current = null
+			toolTipTimeoutIdRef.current = null
 			containerElement.removeEventListener('click', click)
 			containerElement.removeEventListener('mouseover', mouseover)
 			containerElement.removeEventListener('mouseout', hide)
 			containerElement.removeEventListener('focusout', hide)
+			containerElement.removeEventListener(showHintEventName, show)
 		}
 	}, [copyAttribute, toolTipAttribute])
 

--- a/app/ts/components/subcomponents/SomeTimeAgo.tsx
+++ b/app/ts/components/subcomponents/SomeTimeAgo.tsx
@@ -33,7 +33,7 @@ export function SomeTimeAgo(props: SomeTimeAgoProps) {
 
 function humanReadableDateDelta(secondsDiff: number) {
 	if (secondsDiff <= 0) return '0s'
-	if (secondsDiff > 3600 * 24 * 1.5) return `${ Math.floor((secondsDiff + 1800) / 3600 / 24) }d`
+	if (secondsDiff > 3600 * 24 * 1.5) return `${ Math.floor(secondsDiff / (3600 * 24) + 0.5) }d`
 	if (secondsDiff > 3600 * 1.5) return `${ Math.floor((secondsDiff + 1800) / 3600) }h`
 	if (secondsDiff > 60 * 1.5) return `${ Math.floor((secondsDiff + 30) / 60) }m`
 	return `${ Math.floor(secondsDiff + 0.5) }s`

--- a/app/ts/components/subcomponents/TimePicker.tsx
+++ b/app/ts/components/subcomponents/TimePicker.tsx
@@ -13,6 +13,12 @@ export type TimePickerMode = typeof timePickerModeDownOptions[number]
 
 export const parseTimePickerDeltaValue = (value: string) => /^[0-9]+$/.test(value) ? BigInt(value) : undefined
 
+export const hasValidTimePickerValue = (mode: TimePickerMode, absoluteTime: Date | undefined, deltaValue: bigint | undefined) => {
+	if (mode === 'Until') return absoluteTime !== undefined
+	if (mode === 'For') return deltaValue !== undefined
+	return true
+}
+
 export const getTimeManipulatorFromSignals = (timeSelectorMode: TimePickerMode, timeSelectorAbsoluteTime: Date | undefined, timeSelectorDeltaValue: bigint, timeSelectorDeltaUnit: DeltaUnit) => {
 	switch(timeSelectorMode) {
 		case 'No Delay': return { type: 'No Delay' } as const
@@ -123,17 +129,18 @@ export const TimePicker = ({ mode, absoluteTime, deltaValue, deltaUnit, onChange
 	}
 
 	const hasValuesChanged = useComputed(() => {
+		if (!hasValidTimePickerValue(temporaryMode.value, temporaryAbsoluteTime.value, temporaryDeltaValue.value)) return false
 		if (mode.value !== temporaryMode.value) return true
 		if (mode.value === 'For') {
-			if (temporaryDeltaValue.value === undefined) return false
 			return deltaUnit.value !== temporaryDeltaUnit.value || deltaValue.value !== temporaryDeltaValue.value
 		}
-		if (mode.value === 'Until') return absoluteTime.value !== temporaryAbsoluteTime.value && temporaryAbsoluteTime.value !== undefined
+		if (mode.value === 'Until') return absoluteTime.value !== temporaryAbsoluteTime.value
 		return false
 	})
 
 	const commitOptions = () => {
 		if (disabled) return
+		if (!hasValidTimePickerValue(temporaryMode.value, temporaryAbsoluteTime.value, temporaryDeltaValue.value)) return
 		batch(() => {
 			mode.value = temporaryMode.value
 			deltaUnit.value = temporaryDeltaUnit.value
@@ -152,7 +159,7 @@ export const TimePicker = ({ mode, absoluteTime, deltaValue, deltaUnit, onChange
 				<DropDownMenu selected = { temporaryMode } dropDownOptions = { timePickerModeDownOptionsSignal } onChangedCallBack = { changeMode } buttonClassses = { 'btn btn--outline is-small' } disabled = { disabled }/>
 				<TimePickerModeViews mode = { temporaryMode } absoluteTime = { temporaryAbsoluteTime } deltaValue = { temporaryDeltaValue } deltaUnit = { temporaryDeltaUnit } timePickerDeltaOptionsSignal = { timePickerDeltaOptionsSignal } changeDeltaUnit = { changeDeltaUnit } absoluteTimeChanged = { absoluteTimeChanged } changeDeltaValue = { changeDeltaValue } disabled = { disabled }/>
 
-				<button class = 'btn is-small is-primary' disabled = { disabled } onClick = { commitOptions } style = { { visibility: hasValuesChanged.value ? 'visible' : 'hidden' } }>
+				<button class = 'btn is-small is-primary' disabled = { disabled || !hasValuesChanged.value } onClick = { commitOptions } style = { { visibility: hasValuesChanged.value ? 'visible' : 'hidden' } }>
 					Commit
 				</button>
 			</div>

--- a/app/ts/components/subcomponents/clipboardcopy.ts
+++ b/app/ts/components/subcomponents/clipboardcopy.ts
@@ -13,7 +13,11 @@ async function copyClipboardApi (text: string) {
 	return navigator.clipboard.writeText(text)
 }
 
-async function copyExecCommand (text: string) {
+export async function copyExecCommand (text: string) {
+	// Make a selection object representing the range of text selected by the user
+	const selection = globalThis.getSelection()
+	if (!selection) throw makeError()
+
 	// Put the text to copy into a <span>
 	const span = document.createElement('span')
 	span.textContent = text
@@ -26,23 +30,23 @@ async function copyExecCommand (text: string) {
 	// Add the <span> to the page
 	document.body.appendChild(span)
 
-	// Make a selection object representing the range of text selected by the user
-	const selection = globalThis.getSelection()
-	if (!selection) return
-	const range = globalThis.document.createRange()
-	selection.removeAllRanges()
-	range.selectNode(span)
-	selection.addRange(range)
-
-	// Copy text to the clipboard
 	try {
+		const range = globalThis.document.createRange()
+		selection.removeAllRanges()
+		range.selectNode(span)
+		selection.addRange(range)
+
+		// Copy text to the clipboard
 		if (!globalThis.document.execCommand('copy')) {
 			throw makeError()
 		}
 	} finally {
 		// Cleanup
-		selection.removeAllRanges()
-		globalThis.document.body.removeChild(span)
+		try {
+			selection.removeAllRanges()
+		} finally {
+			span.parentNode?.removeChild(span)
+		}
 	}
 }
 

--- a/app/ts/utils/addressValidation.ts
+++ b/app/ts/utils/addressValidation.ts
@@ -7,9 +7,11 @@ export function getIssueWithAddressString(address: string): string | undefined {
 
 	if (address.match(/^(0x)?[0-9a-fA-F]{40}$/)) {
 		const checkSummedAddress = getAddress(address.toLowerCase())
+		const addressBody = address.slice(2)
+		const isUniformlyCased = addressBody === addressBody.toLowerCase() || addressBody === addressBody.toUpperCase()
 
 		// It is a checksummed address with a bad checksum
-		if (checkSummedAddress !== address && address.toLowerCase() !== address) {
+		if (checkSummedAddress !== address && !isUniformlyCased) {
 			return `Bad address checksum, did you mean ${ checkSummedAddress } ?`
 		}
 	} else {

--- a/app/ts/utils/eip712.ts
+++ b/app/ts/utils/eip712.ts
@@ -161,7 +161,7 @@ const validatePrimitiveOrStruct = (typeStr: string, value: typeJSONEncodeable, s
 	const bytesRegex = /^bytes$/
 	const bytesMatch = typeStr.match(bytesRegex)
 	if (bytesMatch) {
-		return typeof value === 'string' && /^0x[a-fA-F0-9]*$/.test(value) ? { valid: true } : { valid: false, reason: `${ value } is invalid bytes string` }
+		return typeof value === 'string' && /^0x(?:[a-fA-F0-9]{2})*$/.test(value) ? { valid: true } : { valid: false, reason: `${ value } is invalid bytes string` }
 	}
 
 	// Other built-in types

--- a/app/ts/utils/ethereumBytes.ts
+++ b/app/ts/utils/ethereumBytes.ts
@@ -46,6 +46,7 @@ export const getAddress = (address: string): Hex => {
 
 export const isAddress = (address: string): boolean => {
 	if (!ADDRESS_REGEX.test(address)) return false
-	if (address.toLowerCase() === address) return true
+	const addressBody = address.slice(2)
+	if (addressBody === addressBody.toLowerCase() || addressBody === addressBody.toUpperCase()) return true
 	return addr.addChecksum(address.toLowerCase()) === address
 }

--- a/app/ts/utils/semaphore.ts
+++ b/app/ts/utils/semaphore.ts
@@ -64,22 +64,22 @@ export class Semaphore {
 			return Promise.resolve(true)
 		}
 
-		// We save the resolver function in the current scope so that we can resolve the promise to false if the time expires.
+		let timeoutId: ReturnType<typeof setTimeout> | undefined
 		let resolver: (result: boolean) => void
 		const promise = new Promise<boolean>(resolve => { resolver = resolve })
+		const queuedResolver = (result: boolean) => {
+			clearTimeout(timeoutId)
+			resolver(result)
+		}
 
 		// The saved resolver gets added to our list of promise resolvers so that it gets a chance to be resolved as a result of a call to signal().
-		this.promiseResolverQueue.push(resolver!)
+		this.promiseResolverQueue.push(queuedResolver)
 
-		setTimeout(() => {
+		timeoutId = setTimeout(() => {
 			// We have to remove the promise resolver from our list. Resolving it twice would not be an issue but signal() always takes the next resolver from the queue and resolves it which would swallow a permit if we didn't remove it.
-			const index = this.promiseResolverQueue.indexOf(resolver)
-			if (index !== -1) {
-				this.promiseResolverQueue.splice(index, 1)
-			} else {
-				// This shouldn't happen, not much we can do at this point
-				console.warn(`Semaphore.waitFor couldn't find its promise resolver in the queue`)
-			}
+			const index = this.promiseResolverQueue.indexOf(queuedResolver)
+			if (index === -1) return
+			this.promiseResolverQueue.splice(index, 1)
 
 			// false because the wait was unsuccessful.
 			resolver(false)

--- a/test/tests/addNewAddress.test.ts
+++ b/test/tests/addNewAddress.test.ts
@@ -130,6 +130,34 @@ describe('add new address save flow', () => {
 		assert.equal(isIdentificationRequestCurrent(changedAddressState, requestedIdentification), false)
 	})
 
+	test('accepts an uppercase address in the add-address identification path', () => {
+		const state: ModifyAddressWindowState = {
+			windowStateId: 'uppercase-address',
+			errorState: undefined,
+			incompleteAddressBookEntry: {
+				addingAddress: true,
+				type: 'contact',
+				address: '0xDE709F2102306220921060314715629080E2FB77',
+				askForAddressAccess: true,
+				name: 'Uppercase address',
+				symbol: undefined,
+				decimals: undefined,
+				logoUri: undefined,
+				entrySource: 'User',
+				abi: undefined,
+				useAsActiveAddress: undefined,
+				declarativeNetRequestBlockMode: undefined,
+				chainId: 1n,
+			},
+		}
+
+		assert.deepEqual(getAddressIdentificationKey(state), {
+			address: 0xde709f2102306220921060314715629080e2fb77n,
+			chainId: 1n,
+			windowStateId: 'uppercase-address',
+		})
+	})
+
 	test('rechecks the same address after its selected chain changes', () => {
 		const state: ModifyAddressWindowState = {
 			windowStateId: 'current-window',

--- a/test/tests/addressValidation.test.ts
+++ b/test/tests/addressValidation.test.ts
@@ -1,0 +1,10 @@
+import * as assert from 'assert'
+import { describe, test } from 'bun:test'
+import { getIssueWithAddressString } from '../../app/ts/utils/addressValidation.js'
+
+describe('address validation', () => {
+	test('accepts uniformly uppercase addresses while still checking mixed-case addresses', () => {
+		assert.equal(getIssueWithAddressString('0xDE709F2102306220921060314715629080E2FB77'), undefined)
+		assert.match(getIssueWithAddressString('0x5A384227B65FA093DEC03EC34e111Db80A040615') ?? '', /Bad address checksum/u)
+	})
+})

--- a/test/tests/clipboardcopy.test.ts
+++ b/test/tests/clipboardcopy.test.ts
@@ -1,0 +1,88 @@
+import * as assert from 'assert'
+import { describe, test } from 'bun:test'
+import { CopyToClipboard, copyToClipboard } from '../../app/ts/components/subcomponents/CopyToClipboard.js'
+import { copyExecCommand } from '../../app/ts/components/subcomponents/clipboardcopy.js'
+import { installDomMock } from './domMock.js'
+
+describe('clipboard copying', () => {
+	test('reports success only after text has been resolved and copied', async () => {
+		const copiedTexts: string[] = []
+		const copy = async (text: string) => { copiedTexts.push(text) }
+		assert.equal(await copyToClipboard({ content: 'direct' }, copy), true)
+		assert.equal(await copyToClipboard({ copyFunction: async () => 'resolved' }, copy), true)
+		assert.equal(await copyToClipboard({ copyFunction: async () => undefined }, copy), false)
+		assert.deepEqual(copiedTexts, ['direct', 'resolved'])
+		await assert.rejects(copyToClipboard({ content: 'failed' }, async () => { throw new Error('copy failed') }), /copy failed/u)
+	})
+
+	test('the component dispatches feedback only after async copy completion', async () => {
+		const previousNavigatorDescriptor = Object.getOwnPropertyDescriptor(globalThis, 'navigator')
+		const previousSelectionDescriptor = Object.getOwnPropertyDescriptor(globalThis, 'getSelection')
+		Object.defineProperty(globalThis, 'navigator', { configurable: true, value: { clipboard: { writeText: async () => undefined } } })
+		let resolveText = (_text: string | undefined) => undefined
+		const pendingText = new Promise<string | undefined>((resolve) => { resolveText = resolve })
+		const dispatchedEvents: Event[] = []
+		const target = { dispatchEvent: (event: Event) => { dispatchedEvents.push(event); return true } }
+		try {
+			const component = CopyToClipboard({ copyFunction: async () => await pendingText, children: 'Copy' })
+			assert.equal(component.props.children.props['data-hint'], undefined)
+			const clickPromise = component.props.onClick({ currentTarget: target, clientX: 12, clientY: 34 })
+			await Promise.resolve()
+			assert.deepEqual(dispatchedEvents, [])
+			resolveText('resolved')
+			await clickPromise
+			assert.equal(dispatchedEvents.length, 1)
+			const successEvent = dispatchedEvents[0]
+			if (!(successEvent instanceof CustomEvent)) throw new Error('expected copy feedback event')
+			assert.deepEqual(successEvent.detail, { content: 'Copied to clipboard!', delay: 1500, x: 12, y: 34 })
+
+			const unexpectedFailureComponent = CopyToClipboard({ copyFunction: async () => { throw new Error('failed') }, children: 'Copy' })
+			await assert.rejects(unexpectedFailureComponent.props.onClick({ currentTarget: target, clientX: 1, clientY: 2 }), /failed/u)
+			assert.equal(dispatchedEvents.length, 1)
+
+			Object.defineProperty(globalThis, 'navigator', { configurable: true, value: { clipboard: { writeText: async () => { throw new DOMException('denied', 'NotAllowedError') } } } })
+			Object.defineProperty(globalThis, 'getSelection', { configurable: true, value: () => undefined })
+			const deniedComponent = CopyToClipboard({ content: 'denied', children: 'Copy' })
+			await deniedComponent.props.onClick({ currentTarget: target, clientX: 1, clientY: 2 })
+			const failureEvent = dispatchedEvents[1]
+			if (!(failureEvent instanceof CustomEvent)) throw new Error('expected copy failure feedback event')
+			assert.deepEqual(failureEvent.detail, { content: 'Could not copy to clipboard.', delay: 1500, x: 1, y: 2 })
+		} finally {
+			if (previousNavigatorDescriptor === undefined) delete globalThis.navigator
+			else Object.defineProperty(globalThis, 'navigator', previousNavigatorDescriptor)
+			if (previousSelectionDescriptor === undefined) delete globalThis.getSelection
+			else Object.defineProperty(globalThis, 'getSelection', previousSelectionDescriptor)
+		}
+	})
+
+	test('fails before appending a fallback element when no selection is available', async () => {
+		const previousDescriptor = Object.getOwnPropertyDescriptor(globalThis, 'getSelection')
+		Object.defineProperty(globalThis, 'getSelection', { configurable: true, value: () => undefined })
+		try {
+			await assert.rejects(copyExecCommand('text'), /The request is not allowed/u)
+		} finally {
+			if (previousDescriptor === undefined) delete globalThis.getSelection
+			else Object.defineProperty(globalThis, 'getSelection', previousDescriptor)
+		}
+	})
+
+	test('removes the fallback element when range setup fails after append', async () => {
+		const dom = installDomMock()
+		const previousDescriptor = Object.getOwnPropertyDescriptor(globalThis, 'getSelection')
+		let selectionCleanupCount = 0
+		Object.defineProperty(globalThis, 'getSelection', {
+			configurable: true,
+			value: () => ({ removeAllRanges: () => { selectionCleanupCount += 1 } }),
+		})
+		try {
+			await assert.rejects(copyExecCommand('sensitive text'), /createRange/u)
+			assert.equal(dom.document.body.textContent, '')
+			assert.equal(dom.document.body.childNodes.length, 0)
+			assert.equal(selectionCleanupCount, 1)
+		} finally {
+			if (previousDescriptor === undefined) delete globalThis.getSelection
+			else Object.defineProperty(globalThis, 'getSelection', previousDescriptor)
+			dom.restore()
+		}
+	})
+})

--- a/test/tests/domMock.test.ts
+++ b/test/tests/domMock.test.ts
@@ -9,6 +9,8 @@ test('installDomMock restore keeps newer interleaved mock globals active', () =>
 	const firstRequestAnimationFrame = globalThis.requestAnimationFrame
 	const firstCancelAnimationFrame = globalThis.cancelAnimationFrame
 	const firstHtmlDialogElement = globalThis.HTMLDialogElement
+	const firstHtmlDivElement = globalThis.HTMLDivElement
+	const firstElement = globalThis.Element
 
 	const second = installDomMock()
 	const secondSetInterval = globalThis.setInterval
@@ -16,6 +18,8 @@ test('installDomMock restore keeps newer interleaved mock globals active', () =>
 	const secondRequestAnimationFrame = globalThis.requestAnimationFrame
 	const secondCancelAnimationFrame = globalThis.cancelAnimationFrame
 	const secondHtmlDialogElement = globalThis.HTMLDialogElement
+	const secondHtmlDivElement = globalThis.HTMLDivElement
+	const secondElement = globalThis.Element
 
 	first.restore()
 
@@ -26,6 +30,10 @@ test('installDomMock restore keeps newer interleaved mock globals active', () =>
 	assert.equal(globalThis.requestAnimationFrame, secondRequestAnimationFrame)
 	assert.equal(globalThis.cancelAnimationFrame, secondCancelAnimationFrame)
 	assert.equal(globalThis.HTMLDialogElement, secondHtmlDialogElement)
+	assert.equal(globalThis.HTMLDivElement, secondHtmlDivElement)
+	assert.equal(globalThis.Element, secondElement)
+	assert.equal(second.document.body instanceof globalThis.HTMLDivElement, true)
+	assert.equal(second.document.body instanceof globalThis.Element, true)
 
 	second.restore()
 
@@ -43,4 +51,8 @@ test('installDomMock restore keeps newer interleaved mock globals active', () =>
 	assert.notEqual(globalThis.cancelAnimationFrame, secondCancelAnimationFrame)
 	assert.notEqual(globalThis.HTMLDialogElement, firstHtmlDialogElement)
 	assert.notEqual(globalThis.HTMLDialogElement, secondHtmlDialogElement)
+	assert.notEqual(globalThis.HTMLDivElement, firstHtmlDivElement)
+	assert.notEqual(globalThis.HTMLDivElement, secondHtmlDivElement)
+	assert.notEqual(globalThis.Element, firstElement)
+	assert.notEqual(globalThis.Element, secondElement)
 })

--- a/test/tests/domMock.ts
+++ b/test/tests/domMock.ts
@@ -95,7 +95,11 @@ class TestElement extends TestNode {
 	readonly nodeType = 1
 	tagName: string
 	nodeName: string
+	clientHeight = 40
+	onscroll: unknown = undefined
+	scrollTop = 0
 	attributes: AttributeMap = {}
+	readonly eventListeners = new Map<string, Set<(event: Event) => unknown>>()
 	style = {
 		setProperty: (name: string, value: string) => {
 			this.style[name] = value
@@ -124,16 +128,47 @@ class TestElement extends TestNode {
 		delete this.attributes[name]
 	}
 
-	addEventListener() { return undefined }
-	removeEventListener() { return undefined }
+	addEventListener(type: string, listener: (event: Event) => unknown) {
+		const listeners = this.eventListeners.get(type) ?? new Set()
+		listeners.add(listener)
+		this.eventListeners.set(type, listeners)
+	}
+
+	removeEventListener(type: string, listener: (event: Event) => unknown) {
+		this.eventListeners.get(type)?.delete(listener)
+	}
+
+	dispatchEvent(event: Event) {
+		if (event.target === null) Object.defineProperty(event, 'target', { configurable: true, value: this })
+		Object.defineProperty(event, 'currentTarget', { configurable: true, value: this })
+		for (const listener of this.eventListeners.get(event.type) ?? []) listener.call(this, event)
+		if (event.bubbles && !event.cancelBubble && this.parentNode instanceof TestElement) this.parentNode.dispatchEvent(event)
+		return !event.defaultPrevented
+	}
 	focus() { return undefined }
 	blur() { return undefined }
 	showPopover() { return undefined }
 	hidePopover() { return undefined }
 	togglePopover() { return undefined }
+	getBoundingClientRect() { return { height: this.clientHeight, width: 100, x: 0, y: 0, top: 0, right: 100, bottom: this.clientHeight, left: 0 } }
 
 	getAttribute(name: string) {
 		return this.attributes[name] ?? null
+	}
+
+	hasAttribute(name: string) {
+		return this.attributes[name] !== undefined
+	}
+
+	closest(selector: string): TestElement | null {
+		const attributeMatch = selector.match(/^\[([^\]]+)\]$/u)
+		if (attributeMatch?.[1] === undefined) return null
+		let element: TestElement | null = this
+		while (element !== null) {
+			if (element.hasAttribute(attributeMatch[1])) return element
+			element = element.parentNode instanceof TestElement ? element.parentNode : null
+		}
+		return null
 	}
 
 	override get textContent() {
@@ -173,11 +208,16 @@ class TestDialogElement extends TestElement {
 
 class TestDocument {
 	body: TestElement
-	readonly dialogElementConstructor: typeof TestDialogElement
+	readonly elementConstructor: new (ownerDocument: TestDocument, tagName: string) => TestElement
+	readonly dialogElementConstructor: new (ownerDocument: TestDocument, tagName: string) => TestElement
 
-	constructor(dialogElementConstructor: typeof TestDialogElement = TestDialogElement) {
+	constructor(
+		elementConstructor: new (ownerDocument: TestDocument, tagName: string) => TestElement = TestElement,
+		dialogElementConstructor: new (ownerDocument: TestDocument, tagName: string) => TestElement = TestDialogElement,
+	) {
+		this.elementConstructor = elementConstructor
 		this.dialogElementConstructor = dialogElementConstructor
-		this.body = new TestElement(this, 'body')
+		this.body = new this.elementConstructor(this, 'body')
 	}
 
 	addEventListener() { return undefined }
@@ -185,7 +225,7 @@ class TestDocument {
 
 	createElement(tagName: string) {
 		if (tagName.toLowerCase() === 'dialog') return new this.dialogElementConstructor(this, tagName)
-		return new TestElement(this, tagName)
+		return new this.elementConstructor(this, tagName)
 	}
 
 	createElementNS(_namespace: string, tagName: string) {
@@ -212,6 +252,8 @@ type DomMockState = {
 	previousRequestAnimationFrame: unknown
 	previousCancelAnimationFrame: unknown
 	previousHtmlDialogElement: unknown
+	previousHtmlDivElement: unknown
+	previousElement: unknown
 }
 
 const fallbackDocument = new TestDocument()
@@ -238,8 +280,22 @@ function restoreOwnedGlobal(name: string, isOwnedByThisMock: boolean, previousVa
 }
 
 export function installDomMock() {
-	class OwnedTestDialogElement extends TestDialogElement {}
-	const document = new TestDocument(OwnedTestDialogElement)
+	class OwnedTestElement extends TestElement {}
+	class OwnedTestDialogElement extends OwnedTestElement {
+		open = false
+		returnValue = ''
+
+		showModal() {
+			this.open = true
+		}
+
+		close(returnValue = '') {
+			this.open = false
+			this.returnValue = returnValue
+			this.dispatchEvent(new Event('close'))
+		}
+	}
+	const document = new TestDocument(OwnedTestElement, OwnedTestDialogElement)
 	const window: TestWindow = {
 		document,
 		addEventListener() { return undefined },
@@ -259,6 +315,8 @@ export function installDomMock() {
 	const previousRequestAnimationFrame = globalThis.requestAnimationFrame
 	const previousCancelAnimationFrame = globalThis.cancelAnimationFrame
 	const previousHtmlDialogElement = globalThis.HTMLDialogElement
+	const previousHtmlDivElement = globalThis.HTMLDivElement
+	const previousElement = globalThis.Element
 	const state: DomMockState = {
 		restored: false,
 		previousDocument,
@@ -268,8 +326,10 @@ export function installDomMock() {
 		previousRequestAnimationFrame,
 		previousCancelAnimationFrame,
 		previousHtmlDialogElement,
+		previousHtmlDivElement,
+		previousElement,
 	}
-	for (const ownedValue of [document, window, setIntervalMock, clearIntervalMock, requestAnimationFrameMock, cancelAnimationFrameMock, OwnedTestDialogElement]) domMockOwners.set(ownedValue, state)
+	for (const ownedValue of [document, window, setIntervalMock, clearIntervalMock, requestAnimationFrameMock, cancelAnimationFrameMock, OwnedTestDialogElement, OwnedTestElement]) domMockOwners.set(ownedValue, state)
 
 	defineGlobalValue('document', document)
 	defineGlobalValue('window', window)
@@ -278,6 +338,8 @@ export function installDomMock() {
 	defineGlobalValue('requestAnimationFrame', requestAnimationFrameMock)
 	defineGlobalValue('cancelAnimationFrame', cancelAnimationFrameMock)
 	defineGlobalValue('HTMLDialogElement', OwnedTestDialogElement)
+	defineGlobalValue('HTMLDivElement', OwnedTestElement)
+	defineGlobalValue('Element', OwnedTestElement)
 
 	return {
 		document,
@@ -291,6 +353,8 @@ export function installDomMock() {
 			restoreOwnedGlobal('requestAnimationFrame', globalThis.requestAnimationFrame === requestAnimationFrameMock, previousRequestAnimationFrame, undefined, (owner) => owner.previousRequestAnimationFrame)
 			restoreOwnedGlobal('cancelAnimationFrame', globalThis.cancelAnimationFrame === cancelAnimationFrameMock, previousCancelAnimationFrame, undefined, (owner) => owner.previousCancelAnimationFrame)
 			restoreOwnedGlobal('HTMLDialogElement', globalThis.HTMLDialogElement === OwnedTestDialogElement, previousHtmlDialogElement, undefined, (owner) => owner.previousHtmlDialogElement)
+			restoreOwnedGlobal('HTMLDivElement', globalThis.HTMLDivElement === OwnedTestElement, previousHtmlDivElement, undefined, (owner) => owner.previousHtmlDivElement)
+			restoreOwnedGlobal('Element', globalThis.Element === OwnedTestElement, previousElement, undefined, (owner) => owner.previousElement)
 		},
 	}
 }

--- a/test/tests/dynamicScrollerLifecycle.test.tsx
+++ b/test/tests/dynamicScrollerLifecycle.test.tsx
@@ -1,0 +1,59 @@
+import * as assert from 'assert'
+import { signal } from '@preact/signals'
+import { describe, test } from 'bun:test'
+import { render } from 'preact'
+import { act } from 'preact/test-utils'
+import { DynamicScroller } from '../../app/ts/components/subcomponents/DynamicScroller.js'
+import { installDomMock } from './domMock.js'
+
+type TestNode = {
+	readonly childNodes?: readonly TestNode[]
+	readonly dispatchEvent?: (event: Event) => boolean
+	readonly tagName?: string
+	scrollTop?: number
+}
+
+function findElement(node: TestNode | undefined, tagName: string): TestNode | undefined {
+	if (node?.tagName === tagName.toUpperCase()) return node
+	for (const child of node?.childNodes ?? []) {
+		const match = findElement(child, tagName)
+		if (match !== undefined) return match
+	}
+	return undefined
+}
+
+describe('DynamicScroller lifecycle', () => {
+	test('does not restore a stale index when a shrunken list grows again', async () => {
+		const dom = installDomMock()
+		const previousResizeObserverDescriptor = Object.getOwnPropertyDescriptor(globalThis, 'ResizeObserver')
+		class TestResizeObserver {
+			readonly callback: ResizeObserverCallback
+			constructor(callback: ResizeObserverCallback) { this.callback = callback }
+			observe() { this.callback([{ contentRect: { height: 160 } }], this) }
+			disconnect() { return undefined }
+		}
+		Object.defineProperty(globalThis, 'ResizeObserver', { configurable: true, value: TestResizeObserver })
+		const items = signal<Readonly<number[]>>([0, 1, 2, 3, 4, 5, 6, 7, 8, 9])
+		try {
+			await act(() => {
+				render(<DynamicScroller items = { items } renderItem = { (item) => item.toString() } />, dom.document.body)
+			})
+			const scrollView = findElement(dom.document.body, 'div')
+			if (scrollView?.dispatchEvent === undefined) throw new Error('scroll view was not rendered')
+			scrollView.scrollTop = 240
+			await act(() => { scrollView.dispatchEvent?.(new Event('scroll')) })
+			assert.equal(dom.document.body.textContent, '6789')
+
+			await act(() => { items.value = [0, 1] })
+			assert.equal(dom.document.body.textContent, '01')
+			await act(() => { items.value = [0, 1, 2, 3, 4, 5, 6, 7, 8, 9] })
+			assert.equal(dom.document.body.textContent, '01234')
+			assert.equal(scrollView.scrollTop, 0)
+		} finally {
+			render(null, dom.document.body)
+			dom.restore()
+			if (previousResizeObserverDescriptor === undefined) delete globalThis.ResizeObserver
+			else Object.defineProperty(globalThis, 'ResizeObserver', previousResizeObserverDescriptor)
+		}
+	})
+})

--- a/test/tests/ethereumPrimitives.test.ts
+++ b/test/tests/ethereumPrimitives.test.ts
@@ -3,6 +3,7 @@ import { describe, test } from 'bun:test'
 import type { Abi, Hex } from '../../app/ts/utils/ethereumPrimitives.js'
 import { bytesToHex, concat, decodeAbiParameters, decodeEventLog, decodeFunctionData, encodeAbiParameters, encodePacked, ens_normalize, formatAbiItem, formatUnits, getAddress, getCreate2Address, hashMessage, hashStruct, hashTypedData, isAddress, keccak256, namehash, parseAbiItem, parseAbiParameters, parseTransaction, privateKeyToAccount, recoverAddress, serializeTransaction, stringToBytes, toEventSelector, toFunctionSelector, toRlp } from '../../app/ts/utils/ethereumPrimitives.js'
 import { encodeFunctionCall } from '../../app/ts/utils/abiRuntime.js'
+import { stringToAddress } from '../../app/ts/utils/bigint.js'
 import { canVerifyStructArray, d2Array, d2ArrayFixed, d3ArrayFixed, hasFixedArray } from './data/eip712Data.js'
 
 const privateKey = '0x0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef'
@@ -225,9 +226,11 @@ describe('local Ethereum primitive helpers', () => {
 		assert.throws(() => getAddress('0x1234'), /invalid/u)
 		assert.equal(isAddress(checksumDeadAddress), true)
 		assert.equal(isAddress(lowercaseDeadAddress), true)
-		assert.equal(isAddress('0x000000000000000000000000000000000000DEAD'), false)
+		assert.equal(isAddress('0x000000000000000000000000000000000000DEAD'), true)
 		assert.equal(isAddress('0X000000000000000000000000000000000000DEAD'), false)
 		assert.equal(isAddress(invalidChecksumDeadAddress), false)
+		assert.equal(isAddress('0xDE709F2102306220921060314715629080E2FB77'), true)
+		assert.equal(stringToAddress('0xDE709F2102306220921060314715629080E2FB77'), 0xde709f2102306220921060314715629080e2fb77n)
 		assert.equal(
 			getCreate2Address({
 				from: checksumDeadAddress,

--- a/test/tests/hintLifecycle.test.tsx
+++ b/test/tests/hintLifecycle.test.tsx
@@ -1,0 +1,63 @@
+import * as assert from 'assert'
+import { describe, test } from 'bun:test'
+import { render } from 'preact'
+import { act } from 'preact/test-utils'
+import Hint, { showHint } from '../../app/ts/components/subcomponents/Hint.js'
+import { installDomMock } from './domMock.js'
+
+type TestNode = {
+	readonly childNodes?: readonly TestNode[]
+	readonly dispatchEvent?: (event: Event) => boolean
+	readonly tagName?: string
+}
+
+function findElement(node: TestNode | undefined, tagName: string): TestNode | undefined {
+	if (node?.tagName === tagName.toUpperCase()) return node
+	for (const child of node?.childNodes ?? []) {
+		const match = findElement(child, tagName)
+		if (match !== undefined) return match
+	}
+	return undefined
+}
+
+describe('Hint lifecycle', () => {
+	test('clears pending timers and removes event listeners on unmount', async () => {
+		const dom = installDomMock()
+		const originalSetTimeout = globalThis.setTimeout
+		const originalClearTimeout = globalThis.clearTimeout
+		let scheduledTimers: Array<ReturnType<typeof setTimeout>> = []
+		const clearedTimers: Array<ReturnType<typeof setTimeout> | undefined> = []
+		globalThis.setTimeout = (callback, delay, ...parameters) => {
+			const timerId = originalSetTimeout(callback, delay, ...parameters)
+			scheduledTimers.push(timerId)
+			return timerId
+		}
+		globalThis.clearTimeout = (timerId) => {
+			clearedTimers.push(timerId)
+			originalClearTimeout(timerId)
+		}
+		try {
+			await act(() => {
+				render(<Hint><button data-tooltip = 'Tooltip'>Copy</button></Hint>, dom.document.body)
+			})
+			const button = findElement(dom.document.body, 'button')
+			if (button?.dispatchEvent === undefined) throw new Error('button was not rendered')
+			showHint(button, { content: 'Copied', delay: 60_000, x: 0, y: 0 })
+			button.dispatchEvent(new Event('mouseover', { bubbles: true }))
+			assert.equal(scheduledTimers.length, 2)
+			const timersAtUnmount = [...scheduledTimers]
+
+			await act(() => { render(null, dom.document.body) })
+			assert.equal(timersAtUnmount.every((timerId) => clearedTimers.includes(timerId)), true)
+
+			scheduledTimers = []
+			showHint(button, { content: 'After unmount', delay: 60_000, x: 0, y: 0 })
+			assert.deepEqual(scheduledTimers, [])
+		} finally {
+			globalThis.setTimeout = originalSetTimeout
+			globalThis.clearTimeout = originalClearTimeout
+			render(null, dom.document.body)
+			dom.restore()
+		}
+	})
+})

--- a/test/tests/inpageSignerBridge.test.ts
+++ b/test/tests/inpageSignerBridge.test.ts
@@ -1853,7 +1853,9 @@ describe('inpage signer bridge', () => {
 			assert.deepEqual((fakeWindow as { web3?: { accounts?: unknown } }).web3?.accounts, [signerAccount])
 
 			const accountEvents: unknown[] = []
+			const disconnectEvents: unknown[] = []
 			provider.on('accountsChanged', (accounts) => accountEvents.push(accounts))
+			provider.on('disconnect', (error) => disconnectEvents.push(error))
 			sendBackgroundMessage({
 				interceptorApproved: true,
 				type: 'result',
@@ -1868,6 +1870,7 @@ describe('inpage signer bridge', () => {
 			})
 			await waitFor(() => provider.selectedAddress === undefined && !provider.isConnected())
 			assert.deepEqual(accountEvents, [[]])
+			assert.deepEqual(disconnectEvents, [{ name: 'disconnect', code: 4900, message: 'Provider disconnected from all chains.' }])
 			assert.deepEqual(provider.send({ id: 4, method: 'eth_accounts', params: [] }).result, [])
 			assert.deepEqual((fakeWindow as { web3?: { accounts?: unknown } }).web3?.accounts, [])
 		})

--- a/test/tests/semaphore.test.ts
+++ b/test/tests/semaphore.test.ts
@@ -1,0 +1,21 @@
+import * as assert from 'assert'
+import { describe, test } from 'bun:test'
+import { Semaphore } from '../../app/ts/utils/semaphore.js'
+
+describe('Semaphore', () => {
+	test('cancels a timed wait timeout after a permit arrives', async () => {
+		const semaphore = new Semaphore(0)
+		const warnings: unknown[][] = []
+		const originalWarn = console.warn
+		console.warn = (...parameters: unknown[]) => { warnings.push(parameters) }
+		try {
+			const waiting = semaphore.waitFor(10)
+			semaphore.signal()
+			assert.equal(await waiting, true)
+			await new Promise((resolve) => setTimeout(resolve, 20))
+			assert.deepEqual(warnings, [])
+		} finally {
+			console.warn = originalWarn
+		}
+	})
+})

--- a/test/tests/signTypedData.test.ts
+++ b/test/tests/signTypedData.test.ts
@@ -60,7 +60,21 @@ describe('EIP712', () => {
 	test('can verify eip712Example message', () => {
 		const verification = verifyEip712Message(JSON.parse(eip712Example))
 		if (verification.valid === false) throw new Error(verification.reason)
-			getMessageAndDomainHash({method: 'eth_signTypedData_v4', params: [0x1n, JSON.parse(eip712Example)]})
+		getMessageAndDomainHash({method: 'eth_signTypedData_v4', params: [0x1n, JSON.parse(eip712Example)]})
+	})
+	test('rejects odd-length dynamic bytes values', () => {
+		const typedData = {
+			types: {
+				EIP712Domain: [],
+				Message: [{ name: 'payload', type: 'bytes' }],
+			},
+			primaryType: 'Message',
+			domain: {},
+			message: { payload: '0x1' },
+		}
+		assert.equal(verifyEip712Message(typedData).valid, false)
+		assert.equal(verifyEip712Message({ ...typedData, message: { payload: '0x' } }).valid, true)
+		assert.equal(verifyEip712Message({ ...typedData, message: { payload: '0x01' } }).valid, true)
 	})
 	test('can verify permit2MessageNumberChainId message', () => {
 		const verification = verifyEip712Message(JSON.parse(permit2MessageNumberChainId))

--- a/test/tests/someTimeAgo.test.ts
+++ b/test/tests/someTimeAgo.test.ts
@@ -2,7 +2,7 @@ import * as assert from 'assert'
 import { h, render } from 'preact'
 import { act } from 'preact/test-utils'
 import { describe, test } from 'bun:test'
-import { getSomeTimeAgoText, SomeTimeAgo } from '../../app/ts/components/subcomponents/SomeTimeAgo.js'
+import { getSomeTimeAgoText, humanReadableDateDeltaLessDetailed, SomeTimeAgo } from '../../app/ts/components/subcomponents/SomeTimeAgo.js'
 import { installDateMock, installDomMock } from './domMock.js'
 
 describe('SomeTimeAgo', () => {
@@ -13,6 +13,11 @@ describe('SomeTimeAgo', () => {
 		const newerTimestamp = new Date('2024-01-01T00:00:09.000Z')
 		assert.equal(getSomeTimeAgoText(olderTimestamp, now, false, formatSeconds), '5s')
 		assert.equal(getSomeTimeAgoText(newerTimestamp, now, false, formatSeconds), '1s')
+	})
+
+	test('rounds multi-day durations using half-day boundaries', () => {
+		assert.equal(humanReadableDateDeltaLessDetailed(36.1 * 60 * 60), '2d ago')
+		assert.equal(humanReadableDateDeltaLessDetailed(47 * 60 * 60), '2d ago')
 	})
 
 	test('updates the rendered output when rerendered with a fresher timestamp', async () => {

--- a/test/tests/tooltipAndDynamicScroller.test.ts
+++ b/test/tests/tooltipAndDynamicScroller.test.ts
@@ -1,7 +1,8 @@
 import * as assert from 'assert'
 import { signal } from '@preact/signals'
 import { describe, test } from 'bun:test'
-import { getDynamicScrollOffset } from '../../app/ts/components/subcomponents/DynamicScroller.js'
+import { getClampedDynamicScrollStartIndex, getDynamicScrollOffset } from '../../app/ts/components/subcomponents/DynamicScroller.js'
+import { clearHintTimeouts } from '../../app/ts/components/subcomponents/Hint.js'
 import { scheduleTooltipDismissal, type TooltipConfig } from '../../app/ts/components/subcomponents/Tooltip.js'
 
 describe('tooltip dismissal', () => {
@@ -51,5 +52,18 @@ describe('dynamic scrolling offset', () => {
 
 	test('clamps the requested offset to the final full viewport', () => {
 		assert.equal(getDynamicScrollOffset(8, 40, 10, 4), 240)
+	})
+
+	test('clamps a stale start index when the item list shrinks', () => {
+		assert.equal(getClampedDynamicScrollStartIndex(8, 2, 4), 0)
+		assert.equal(getClampedDynamicScrollStartIndex(8, 10, 4), 6)
+	})
+})
+
+describe('hint cleanup', () => {
+	test('clears both pending hint timers on cleanup', () => {
+		const clearedTimers: Array<number | undefined> = []
+		clearHintTimeouts([7, 11], (timerId) => { clearedTimers.push(timerId) })
+		assert.deepEqual(clearedTimers, [7, 11])
 	})
 })

--- a/test/tests/uiBoundaryFixes.test.tsx
+++ b/test/tests/uiBoundaryFixes.test.tsx
@@ -6,7 +6,7 @@ import { act } from 'preact/test-utils'
 import { findChainEntryByName, findRpcEntryByUrl, getRpcEntryLabel } from '../../app/ts/components/subcomponents/ChainSelector.js'
 import { DropDownMenu } from '../../app/ts/components/subcomponents/DropDownMenu.js'
 import { InlineCard } from '../../app/ts/components/subcomponents/InlineCard.js'
-import { parseTimePickerDeltaValue, TimePicker } from '../../app/ts/components/subcomponents/TimePicker.js'
+import { hasValidTimePickerValue, parseTimePickerDeltaValue, TimePicker } from '../../app/ts/components/subcomponents/TimePicker.js'
 import { rpcEntriesToChainEntriesWithAllChainsEntry } from '../../app/ts/components/ui-utils.js'
 import { parseRpcFormData } from '../../app/ts/utils/rpcFormData.js'
 import { removeAddressBookEntryAndClose } from '../../app/ts/AddressBook.js'
@@ -274,6 +274,14 @@ describe('UI boundary fixes', () => {
 			render(null, dom.document.body)
 			dom.restore()
 		}
+	})
+
+	test('requires a value before committing Until or For time picker modes', () => {
+		assert.equal(hasValidTimePickerValue('Until', undefined, 1n), false)
+		assert.equal(hasValidTimePickerValue('Until', new Date('2024-01-01T00:00:00.000Z'), undefined), true)
+		assert.equal(hasValidTimePickerValue('For', undefined, undefined), false)
+		assert.equal(hasValidTimePickerValue('For', undefined, 0n), true)
+		assert.equal(hasValidTimePickerValue('No Delay', undefined, undefined), true)
 	})
 
 	test('keeps a block explorer URL when its API key is empty', () => {


### PR DESCRIPTION
## Summary

- tighten EIP-712 bytes and Ethereum address validation, including uppercase address workflows
- correct provider disconnect semantics, TimePicker validity, relative-day rounding, and DynamicScroller state synchronization
- make clipboard feedback and fallback cleanup reliable, and cancel stale Hint and Semaphore timers
- add focused regression coverage for all ten fixes, including mounted lifecycle and integration paths

## Validation

- `bun run test` — 1,110 tests passed
- `bun run setup-chrome`
- `bun run typecheck`
- `bun run lint`
- `git diff --check`

`bun run test:chrome-communication` was not run because MV3 registration, approval popup routing, and page-to-extension transport were unchanged.

## Review

The final project reviewer pass found no High, Medium, or Low issues and scored the diff 94/100.