### PR TITLE
Prevent ignored Chrome promises from leaking rejections

### DIFF
--- a/app/ts/utils/requests.ts
+++ b/app/ts/utils/requests.ts
@@ -159,8 +159,8 @@ export const getHostWithPort = (urlString: string): string => {
 	return url.port ? `${ url.hostname }:${ url.port }` : url.hostname
 }
 
-export const silenceChromeUnCaughtPromise = async <ReturnValue>(maybeAwaitedFunction: Promise<ReturnValue>) => {
-	maybeAwaitedFunction.catch(() => undefined)
+export const silenceChromeUnCaughtPromise = <ReturnValue>(maybeAwaitedFunction: Promise<ReturnValue>) => {
+	void maybeAwaitedFunction.catch(() => undefined)
 	return maybeAwaitedFunction
 }
 

--- a/test/tests/requestsPromiseHandling.test.ts
+++ b/test/tests/requestsPromiseHandling.test.ts
@@ -1,0 +1,31 @@
+import * as assert from 'node:assert'
+import { describe, test } from 'bun:test'
+import { silenceChromeUnCaughtPromise } from '../../app/ts/utils/requests.js'
+
+describe('request promise handling', () => {
+	test('silences a rejected promise without creating another rejecting promise', async () => {
+		const expectedError = new Error('expected rejection')
+		const rejectedPromise = Promise.reject<number>(expectedError)
+
+		const silencedPromise = silenceChromeUnCaughtPromise(rejectedPromise)
+
+		assert.equal(silencedPromise, rejectedPromise)
+		await assert.rejects(silencedPromise, (error: unknown) => error === expectedError)
+	})
+
+	test('does not emit an unhandled rejection when its return value is ignored', async () => {
+		const expectedError = new Error('ignored expected rejection')
+		let emittedExpectedRejection = false
+		const onUnhandledRejection = (reason: unknown) => {
+			if (reason === expectedError) emittedExpectedRejection = true
+		}
+		process.on('unhandledRejection', onUnhandledRejection)
+		try {
+			silenceChromeUnCaughtPromise(Promise.reject(expectedError))
+			await new Promise((resolve) => setTimeout(resolve, 0))
+			assert.equal(emittedExpectedRejection, false)
+		} finally {
+			process.off('unhandledRejection', onUnhandledRejection)
+		}
+	})
+})


### PR DESCRIPTION
## Summary
- return the original promise from the Chrome rejection-suppression helper
- attach a handled catch without creating an async wrapper that can reject unobserved
- cover both awaited and intentionally ignored call sites

## Impact
The helper is used throughout background startup and update paths where its return value is intentionally ignored. Because it was async, it created a second promise that could reject without a handler even though the input promise had a catch attached.

## Validation
- bun test test/tests/requestsPromiseHandling.test.ts (2 pass)
- bun run test (1261 pass, 0 fail)
- bun run setup-chrome
- bun run typecheck
- bun run lint

## Review
- pass 1: 92/100; one Low coverage gap
- pass 2: 98/100; no findings

No existing open PR matched this defect.