### PR TITLE
Fix pending confirmation storage recovery deadlock

### DIFF
--- a/app/ts/background/storageVariables.ts
+++ b/app/ts/background/storageVariables.ts
@@ -1,3 +1,4 @@
+import { ValidationError } from 'funtypes'
 import { DEFAULT_TAB_CONNECTION, getChainName } from '../utils/constants.js'
 import { Semaphore } from '../utils/semaphore.js'
 import type { PendingChainChangeConfirmationPromise, PendingFetchSimulationStackRequestPromise, RpcConnectionStatus, StoredWatchAssetRequest, TabState } from '../types/user-interface-types.js'
@@ -37,21 +38,35 @@ export const getIdsOfOpenedTabs = idsOfOpenedTabsRepository.get
 export const setIdsOfOpenedTabs = async (ids: PartialIdsOfOpenedTabs) => { await idsOfOpenedTabsRepository.update((previous) => ({ ...previous, ...ids })) }
 
 const pendingTransactionsSemaphore = new Semaphore(1)
-export async function getPendingTransactionsAndMessages(): Promise<readonly PendingTransactionOrSignableMessage[]> {
+async function readPendingTransactionsAndMessages() {
+	return (await browserStorageLocalGet2('pendingTransactionsAndMessages'))?.pendingTransactionsAndMessages ?? []
+}
+
+async function readPendingTransactionsAndMessagesWithRecovery(): Promise<readonly PendingTransactionOrSignableMessage[]> {
 	try {
-		return (await browserStorageLocalGet2('pendingTransactionsAndMessages'))?.pendingTransactionsAndMessages ?? []
+		return await readPendingTransactionsAndMessages()
 	} catch(e) {
+		if (!(e instanceof ValidationError)) throw e
 		console.warn('Pending transactions were corrupt:')
 		console.warn(e)
-		await pendingTransactionsSemaphore.execute(async () => await browserStorageLocalSet2({ pendingTransactionsAndMessages: [] }))
+		await browserStorageLocalSet2({ pendingTransactionsAndMessages: [] })
 		return []
+	}
+}
+
+export async function getPendingTransactionsAndMessages(): Promise<readonly PendingTransactionOrSignableMessage[]> {
+	try {
+		return await readPendingTransactionsAndMessages()
+	} catch(e) {
+		if (!(e instanceof ValidationError)) throw e
+		return await pendingTransactionsSemaphore.execute(readPendingTransactionsAndMessagesWithRecovery)
 	}
 }
 
 export const clearPendingTransactions = async () => await updatePendingTransactionOrMessages(async () => [])
 async function updatePendingTransactionOrMessages(update: (pendingTransactionsOrMessages: readonly PendingTransactionOrSignableMessage[]) => Promise<readonly PendingTransactionOrSignableMessage[]>) {
 	return await pendingTransactionsSemaphore.execute(async () => {
-		const pendingTransactionsAndMessages = await update(await getPendingTransactionsAndMessages())
+		const pendingTransactionsAndMessages = await update(await readPendingTransactionsAndMessagesWithRecovery())
 		await browserStorageLocalSet2({ pendingTransactionsAndMessages })
 	})
 }

--- a/test/tests/pendingTransactionStorageRecovery.test.ts
+++ b/test/tests/pendingTransactionStorageRecovery.test.ts
@@ -1,0 +1,54 @@
+import * as assert from 'assert'
+import { beforeEach, test } from 'bun:test'
+import { withSilencedConsole } from './consoleSilence.js'
+
+const storageState: Record<string, unknown> = {}
+const storageWrites: Record<string, unknown>[] = []
+let storageReadError: Error | undefined
+
+globalThis.browser = {
+	storage: {
+		local: {
+			async get(keys?: string | string[] | Record<string, unknown> | null) {
+				if (storageReadError !== undefined) throw storageReadError
+				if (keys === undefined || keys === null) return { ...storageState }
+				if (Array.isArray(keys)) return Object.fromEntries(keys.map((key) => [key, storageState[key]]))
+				if (typeof keys === 'string') return { [keys]: storageState[keys] }
+				return Object.fromEntries(Object.entries(keys).map(([key, defaultValue]) => [key, key in storageState ? storageState[key] : defaultValue]))
+			},
+			async set(items: Record<string, unknown>) {
+				storageWrites.push(items)
+				Object.assign(storageState, items)
+			},
+			async remove(keys: string | string[]) {
+				for (const key of Array.isArray(keys) ? keys : [keys]) delete storageState[key]
+			},
+		},
+	},
+} as unknown as typeof globalThis.browser
+
+const { clearPendingTransactions } = await import('../../app/ts/background/storageVariables.js')
+
+beforeEach(() => {
+	for (const key of Object.keys(storageState)) delete storageState[key]
+	storageWrites.length = 0
+	storageReadError = undefined
+})
+
+test('repairs corrupt pending transaction storage without deadlocking a mutation', async () => {
+	storageState.pendingTransactionsAndMessages = 'corrupt'
+
+	await withSilencedConsole(async () => await clearPendingTransactions())
+
+	assert.deepEqual(storageState.pendingTransactionsAndMessages, [])
+})
+
+test('does not erase pending transaction storage after a transient read failure', async () => {
+	storageState.pendingTransactionsAndMessages = []
+	storageReadError = new Error('Storage temporarily unavailable')
+
+	await assert.rejects(clearPendingTransactions(), /Storage temporarily unavailable/)
+
+	assert.deepEqual(storageState.pendingTransactionsAndMessages, [])
+	assert.equal(storageWrites.length, 0)
+})


### PR DESCRIPTION
## Summary
- avoid recursively acquiring the pending-confirmation semaphore during corrupt-storage recovery
- recover corrupt pending data while the mutation lock is already held
- propagate transient browser-storage failures without erasing data
- add focused corruption and transient-failure regression tests

## Validation
- `bun run test` (1261 passed)
- `bun run setup-chrome`
- `bun run typecheck`
- `bun run lint`

Audit finding: #2