### PR TITLE
Preserve custom RPCs when storage reads fail

### DIFF
--- a/app/ts/background/storageVariables.ts
+++ b/app/ts/background/storageVariables.ts
@@ -21,8 +21,10 @@ import { SafeTransactionStacks } from '../types/safeTypes.js'
 import { createStoredValueRepository } from '../utils/storedValue.js'
 import { isValidErc20Decimals } from '../utils/erc20.js'
 import { getAddressBookEntriesForChainIdMorePreciseFirst } from '../utils/addressBook.js'
+import { ValidationError } from 'funtypes'
 
 const reportCorruptStoredValue = (label: string) => async (error: unknown) => {
+	if (!(error instanceof ValidationError)) throw error
 	console.warn(`${ label } was corrupt:`)
 	console.warn(error)
 }

--- a/test/tests/storageUtils.test.ts
+++ b/test/tests/storageUtils.test.ts
@@ -1,8 +1,11 @@
 import * as assert from 'assert'
 import { beforeEach, describe, test } from 'bun:test'
+import type { RpcEntry } from '../../app/ts/types/rpc.js'
+import { withSilencedConsole } from './consoleSilence.js'
 
 const storedItems: Record<string, unknown> = {}
 const writes: Record<string, unknown>[] = []
+let nextStorageReadError: Error | undefined
 
 Object.defineProperty(globalThis, 'browser', {
 	configurable: true,
@@ -11,6 +14,11 @@ Object.defineProperty(globalThis, 'browser', {
 		storage: {
 			local: {
 				get: async (keys: string | readonly string[]) => {
+					if (nextStorageReadError !== undefined) {
+						const error = nextStorageReadError
+						nextStorageReadError = undefined
+						throw error
+					}
 					const requestedKeys = Array.isArray(keys) ? keys : [keys]
 					return Object.fromEntries(requestedKeys.filter((key) => key in storedItems).map((key) => [key, storedItems[key]]))
 				},
@@ -25,11 +33,13 @@ Object.defineProperty(globalThis, 'browser', {
 })
 
 const { browserStorageLocalGet, browserStorageLocalSet } = await import('../../app/ts/utils/storageUtils.js')
+const { getRpcList, promoteRpcAsPrimary } = await import('../../app/ts/background/storageVariables.js')
 
 describe('local storage codecs', () => {
 	beforeEach(() => {
 		for (const key of Object.keys(storedItems)) delete storedItems[key]
 		writes.length = 0
+		nextStorageReadError = undefined
 	})
 
 	test('serializes only present active-address properties, including explicit clears', async () => {
@@ -57,5 +67,51 @@ describe('local storage codecs', () => {
 
 		storedItems.activeSigningAddress = 'not-an-address'
 		await assert.rejects(browserStorageLocalGet('activeSigningAddress'))
+	})
+})
+
+describe('RPC storage recovery', () => {
+	const customPrimaryRpc: RpcEntry = {
+		name: 'Custom primary',
+		chainId: 1n,
+		httpsRpc: 'https://primary.example',
+		currencyName: 'Ether',
+		currencyTicker: 'ETH',
+		primary: true,
+		minimized: true,
+	}
+	const customFallbackRpc: RpcEntry = {
+		...customPrimaryRpc,
+		name: 'Custom fallback',
+		httpsRpc: 'https://fallback.example',
+		primary: false,
+	}
+
+	beforeEach(async () => {
+		for (const key of Object.keys(storedItems)) delete storedItems[key]
+		writes.length = 0
+		nextStorageReadError = undefined
+		await browserStorageLocalSet({ rpcEntries: [customPrimaryRpc, customFallbackRpc] })
+		writes.length = 0
+	})
+
+	test('does not overwrite custom RPCs when extension storage temporarily rejects a read', async () => {
+		const storedRpcEntries = storedItems.rpcEntries
+		const readError = new Error('Extension storage is temporarily unavailable')
+		nextStorageReadError = readError
+
+		await assert.rejects(promoteRpcAsPrimary(customFallbackRpc), (error: unknown) => error === readError)
+
+		assert.equal(writes.length, 0)
+		assert.deepEqual(storedItems.rpcEntries, storedRpcEntries)
+	})
+
+	test('continues to use defaults for a corrupt stored RPC value', async () => {
+		storedItems.rpcEntries = 'not-an-rpc-list'
+
+		const rpcs = await withSilencedConsole(getRpcList)
+
+		assert.equal(rpcs[0]?.name, 'Ethereum Mainnet')
+		assert.equal(rpcs[0]?.primary, true)
 	})
 })


### PR DESCRIPTION
## Summary
- distinguish corrupt RPC storage from operational browser storage failures
- propagate transient read errors instead of substituting defaults that can later overwrite custom RPCs
- cover both the no-write failure path and the intended corrupt-value fallback

## Why this matters
`promoteRpcAsPrimary()` reads and rewrites the complete RPC list. Previously, any `browser.storage.local.get()` rejection was treated as corrupt data, so the read returned `DEFAULT_RPCS` and the subsequent write erased the user's custom RPC configuration.

## Validation
- `bun test test/tests/storageUtils.test.ts`
- `bun run test` (1,261 passed)
- `bun run setup-chrome`
- `bun run typecheck`
- `bun run lint`
- independent reviewer: 95/100, no findings