### PR TITLE
Prevent concurrent RPC updates from losing settings

### DIFF
--- a/app/ts/background/storageVariables.ts
+++ b/app/ts/background/storageVariables.ts
@@ -228,8 +228,7 @@ export const getInterceptorStartSleepingTimestamp = async () => (await browserSt
 
 export const promoteRpcAsPrimary = async (rpcNetwork: RpcNetwork) => {
 	if (rpcNetwork.primary) return
-	const rpcs = await getRpcList()
-	await setRpcList(rpcs.map((rpc) => rpc.chainId === rpcNetwork.chainId ? modifyObject(rpc, { primary: rpc.httpsRpc === rpcNetwork.httpsRpc }) : rpc))
+	await rpcListRepository.update((rpcs) => rpcs.map((rpc) => rpc.chainId === rpcNetwork.chainId ? modifyObject(rpc, { primary: rpc.httpsRpc === rpcNetwork.httpsRpc }) : rpc))
 }
 
 export const getPrimaryRpcForChain = async (chainId: bigint) => {

--- a/app/ts/utils/storedValue.ts
+++ b/app/ts/utils/storedValue.ts
@@ -26,11 +26,11 @@ export function createStoredValueRepository<T>(options: StoredValueRepositoryOpt
 			return defaultValue
 		}
 	}
-	const set = async (value: T) => await options.write(value)
+	const set = async (value: T) => await updateSemaphore.execute(async () => await options.write(value))
 	const update = async (updateValue: (previous: T) => T | Promise<T>) => await updateSemaphore.execute(async () => {
 		const previous = await get()
 		const current = await updateValue(previous)
-		await set(current)
+		await options.write(current)
 		return { previous, current }
 	})
 	return { get, set, update }

--- a/test/tests/rpcListConcurrency.test.ts
+++ b/test/tests/rpcListConcurrency.test.ts
@@ -1,0 +1,91 @@
+import * as assert from 'node:assert'
+import { beforeEach, describe, test } from 'bun:test'
+import type { RpcEntries } from '../../app/ts/types/rpc.js'
+
+const storedItems: Record<string, unknown> = {}
+let blockNextRpcListRead = false
+let releaseBlockedRead = () => undefined
+let signalBlockedReadStarted = () => undefined
+let blockedReadStarted = Promise.resolve()
+
+Object.defineProperty(globalThis, 'browser', {
+	configurable: true,
+	writable: true,
+	value: {
+		storage: {
+			local: {
+				get: async (keys: string | readonly string[]) => {
+					const requestedKeys = Array.isArray(keys) ? keys : [keys]
+					const snapshot = Object.fromEntries(requestedKeys.filter((key) => key in storedItems).map((key) => [key, storedItems[key]]))
+					if (!blockNextRpcListRead || !requestedKeys.includes('rpcEntries')) return snapshot
+					blockNextRpcListRead = false
+					signalBlockedReadStarted()
+					await new Promise<void>((resolve) => { releaseBlockedRead = resolve })
+					return snapshot
+				},
+				set: async (items: Record<string, unknown>) => { Object.assign(storedItems, items) },
+				remove: async () => undefined,
+			},
+		},
+	},
+})
+
+const { getRpcList, promoteRpcAsPrimary, setRpcList } = await import('../../app/ts/background/storageVariables.js')
+
+const existingRpcEntries = [
+	{
+		name: 'Primary RPC',
+		chainId: 1n,
+		httpsRpc: 'https://primary.invalid',
+		currencyName: 'Ether',
+		currencyTicker: 'ETH',
+		primary: true,
+		minimized: true,
+	},
+	{
+		name: 'Secondary RPC',
+		chainId: 1n,
+		httpsRpc: 'https://secondary.invalid',
+		currencyName: 'Ether',
+		currencyTicker: 'ETH',
+		primary: false,
+		minimized: true,
+	},
+] as const satisfies RpcEntries
+
+const editedRpcEntries = [
+	...existingRpcEntries,
+	{
+		name: 'User RPC',
+		chainId: 10n,
+		httpsRpc: 'https://user.invalid',
+		currencyName: 'Ether',
+		currencyTicker: 'ETH',
+		primary: true,
+		minimized: false,
+	},
+] as const satisfies RpcEntries
+
+describe('RPC list concurrency', () => {
+	beforeEach(async () => {
+		for (const key of Object.keys(storedItems)) delete storedItems[key]
+		blockNextRpcListRead = false
+		releaseBlockedRead = () => undefined
+		signalBlockedReadStarted = () => undefined
+		blockedReadStarted = Promise.resolve()
+		await setRpcList(existingRpcEntries)
+	})
+
+	test('does not let primary promotion overwrite a later settings save', async () => {
+		blockNextRpcListRead = true
+		blockedReadStarted = new Promise<void>((resolve) => { signalBlockedReadStarted = resolve })
+		const promotionPromise = promoteRpcAsPrimary(existingRpcEntries[1])
+		await blockedReadStarted
+
+		const settingsSavePromise = setRpcList(editedRpcEntries)
+		releaseBlockedRead()
+		await Promise.all([promotionPromise, settingsSavePromise])
+
+		assert.deepEqual(await getRpcList(), editedRpcEntries)
+	})
+})

--- a/test/tests/storedValue.test.ts
+++ b/test/tests/storedValue.test.ts
@@ -32,4 +32,29 @@ describe('stored value repository', () => {
 		assert.equal(await repository.get(), 4)
 		assert.deepEqual(calls, ['recover:4'])
 	})
+
+	test('serializes direct writes behind an in-flight read-modify-write update', async () => {
+		let storedValue = 1
+		let releaseUpdate = () => undefined
+		let signalUpdateStarted = () => undefined
+		const updateStarted = new Promise<void>((resolve) => { signalUpdateStarted = resolve })
+		const continueUpdate = new Promise<void>((resolve) => { releaseUpdate = resolve })
+		const repository = createStoredValueRepository({
+			read: async () => storedValue,
+			write: async (value: number) => { storedValue = value },
+			getDefault: () => 0,
+		})
+
+		const updatePromise = repository.update(async (previous) => {
+			signalUpdateStarted()
+			await continueUpdate
+			return previous + 1
+		})
+		await updateStarted
+		const setPromise = repository.set(10)
+		releaseUpdate()
+		await Promise.all([updatePromise, setPromise])
+
+		assert.equal(storedValue, 10)
+	})
 })


### PR DESCRIPTION
## Summary
- serialize direct stored-value writes with read-modify-write updates
- promote an RPC to primary through the atomic repository update path
- reproduce the race where promotion overwrote a later settings save and removed a custom RPC

## Impact
Primary RPC promotion previously read the entire RPC list and wrote it back separately. A settings save that completed between those operations could be overwritten by the stale list, losing user RPC edits.

This is separate from #1599, which handles storage read failures. This PR handles two successful storage operations interleaving.

## Validation
- bun test test/tests/storedValue.test.ts test/tests/rpcListConcurrency.test.ts (4 pass)
- bun run test (1261 pass, 0 fail)
- bun run setup-chrome
- bun run typecheck
- bun run lint

## Review
- pass 1: 95/100; no findings

No existing open PR matched this concurrency defect.