### PR TITLE
Refresh content scripts after website access removal

### DIFF
--- a/app/ts/background/popupMessageHandlers.ts
+++ b/app/ts/background/popupMessageHandlers.ts
@@ -57,7 +57,7 @@ export { getLastKnownCurrentTabId } from './currentTab.js'
 export { exportSettings, importSettings, setNewRpcList, settingsOpened } from './popupMessageHandlers/settings.js'
 export { allowOrPreventAddressAccessForWebsite, blockOrAllowExternalRequests, disableInterceptor, reloadConnectedTabs, removeWebsiteAccess, removeWebsiteAddressAccess, retrieveWebsiteAccess } from './popupMessageHandlers/websiteAccess.js'
 import { getLastKnownCurrentTabId } from './currentTab.js'
-import { disableInterceptorForPage } from './popupMessageHandlers/websiteAccess.js'
+import { reloadConnectedTabs, updateContentScriptInjectionStrategy } from './popupMessageHandlers/websiteAccess.js'
 import { getConfiguredSigningSafeForChain } from './signingAddressSelection.js'
 
 type TimestampedPopupVisualisation = {
@@ -422,11 +422,10 @@ export async function changeInterceptorAccess(ethereum: EthereumClientService, t
 		})
 	})
 
-	const interceptorDisablesChanged = accessChange.data.filter((x) => x.newEntry.interceptorDisabled !== x.oldEntry.interceptorDisabled).map((x) => x)
-	await Promise.all(interceptorDisablesChanged.map(async (disable) => {
-		if (disable.newEntry.interceptorDisabled === undefined) return
-		return await disableInterceptorForPage(websiteTabConnections, disable.newEntry.website, disable.newEntry.interceptorDisabled)
-	}))
+	const interceptorDisabledStateChanged = accessChange.data.some((change) => change.newEntry.interceptorDisabled !== change.oldEntry.interceptorDisabled)
+	const disabledWebsiteRemoved = accessChange.data.some((change) => change.removed && change.oldEntry.interceptorDisabled === true)
+	if (interceptorDisabledStateChanged || disabledWebsiteRemoved) await updateContentScriptInjectionStrategy()
+	if (interceptorDisabledStateChanged) await reloadConnectedTabs(websiteTabConnections)
 
 	await updateWebsiteApprovalAccesses(ethereum, tokenPriceService, resetSimulationServices, websiteTabConnections, await getSettings(), true)
 	await sendPopupMessageToOpenWindows({ method: 'popup_interceptor_access_changed' })

--- a/app/ts/background/popupMessageHandlers/websiteAccess.ts
+++ b/app/ts/background/popupMessageHandlers/websiteAccess.ts
@@ -36,10 +36,14 @@ export async function reloadConnectedTabs(websiteTabConnections: WebsiteTabConne
 	}
 }
 
-export const disableInterceptorForPage = async (websiteTabConnections: WebsiteTabConnections, website: Website, interceptorDisabled: boolean) => {
-	await setInterceptorDisabledForWebsite(website, interceptorDisabled)
+export const updateContentScriptInjectionStrategy = async () => {
 	if (browser.runtime.getManifest().manifest_version === 3) await updateContentScriptInjectionStrategyManifestV3()
 	else await updateContentScriptInjectionStrategyManifestV2()
+}
+
+export const disableInterceptorForPage = async (websiteTabConnections: WebsiteTabConnections, website: Website, interceptorDisabled: boolean) => {
+	await setInterceptorDisabledForWebsite(website, interceptorDisabled)
+	await updateContentScriptInjectionStrategy()
 	await reloadConnectedTabs(websiteTabConnections)
 }
 
@@ -101,6 +105,7 @@ export async function allowOrPreventAddressAccessForWebsite(websiteTabConnection
 
 export async function removeWebsiteAccess(ethereum: EthereumClientService, tokenPriceService: TokenPriceService, resetSimulationServices: ResetSimulationServices, websiteTabConnections: WebsiteTabConnections, parsedRequest: RemoveWebsiteAccess) {
 	await updateWebsiteAccess((previousAccess) => previousAccess.filter((access) => access.website.websiteOrigin !== parsedRequest.data.websiteOrigin))
+	await updateContentScriptInjectionStrategy()
 	await updateWebsiteApprovalAccesses(ethereum, tokenPriceService, resetSimulationServices, websiteTabConnections, await getSettings(), true)
 	await sendPopupMessageToOpenWindows({ method: 'popup_websiteAccess_changed' })
 }

--- a/test/tests/popupMessageDispatcher.test.ts
+++ b/test/tests/popupMessageDispatcher.test.ts
@@ -8,6 +8,7 @@ import type { Settings } from '../../app/ts/types/interceptor-messages.js'
 const storageState: Record<string, unknown> = {}
 const sentMessages: unknown[] = []
 const dynamicRuleUpdates: unknown[] = []
+const contentScriptUpdateBatches: { readonly id: string, readonly excludeMatches?: readonly string[] }[][] = []
 const dispatcherEvents: ({ type: 'message', message: unknown } | { type: 'dynamicRuleUpdate' })[] = []
 let storageSetError: Error | undefined
 let dynamicRuleUpdateError: Error | undefined
@@ -79,6 +80,15 @@ Reflect.set(globalThis, 'browser', {
 		},
 		updateSessionRules: async () => undefined,
 	},
+	scripting: {
+		getRegisteredContentScripts: async () => [
+			{ id: 'inpage', excludeMatches: ['*://*.disabled.test/*'] },
+			{ id: 'inpage2', excludeMatches: ['*://*.disabled.test/*'] },
+		],
+		registerContentScripts: async () => undefined,
+		updateContentScripts: async (scripts: { readonly id: string, readonly excludeMatches?: readonly string[] }[]) => { contentScriptUpdateBatches.push(scripts) },
+		unregisterContentScripts: async () => undefined,
+	},
 })
 
 const [
@@ -113,6 +123,18 @@ const settings: Settings = {
 	simulationMode: true,
 }
 
+const disabledWebsiteAccess: Settings['websiteAccess'][number] = {
+	website: {
+		websiteOrigin: 'disabled.test',
+		icon: undefined,
+		title: 'Disabled website',
+	},
+	addressAccess: [],
+	access: false,
+	interceptorDisabled: true,
+	declarativeNetRequestBlockMode: 'disabled',
+}
+
 function createDispatcherContext(resetSimulationState: () => Promise<void>): PopupMessageDispatcherContext {
 	const ethereum: EthereumClientService = Object.create(EthereumClientServiceConstructor.prototype)
 	const tokenPriceService: TokenPriceService = Object.create(TokenPriceServiceConstructor.prototype)
@@ -136,10 +158,47 @@ beforeEach(() => {
 	for (const key of Object.keys(storageState)) delete storageState[key]
 	sentMessages.splice(0, sentMessages.length)
 	dynamicRuleUpdates.splice(0, dynamicRuleUpdates.length)
+	contentScriptUpdateBatches.splice(0, contentScriptUpdateBatches.length)
 	dispatcherEvents.splice(0, dispatcherEvents.length)
 })
 
 describe('popup message dispatcher seams', () => {
+	test('refreshes manifest v3 content script exclusions after removing a disabled website', async () => {
+		storageState.websiteAccess = [disabledWebsiteAccess]
+
+		await dispatchPopupMessage(createDispatcherContext(async () => undefined), {
+			method: 'popup_removeWebsiteAccess',
+			data: { websiteOrigin: 'disabled.test' },
+		})
+
+		assert.deepEqual(storageState.websiteAccess, [])
+		assert.equal(contentScriptUpdateBatches.length, 1)
+		assert.deepEqual(contentScriptUpdateBatches.at(-1)?.map(({ id, excludeMatches }) => ({ id, excludeMatches })), [
+			{ id: 'inpage2', excludeMatches: [] },
+			{ id: 'inpage', excludeMatches: [] },
+		])
+	})
+
+	test('refreshes manifest v3 content script exclusions after the access editor removes a disabled website', async () => {
+		storageState.websiteAccess = [disabledWebsiteAccess]
+
+		await dispatchPopupMessage(createDispatcherContext(async () => undefined), {
+			method: 'popup_changeInterceptorAccess',
+			data: [{
+				oldEntry: disabledWebsiteAccess,
+				newEntry: disabledWebsiteAccess,
+				removed: true,
+			}],
+		})
+
+		assert.deepEqual(storageState.websiteAccess, [])
+		assert.equal(contentScriptUpdateBatches.length, 1)
+		assert.deepEqual(contentScriptUpdateBatches.at(-1)?.map(({ id, excludeMatches }) => ({ id, excludeMatches })), [
+			{ id: 'inpage2', excludeMatches: [] },
+			{ id: 'inpage', excludeMatches: [] },
+		])
+	})
+
 	test('returns a save failure when address-book persistence fails', async () => {
 		storageSetError = new Error('Address-book storage unavailable.')
 


### PR DESCRIPTION
## Summary
- refresh the manifest-specific injection strategy after removing website access
- cover both direct website removal and access-editor removal workflows
- update MV3 registrations once per batch and avoid redundant refresh/reload work
- add dispatcher regressions for stale disabled-site exclusions

## Validation
- `bun run test` (1261 passed)
- `bun run setup-chrome`
- `bun run typecheck`
- `bun run lint`
- `bun run test:chrome-communication`

Audit finding: #3