### PR TITLE
Read settings from one storage snapshot

### DIFF
--- a/app/ts/background/settings.ts
+++ b/app/ts/background/settings.ts
@@ -4,7 +4,7 @@ import { Semaphore } from '../utils/semaphore.js'
 import type { EthereumAddress } from '../types/wire-types.js'
 import type { Website, WebsiteAccessArray } from '../types/websiteAccessTypes.js'
 import type { BlockExplorer, RpcNetwork } from '../types/rpc.js'
-import { type RichListElement, browserStorageLocalGet, browserStorageLocalSafeParseGet, browserStorageLocalSet } from '../utils/storageUtils.js'
+import { type RichListElement, browserStorageLocalGet, browserStorageLocalSafeParse, browserStorageLocalSet } from '../utils/storageUtils.js'
 import { getUserAddressBookEntries, updateUserAddressBookEntries } from './storageVariables.js'
 import { getUniqueItemsByProperties } from '../utils/typed-arrays.js'
 import type { AddressBookEntry } from '../types/addressBookTypes.js'
@@ -13,6 +13,7 @@ import { DEFAULT_ACTIVE_ADDRESSES, DEFAULT_BLOCK_MANIPULATION, DEFAULT_RPCS } fr
 import { silenceChromeUnCaughtPromise } from '../utils/requests.js'
 import { mergeStoredWebsiteMetadata, sanitizeWebsiteAccess } from '../utils/websiteIcons.js'
 import type { SigningAddressPreference, SigningAddressPreferences } from '../types/signerTypes.js'
+import { hasOwnKey } from '../utils/methodHandlers.js'
 
 export const defaultActiveAddresses = DEFAULT_ACTIVE_ADDRESSES
 
@@ -54,9 +55,10 @@ type StartupStorageDefaults = {
 	signingAddressPreferences: SigningAddressPreferences
 }
 
-async function getParsedStorageValueOrDefault<Key extends keyof StartupStorageDefaults>(key: Key, defaultValue: StartupStorageDefaults[Key]): Promise<StartupStorageDefaults[Key]> {
-	const rawValue = (await browser.storage.local.get(key))[key]
-	const parsedValue: Readonly<Partial<StartupStorageDefaults>> | undefined = await browserStorageLocalSafeParseGet(key)
+async function getParsedStorageValueOrDefaultFromItems<Key extends keyof StartupStorageDefaults>(storedItems: Readonly<Record<string, unknown>>, key: Key, defaultValue: StartupStorageDefaults[Key]): Promise<StartupStorageDefaults[Key]> {
+	const rawValue = storedItems[key]
+	const storedItem = hasOwnKey(storedItems, key) ? { [key]: rawValue } : {}
+	const parsedValue: Readonly<Partial<StartupStorageDefaults>> | undefined = browserStorageLocalSafeParse(storedItem)
 	if (parsedValue !== undefined && key in parsedValue) return parsedValue[key] as StartupStorageDefaults[Key]
 	if (rawValue === undefined) return defaultValue
 	console.warn(`${ key } was corrupt:`)
@@ -65,16 +67,29 @@ async function getParsedStorageValueOrDefault<Key extends keyof StartupStorageDe
 	return defaultValue
 }
 
+async function getParsedStorageValueOrDefault<Key extends keyof StartupStorageDefaults>(key: Key, defaultValue: StartupStorageDefaults[Key]): Promise<StartupStorageDefaults[Key]> {
+	return await getParsedStorageValueOrDefaultFromItems(await browser.storage.local.get(key), key, defaultValue)
+}
+
 export async function getSettings() : Promise<Settings> {
 	if (defaultRpcs[0] === undefined || defaultActiveAddresses[0] === undefined) throw new Error('default rpc or default address was missing')
 	const defaultPage: Page = { page: 'Home' }
-	const activeSimulationAddressPromise = silenceChromeUnCaughtPromise(getParsedStorageValueOrDefault('independentActiveSimulationAddress', defaultActiveAddresses[0].address))
-	const activeSigningSafeAddressPromise = silenceChromeUnCaughtPromise(getParsedStorageValueOrDefault('activeSigningSafeAddress', undefined))
-	const openedPagePromise = silenceChromeUnCaughtPromise(getParsedStorageValueOrDefault('openedPageV2', defaultPage))
-	const useSignersAddressAsActiveAddressPromise = silenceChromeUnCaughtPromise(getParsedStorageValueOrDefault('useSignersAddressAsActiveAddress', false))
-	const websiteAccessPromise = silenceChromeUnCaughtPromise(getWebsiteAccess())
-	const simulationModePromise = silenceChromeUnCaughtPromise(getParsedStorageValueOrDefault('simulationMode', defaultSimulationMode))
-	const activeRpcNetworkPromise = silenceChromeUnCaughtPromise(getParsedStorageValueOrDefault('activeRpcNetwork', defaultRpcs[0]))
+	const storedItems = await silenceChromeUnCaughtPromise(browser.storage.local.get([
+		'independentActiveSimulationAddress',
+		'activeSigningSafeAddress',
+		'openedPageV2',
+		'useSignersAddressAsActiveAddress',
+		'websiteAccess',
+		'simulationMode',
+		'activeRpcNetwork',
+	]))
+	const activeSimulationAddressPromise = silenceChromeUnCaughtPromise(getParsedStorageValueOrDefaultFromItems(storedItems, 'independentActiveSimulationAddress', defaultActiveAddresses[0].address))
+	const activeSigningSafeAddressPromise = silenceChromeUnCaughtPromise(getParsedStorageValueOrDefaultFromItems(storedItems, 'activeSigningSafeAddress', undefined))
+	const openedPagePromise = silenceChromeUnCaughtPromise(getParsedStorageValueOrDefaultFromItems(storedItems, 'openedPageV2', defaultPage))
+	const useSignersAddressAsActiveAddressPromise = silenceChromeUnCaughtPromise(getParsedStorageValueOrDefaultFromItems(storedItems, 'useSignersAddressAsActiveAddress', false))
+	const websiteAccessPromise = silenceChromeUnCaughtPromise(getParsedStorageValueOrDefaultFromItems(storedItems, 'websiteAccess', []).then(sanitizeWebsiteAccess))
+	const simulationModePromise = silenceChromeUnCaughtPromise(getParsedStorageValueOrDefaultFromItems(storedItems, 'simulationMode', defaultSimulationMode))
+	const activeRpcNetworkPromise = silenceChromeUnCaughtPromise(getParsedStorageValueOrDefaultFromItems(storedItems, 'activeRpcNetwork', defaultRpcs[0]))
 	const [activeSimulationAddress, activeSigningSafeAddress, openedPage, useSignersAddressAsActiveAddress, websiteAccess, activeRpcNetwork, simulationMode] = await Promise.all([
 		activeSimulationAddressPromise,
 		activeSigningSafeAddressPromise,

--- a/app/ts/utils/storageUtils.ts
+++ b/app/ts/utils/storageUtils.ts
@@ -165,10 +165,13 @@ export async function browserStorageLocalSet2(items: LocalStorageItems2) {
 export async function browserStorageLocalGet(keys: LocalStorageKey | LocalStorageKey[]): Promise<LocalStorageItems> {
 	return LocalStorageItems.parse(await browser.storage.local.get(Array.isArray(keys) ? keys : [keys]))
 }
-export async function browserStorageLocalSafeParseGet(keys: LocalStorageKey | LocalStorageKey[]): Promise<LocalStorageItems | undefined> {
-	const parsed = LocalStorageItems.safeParse(await browser.storage.local.get(Array.isArray(keys) ? keys : [keys]))
+export function browserStorageLocalSafeParse(items: unknown): LocalStorageItems | undefined {
+	const parsed = LocalStorageItems.safeParse(items)
 	if (parsed.success) return parsed.value
 	return undefined
+}
+export async function browserStorageLocalSafeParseGet(keys: LocalStorageKey | LocalStorageKey[]): Promise<LocalStorageItems | undefined> {
+	return browserStorageLocalSafeParse(await browser.storage.local.get(Array.isArray(keys) ? keys : [keys]))
 }
 
 export async function browserStorageLocalRemove(keys: LocalStorageKey | LocalStorageKey[]) {

--- a/test/tests/settingsSnapshot.test.ts
+++ b/test/tests/settingsSnapshot.test.ts
@@ -1,0 +1,76 @@
+import * as assert from 'assert'
+import { test } from 'bun:test'
+
+const firstSnapshot = {
+	independentActiveSimulationAddress: '0x1111111111111111111111111111111111111111',
+	activeSigningSafeAddress: '0x3333333333333333333333333333333333333333',
+	openedPageV2: { page: 'Home' },
+	useSignersAddressAsActiveAddress: false,
+	websiteAccess: [],
+	simulationMode: true,
+	activeRpcNetwork: {
+		name: 'First network',
+		chainId: '0x1',
+		httpsRpc: 'https://first.example',
+		currencyName: 'Ether',
+		currencyTicker: 'ETH',
+		primary: true,
+		minimized: true,
+	},
+}
+
+const secondSnapshot = {
+	independentActiveSimulationAddress: '0x2222222222222222222222222222222222222222',
+	activeSigningSafeAddress: '0x4444444444444444444444444444444444444444',
+	openedPageV2: { page: 'Settings' },
+	useSignersAddressAsActiveAddress: true,
+	websiteAccess: [],
+	simulationMode: false,
+	activeRpcNetwork: {
+		name: 'Second network',
+		chainId: '0xa',
+		httpsRpc: 'https://second.example',
+		currencyName: 'Ether',
+		currencyTicker: 'ETH',
+		primary: true,
+		minimized: true,
+	},
+}
+
+let storageReadCount = 0
+
+Object.defineProperty(globalThis, 'browser', {
+	configurable: true,
+	writable: true,
+	value: {
+		storage: {
+			local: {
+				async get(keys: string | readonly string[]) {
+					const snapshot = storageReadCount++ === 0 ? firstSnapshot : secondSnapshot
+					const requestedKeys = Array.isArray(keys) ? keys : [keys]
+					return Object.fromEntries(Object.entries(snapshot).filter(([key]) => requestedKeys.includes(key)))
+				},
+				async set() {
+					throw new Error('Valid settings should not require repair writes')
+				},
+			},
+		},
+	},
+})
+
+const { getSettings } = await import('../../app/ts/background/settings.js')
+
+test('getSettings returns one atomic browser storage snapshot', async () => {
+	storageReadCount = 0
+
+	const settings = await getSettings()
+
+	assert.equal(storageReadCount, 1)
+	assert.equal(settings.activeSimulationAddress, 0x1111111111111111111111111111111111111111n)
+	assert.equal(settings.activeSigningSafeAddress, 0x3333333333333333333333333333333333333333n)
+	assert.deepEqual(settings.openedPage, { page: 'Home' })
+	assert.equal(settings.useSignersAddressAsActiveAddress, false)
+	assert.equal(settings.simulationMode, true)
+	assert.equal(settings.activeRpcNetwork.name, 'First network')
+	assert.equal(settings.activeRpcNetwork.chainId, 1n)
+})


### PR DESCRIPTION
## Summary
- acquire every `getSettings()` field in one `browser.storage.local.get()` call
- validate and recover each field independently from that shared snapshot
- retain missing-value defaults, explicit address clears, and website icon sanitization
- add a regression proving later storage state cannot be mixed into the returned settings

## Why this matters
Settings writers can update simulation mode, address, and RPC together in one storage call. Previously, `getSettings()` performed two reads per field across seven parallel getters, so a concurrent mode change or import could return a torn combination of old and new security settings. That mixed state feeds provider routing, access decisions, and simulation behavior.

## Validation
- focused settings/storage suites (33 passed)
- `bun run test` (1,260 passed)
- `bun run setup-chrome`
- `bun run typecheck`
- `bun run lint`
- independent reviewer: 95/100, no findings