### PR TITLE
Serialize account and network changes with safe access and toolbar updates

### DIFF
--- a/app/ts/background/accessManagement.ts
+++ b/app/ts/background/accessManagement.ts
@@ -290,12 +290,8 @@ function addIconRefreshTarget(iconRefreshTargets: Map<string, { tabId: number, w
 }
 
 async function updateTabConnections(
-	ethereum: EthereumClientService | undefined,
-	tokenPriceService: TokenPriceService | undefined,
-	resetSimulationServices: ResetSimulationServices | undefined,
 	websiteTabConnections: WebsiteTabConnections,
 	tabConnection: TabConnection,
-	promptForAccessesIfNeeded: boolean,
 	settings: Settings,
 ): Promise<Map<string, { tabId: number, websiteOrigin: string }>> {
 	const iconRefreshTargets = new Map<string, { tabId: number, websiteOrigin: string }>()
@@ -316,13 +312,27 @@ async function updateTabConnections(
 		} else if (access === 'hasAccess' && !connection.approved) {
 			connectToPort(websiteTabConnections, connection.socket, settings, currentActiveAddress?.address)
 		}
-
-		if (access === 'askAccess' && connection.wantsToConnect && promptForAccessesIfNeeded && ethereum !== undefined && tokenPriceService !== undefined && resetSimulationServices !== undefined) {
-			const activeAddress = currentActiveAddress !== undefined ? currentActiveAddress : undefined
-			await askUserForAccessOnConnectionUpdate(ethereum, tokenPriceService, resetSimulationServices, websiteTabConnections, connection.socket, connection.websiteOrigin, activeAddress, settings)
-		}
 	}
 	return iconRefreshTargets
+}
+
+// Prompts acquire the access-dialog lock, so callers holding the active-settings lock must defer this phase.
+export async function promptForWebsiteAccesses(ethereum: EthereumClientService, tokenPriceService: TokenPriceService, resetSimulationServices: ResetSimulationServices, websiteTabConnections: WebsiteTabConnections, throwOnError = false) {
+	try {
+		for (const tabConnection of websiteTabConnections.values()) {
+			for (const connection of Object.values(tabConnection.connections)) {
+				if (!connection.wantsToConnect) continue
+				const settings = await getSettings()
+				const activeAddress = await getActiveAddressForCurrentSignerState(websiteTabConnections, settings, connection.socket.tabId, async () => await getActiveAddress(settings, connection.socket.tabId))
+				const access = activeAddress ? hasAddressAccess(settings.websiteAccess, connection.websiteOrigin, activeAddress) : hasAccess(settings.websiteAccess, connection.websiteOrigin)
+				if (access !== 'askAccess') continue
+				await askUserForAccessOnConnectionUpdate(ethereum, tokenPriceService, resetSimulationServices, websiteTabConnections, connection.socket, connection.websiteOrigin, activeAddress, settings)
+			}
+		}
+	} catch (error) {
+		if (throwOnError) throw error
+		await reportUnexpectedError(error)
+	}
 }
 
 const getApprovedTabs = (websiteTabConnections: WebsiteTabConnections) => {
@@ -441,7 +451,7 @@ export async function updateWebsiteApprovalAccesses(
 	}
 	// update port connections and disconnect from ports that should not have access anymore
 	const updatePromises = [...websiteTabConnections.entries()].map(async ([_tab, tabConnection]) => {
-		const tabIconRefreshTargets = await updateTabConnections(ethereum, tokenPriceService, resetSimulationServices, websiteTabConnections, tabConnection, promptForAccessesIfNeeded, settings)
+		const tabIconRefreshTargets = await updateTabConnections(websiteTabConnections, tabConnection, settings)
 		for (const iconRefreshTarget of tabIconRefreshTargets.values()) addIconRefreshTarget(iconRefreshTargets, iconRefreshTarget.tabId, iconRefreshTarget.websiteOrigin)
 	})
 	for (const tabState of allTabStates) {
@@ -451,6 +461,9 @@ export async function updateWebsiteApprovalAccesses(
 	}
 	try {
 		await Promise.all(updatePromises)
+		if (promptForAccessesIfNeeded && ethereum !== undefined && tokenPriceService !== undefined && resetSimulationServices !== undefined) {
+			await promptForWebsiteAccesses(ethereum, tokenPriceService, resetSimulationServices, websiteTabConnections, throwOnError)
+		}
 	} catch (error) {
 		if (throwOnError) throw error
 		await reportUnexpectedError(error)

--- a/app/ts/background/accessManagement.ts
+++ b/app/ts/background/accessManagement.ts
@@ -429,8 +429,7 @@ export const areWeBlocking = async (websiteTabConnections: WebsiteTabConnections
 	return false
 }
 
-// Apply the ordered access decisions now; callers finish UI work after releasing any settings lock.
-export async function reconcileWebsiteApprovalAccesses(
+async function reconcileWebsiteApprovalAccesses(
 	ethereum: EthereumClientService | undefined,
 	tokenPriceService: TokenPriceService | undefined,
 	resetSimulationServices: ResetSimulationServices | undefined,
@@ -480,6 +479,32 @@ export async function reconcileWebsiteApprovalAccesses(
 	return { popupRefreshGeneration, finish }
 }
 
+export type WebsiteAccessReconciler = (settings: Settings) => Promise<number>
+
+// Own all completion work so a caller cannot omit it or skip it by throwing after a committed access update.
+export async function runWithWebsiteAccessUpdates<T>(
+	ethereum: EthereumClientService | undefined,
+	tokenPriceService: TokenPriceService | undefined,
+	resetSimulationServices: ResetSimulationServices | undefined,
+	websiteTabConnections: WebsiteTabConnections,
+	promptForAccessesIfNeeded: boolean,
+	runOrdered: (operation: () => Promise<T>) => Promise<T>,
+	change: (reconcile: WebsiteAccessReconciler) => Promise<T>,
+	throwOnError = false,
+): Promise<T> {
+	const completions: Array<() => Promise<void>> = []
+	try {
+		return await runOrdered(async () => await change(async (settings) => {
+			const update = await reconcileWebsiteApprovalAccesses(ethereum, tokenPriceService, resetSimulationServices, websiteTabConnections, settings, promptForAccessesIfNeeded, throwOnError)
+			completions.push(update.finish)
+			return update.popupRefreshGeneration
+		}))
+	} finally {
+		// The ordered executor has released its lock before access dialogs or toolbar updates begin.
+		for (const complete of completions) await complete()
+	}
+}
+
 export async function updateWebsiteApprovalAccesses(
 	ethereum: EthereumClientService | undefined,
 	tokenPriceService: TokenPriceService | undefined,
@@ -489,9 +514,11 @@ export async function updateWebsiteApprovalAccesses(
 	promptForAccessesIfNeeded: boolean,
 	throwOnError = false,
 ): Promise<number> {
-	const update = await reconcileWebsiteApprovalAccesses(ethereum, tokenPriceService, resetSimulationServices, websiteTabConnections, settings, promptForAccessesIfNeeded, throwOnError)
-	await update.finish()
-	return update.popupRefreshGeneration
+	return await runWithWebsiteAccessUpdates<number>(ethereum, tokenPriceService, resetSimulationServices, websiteTabConnections, promptForAccessesIfNeeded,
+		async (operation) => await operation(),
+		async (reconcile) => await reconcile(settings),
+		throwOnError,
+	)
 }
 
 export async function finalizeWebsiteAccessChange(

--- a/app/ts/background/accessManagement.ts
+++ b/app/ts/background/accessManagement.ts
@@ -316,8 +316,7 @@ async function updateTabConnections(
 	return iconRefreshTargets
 }
 
-// Prompts acquire the access-dialog lock, so callers holding the active-settings lock must defer this phase.
-export async function promptForWebsiteAccesses(ethereum: EthereumClientService, tokenPriceService: TokenPriceService, resetSimulationServices: ResetSimulationServices, websiteTabConnections: WebsiteTabConnections, throwOnError = false) {
+async function promptForWebsiteAccesses(ethereum: EthereumClientService, tokenPriceService: TokenPriceService, resetSimulationServices: ResetSimulationServices, websiteTabConnections: WebsiteTabConnections, throwOnError = false) {
 	for (const tabConnection of websiteTabConnections.values()) {
 		for (const connection of Object.values(tabConnection.connections)) {
 			if (!connection.wantsToConnect) continue
@@ -430,6 +429,57 @@ export const areWeBlocking = async (websiteTabConnections: WebsiteTabConnections
 	return false
 }
 
+// Apply the ordered access decisions now; callers finish UI work after releasing any settings lock.
+export async function reconcileWebsiteApprovalAccesses(
+	ethereum: EthereumClientService | undefined,
+	tokenPriceService: TokenPriceService | undefined,
+	resetSimulationServices: ResetSimulationServices | undefined,
+	websiteTabConnections: WebsiteTabConnections,
+	settings: Settings,
+	promptForAccessesIfNeeded: boolean,
+	throwOnError = false,
+) {
+	const popupRefreshGeneration = bumpPopupRefreshGeneration()
+	const iconRefreshTargets = new Map<string, { tabId: number, websiteOrigin: string }>()
+
+	try {
+		await updateDeclarativeNetRequestBlocks(websiteTabConnections)
+	} catch (error) {
+		if (throwOnError) throw error
+		await reportUnexpectedError(error)
+	}
+	const updatePromises = [...websiteTabConnections.values()].map(async (tabConnection) => {
+		const tabIconRefreshTargets = await updateTabConnections(websiteTabConnections, tabConnection, settings)
+		for (const iconRefreshTarget of tabIconRefreshTargets.values()) addIconRefreshTarget(iconRefreshTargets, iconRefreshTarget.tabId, iconRefreshTarget.websiteOrigin)
+	})
+	try {
+		await Promise.all(updatePromises)
+	} catch (error) {
+		if (throwOnError) throw error
+		await reportUnexpectedError(error)
+	}
+
+	const finish = async () => {
+		if (promptForAccessesIfNeeded && ethereum !== undefined && tokenPriceService !== undefined && resetSimulationServices !== undefined) {
+			await promptForWebsiteAccesses(ethereum, tokenPriceService, resetSimulationServices, websiteTabConnections, throwOnError)
+		}
+		try {
+			for (const tabState of await getAllTabStates()) {
+				if (websiteTabConnections.has(tabState.tabId)) continue
+				if (tabState.website?.websiteOrigin === undefined) continue
+				addIconRefreshTarget(iconRefreshTargets, tabState.tabId, tabState.website.websiteOrigin)
+			}
+			await Promise.all([...iconRefreshTargets.values()].map(({ tabId, websiteOrigin }) =>
+				updateExtensionIcon(websiteTabConnections, tabId, websiteOrigin, popupRefreshGeneration)
+			))
+		} catch (error) {
+			if (throwOnError) throw error
+			await reportUnexpectedError(error)
+		}
+	}
+	return { popupRefreshGeneration, finish }
+}
+
 export async function updateWebsiteApprovalAccesses(
 	ethereum: EthereumClientService | undefined,
 	tokenPriceService: TokenPriceService | undefined,
@@ -439,45 +489,9 @@ export async function updateWebsiteApprovalAccesses(
 	promptForAccessesIfNeeded: boolean,
 	throwOnError = false,
 ): Promise<number> {
-	const popupRefreshGeneration = bumpPopupRefreshGeneration()
-	const allTabStates = await getAllTabStates()
-	const iconRefreshTargets = new Map<string, { tabId: number, websiteOrigin: string }>()
-
-	try {
-		await updateDeclarativeNetRequestBlocks(websiteTabConnections)
-	} catch (error) {
-		if (throwOnError) throw error
-		await reportUnexpectedError(error)
-	}
-	// update port connections and disconnect from ports that should not have access anymore
-	const updatePromises = [...websiteTabConnections.entries()].map(async ([_tab, tabConnection]) => {
-		const tabIconRefreshTargets = await updateTabConnections(websiteTabConnections, tabConnection, settings)
-		for (const iconRefreshTarget of tabIconRefreshTargets.values()) addIconRefreshTarget(iconRefreshTargets, iconRefreshTarget.tabId, iconRefreshTarget.websiteOrigin)
-	})
-	for (const tabState of allTabStates) {
-		if (websiteTabConnections.has(tabState.tabId)) continue
-		if (tabState.website?.websiteOrigin === undefined) continue
-		addIconRefreshTarget(iconRefreshTargets, tabState.tabId, tabState.website.websiteOrigin)
-	}
-	try {
-		await Promise.all(updatePromises)
-		if (promptForAccessesIfNeeded && ethereum !== undefined && tokenPriceService !== undefined && resetSimulationServices !== undefined) {
-			await promptForWebsiteAccesses(ethereum, tokenPriceService, resetSimulationServices, websiteTabConnections, throwOnError)
-		}
-	} catch (error) {
-		if (throwOnError) throw error
-		await reportUnexpectedError(error)
-	}
-	const iconRefreshPromises = [...iconRefreshTargets.values()].map(({ tabId, websiteOrigin }) =>
-		updateExtensionIcon(websiteTabConnections, tabId, websiteOrigin, popupRefreshGeneration)
-	)
-	try {
-		await Promise.all(iconRefreshPromises)
-	} catch (error) {
-		if (throwOnError) throw error
-		await reportUnexpectedError(error)
-	}
-	return popupRefreshGeneration
+	const update = await reconcileWebsiteApprovalAccesses(ethereum, tokenPriceService, resetSimulationServices, websiteTabConnections, settings, promptForAccessesIfNeeded, throwOnError)
+	await update.finish()
+	return update.popupRefreshGeneration
 }
 
 export async function finalizeWebsiteAccessChange(

--- a/app/ts/background/accessManagement.ts
+++ b/app/ts/background/accessManagement.ts
@@ -429,15 +429,17 @@ export const areWeBlocking = async (websiteTabConnections: WebsiteTabConnections
 	return false
 }
 
-async function reconcileWebsiteApprovalAccesses(
-	ethereum: EthereumClientService | undefined,
-	tokenPriceService: TokenPriceService | undefined,
-	resetSimulationServices: ResetSimulationServices | undefined,
+export type WebsiteAccessUpdate = {
+	readonly popupRefreshGeneration: number
+	readonly iconRefreshTargets: readonly { readonly tabId: number, readonly websiteOrigin: string }[]
+}
+
+// Reconcile approvals with the committed settings while the caller owns the settings lock.
+export async function reconcileWebsiteApprovalAccesses(
 	websiteTabConnections: WebsiteTabConnections,
 	settings: Settings,
-	promptForAccessesIfNeeded: boolean,
 	throwOnError = false,
-) {
+): Promise<WebsiteAccessUpdate> {
 	const popupRefreshGeneration = bumpPopupRefreshGeneration()
 	const iconRefreshTargets = new Map<string, { tabId: number, websiteOrigin: string }>()
 
@@ -458,50 +460,36 @@ async function reconcileWebsiteApprovalAccesses(
 		await reportUnexpectedError(error)
 	}
 
-	const finish = async () => {
-		if (promptForAccessesIfNeeded && ethereum !== undefined && tokenPriceService !== undefined && resetSimulationServices !== undefined) {
-			await promptForWebsiteAccesses(ethereum, tokenPriceService, resetSimulationServices, websiteTabConnections, throwOnError)
-		}
-		try {
-			for (const tabState of await getAllTabStates()) {
-				if (websiteTabConnections.has(tabState.tabId)) continue
-				if (tabState.website?.websiteOrigin === undefined) continue
-				addIconRefreshTarget(iconRefreshTargets, tabState.tabId, tabState.website.websiteOrigin)
-			}
-			await Promise.all([...iconRefreshTargets.values()].map(({ tabId, websiteOrigin }) =>
-				updateExtensionIcon(websiteTabConnections, tabId, websiteOrigin, popupRefreshGeneration)
-			))
-		} catch (error) {
-			if (throwOnError) throw error
-			await reportUnexpectedError(error)
-		}
-	}
-	return { popupRefreshGeneration, finish }
+	return { popupRefreshGeneration, iconRefreshTargets: [...iconRefreshTargets.values()] }
 }
 
-export type WebsiteAccessReconciler = (settings: Settings) => Promise<number>
-
-// Own all completion work so a caller cannot omit it or skip it by throwing after a committed access update.
-export async function runWithWebsiteAccessUpdates<T>(
+// Call after releasing the settings lock: access dialogs can activate another address.
+export async function finishWebsiteAccessUpdate(
 	ethereum: EthereumClientService | undefined,
 	tokenPriceService: TokenPriceService | undefined,
 	resetSimulationServices: ResetSimulationServices | undefined,
 	websiteTabConnections: WebsiteTabConnections,
+	update: WebsiteAccessUpdate,
 	promptForAccessesIfNeeded: boolean,
-	runOrdered: (operation: () => Promise<T>) => Promise<T>,
-	change: (reconcile: WebsiteAccessReconciler) => Promise<T>,
 	throwOnError = false,
-): Promise<T> {
-	const completions: Array<() => Promise<void>> = []
+) {
+	const iconRefreshTargets = new Map<string, { tabId: number, websiteOrigin: string }>()
+	for (const target of update.iconRefreshTargets) addIconRefreshTarget(iconRefreshTargets, target.tabId, target.websiteOrigin)
+	if (promptForAccessesIfNeeded && ethereum !== undefined && tokenPriceService !== undefined && resetSimulationServices !== undefined) {
+		await promptForWebsiteAccesses(ethereum, tokenPriceService, resetSimulationServices, websiteTabConnections, throwOnError)
+	}
 	try {
-		return await runOrdered(async () => await change(async (settings) => {
-			const update = await reconcileWebsiteApprovalAccesses(ethereum, tokenPriceService, resetSimulationServices, websiteTabConnections, settings, promptForAccessesIfNeeded, throwOnError)
-			completions.push(update.finish)
-			return update.popupRefreshGeneration
-		}))
-	} finally {
-		// The ordered executor has released its lock before access dialogs or toolbar updates begin.
-		for (const complete of completions) await complete()
+		for (const tabState of await getAllTabStates()) {
+			if (websiteTabConnections.has(tabState.tabId)) continue
+			if (tabState.website?.websiteOrigin === undefined) continue
+			addIconRefreshTarget(iconRefreshTargets, tabState.tabId, tabState.website.websiteOrigin)
+		}
+		await Promise.all([...iconRefreshTargets.values()].map(({ tabId, websiteOrigin }) =>
+			updateExtensionIcon(websiteTabConnections, tabId, websiteOrigin, update.popupRefreshGeneration)
+		))
+	} catch (error) {
+		if (throwOnError) throw error
+		await reportUnexpectedError(error)
 	}
 }
 
@@ -514,11 +502,9 @@ export async function updateWebsiteApprovalAccesses(
 	promptForAccessesIfNeeded: boolean,
 	throwOnError = false,
 ): Promise<number> {
-	return await runWithWebsiteAccessUpdates<number>(ethereum, tokenPriceService, resetSimulationServices, websiteTabConnections, promptForAccessesIfNeeded,
-		async (operation) => await operation(),
-		async (reconcile) => await reconcile(settings),
-		throwOnError,
-	)
+	const update = await reconcileWebsiteApprovalAccesses(websiteTabConnections, settings, throwOnError)
+	await finishWebsiteAccessUpdate(ethereum, tokenPriceService, resetSimulationServices, websiteTabConnections, update, promptForAccessesIfNeeded, throwOnError)
+	return update.popupRefreshGeneration
 }
 
 export async function finalizeWebsiteAccessChange(

--- a/app/ts/background/accessManagement.ts
+++ b/app/ts/background/accessManagement.ts
@@ -289,6 +289,12 @@ function addIconRefreshTarget(iconRefreshTargets: Map<string, { tabId: number, w
 	iconRefreshTargets.set(key, { tabId, websiteOrigin })
 }
 
+async function getConnectionAccess(websiteTabConnections: WebsiteTabConnections, connection: TabConnection['connections'][string], settings: Settings) {
+	const activeAddress = await getActiveAddressForCurrentSignerState(websiteTabConnections, settings, connection.socket.tabId, async () => await getActiveAddress(settings, connection.socket.tabId))
+	const access = activeAddress ? hasAddressAccess(settings.websiteAccess, connection.websiteOrigin, activeAddress) : hasAccess(settings.websiteAccess, connection.websiteOrigin)
+	return { activeAddress, access }
+}
+
 async function updateTabConnections(
 	websiteTabConnections: WebsiteTabConnections,
 	tabConnection: TabConnection,
@@ -298,19 +304,13 @@ async function updateTabConnections(
 	for (const key in tabConnection.connections) {
 		const connection = tabConnection.connections[key]
 		if (connection === undefined) throw new Error('missing connection')
-		const currentActiveAddress = await getActiveAddressForCurrentSignerState(
-			websiteTabConnections,
-			settings,
-			connection.socket.tabId,
-			async () => await getActiveAddress(settings, connection.socket.tabId),
-		)
+		const { activeAddress, access } = await getConnectionAccess(websiteTabConnections, connection, settings)
 		addIconRefreshTarget(iconRefreshTargets, connection.socket.tabId, connection.websiteOrigin)
-		const access = currentActiveAddress ? hasAddressAccess(settings.websiteAccess, connection.websiteOrigin, currentActiveAddress) : hasAccess(settings.websiteAccess, connection.websiteOrigin)
 
 		if (access !== 'hasAccess' && connection.approved) {
 			disconnectFromPort(websiteTabConnections, connection.socket)
 		} else if (access === 'hasAccess' && !connection.approved) {
-			connectToPort(websiteTabConnections, connection.socket, settings, currentActiveAddress?.address)
+			connectToPort(websiteTabConnections, connection.socket, settings, activeAddress?.address)
 		}
 	}
 	return iconRefreshTargets
@@ -318,20 +318,20 @@ async function updateTabConnections(
 
 // Prompts acquire the access-dialog lock, so callers holding the active-settings lock must defer this phase.
 export async function promptForWebsiteAccesses(ethereum: EthereumClientService, tokenPriceService: TokenPriceService, resetSimulationServices: ResetSimulationServices, websiteTabConnections: WebsiteTabConnections, throwOnError = false) {
-	try {
-		for (const tabConnection of websiteTabConnections.values()) {
-			for (const connection of Object.values(tabConnection.connections)) {
-				if (!connection.wantsToConnect) continue
+	for (const tabConnection of websiteTabConnections.values()) {
+		for (const connection of Object.values(tabConnection.connections)) {
+			if (!connection.wantsToConnect) continue
+			try {
+				// Reconciliation uses the committed snapshot; deferred prompts must recheck the latest settings.
 				const settings = await getSettings()
-				const activeAddress = await getActiveAddressForCurrentSignerState(websiteTabConnections, settings, connection.socket.tabId, async () => await getActiveAddress(settings, connection.socket.tabId))
-				const access = activeAddress ? hasAddressAccess(settings.websiteAccess, connection.websiteOrigin, activeAddress) : hasAccess(settings.websiteAccess, connection.websiteOrigin)
+				const { activeAddress, access } = await getConnectionAccess(websiteTabConnections, connection, settings)
 				if (access !== 'askAccess') continue
 				await askUserForAccessOnConnectionUpdate(ethereum, tokenPriceService, resetSimulationServices, websiteTabConnections, connection.socket, connection.websiteOrigin, activeAddress, settings)
+			} catch (error) {
+				if (throwOnError) throw error
+				await reportUnexpectedError(error)
 			}
 		}
-	} catch (error) {
-		if (throwOnError) throw error
-		await reportUnexpectedError(error)
 	}
 }
 

--- a/app/ts/background/activeSettings.ts
+++ b/app/ts/background/activeSettings.ts
@@ -50,19 +50,21 @@ const keepTrackOfPreviousAddressForRichList = async () => {
 	await trackPreviousActiveAddressForMakeMeRichList(previousActiveAddress)
 }
 
+type ActiveAddressAndChainChange = {
+	simulationMode: boolean
+	activeAddress?: bigint
+	signingAddressSelection?: 'signer' | 'safe'
+	rpcNetwork?: RpcNetwork
+	promptForAccessesIfNeeded?: boolean
+}
+
 const changeActiveAddressAndChainSemaphore = new Semaphore(1)
-export async function changeActiveAddressAndChain(
+async function changeActiveAddressAndChainUnlocked(
 	ethereum: EthereumClientService,
 	tokenPriceService: TokenPriceService,
 	resetSimulationServices: ResetSimulationServices,
 	websiteTabConnections: WebsiteTabConnections,
-	change: {
-		simulationMode: boolean,
-		activeAddress?: bigint,
-		signingAddressSelection?: 'signer' | 'safe',
-		rpcNetwork?: RpcNetwork,
-		promptForAccessesIfNeeded?: boolean,
-	},
+	change: ActiveAddressAndChainChange,
 ) {
 	if (change.simulationMode && change.activeAddress !== undefined) await keepTrackOfPreviousAddressForRichList()
 	const previousSettings = await getSettings()
@@ -88,25 +90,39 @@ export async function changeActiveAddressAndChain(
 	const popupRefreshGeneration = await updateWebsiteApprovalAccesses(ethereum, tokenPriceService, resetSimulationServices, websiteTabConnections, updatedSettings, change.promptForAccessesIfNeeded ?? true)
 	sendPopupMessageToOpenWindows({ method: 'popup_settingsUpdated', data: updatedSettings, popupRefreshGeneration })
 	sendPopupMessageToOpenWindows({ method: 'popup_accounts_update' })
-	await changeActiveAddressAndChainSemaphore.execute(async () => {
-		const activeSigningSafeContextChanged = !updatedSettings.simulationMode
-			&& updatedSettings.activeSigningSafeAddress !== undefined
-			&& !activeStackContextsEqual(getActiveStackContext(previousSettings), getActiveStackContext(updatedSettings))
-		if (change.rpcNetwork !== undefined) {
-			const rpcChainChanged = previousSettings.activeRpcNetwork.chainId !== change.rpcNetwork.chainId
-			if (change.rpcNetwork.httpsRpc !== undefined) resetSimulationServices(change.rpcNetwork)
-			sendMessageToApprovedWebsitePorts(websiteTabConnections, { method: 'chainChanged', result: change.rpcNetwork.chainId })
-			sendPopupMessageToOpenWindows({ method: 'popup_chain_update' })
+	const activeSigningSafeContextChanged = !updatedSettings.simulationMode
+		&& updatedSettings.activeSigningSafeAddress !== undefined
+		&& !activeStackContextsEqual(getActiveStackContext(previousSettings), getActiveStackContext(updatedSettings))
+	if (change.rpcNetwork !== undefined) {
+		const rpcChainChanged = previousSettings.activeRpcNetwork.chainId !== change.rpcNetwork.chainId
+		if (change.rpcNetwork.httpsRpc !== undefined) resetSimulationServices(change.rpcNetwork)
+		sendMessageToApprovedWebsitePorts(websiteTabConnections, { method: 'chainChanged', result: change.rpcNetwork.chainId })
+		sendPopupMessageToOpenWindows({ method: 'popup_chain_update' })
 
-			if (updatedSettings.simulationMode && rpcChainChanged) {
-				await resetSimulationStateFromConfig(ethereum, tokenPriceService)
-			} else if (updatedSettings.simulationMode) {
-				await updatePopupVisualisationIfNeeded(ethereum, tokenPriceService, false, false)
-			}
+		if (updatedSettings.simulationMode && rpcChainChanged) {
+			await resetSimulationStateFromConfig(ethereum, tokenPriceService)
+		} else if (updatedSettings.simulationMode) {
+			await updatePopupVisualisationIfNeeded(ethereum, tokenPriceService, false, false)
 		}
-		if (activeSigningSafeContextChanged) await updatePopupVisualisationIfNeeded(ethereum, tokenPriceService, false, false)
-		await sendActiveAccountChangeToApprovedWebsitePorts(websiteTabConnections, await getSettings())
-	})
+	}
+	if (activeSigningSafeContextChanged) await updatePopupVisualisationIfNeeded(ethereum, tokenPriceService, false, false)
+	await sendActiveAccountChangeToApprovedWebsitePorts(websiteTabConnections, await getSettings())
+}
+
+export async function changeActiveAddressAndChain(
+	ethereum: EthereumClientService,
+	tokenPriceService: TokenPriceService,
+	resetSimulationServices: ResetSimulationServices,
+	websiteTabConnections: WebsiteTabConnections,
+	change: ActiveAddressAndChainChange,
+) {
+	await changeActiveAddressAndChainSemaphore.execute(async () => await changeActiveAddressAndChainUnlocked(
+		ethereum,
+		tokenPriceService,
+		resetSimulationServices,
+		websiteTabConnections,
+		change,
+	))
 }
 
 export async function activateAddressSelection(
@@ -122,28 +138,30 @@ export async function activateAddressSelection(
 		readonly promptForAccessesIfNeeded?: boolean
 	},
 ) {
-	const useSignerAddress = selection?.type === 'signer' || (!options.simulationMode && selection === undefined)
-	if (options.simulationMode) {
-		await setUseSignersAddressAsActiveAddress(useSignerAddress, useSignerAddress ? selection?.type === 'signer' ? selection.address : options.signerAddress : undefined)
-	}
-	await changeActiveAddressAndChain(ethereum, tokenPriceService, resetSimulationServices, websiteTabConnections, {
-		simulationMode: options.simulationMode,
-		activeAddress: selection?.type === 'signer' ? selection.address : selection?.entry.address,
-		...(!options.simulationMode ? { signingAddressSelection: selection?.type === 'addressBookEntry' && selection.entry.type === 'safe' ? 'safe' as const : 'signer' as const } : {}),
-		...(options.rpcNetwork === undefined ? {} : { rpcNetwork: options.rpcNetwork }),
-		...(options.promptForAccessesIfNeeded === undefined ? {} : { promptForAccessesIfNeeded: options.promptForAccessesIfNeeded }),
-	})
-	if (options.simulationMode || options.signerAddress === undefined || selection === undefined) return
-	if (selection.type === 'signer') {
-		await rememberSigningAddressSelection({ signerAddress: options.signerAddress, selection: 'signer' })
-		return
-	}
-	if (selection.entry.type !== 'safe') throw new Error('Signing mode can only activate the external signer or an owned Gnosis Safe.')
-	await rememberSigningAddressSelection({
-		signerAddress: options.signerAddress,
-		selection: 'safe',
-		safeAddress: selection.entry.address,
-		chainId: selection.entry.chainId,
+	await changeActiveAddressAndChainSemaphore.execute(async () => {
+		const useSignerAddress = selection?.type === 'signer' || (!options.simulationMode && selection === undefined)
+		if (options.simulationMode) {
+			await setUseSignersAddressAsActiveAddress(useSignerAddress, useSignerAddress ? selection?.type === 'signer' ? selection.address : options.signerAddress : undefined)
+		}
+		await changeActiveAddressAndChainUnlocked(ethereum, tokenPriceService, resetSimulationServices, websiteTabConnections, {
+			simulationMode: options.simulationMode,
+			activeAddress: selection?.type === 'signer' ? selection.address : selection?.entry.address,
+			...(!options.simulationMode ? { signingAddressSelection: selection?.type === 'addressBookEntry' && selection.entry.type === 'safe' ? 'safe' as const : 'signer' as const } : {}),
+			...(options.rpcNetwork === undefined ? {} : { rpcNetwork: options.rpcNetwork }),
+			...(options.promptForAccessesIfNeeded === undefined ? {} : { promptForAccessesIfNeeded: options.promptForAccessesIfNeeded }),
+		})
+		if (options.simulationMode || options.signerAddress === undefined || selection === undefined) return
+		if (selection.type === 'signer') {
+			await rememberSigningAddressSelection({ signerAddress: options.signerAddress, selection: 'signer' })
+			return
+		}
+		if (selection.entry.type !== 'safe') throw new Error('Signing mode can only activate the external signer or an owned Gnosis Safe.')
+		await rememberSigningAddressSelection({
+			signerAddress: options.signerAddress,
+			selection: 'safe',
+			safeAddress: selection.entry.address,
+			chainId: selection.entry.chainId,
+		})
 	})
 }
 

--- a/app/ts/background/activeSettings.ts
+++ b/app/ts/background/activeSettings.ts
@@ -4,7 +4,8 @@ import type { TokenPriceService } from '../simulation/services/priceEstimator.js
 import type { RpcNetwork } from '../types/rpc.js'
 import type { WebsiteTabConnections } from '../types/user-interface-types.js'
 import { Semaphore } from '../utils/semaphore.js'
-import { reconcileWebsiteApprovalAccesses, sendActiveAccountChangeToApprovedWebsitePorts, sendMessageToApprovedWebsitePorts } from './accessManagement.js'
+import type { WebsiteAccessReconciler } from './accessManagement.js'
+import { runWithWebsiteAccessUpdates, sendActiveAccountChangeToApprovedWebsitePorts, sendMessageToApprovedWebsitePorts } from './accessManagement.js'
 import { sendPopupMessageToOpenWindows } from './backgroundUtils.js'
 import { updatePopupVisualisationIfNeeded } from './popupVisualisationUpdater.js'
 import { bumpPopupRefreshGeneration } from './popupRefreshGeneration.js'
@@ -59,11 +60,19 @@ type ActiveAddressAndChainChange = {
 }
 
 const changeActiveAddressAndChainSemaphore = new Semaphore(1)
-async function runActiveSettingsChange(change: () => Promise<() => Promise<void>>) {
+async function runActiveSettingsChange(
+	ethereum: EthereumClientService,
+	tokenPriceService: TokenPriceService,
+	resetSimulationServices: ResetSimulationServices,
+	websiteTabConnections: WebsiteTabConnections,
+	promptForAccessesIfNeeded: boolean,
+	change: (reconcile: WebsiteAccessReconciler) => Promise<void>,
+) {
 	// Global settings, port approvals, service resets and notifications must describe the same ordered transition.
-	const finishAccessUpdate = await changeActiveAddressAndChainSemaphore.execute(change)
-	// Access dialogs and icon refreshes do not hold up another transition or invert the dialog/settings lock order.
-	await finishAccessUpdate()
+	await runWithWebsiteAccessUpdates(ethereum, tokenPriceService, resetSimulationServices, websiteTabConnections, promptForAccessesIfNeeded,
+		async (operation) => await changeActiveAddressAndChainSemaphore.execute(operation),
+		change,
+	)
 }
 
 async function changeActiveAddressAndChainUnlocked(
@@ -72,6 +81,7 @@ async function changeActiveAddressAndChainUnlocked(
 	resetSimulationServices: ResetSimulationServices,
 	websiteTabConnections: WebsiteTabConnections,
 	change: ActiveAddressAndChainChange,
+	reconcile: WebsiteAccessReconciler,
 ) {
 	if (change.simulationMode && change.activeAddress !== undefined) await keepTrackOfPreviousAddressForRichList()
 	const previousSettings = await getSettings()
@@ -94,8 +104,8 @@ async function changeActiveAddressAndChainUnlocked(
 	}
 
 	const updatedSettings = await getSettings()
-	const accessUpdate = await reconcileWebsiteApprovalAccesses(ethereum, tokenPriceService, resetSimulationServices, websiteTabConnections, updatedSettings, change.promptForAccessesIfNeeded ?? true)
-	sendPopupMessageToOpenWindows({ method: 'popup_settingsUpdated', data: updatedSettings, popupRefreshGeneration: accessUpdate.popupRefreshGeneration })
+	const popupRefreshGeneration = await reconcile(updatedSettings)
+	sendPopupMessageToOpenWindows({ method: 'popup_settingsUpdated', data: updatedSettings, popupRefreshGeneration })
 	sendPopupMessageToOpenWindows({ method: 'popup_accounts_update' })
 	const activeSigningSafeContextChanged = !updatedSettings.simulationMode
 		&& updatedSettings.activeSigningSafeAddress !== undefined
@@ -114,7 +124,6 @@ async function changeActiveAddressAndChainUnlocked(
 	}
 	if (activeSigningSafeContextChanged) await updatePopupVisualisationIfNeeded(ethereum, tokenPriceService, false, false)
 	await sendActiveAccountChangeToApprovedWebsitePorts(websiteTabConnections, await getSettings())
-	return accessUpdate.finish
 }
 
 export async function changeActiveAddressAndChain(
@@ -124,12 +133,13 @@ export async function changeActiveAddressAndChain(
 	websiteTabConnections: WebsiteTabConnections,
 	change: ActiveAddressAndChainChange,
 ) {
-	await runActiveSettingsChange(async () => await changeActiveAddressAndChainUnlocked(
+	await runActiveSettingsChange(ethereum, tokenPriceService, resetSimulationServices, websiteTabConnections, change.promptForAccessesIfNeeded ?? true, async (reconcile) => await changeActiveAddressAndChainUnlocked(
 		ethereum,
 		tokenPriceService,
 		resetSimulationServices,
 		websiteTabConnections,
 		change,
+		reconcile,
 	))
 }
 
@@ -146,31 +156,30 @@ export async function activateAddressSelection(
 		readonly promptForAccessesIfNeeded?: boolean
 	},
 ) {
-	await runActiveSettingsChange(async () => {
+	await runActiveSettingsChange(ethereum, tokenPriceService, resetSimulationServices, websiteTabConnections, options.promptForAccessesIfNeeded ?? true, async (reconcile) => {
+		const selectedSafe = selection?.type === 'addressBookEntry' && selection.entry.type === 'safe' ? selection.entry : undefined
+		if (!options.simulationMode && selection?.type === 'addressBookEntry' && selectedSafe === undefined) throw new Error('Signing mode can only activate the external signer or an owned Gnosis Safe.')
 		const useSignerAddress = selection?.type === 'signer' || (!options.simulationMode && selection === undefined)
 		if (options.simulationMode) {
 			await setUseSignersAddressAsActiveAddress(useSignerAddress, useSignerAddress ? selection?.type === 'signer' ? selection.address : options.signerAddress : undefined)
 		}
-		const finishAccessUpdate = await changeActiveAddressAndChainUnlocked(ethereum, tokenPriceService, resetSimulationServices, websiteTabConnections, {
+		await changeActiveAddressAndChainUnlocked(ethereum, tokenPriceService, resetSimulationServices, websiteTabConnections, {
 			simulationMode: options.simulationMode,
-			promptForAccessesIfNeeded: options.promptForAccessesIfNeeded ?? true,
 			activeAddress: selection?.type === 'signer' ? selection.address : selection?.entry.address,
 			...(!options.simulationMode ? { signingAddressSelection: selection?.type === 'addressBookEntry' && selection.entry.type === 'safe' ? 'safe' as const : 'signer' as const } : {}),
 			...(options.rpcNetwork === undefined ? {} : { rpcNetwork: options.rpcNetwork }),
-		})
-		if (options.simulationMode || options.signerAddress === undefined || selection === undefined) return finishAccessUpdate
-		if (selection.type === 'signer') {
+		}, reconcile)
+		if (options.simulationMode || options.signerAddress === undefined || selection === undefined) return
+		if (selectedSafe === undefined) {
 			await rememberSigningAddressSelection({ signerAddress: options.signerAddress, selection: 'signer' })
-			return finishAccessUpdate
+			return
 		}
-		if (selection.entry.type !== 'safe') throw new Error('Signing mode can only activate the external signer or an owned Gnosis Safe.')
 		await rememberSigningAddressSelection({
 			signerAddress: options.signerAddress,
 			selection: 'safe',
-			safeAddress: selection.entry.address,
-			chainId: selection.entry.chainId,
+			safeAddress: selectedSafe.address,
+			chainId: selectedSafe.chainId,
 		})
-		return finishAccessUpdate
 	})
 }
 

--- a/app/ts/background/activeSettings.ts
+++ b/app/ts/background/activeSettings.ts
@@ -59,6 +59,19 @@ type ActiveAddressAndChainChange = {
 }
 
 const changeActiveAddressAndChainSemaphore = new Semaphore(1)
+async function runActiveSettingsChange(
+	ethereum: EthereumClientService,
+	tokenPriceService: TokenPriceService,
+	resetSimulationServices: ResetSimulationServices,
+	websiteTabConnections: WebsiteTabConnections,
+	promptForAccessesIfNeeded: boolean,
+	change: () => Promise<void>,
+) {
+	await changeActiveAddressAndChainSemaphore.execute(change)
+	// Access approvals can change the active address while holding the dialog lock; prompt only after releasing our lock.
+	if (promptForAccessesIfNeeded) await promptForWebsiteAccesses(ethereum, tokenPriceService, resetSimulationServices, websiteTabConnections)
+}
+
 async function changeActiveAddressAndChainUnlocked(
 	ethereum: EthereumClientService,
 	tokenPriceService: TokenPriceService,
@@ -87,7 +100,6 @@ async function changeActiveAddressAndChainUnlocked(
 	}
 
 	const updatedSettings = await getSettings()
-	// Access approvals can change the active address while holding the dialog lock; prompt only after releasing our lock.
 	const popupRefreshGeneration = await updateWebsiteApprovalAccesses(ethereum, tokenPriceService, resetSimulationServices, websiteTabConnections, updatedSettings, false)
 	sendPopupMessageToOpenWindows({ method: 'popup_settingsUpdated', data: updatedSettings, popupRefreshGeneration })
 	sendPopupMessageToOpenWindows({ method: 'popup_accounts_update' })
@@ -117,14 +129,13 @@ export async function changeActiveAddressAndChain(
 	websiteTabConnections: WebsiteTabConnections,
 	change: ActiveAddressAndChainChange,
 ) {
-	await changeActiveAddressAndChainSemaphore.execute(async () => await changeActiveAddressAndChainUnlocked(
+	await runActiveSettingsChange(ethereum, tokenPriceService, resetSimulationServices, websiteTabConnections, change.promptForAccessesIfNeeded ?? true, async () => await changeActiveAddressAndChainUnlocked(
 		ethereum,
 		tokenPriceService,
 		resetSimulationServices,
 		websiteTabConnections,
 		change,
 	))
-	if (change.promptForAccessesIfNeeded ?? true) await promptForWebsiteAccesses(ethereum, tokenPriceService, resetSimulationServices, websiteTabConnections)
 }
 
 export async function activateAddressSelection(
@@ -140,7 +151,7 @@ export async function activateAddressSelection(
 		readonly promptForAccessesIfNeeded?: boolean
 	},
 ) {
-	await changeActiveAddressAndChainSemaphore.execute(async () => {
+	await runActiveSettingsChange(ethereum, tokenPriceService, resetSimulationServices, websiteTabConnections, options.promptForAccessesIfNeeded ?? true, async () => {
 		const useSignerAddress = selection?.type === 'signer' || (!options.simulationMode && selection === undefined)
 		if (options.simulationMode) {
 			await setUseSignersAddressAsActiveAddress(useSignerAddress, useSignerAddress ? selection?.type === 'signer' ? selection.address : options.signerAddress : undefined)
@@ -164,7 +175,6 @@ export async function activateAddressSelection(
 			chainId: selection.entry.chainId,
 		})
 	})
-	if (options.promptForAccessesIfNeeded ?? true) await promptForWebsiteAccesses(ethereum, tokenPriceService, resetSimulationServices, websiteTabConnections)
 }
 
 export async function changeActiveRpc(ethereum: EthereumClientService, tokenPriceService: TokenPriceService, resetSimulationServices: ResetSimulationServices, websiteTabConnections: WebsiteTabConnections, rpcNetwork: RpcNetwork, simulationMode: boolean, signerTabId: number | undefined) {

--- a/app/ts/background/activeSettings.ts
+++ b/app/ts/background/activeSettings.ts
@@ -1,11 +1,12 @@
 import type { EthereumClientService } from '../simulation/services/EthereumClientService.js'
 import type { ResetSimulationServices } from '../simulation/serviceLifecycle.js'
 import type { TokenPriceService } from '../simulation/services/priceEstimator.js'
+import type { SigningAddressPreference } from '../types/signerTypes.js'
 import type { RpcNetwork } from '../types/rpc.js'
 import type { WebsiteTabConnections } from '../types/user-interface-types.js'
 import { Semaphore } from '../utils/semaphore.js'
-import type { WebsiteAccessReconciler } from './accessManagement.js'
-import { runWithWebsiteAccessUpdates, sendActiveAccountChangeToApprovedWebsitePorts, sendMessageToApprovedWebsitePorts } from './accessManagement.js'
+import type { WebsiteAccessUpdate } from './accessManagement.js'
+import { reconcileWebsiteApprovalAccesses, finishWebsiteAccessUpdate, sendActiveAccountChangeToApprovedWebsitePorts, sendMessageToApprovedWebsitePorts } from './accessManagement.js'
 import { sendPopupMessageToOpenWindows } from './backgroundUtils.js'
 import { updatePopupVisualisationIfNeeded } from './popupVisualisationUpdater.js'
 import { bumpPopupRefreshGeneration } from './popupRefreshGeneration.js'
@@ -59,71 +60,78 @@ type ActiveAddressAndChainChange = {
 	promptForAccessesIfNeeded?: boolean
 }
 
+type ActiveSettingsTransition = {
+	readonly change: ActiveAddressAndChainChange
+	readonly simulationSignerSelection?: { readonly useSignerAddress: boolean, readonly signerAddress: bigint | undefined }
+	readonly signingPreference?: SigningAddressPreference
+}
+
 const changeActiveAddressAndChainSemaphore = new Semaphore(1)
 async function runActiveSettingsChange(
 	ethereum: EthereumClientService,
 	tokenPriceService: TokenPriceService,
 	resetSimulationServices: ResetSimulationServices,
 	websiteTabConnections: WebsiteTabConnections,
-	promptForAccessesIfNeeded: boolean,
-	change: (reconcile: WebsiteAccessReconciler) => Promise<void>,
+	transition: ActiveSettingsTransition,
 ) {
-	// Global settings, port approvals, service resets and notifications must describe the same ordered transition.
-	await runWithWebsiteAccessUpdates(ethereum, tokenPriceService, resetSimulationServices, websiteTabConnections, promptForAccessesIfNeeded,
-		async (operation) => await changeActiveAddressAndChainSemaphore.execute(operation),
-		change,
-	)
-}
+	const { change } = transition
+	let accessUpdate: WebsiteAccessUpdate | undefined
+	try {
+		// Settings, approvals, resets, notifications and selection preferences form one ordered transition.
+		await changeActiveAddressAndChainSemaphore.execute(async () => {
+			if (transition.simulationSignerSelection !== undefined) {
+				const { useSignerAddress, signerAddress } = transition.simulationSignerSelection
+				await setUseSignersAddressAsActiveAddress(useSignerAddress, signerAddress)
+			}
+			if (change.simulationMode && change.activeAddress !== undefined) await keepTrackOfPreviousAddressForRichList()
+			const previousSettings = await getSettings()
 
-async function changeActiveAddressAndChainUnlocked(
-	ethereum: EthereumClientService,
-	tokenPriceService: TokenPriceService,
-	resetSimulationServices: ResetSimulationServices,
-	websiteTabConnections: WebsiteTabConnections,
-	change: ActiveAddressAndChainChange,
-	reconcile: WebsiteAccessReconciler,
-) {
-	if (change.simulationMode && change.activeAddress !== undefined) await keepTrackOfPreviousAddressForRichList()
-	const previousSettings = await getSettings()
+			if (change.simulationMode) {
+				await changeSimulationMode({
+					simulationMode: change.simulationMode,
+					...('activeAddress' in change ? { activeSimulationAddress: change.activeAddress } : {}),
+					...(change.rpcNetwork !== undefined ? { rpcNetwork: change.rpcNetwork } : {}),
+				})
+			} else {
+				if ('activeAddress' in change && change.signingAddressSelection === undefined) throw new Error('Signing address changes must identify whether the selection is the signer or a Safe.')
+				const selectsSafe = change.signingAddressSelection === 'safe'
+				await changeSimulationMode({
+					simulationMode: change.simulationMode,
+					...(!selectsSafe && 'activeAddress' in change ? { activeSigningAddress: change.activeAddress } : {}),
+					...('activeAddress' in change ? { activeSigningSafeAddress: selectsSafe ? change.activeAddress : undefined } : {}),
+					...(change.rpcNetwork !== undefined ? { rpcNetwork: change.rpcNetwork } : {}),
+				})
+			}
 
-	if (change.simulationMode) {
-		await changeSimulationMode({
-			simulationMode: change.simulationMode,
-			...('activeAddress' in change ? { activeSimulationAddress: change.activeAddress } : {}),
-			...(change.rpcNetwork !== undefined ? { rpcNetwork: change.rpcNetwork } : {}),
+			const updatedSettings = await getSettings()
+			accessUpdate = await reconcileWebsiteApprovalAccesses(websiteTabConnections, updatedSettings)
+			sendPopupMessageToOpenWindows({ method: 'popup_settingsUpdated', data: updatedSettings, popupRefreshGeneration: accessUpdate.popupRefreshGeneration })
+			sendPopupMessageToOpenWindows({ method: 'popup_accounts_update' })
+			const activeSigningSafeContextChanged = !updatedSettings.simulationMode
+				&& updatedSettings.activeSigningSafeAddress !== undefined
+				&& !activeStackContextsEqual(getActiveStackContext(previousSettings), getActiveStackContext(updatedSettings))
+			if (change.rpcNetwork !== undefined) {
+				const rpcChainChanged = previousSettings.activeRpcNetwork.chainId !== change.rpcNetwork.chainId
+				if (change.rpcNetwork.httpsRpc !== undefined) resetSimulationServices(change.rpcNetwork)
+				sendMessageToApprovedWebsitePorts(websiteTabConnections, { method: 'chainChanged', result: change.rpcNetwork.chainId })
+				sendPopupMessageToOpenWindows({ method: 'popup_chain_update' })
+
+				if (updatedSettings.simulationMode && rpcChainChanged) {
+					await resetSimulationStateFromConfig(ethereum, tokenPriceService)
+				} else if (updatedSettings.simulationMode) {
+					await updatePopupVisualisationIfNeeded(ethereum, tokenPriceService, false, false)
+				}
+			}
+			if (activeSigningSafeContextChanged) await updatePopupVisualisationIfNeeded(ethereum, tokenPriceService, false, false)
+			await sendActiveAccountChangeToApprovedWebsitePorts(websiteTabConnections, await getSettings())
+			if (transition.signingPreference !== undefined) await rememberSigningAddressSelection(transition.signingPreference)
 		})
-	} else {
-		if ('activeAddress' in change && change.signingAddressSelection === undefined) throw new Error('Signing address changes must identify whether the selection is the signer or a Safe.')
-		const selectsSafe = change.signingAddressSelection === 'safe'
-		await changeSimulationMode({
-			simulationMode: change.simulationMode,
-			...(!selectsSafe && 'activeAddress' in change ? { activeSigningAddress: change.activeAddress } : {}),
-			...('activeAddress' in change ? { activeSigningSafeAddress: selectsSafe ? change.activeAddress : undefined } : {}),
-			...(change.rpcNetwork !== undefined ? { rpcNetwork: change.rpcNetwork } : {}),
-		})
-	}
-
-	const updatedSettings = await getSettings()
-	const popupRefreshGeneration = await reconcile(updatedSettings)
-	sendPopupMessageToOpenWindows({ method: 'popup_settingsUpdated', data: updatedSettings, popupRefreshGeneration })
-	sendPopupMessageToOpenWindows({ method: 'popup_accounts_update' })
-	const activeSigningSafeContextChanged = !updatedSettings.simulationMode
-		&& updatedSettings.activeSigningSafeAddress !== undefined
-		&& !activeStackContextsEqual(getActiveStackContext(previousSettings), getActiveStackContext(updatedSettings))
-	if (change.rpcNetwork !== undefined) {
-		const rpcChainChanged = previousSettings.activeRpcNetwork.chainId !== change.rpcNetwork.chainId
-		if (change.rpcNetwork.httpsRpc !== undefined) resetSimulationServices(change.rpcNetwork)
-		sendMessageToApprovedWebsitePorts(websiteTabConnections, { method: 'chainChanged', result: change.rpcNetwork.chainId })
-		sendPopupMessageToOpenWindows({ method: 'popup_chain_update' })
-
-		if (updatedSettings.simulationMode && rpcChainChanged) {
-			await resetSimulationStateFromConfig(ethereum, tokenPriceService)
-		} else if (updatedSettings.simulationMode) {
-			await updatePopupVisualisationIfNeeded(ethereum, tokenPriceService, false, false)
+	} finally {
+		// Complete committed access updates after releasing the semaphore, even if a later reset or notification fails.
+		if (accessUpdate !== undefined) {
+			await finishWebsiteAccessUpdate(ethereum, tokenPriceService, resetSimulationServices, websiteTabConnections, accessUpdate, change.promptForAccessesIfNeeded ?? true)
 		}
 	}
-	if (activeSigningSafeContextChanged) await updatePopupVisualisationIfNeeded(ethereum, tokenPriceService, false, false)
-	await sendActiveAccountChangeToApprovedWebsitePorts(websiteTabConnections, await getSettings())
 }
 
 export async function changeActiveAddressAndChain(
@@ -133,14 +141,7 @@ export async function changeActiveAddressAndChain(
 	websiteTabConnections: WebsiteTabConnections,
 	change: ActiveAddressAndChainChange,
 ) {
-	await runActiveSettingsChange(ethereum, tokenPriceService, resetSimulationServices, websiteTabConnections, change.promptForAccessesIfNeeded ?? true, async (reconcile) => await changeActiveAddressAndChainUnlocked(
-		ethereum,
-		tokenPriceService,
-		resetSimulationServices,
-		websiteTabConnections,
-		change,
-		reconcile,
-	))
+	await runActiveSettingsChange(ethereum, tokenPriceService, resetSimulationServices, websiteTabConnections, { change })
 }
 
 export async function activateAddressSelection(
@@ -156,30 +157,27 @@ export async function activateAddressSelection(
 		readonly promptForAccessesIfNeeded?: boolean
 	},
 ) {
-	await runActiveSettingsChange(ethereum, tokenPriceService, resetSimulationServices, websiteTabConnections, options.promptForAccessesIfNeeded ?? true, async (reconcile) => {
-		const selectedSafe = selection?.type === 'addressBookEntry' && selection.entry.type === 'safe' ? selection.entry : undefined
-		if (!options.simulationMode && selection?.type === 'addressBookEntry' && selectedSafe === undefined) throw new Error('Signing mode can only activate the external signer or an owned Gnosis Safe.')
-		const useSignerAddress = selection?.type === 'signer' || (!options.simulationMode && selection === undefined)
-		if (options.simulationMode) {
-			await setUseSignersAddressAsActiveAddress(useSignerAddress, useSignerAddress ? selection?.type === 'signer' ? selection.address : options.signerAddress : undefined)
-		}
-		await changeActiveAddressAndChainUnlocked(ethereum, tokenPriceService, resetSimulationServices, websiteTabConnections, {
+	const selectedSafe = selection?.type === 'addressBookEntry' && selection.entry.type === 'safe' ? selection.entry : undefined
+	if (!options.simulationMode && selection?.type === 'addressBookEntry' && selectedSafe === undefined) throw new Error('Signing mode can only activate the external signer or an owned Gnosis Safe.')
+	const useSignerAddress = selection?.type === 'signer' || (!options.simulationMode && selection === undefined)
+	const signingPreference: SigningAddressPreference | undefined = options.simulationMode || options.signerAddress === undefined || selection === undefined
+		? undefined
+		: selectedSafe === undefined
+			? { signerAddress: options.signerAddress, selection: 'signer' }
+			: { signerAddress: options.signerAddress, selection: 'safe', safeAddress: selectedSafe.address, chainId: selectedSafe.chainId }
+	await runActiveSettingsChange(ethereum, tokenPriceService, resetSimulationServices, websiteTabConnections, {
+		change: {
 			simulationMode: options.simulationMode,
 			activeAddress: selection?.type === 'signer' ? selection.address : selection?.entry.address,
-			...(!options.simulationMode ? { signingAddressSelection: selection?.type === 'addressBookEntry' && selection.entry.type === 'safe' ? 'safe' as const : 'signer' as const } : {}),
+			...(!options.simulationMode ? { signingAddressSelection: selectedSafe === undefined ? 'signer' as const : 'safe' as const } : {}),
 			...(options.rpcNetwork === undefined ? {} : { rpcNetwork: options.rpcNetwork }),
-		}, reconcile)
-		if (options.simulationMode || options.signerAddress === undefined || selection === undefined) return
-		if (selectedSafe === undefined) {
-			await rememberSigningAddressSelection({ signerAddress: options.signerAddress, selection: 'signer' })
-			return
-		}
-		await rememberSigningAddressSelection({
-			signerAddress: options.signerAddress,
-			selection: 'safe',
-			safeAddress: selectedSafe.address,
-			chainId: selectedSafe.chainId,
-		})
+			...(options.promptForAccessesIfNeeded === undefined ? {} : { promptForAccessesIfNeeded: options.promptForAccessesIfNeeded }),
+		},
+		...(options.simulationMode ? { simulationSignerSelection: {
+			useSignerAddress,
+			signerAddress: useSignerAddress ? selection?.type === 'signer' ? selection.address : options.signerAddress : undefined,
+		} } : {}),
+		...(signingPreference === undefined ? {} : { signingPreference }),
 	})
 }
 

--- a/app/ts/background/activeSettings.ts
+++ b/app/ts/background/activeSettings.ts
@@ -4,7 +4,7 @@ import type { TokenPriceService } from '../simulation/services/priceEstimator.js
 import type { RpcNetwork } from '../types/rpc.js'
 import type { WebsiteTabConnections } from '../types/user-interface-types.js'
 import { Semaphore } from '../utils/semaphore.js'
-import { promptForWebsiteAccesses, sendActiveAccountChangeToApprovedWebsitePorts, sendMessageToApprovedWebsitePorts, updateWebsiteApprovalAccesses } from './accessManagement.js'
+import { reconcileWebsiteApprovalAccesses, sendActiveAccountChangeToApprovedWebsitePorts, sendMessageToApprovedWebsitePorts } from './accessManagement.js'
 import { sendPopupMessageToOpenWindows } from './backgroundUtils.js'
 import { updatePopupVisualisationIfNeeded } from './popupVisualisationUpdater.js'
 import { bumpPopupRefreshGeneration } from './popupRefreshGeneration.js'
@@ -59,17 +59,11 @@ type ActiveAddressAndChainChange = {
 }
 
 const changeActiveAddressAndChainSemaphore = new Semaphore(1)
-async function runActiveSettingsChange(
-	ethereum: EthereumClientService,
-	tokenPriceService: TokenPriceService,
-	resetSimulationServices: ResetSimulationServices,
-	websiteTabConnections: WebsiteTabConnections,
-	promptForAccessesIfNeeded: boolean,
-	change: () => Promise<void>,
-) {
-	await changeActiveAddressAndChainSemaphore.execute(change)
-	// Access approvals can change the active address while holding the dialog lock; prompt only after releasing our lock.
-	if (promptForAccessesIfNeeded) await promptForWebsiteAccesses(ethereum, tokenPriceService, resetSimulationServices, websiteTabConnections)
+async function runActiveSettingsChange(change: () => Promise<() => Promise<void>>) {
+	// Global settings, port approvals, service resets and notifications must describe the same ordered transition.
+	const finishAccessUpdate = await changeActiveAddressAndChainSemaphore.execute(change)
+	// Access dialogs and icon refreshes do not hold up another transition or invert the dialog/settings lock order.
+	await finishAccessUpdate()
 }
 
 async function changeActiveAddressAndChainUnlocked(
@@ -100,8 +94,8 @@ async function changeActiveAddressAndChainUnlocked(
 	}
 
 	const updatedSettings = await getSettings()
-	const popupRefreshGeneration = await updateWebsiteApprovalAccesses(ethereum, tokenPriceService, resetSimulationServices, websiteTabConnections, updatedSettings, false)
-	sendPopupMessageToOpenWindows({ method: 'popup_settingsUpdated', data: updatedSettings, popupRefreshGeneration })
+	const accessUpdate = await reconcileWebsiteApprovalAccesses(ethereum, tokenPriceService, resetSimulationServices, websiteTabConnections, updatedSettings, change.promptForAccessesIfNeeded ?? true)
+	sendPopupMessageToOpenWindows({ method: 'popup_settingsUpdated', data: updatedSettings, popupRefreshGeneration: accessUpdate.popupRefreshGeneration })
 	sendPopupMessageToOpenWindows({ method: 'popup_accounts_update' })
 	const activeSigningSafeContextChanged = !updatedSettings.simulationMode
 		&& updatedSettings.activeSigningSafeAddress !== undefined
@@ -120,6 +114,7 @@ async function changeActiveAddressAndChainUnlocked(
 	}
 	if (activeSigningSafeContextChanged) await updatePopupVisualisationIfNeeded(ethereum, tokenPriceService, false, false)
 	await sendActiveAccountChangeToApprovedWebsitePorts(websiteTabConnections, await getSettings())
+	return accessUpdate.finish
 }
 
 export async function changeActiveAddressAndChain(
@@ -129,7 +124,7 @@ export async function changeActiveAddressAndChain(
 	websiteTabConnections: WebsiteTabConnections,
 	change: ActiveAddressAndChainChange,
 ) {
-	await runActiveSettingsChange(ethereum, tokenPriceService, resetSimulationServices, websiteTabConnections, change.promptForAccessesIfNeeded ?? true, async () => await changeActiveAddressAndChainUnlocked(
+	await runActiveSettingsChange(async () => await changeActiveAddressAndChainUnlocked(
 		ethereum,
 		tokenPriceService,
 		resetSimulationServices,
@@ -151,21 +146,22 @@ export async function activateAddressSelection(
 		readonly promptForAccessesIfNeeded?: boolean
 	},
 ) {
-	await runActiveSettingsChange(ethereum, tokenPriceService, resetSimulationServices, websiteTabConnections, options.promptForAccessesIfNeeded ?? true, async () => {
+	await runActiveSettingsChange(async () => {
 		const useSignerAddress = selection?.type === 'signer' || (!options.simulationMode && selection === undefined)
 		if (options.simulationMode) {
 			await setUseSignersAddressAsActiveAddress(useSignerAddress, useSignerAddress ? selection?.type === 'signer' ? selection.address : options.signerAddress : undefined)
 		}
-		await changeActiveAddressAndChainUnlocked(ethereum, tokenPriceService, resetSimulationServices, websiteTabConnections, {
+		const finishAccessUpdate = await changeActiveAddressAndChainUnlocked(ethereum, tokenPriceService, resetSimulationServices, websiteTabConnections, {
 			simulationMode: options.simulationMode,
+			promptForAccessesIfNeeded: options.promptForAccessesIfNeeded ?? true,
 			activeAddress: selection?.type === 'signer' ? selection.address : selection?.entry.address,
 			...(!options.simulationMode ? { signingAddressSelection: selection?.type === 'addressBookEntry' && selection.entry.type === 'safe' ? 'safe' as const : 'signer' as const } : {}),
 			...(options.rpcNetwork === undefined ? {} : { rpcNetwork: options.rpcNetwork }),
 		})
-		if (options.simulationMode || options.signerAddress === undefined || selection === undefined) return
+		if (options.simulationMode || options.signerAddress === undefined || selection === undefined) return finishAccessUpdate
 		if (selection.type === 'signer') {
 			await rememberSigningAddressSelection({ signerAddress: options.signerAddress, selection: 'signer' })
-			return
+			return finishAccessUpdate
 		}
 		if (selection.entry.type !== 'safe') throw new Error('Signing mode can only activate the external signer or an owned Gnosis Safe.')
 		await rememberSigningAddressSelection({
@@ -174,6 +170,7 @@ export async function activateAddressSelection(
 			safeAddress: selection.entry.address,
 			chainId: selection.entry.chainId,
 		})
+		return finishAccessUpdate
 	})
 }
 

--- a/app/ts/background/activeSettings.ts
+++ b/app/ts/background/activeSettings.ts
@@ -4,7 +4,7 @@ import type { TokenPriceService } from '../simulation/services/priceEstimator.js
 import type { RpcNetwork } from '../types/rpc.js'
 import type { WebsiteTabConnections } from '../types/user-interface-types.js'
 import { Semaphore } from '../utils/semaphore.js'
-import { sendActiveAccountChangeToApprovedWebsitePorts, sendMessageToApprovedWebsitePorts, updateWebsiteApprovalAccesses } from './accessManagement.js'
+import { promptForWebsiteAccesses, sendActiveAccountChangeToApprovedWebsitePorts, sendMessageToApprovedWebsitePorts, updateWebsiteApprovalAccesses } from './accessManagement.js'
 import { sendPopupMessageToOpenWindows } from './backgroundUtils.js'
 import { updatePopupVisualisationIfNeeded } from './popupVisualisationUpdater.js'
 import { bumpPopupRefreshGeneration } from './popupRefreshGeneration.js'
@@ -87,7 +87,8 @@ async function changeActiveAddressAndChainUnlocked(
 	}
 
 	const updatedSettings = await getSettings()
-	const popupRefreshGeneration = await updateWebsiteApprovalAccesses(ethereum, tokenPriceService, resetSimulationServices, websiteTabConnections, updatedSettings, change.promptForAccessesIfNeeded ?? true)
+	// Access approvals can change the active address while holding the dialog lock; prompt only after releasing our lock.
+	const popupRefreshGeneration = await updateWebsiteApprovalAccesses(ethereum, tokenPriceService, resetSimulationServices, websiteTabConnections, updatedSettings, false)
 	sendPopupMessageToOpenWindows({ method: 'popup_settingsUpdated', data: updatedSettings, popupRefreshGeneration })
 	sendPopupMessageToOpenWindows({ method: 'popup_accounts_update' })
 	const activeSigningSafeContextChanged = !updatedSettings.simulationMode
@@ -123,6 +124,7 @@ export async function changeActiveAddressAndChain(
 		websiteTabConnections,
 		change,
 	))
+	if (change.promptForAccessesIfNeeded ?? true) await promptForWebsiteAccesses(ethereum, tokenPriceService, resetSimulationServices, websiteTabConnections)
 }
 
 export async function activateAddressSelection(
@@ -148,7 +150,6 @@ export async function activateAddressSelection(
 			activeAddress: selection?.type === 'signer' ? selection.address : selection?.entry.address,
 			...(!options.simulationMode ? { signingAddressSelection: selection?.type === 'addressBookEntry' && selection.entry.type === 'safe' ? 'safe' as const : 'signer' as const } : {}),
 			...(options.rpcNetwork === undefined ? {} : { rpcNetwork: options.rpcNetwork }),
-			...(options.promptForAccessesIfNeeded === undefined ? {} : { promptForAccessesIfNeeded: options.promptForAccessesIfNeeded }),
 		})
 		if (options.simulationMode || options.signerAddress === undefined || selection === undefined) return
 		if (selection.type === 'signer') {
@@ -163,6 +164,7 @@ export async function activateAddressSelection(
 			chainId: selection.entry.chainId,
 		})
 	})
+	if (options.promptForAccessesIfNeeded ?? true) await promptForWebsiteAccesses(ethereum, tokenPriceService, resetSimulationServices, websiteTabConnections)
 }
 
 export async function changeActiveRpc(ethereum: EthereumClientService, tokenPriceService: TokenPriceService, resetSimulationServices: ResetSimulationServices, websiteTabConnections: WebsiteTabConnections, rpcNetwork: RpcNetwork, simulationMode: boolean, signerTabId: number | undefined) {

--- a/app/ts/background/iconHandler.ts
+++ b/app/ts/background/iconHandler.ts
@@ -1,6 +1,7 @@
 import { ICON_ACCESS_DENIED, ICON_ACTIVE, ICON_ACTIVE_WITH_SHIELD, ICON_INTERCEPTOR_DISABLED, ICON_NOT_ACTIVE, ICON_NOT_ACTIVE_WITH_SHIELD, ICON_SIGNING, ICON_SIGNING_NOT_SUPPORTED, ICON_SIGNING_NOT_SUPPORTED_WITH_SHIELD, ICON_SIGNING_WITH_SHIELD, ICON_SIMULATING, ICON_SIMULATING_WITH_SHIELD, PRIMARY_COLOR, WARNING_COLOR } from '../utils/constants.js'
 import { areWeBlocking, hasAccess, hasAddressAccess } from './accessManagement.js'
 import { getActiveAddress, sendPopupMessageToOpenWindows, setExtensionBadgeBackgroundColor, setExtensionBadgeText, setExtensionIcon, setExtensionTitle } from './backgroundUtils.js'
+import { createScopedKeyedSerialExecutor } from '../utils/semaphore.js'
 import { Future } from '../utils/future.js'
 import type { TabIcon, TabState, WebsiteTabConnections } from '../types/user-interface-types.js'
 import { getSettings, getWebsiteAccess } from './settings.js'
@@ -106,32 +107,37 @@ async function waitForLoadedTab(tabId: number) {
 	}
 }
 
-export async function updateExtensionIcon(websiteTabConnections: WebsiteTabConnections, tabId: number, websiteOrigin: string, popupRefreshGeneration: number) {
-	if (!(await doesTabExist(tabId))) {
-		await removeTabState(tabId)
-		return
-	}
-	const blockingWebsitePromise = areWeBlocking(websiteTabConnections, tabId, websiteOrigin)
-	silenceChromeUnCaughtPromise(blockingWebsitePromise)
-	const addShieldIfNeeded = async (icon: TabIcon): Promise<TabIcon> => await blockingWebsitePromise ? addBlockingShieldToIcon(icon) : icon
-	const setIcon = async (icon: TabIcon, iconReason: string) => setInterceptorIcon(tabId, await addShieldIfNeeded(icon), await blockingWebsitePromise ? `${ iconReason } The Interceptor is blocking external requests made by the website.` : iconReason, popupRefreshGeneration)
+const runTabIconUpdate = createScopedKeyedSerialExecutor<object, number>()
 
-	const settings = await getSettings()
-	if (hasAccess(settings.websiteAccess, websiteOrigin) === 'interceptorDisabled') return setIcon(ICON_INTERCEPTOR_DISABLED, `The Interceptor is disabled for ${ websiteOrigin } by user request.`)
-	const activeAddress = await getActiveAddress(settings, tabId)
-	if (activeAddress === undefined) return setIcon(ICON_NOT_ACTIVE, 'No active address selected.')
-	const addressAccess = hasAddressAccess(settings.websiteAccess, websiteOrigin, activeAddress)
-	if (addressAccess === 'askAccess') return setIcon(ICON_NOT_ACTIVE, `${ websiteOrigin } has PENDING access request for ${ activeAddress.name }!`)
-	if (addressAccess !== 'hasAccess') {
-		if (hasAccess(settings.websiteAccess, websiteOrigin) === 'noAccess') {
-			return setIcon(ICON_ACCESS_DENIED, `The access for ${ websiteOrigin } has been DENIED!`)
+export async function updateExtensionIcon(websiteTabConnections: WebsiteTabConnections, tabId: number, websiteOrigin: string, popupRefreshGeneration: number) {
+	// Keep a tab's stored state and browser action writes ordered, without blocking active settings or other tabs.
+	await runTabIconUpdate(browser, tabId, async () => {
+		if (!(await doesTabExist(tabId))) {
+			await removeTabState(tabId)
+			return
 		}
-		return setIcon(ICON_ACCESS_DENIED, `The access to ${ activeAddress.name } for ${ websiteOrigin } has been DENIED!`)
-	}
-	if (settings.simulationMode) return setIcon(ICON_SIMULATING, 'The Interceptor simulates your sent transactions.')
-	if (settings.activeRpcNetwork.httpsRpc === undefined) return setIcon(ICON_SIGNING_NOT_SUPPORTED, `The Interceptor is disabled while it's on an unsupported network`)
-	const tabState = await getTabState(tabId)
-	return setIcon(ICON_SIGNING, `The Interceptor forwards your transactions to ${ getPrettySignerName(tabState.signerName) } once sent.`)
+		const blockingWebsitePromise = areWeBlocking(websiteTabConnections, tabId, websiteOrigin)
+		silenceChromeUnCaughtPromise(blockingWebsitePromise)
+		const addShieldIfNeeded = async (icon: TabIcon): Promise<TabIcon> => await blockingWebsitePromise ? addBlockingShieldToIcon(icon) : icon
+		const setIcon = async (icon: TabIcon, iconReason: string) => setInterceptorIcon(tabId, await addShieldIfNeeded(icon), await blockingWebsitePromise ? `${ iconReason } The Interceptor is blocking external requests made by the website.` : iconReason, popupRefreshGeneration)
+
+		const settings = await getSettings()
+		if (hasAccess(settings.websiteAccess, websiteOrigin) === 'interceptorDisabled') return setIcon(ICON_INTERCEPTOR_DISABLED, `The Interceptor is disabled for ${ websiteOrigin } by user request.`)
+		const activeAddress = await getActiveAddress(settings, tabId)
+		if (activeAddress === undefined) return setIcon(ICON_NOT_ACTIVE, 'No active address selected.')
+		const addressAccess = hasAddressAccess(settings.websiteAccess, websiteOrigin, activeAddress)
+		if (addressAccess === 'askAccess') return setIcon(ICON_NOT_ACTIVE, `${ websiteOrigin } has PENDING access request for ${ activeAddress.name }!`)
+		if (addressAccess !== 'hasAccess') {
+			if (hasAccess(settings.websiteAccess, websiteOrigin) === 'noAccess') {
+				return setIcon(ICON_ACCESS_DENIED, `The access for ${ websiteOrigin } has been DENIED!`)
+			}
+			return setIcon(ICON_ACCESS_DENIED, `The access to ${ activeAddress.name } for ${ websiteOrigin } has been DENIED!`)
+		}
+		if (settings.simulationMode) return setIcon(ICON_SIMULATING, 'The Interceptor simulates your sent transactions.')
+		if (settings.activeRpcNetwork.httpsRpc === undefined) return setIcon(ICON_SIGNING_NOT_SUPPORTED, `The Interceptor is disabled while it's on an unsupported network`)
+		const tabState = await getTabState(tabId)
+		return setIcon(ICON_SIGNING, `The Interceptor forwards your transactions to ${ getPrettySignerName(tabState.signerName) } once sent.`)
+	})
 }
 
 export async function updateExtensionBadge() {

--- a/test/tests/activeAddressSelection.test.ts
+++ b/test/tests/activeAddressSelection.test.ts
@@ -296,7 +296,7 @@ describe('active address selection', () => {
 	})
 
 	test('keeps activation choreography in the shared background orchestrator', () => {
-		assert.match(activeSettingsSource, /export async function activateAddressSelection[\s\S]*?setUseSignersAddressAsActiveAddress[\s\S]*?changeActiveAddressAndChain[\s\S]*?rememberSigningAddressSelection/u)
+		assert.match(activeSettingsSource, /async function runActiveSettingsChange[\s\S]*?setUseSignersAddressAsActiveAddress[\s\S]*?changeSimulationMode[\s\S]*?rememberSigningAddressSelection/u)
 		assert.doesNotMatch(activeSettingsSource, /inferredSafeEntryOnActiveChain/u)
 		assert.match(activeSettingsSource, /Signing address changes must identify whether the selection is the signer or a Safe\./u)
 		assert.match(providerMessageHandlersSource, /!settings\.simulationMode \? \{ signingAddressSelection: 'signer'/u)

--- a/test/tests/activeSettingsConcurrency.test.ts
+++ b/test/tests/activeSettingsConcurrency.test.ts
@@ -1,0 +1,59 @@
+import * as assert from 'node:assert'
+import { describe, test } from 'bun:test'
+import type { ResetSimulationServices } from '../../app/ts/simulation/serviceLifecycle.js'
+import type { RpcEntry } from '../../app/ts/types/rpc.js'
+import { createDeferredSignal, createEthereumWithGetBlockCounter, installBrowserMock, loadModules } from './backgroundEthAccountsTestHarness.js'
+
+describe('active settings concurrency', () => {
+	test('publishes concurrent network transitions in persisted order', async () => {
+		installBrowserMock()
+		const firstRpcWriteStarted = createDeferredSignal()
+		const originalStorageSet = browser.storage.local.set.bind(browser.storage.local)
+		let deferredFirstRpcWrite = false
+		Object.defineProperty(browser.storage.local, 'set', {
+			configurable: true,
+			value: async (items: object) => {
+				await originalStorageSet(items)
+				if (deferredFirstRpcWrite || !('activeRpcNetwork' in items)) return
+				deferredFirstRpcWrite = true
+				firstRpcWriteStarted.resolve()
+				await new Promise((resolve) => setTimeout(resolve, 0))
+			},
+		})
+		const { changeActiveAddressAndChain, getSettings } = await loadModules()
+		const previousNetwork = (await getSettings()).activeRpcNetwork
+		const firstNetwork = {
+			...previousNetwork,
+			name: 'First network',
+			chainId: 10n,
+			httpsRpc: 'https://first.invalid',
+			primary: false,
+		} satisfies RpcEntry
+		const secondNetwork = {
+			...previousNetwork,
+			name: 'Second network',
+			chainId: 42161n,
+			httpsRpc: 'https://second.invalid',
+			primary: false,
+		} satisfies RpcEntry
+		const resetNetworks: RpcEntry[] = []
+		const resetSimulationServices: ResetSimulationServices = (network) => { resetNetworks.push(network) }
+		const { ethereum, tokenPriceService } = createEthereumWithGetBlockCounter({ count: 0 })
+
+		const firstTransition = changeActiveAddressAndChain(ethereum, tokenPriceService, resetSimulationServices, new Map(), {
+			simulationMode: false,
+			rpcNetwork: firstNetwork,
+			promptForAccessesIfNeeded: false,
+		})
+		await firstRpcWriteStarted.promise
+		const secondTransition = changeActiveAddressAndChain(ethereum, tokenPriceService, resetSimulationServices, new Map(), {
+			simulationMode: false,
+			rpcNetwork: secondNetwork,
+			promptForAccessesIfNeeded: false,
+		})
+		await Promise.all([firstTransition, secondTransition])
+
+		assert.deepEqual(resetNetworks.map((network) => network.chainId), [firstNetwork.chainId, secondNetwork.chainId])
+		assert.equal((await getSettings()).activeRpcNetwork.chainId, secondNetwork.chainId)
+	})
+})

--- a/test/tests/activeSettingsConcurrency.test.ts
+++ b/test/tests/activeSettingsConcurrency.test.ts
@@ -1,7 +1,7 @@
 import * as assert from 'node:assert'
 import { describe, expect, test } from 'bun:test'
 import type { ContactEntry, SafeEntry } from '../../app/ts/types/addressBookTypes.js'
-import type { WebsiteTabConnections } from '../../app/ts/types/user-interface-types.js'
+import type { TabConnection, WebsiteTabConnections } from '../../app/ts/types/user-interface-types.js'
 import type { ResetSimulationServices } from '../../app/ts/simulation/serviceLifecycle.js'
 import type { RpcEntry } from '../../app/ts/types/rpc.js'
 import { createDeferredSignal, createEthereumWithGetBlockCounter, createPort, installBrowserMock, loadModules, noopPublishRpcConnectionStatus } from './backgroundEthAccountsTestHarness.js'
@@ -213,5 +213,46 @@ describe('active settings concurrency', () => {
 		assert.equal((await getSettings()).activeSimulationAddress, selectedAddress.address)
 		assert.equal((await getLatestUnexpectedError())?.data.message, 'Access popup failed to open')
 		await assert.rejects(updateWebsiteApprovalAccesses(ethereum, tokenPriceService, resetSimulationServices, connections, await getSettings(), true, true), /Access popup failed to open/u)
+	})
+
+	test.each([1, 2])('continues prompting after a failure when the next connection is in tab %j', async (secondTabId) => {
+		installBrowserMock()
+		const { changeActiveAddressAndChain, getLatestUnexpectedError, updateUserAddressBookEntries, websiteSocketToString, getPendingAccessRequests, resolveInterceptorAccess } = await loadModules()
+		const selectedAddress = { ...secondAddress, askForAddressAccess: true }
+		await updateUserAddressBookEntries(() => [selectedAddress])
+		const connections: WebsiteTabConnections = new Map()
+		for (const [tabId, connectionName, websiteOrigin] of [[1, 0n, 'first.test'], [secondTabId, 1n, 'second.test']] as const) {
+			const socket = { tabId, connectionName }
+			const { port } = createPort(tabId, undefined, undefined, connectionName)
+			const tab: TabConnection = connections.get(tabId) ?? { connections: {} }
+			tab.connections[websiteSocketToString(socket)] = { port, socket, websiteOrigin, approved: false, wantsToConnect: true }
+			connections.set(tabId, tab)
+		}
+		const originalCreate = browser.windows.create.bind(browser.windows)
+		let promptAttempts = 0
+		Object.defineProperty(browser.windows, 'create', {
+			configurable: true,
+			value: async (...args: Parameters<typeof browser.windows.create>) => {
+				promptAttempts += 1
+				if (promptAttempts === 1) throw new Error('First connection prompt failed')
+				return await originalCreate(...args)
+			},
+		})
+		const { ethereum, tokenPriceService, resetSimulationServices } = createEthereumWithGetBlockCounter({ count: 0 })
+		await changeActiveAddressAndChain(ethereum, tokenPriceService, resetSimulationServices, connections, { simulationMode: true, activeAddress: selectedAddress.address })
+		const pending = await getPendingAccessRequests()
+		try {
+			assert.equal(promptAttempts, 2)
+			assert.equal((await getLatestUnexpectedError())?.data.message, 'First connection prompt failed')
+			expect(pending.map((request) => request.website.websiteOrigin)).toEqual(['second.test'])
+		} finally {
+			// Close the successful prompt so the shared dialog state cannot leak into another test.
+			for (const request of pending) {
+				await resolveInterceptorAccess(ethereum, tokenPriceService, resetSimulationServices, connections, {
+					userReply: 'noResponse', accessRequestId: request.accessRequestId,
+					originalRequestAccessToAddress: selectedAddress.address, requestAccessToAddress: selectedAddress.address,
+				}, noopPublishRpcConnectionStatus)
+			}
+		}
 	})
 })

--- a/test/tests/activeSettingsConcurrency.test.ts
+++ b/test/tests/activeSettingsConcurrency.test.ts
@@ -317,9 +317,9 @@ describe('active settings concurrency', () => {
 		expect((await getTabState(1)).tabIconDetails).toEqual({ icon: ICON_NOT_ACTIVE, iconReason: expectedTitle })
 	})
 
-	test.each(['immediate', 'scoped'])('%s access updates prompt for the latest address rather than the reconciliation snapshot', async (completion) => {
+	test.each(['immediate', 'staged'])('%s access updates prompt for the latest address rather than the reconciliation snapshot', async (completion) => {
 		installBrowserMock()
-		const { changeSimulationMode, getSettings, updateUserAddressBookEntries, websiteSocketToString, runWithWebsiteAccessUpdates, updateWebsiteApprovalAccesses, getPendingAccessRequests, resolveInterceptorAccess } = await loadModules()
+		const { changeSimulationMode, getSettings, updateUserAddressBookEntries, websiteSocketToString, reconcileWebsiteApprovalAccesses, finishWebsiteAccessUpdate, updateWebsiteApprovalAccesses, getPendingAccessRequests, resolveInterceptorAccess } = await loadModules()
 		const originalAddress = { ...firstAddress, askForAddressAccess: true }
 		const selectedAddress = { ...secondAddress, askForAddressAccess: true }
 		await updateUserAddressBookEntries(() => [originalAddress, selectedAddress])
@@ -331,14 +331,10 @@ describe('active settings concurrency', () => {
 			[websiteSocketToString(socket)]: { port, socket, websiteOrigin: 'example.test', approved: false, wantsToConnect: true },
 		} }]])
 		const { ethereum, tokenPriceService, resetSimulationServices } = createEthereumWithGetBlockCounter({ count: 0 })
-		if (completion === 'scoped') {
-			await runWithWebsiteAccessUpdates(ethereum, tokenPriceService, resetSimulationServices, connections, true,
-				async (operation) => await operation(),
-				async (reconcile) => {
-					await reconcile(snapshot)
-					await changeSimulationMode({ simulationMode: true, activeSimulationAddress: selectedAddress.address })
-				},
-			)
+		if (completion === 'staged') {
+			const update = await reconcileWebsiteApprovalAccesses(connections, snapshot)
+			await changeSimulationMode({ simulationMode: true, activeSimulationAddress: selectedAddress.address })
+			await finishWebsiteAccessUpdate(ethereum, tokenPriceService, resetSimulationServices, connections, update, true)
 		} else {
 			await changeSimulationMode({ simulationMode: true, activeSimulationAddress: selectedAddress.address })
 			await updateWebsiteApprovalAccesses(ethereum, tokenPriceService, resetSimulationServices, connections, snapshot, true)

--- a/test/tests/activeSettingsConcurrency.test.ts
+++ b/test/tests/activeSettingsConcurrency.test.ts
@@ -317,9 +317,9 @@ describe('active settings concurrency', () => {
 		expect((await getTabState(1)).tabIconDetails).toEqual({ icon: ICON_NOT_ACTIVE, iconReason: expectedTitle })
 	})
 
-	test.each(['immediate', 'deferred'])('%s access updates prompt for the latest address rather than the reconciliation snapshot', async (completion) => {
+	test.each(['immediate', 'scoped'])('%s access updates prompt for the latest address rather than the reconciliation snapshot', async (completion) => {
 		installBrowserMock()
-		const { changeSimulationMode, getSettings, updateUserAddressBookEntries, websiteSocketToString, reconcileWebsiteApprovalAccesses, updateWebsiteApprovalAccesses, getPendingAccessRequests, resolveInterceptorAccess } = await loadModules()
+		const { changeSimulationMode, getSettings, updateUserAddressBookEntries, websiteSocketToString, runWithWebsiteAccessUpdates, updateWebsiteApprovalAccesses, getPendingAccessRequests, resolveInterceptorAccess } = await loadModules()
 		const originalAddress = { ...firstAddress, askForAddressAccess: true }
 		const selectedAddress = { ...secondAddress, askForAddressAccess: true }
 		await updateUserAddressBookEntries(() => [originalAddress, selectedAddress])
@@ -331,15 +331,65 @@ describe('active settings concurrency', () => {
 			[websiteSocketToString(socket)]: { port, socket, websiteOrigin: 'example.test', approved: false, wantsToConnect: true },
 		} }]])
 		const { ethereum, tokenPriceService, resetSimulationServices } = createEthereumWithGetBlockCounter({ count: 0 })
-		const update = completion === 'deferred'
-			? await reconcileWebsiteApprovalAccesses(ethereum, tokenPriceService, resetSimulationServices, connections, snapshot, true)
-			: undefined
-		await changeSimulationMode({ simulationMode: true, activeSimulationAddress: selectedAddress.address })
-		if (update !== undefined) await update.finish()
-		else await updateWebsiteApprovalAccesses(ethereum, tokenPriceService, resetSimulationServices, connections, snapshot, true)
+		if (completion === 'scoped') {
+			await runWithWebsiteAccessUpdates(ethereum, tokenPriceService, resetSimulationServices, connections, true,
+				async (operation) => await operation(),
+				async (reconcile) => {
+					await reconcile(snapshot)
+					await changeSimulationMode({ simulationMode: true, activeSimulationAddress: selectedAddress.address })
+				},
+			)
+		} else {
+			await changeSimulationMode({ simulationMode: true, activeSimulationAddress: selectedAddress.address })
+			await updateWebsiteApprovalAccesses(ethereum, tokenPriceService, resetSimulationServices, connections, snapshot, true)
+		}
 		const pending = await getPendingAccessRequests()
 		try {
 			expect(pending.map((request) => request.requestAccessToAddress?.address)).toEqual([selectedAddress.address])
+		} finally {
+			for (const request of pending) {
+				await resolveInterceptorAccess(ethereum, tokenPriceService, resetSimulationServices, connections, {
+					userReply: 'noResponse', accessRequestId: request.accessRequestId,
+					originalRequestAccessToAddress: selectedAddress.address, requestAccessToAddress: selectedAddress.address,
+				}, noopPublishRpcConnectionStatus)
+			}
+		}
+	})
+
+	test('rejects an invalid signing selection before changing stored settings', async () => {
+		installBrowserMock()
+		const { activateAddressSelection } = await loadModules()
+		const before = await browser.storage.local.get()
+		const { ethereum, tokenPriceService, resetSimulationServices } = createEthereumWithGetBlockCounter({ count: 0 })
+		await assert.rejects(activateAddressSelection(ethereum, tokenPriceService, resetSimulationServices, new Map(), { type: 'addressBookEntry', entry: secondAddress }, {
+			simulationMode: false, signerAddress: firstAddress.address,
+		}), /Signing mode can only activate the external signer or an owned Gnosis Safe/u)
+		expect(await browser.storage.local.get()).toEqual(before)
+	})
+
+	test.each(['direct', 'selection'])('completes access UI after a persisted %s transition throws', async (entryPoint) => {
+		installBrowserMock()
+		const { activateAddressSelection, changeActiveAddressAndChain, getSettings, getTabState, updateUserAddressBookEntries, websiteSocketToString, getPendingAccessRequests, resolveInterceptorAccess } = await loadModules()
+		const selectedAddress = { ...secondAddress, askForAddressAccess: true }
+		await updateUserAddressBookEntries(() => [selectedAddress])
+		const socket = { tabId: 1, connectionName: 0n }
+		const { port } = createPort(1)
+		const connections: WebsiteTabConnections = new Map([[1, { connections: {
+			[websiteSocketToString(socket)]: { port, socket, websiteOrigin: 'example.test', approved: false, wantsToConnect: true },
+		} }]])
+		const { ethereum, tokenPriceService, resetSimulationServices } = createEthereumWithGetBlockCounter({ count: 0 })
+		const rpcNetwork = (await getSettings()).activeRpcNetwork
+		const failure = new Error('Service reset failed after settings persisted')
+		const failReset: ResetSimulationServices = () => { throw failure }
+		const transition = entryPoint === 'direct'
+			? changeActiveAddressAndChain(ethereum, tokenPriceService, failReset, connections, { simulationMode: true, activeAddress: selectedAddress.address, rpcNetwork })
+			: activateAddressSelection(ethereum, tokenPriceService, failReset, connections, { type: 'addressBookEntry', entry: selectedAddress }, { simulationMode: true, signerAddress: undefined, rpcNetwork })
+		await assert.rejects(transition, (error: unknown) => error === failure)
+		const pending = await getPendingAccessRequests()
+		try {
+			assert.equal((await getSettings()).activeSimulationAddress, selectedAddress.address)
+			expect(pending.map((request) => request.requestAccessToAddress?.address)).toEqual([selectedAddress.address])
+			expect((await getTabState(1)).tabIconDetails).toEqual({ icon: ICON_NOT_ACTIVE, iconReason: 'example.test has PENDING access request for Second address!' })
 		} finally {
 			for (const request of pending) {
 				await resolveInterceptorAccess(ethereum, tokenPriceService, resetSimulationServices, connections, {

--- a/test/tests/activeSettingsConcurrency.test.ts
+++ b/test/tests/activeSettingsConcurrency.test.ts
@@ -3,6 +3,7 @@ import { describe, expect, test } from 'bun:test'
 import type { ContactEntry, SafeEntry } from '../../app/ts/types/addressBookTypes.js'
 import type { TabConnection, WebsiteTabConnections } from '../../app/ts/types/user-interface-types.js'
 import type { ResetSimulationServices } from '../../app/ts/simulation/serviceLifecycle.js'
+import { ICON_NOT_ACTIVE } from '../../app/ts/utils/constants.js'
 import type { RpcEntry } from '../../app/ts/types/rpc.js'
 import { createDeferredSignal, createEthereumWithGetBlockCounter, createPort, installBrowserMock, loadModules, noopPublishRpcConnectionStatus } from './backgroundEthAccountsTestHarness.js'
 
@@ -247,6 +248,99 @@ describe('active settings concurrency', () => {
 			expect(pending.map((request) => request.website.websiteOrigin)).toEqual(['second.test'])
 		} finally {
 			// Close the successful prompt so the shared dialog state cannot leak into another test.
+			for (const request of pending) {
+				await resolveInterceptorAccess(ethereum, tokenPriceService, resetSimulationServices, connections, {
+					userReply: 'noResponse', accessRequestId: request.accessRequestId,
+					originalRequestAccessToAddress: selectedAddress.address, requestAccessToAddress: selectedAddress.address,
+				}, noopPublishRpcConnectionStatus)
+			}
+		}
+	})
+
+	test('a slow icon refresh does not block the next address change or leave stale toolbar state', async () => {
+		installBrowserMock()
+		const { changeActiveAddressAndChain, getSettings, updateUserAddressBookEntries, updateWebsiteAccess, websiteSocketToString, getTabState } = await loadModules()
+		await updateUserAddressBookEntries(() => [firstAddress, { ...secondAddress, askForAddressAccess: true }])
+		const websiteOrigin = 'example.test'
+		await updateWebsiteAccess(() => [{ website: { websiteOrigin }, access: true }])
+		const secondAccountPublished = createDeferredSignal()
+		const { port } = createPort(1, (message) => {
+			if (message.method === 'accountsChanged' && Array.isArray(message.result) && message.result.length === 0) secondAccountPublished.resolve()
+		})
+		const socket = { tabId: 1, connectionName: 0n }
+		const connections: WebsiteTabConnections = new Map([[1, { connections: {
+			[websiteSocketToString(socket)]: { port, socket, websiteOrigin, approved: true, wantsToConnect: true },
+		} }]])
+		const iconStarted = createDeferredSignal()
+		const releaseIcon = createDeferredSignal()
+		const originalSetIcon = browser.action.setIcon.bind(browser.action)
+		let lastIcon: unknown
+		let lastTitle: string | undefined
+		Object.defineProperty(browser.action, 'setTitle', {
+			configurable: true,
+			value: async (details: Parameters<typeof browser.action.setTitle>[0]) => { lastTitle = details.title },
+		})
+		let paused = false
+		Object.defineProperty(browser.action, 'setIcon', {
+			configurable: true,
+			value: async (...args: Parameters<typeof browser.action.setIcon>) => {
+				if (!paused) {
+					paused = true
+					iconStarted.resolve()
+					await releaseIcon.promise
+				}
+				lastIcon = args[0].path
+				return await originalSetIcon(...args)
+			},
+		})
+		const { ethereum, tokenPriceService, resetSimulationServices } = createEthereumWithGetBlockCounter({ count: 0 })
+		const first = changeActiveAddressAndChain(ethereum, tokenPriceService, resetSimulationServices, connections, { simulationMode: true, activeAddress: firstAddress.address, promptForAccessesIfNeeded: false })
+		await iconStarted.promise
+		const second = changeActiveAddressAndChain(ethereum, tokenPriceService, resetSimulationServices, connections, { simulationMode: true, activeAddress: secondAddress.address, promptForAccessesIfNeeded: false })
+		let timeout: ReturnType<typeof setTimeout> | undefined
+		try {
+			await Promise.race([
+				secondAccountPublished.promise,
+				new Promise((_, reject) => { timeout = setTimeout(() => reject(new Error('Icon refresh blocked the next settings transition')), 1000) }),
+			])
+			assert.equal((await getSettings()).activeSimulationAddress, secondAddress.address)
+			// Let any unqueued second icon update finish before the first browser call resumes.
+			await new Promise((resolve) => setTimeout(resolve, 0))
+		} finally {
+			clearTimeout(timeout)
+			releaseIcon.resolve()
+			await Promise.all([first, second])
+		}
+		const expectedTitle = 'example.test has PENDING access request for Second address!'
+		expect(lastIcon).toEqual({ 128: ICON_NOT_ACTIVE })
+		assert.equal(lastTitle, expectedTitle)
+		expect((await getTabState(1)).tabIconDetails).toEqual({ icon: ICON_NOT_ACTIVE, iconReason: expectedTitle })
+	})
+
+	test.each(['immediate', 'deferred'])('%s access updates prompt for the latest address rather than the reconciliation snapshot', async (completion) => {
+		installBrowserMock()
+		const { changeSimulationMode, getSettings, updateUserAddressBookEntries, websiteSocketToString, reconcileWebsiteApprovalAccesses, updateWebsiteApprovalAccesses, getPendingAccessRequests, resolveInterceptorAccess } = await loadModules()
+		const originalAddress = { ...firstAddress, askForAddressAccess: true }
+		const selectedAddress = { ...secondAddress, askForAddressAccess: true }
+		await updateUserAddressBookEntries(() => [originalAddress, selectedAddress])
+		await changeSimulationMode({ simulationMode: true, activeSimulationAddress: originalAddress.address })
+		const snapshot = await getSettings()
+		const socket = { tabId: 1, connectionName: 0n }
+		const { port } = createPort(1)
+		const connections: WebsiteTabConnections = new Map([[1, { connections: {
+			[websiteSocketToString(socket)]: { port, socket, websiteOrigin: 'example.test', approved: false, wantsToConnect: true },
+		} }]])
+		const { ethereum, tokenPriceService, resetSimulationServices } = createEthereumWithGetBlockCounter({ count: 0 })
+		const update = completion === 'deferred'
+			? await reconcileWebsiteApprovalAccesses(ethereum, tokenPriceService, resetSimulationServices, connections, snapshot, true)
+			: undefined
+		await changeSimulationMode({ simulationMode: true, activeSimulationAddress: selectedAddress.address })
+		if (update !== undefined) await update.finish()
+		else await updateWebsiteApprovalAccesses(ethereum, tokenPriceService, resetSimulationServices, connections, snapshot, true)
+		const pending = await getPendingAccessRequests()
+		try {
+			expect(pending.map((request) => request.requestAccessToAddress?.address)).toEqual([selectedAddress.address])
+		} finally {
 			for (const request of pending) {
 				await resolveInterceptorAccess(ethereum, tokenPriceService, resetSimulationServices, connections, {
 					userReply: 'noResponse', accessRequestId: request.accessRequestId,

--- a/test/tests/activeSettingsConcurrency.test.ts
+++ b/test/tests/activeSettingsConcurrency.test.ts
@@ -1,26 +1,45 @@
 import * as assert from 'node:assert'
-import { describe, test } from 'bun:test'
+import { describe, expect, test } from 'bun:test'
+import type { ContactEntry, SafeEntry } from '../../app/ts/types/addressBookTypes.js'
+import type { WebsiteTabConnections } from '../../app/ts/types/user-interface-types.js'
 import type { ResetSimulationServices } from '../../app/ts/simulation/serviceLifecycle.js'
 import type { RpcEntry } from '../../app/ts/types/rpc.js'
-import { createDeferredSignal, createEthereumWithGetBlockCounter, installBrowserMock, loadModules } from './backgroundEthAccountsTestHarness.js'
+import { createDeferredSignal, createEthereumWithGetBlockCounter, createPort, installBrowserMock, loadModules, noopPublishRpcConnectionStatus } from './backgroundEthAccountsTestHarness.js'
+
+const firstAddress: ContactEntry = { type: 'contact', name: 'First address', address: 1n, chainId: 'AllChains', entrySource: 'User', useAsActiveAddress: true, askForAddressAccess: false }
+const secondAddress: ContactEntry = { ...firstAddress, name: 'Second address', address: 2n }
+
+// Yield after persistence so the next transition can attempt to overtake unfinished side effects.
+function pauseAfterFirstStorageWrite(key: string) {
+	const started = createDeferredSignal()
+	const originalSet = browser.storage.local.set.bind(browser.storage.local)
+	let paused = false
+	Object.defineProperty(browser.storage.local, 'set', {
+		configurable: true,
+		value: async (items: object) => {
+			await originalSet(items)
+			if (paused || !(key in items)) return
+			paused = true
+			started.resolve()
+			await new Promise((resolve) => setTimeout(resolve, 0))
+		},
+	})
+	return started.promise
+}
 
 describe('active settings concurrency', () => {
 	test('publishes concurrent network transitions in persisted order', async () => {
 		installBrowserMock()
-		const firstRpcWriteStarted = createDeferredSignal()
-		const originalStorageSet = browser.storage.local.set.bind(browser.storage.local)
-		let deferredFirstRpcWrite = false
-		Object.defineProperty(browser.storage.local, 'set', {
-			configurable: true,
-			value: async (items: object) => {
-				await originalStorageSet(items)
-				if (deferredFirstRpcWrite || !('activeRpcNetwork' in items)) return
-				deferredFirstRpcWrite = true
-				firstRpcWriteStarted.resolve()
-				await new Promise((resolve) => setTimeout(resolve, 0))
-			},
-		})
-		const { changeActiveAddressAndChain, getSettings } = await loadModules()
+		const { changeActiveAddressAndChain, getSettings, updateUserAddressBookEntries, updateWebsiteAccess, websiteSocketToString } = await loadModules()
+		await updateUserAddressBookEntries(() => [firstAddress, secondAddress])
+		const websiteOrigin = 'example.test'
+		await updateWebsiteAccess(() => [{ website: { websiteOrigin }, access: true }])
+		const { port, messages } = createPort(1)
+		const socket = { tabId: 1, connectionName: 0n }
+		const connections: WebsiteTabConnections = new Map([[1, { connections: {
+			[websiteSocketToString(socket)]: { port, socket, websiteOrigin, approved: true, wantsToConnect: true },
+		} }]])
+		const firstRpcWriteStarted = pauseAfterFirstStorageWrite('activeRpcNetwork')
 		const previousNetwork = (await getSettings()).activeRpcNetwork
 		const firstNetwork = {
 			...previousNetwork,
@@ -40,20 +59,159 @@ describe('active settings concurrency', () => {
 		const resetSimulationServices: ResetSimulationServices = (network) => { resetNetworks.push(network) }
 		const { ethereum, tokenPriceService } = createEthereumWithGetBlockCounter({ count: 0 })
 
-		const firstTransition = changeActiveAddressAndChain(ethereum, tokenPriceService, resetSimulationServices, new Map(), {
-			simulationMode: false,
+		const firstTransition = changeActiveAddressAndChain(ethereum, tokenPriceService, resetSimulationServices, connections, {
+			simulationMode: true,
 			rpcNetwork: firstNetwork,
+			activeAddress: firstAddress.address,
 			promptForAccessesIfNeeded: false,
 		})
-		await firstRpcWriteStarted.promise
-		const secondTransition = changeActiveAddressAndChain(ethereum, tokenPriceService, resetSimulationServices, new Map(), {
-			simulationMode: false,
+		await firstRpcWriteStarted
+		const secondTransition = changeActiveAddressAndChain(ethereum, tokenPriceService, resetSimulationServices, connections, {
+			simulationMode: true,
 			rpcNetwork: secondNetwork,
+			activeAddress: secondAddress.address,
 			promptForAccessesIfNeeded: false,
 		})
 		await Promise.all([firstTransition, secondTransition])
 
+		expect(messages.filter(({ method }) => method === 'chainChanged' || method === 'accountsChanged').map(({ method, result }) => ({ method, result }))).toEqual([
+			{ method: 'chainChanged', result: '0xa' },
+			{ method: 'accountsChanged', result: ['0x0000000000000000000000000000000000000001'] },
+			{ method: 'chainChanged', result: '0xa4b1' },
+			{ method: 'accountsChanged', result: ['0x0000000000000000000000000000000000000002'] },
+		])
 		assert.deepEqual(resetNetworks.map((network) => network.chainId), [firstNetwork.chainId, secondNetwork.chainId])
 		assert.equal((await getSettings()).activeRpcNetwork.chainId, secondNetwork.chainId)
+	})
+
+	test.each([true, false])('keeps concurrent simulation selections consistent when selecting signer first: %j', async (signerFirst) => {
+		installBrowserMock()
+		const { activateAddressSelection, getSettings } = await loadModules()
+		const { ethereum, tokenPriceService } = createEthereumWithGetBlockCounter({ count: 0 })
+		const signerSelection = { type: 'signer', address: firstAddress.address } as const
+		const addressSelection = { type: 'addressBookEntry', entry: secondAddress } as const
+		const firstWriteStarted = pauseAfterFirstStorageWrite('useSignersAddressAsActiveAddress')
+		const options = { simulationMode: true, signerAddress: firstAddress.address, promptForAccessesIfNeeded: false }
+		const first = activateAddressSelection(ethereum, tokenPriceService, () => undefined, new Map(), signerFirst ? signerSelection : addressSelection, options)
+		await firstWriteStarted
+		const second = activateAddressSelection(ethereum, tokenPriceService, () => undefined, new Map(), signerFirst ? addressSelection : signerSelection, options)
+		await Promise.all([first, second])
+
+		const settings = await getSettings()
+		assert.equal(settings.activeSimulationAddress, signerFirst ? secondAddress.address : firstAddress.address)
+		assert.equal(settings.useSignersAddressAsActiveAddress, !signerFirst)
+	})
+
+	test.each([true, false])('remembers the final concurrent signing selection when selecting Safe first: %j', async (safeFirst) => {
+		installBrowserMock()
+		const { activateAddressSelection, getSettings, getSigningAddressPreferences, updateUserAddressBookEntries } = await loadModules()
+		const { ethereum, tokenPriceService } = createEthereumWithGetBlockCounter({ count: 0 })
+		const safe: SafeEntry = { type: 'safe', name: 'Owned Safe', address: 3n, chainId: (await getSettings()).activeRpcNetwork.chainId, entrySource: 'User', useAsActiveAddress: true, safeSignerAddresses: [firstAddress.address] }
+		await updateUserAddressBookEntries(() => [firstAddress, safe])
+		const signerSelection = { type: 'signer', address: firstAddress.address } as const
+		const safeSelection = { type: 'addressBookEntry', entry: safe } as const
+		const firstWriteStarted = pauseAfterFirstStorageWrite('activeSigningSafeAddress')
+		const options = { simulationMode: false, signerAddress: firstAddress.address, promptForAccessesIfNeeded: false }
+		const first = activateAddressSelection(ethereum, tokenPriceService, () => undefined, new Map(), safeFirst ? safeSelection : signerSelection, options)
+		await firstWriteStarted
+		const second = activateAddressSelection(ethereum, tokenPriceService, () => undefined, new Map(), safeFirst ? signerSelection : safeSelection, options)
+		await Promise.all([first, second])
+
+		assert.equal((await getSettings()).activeSigningSafeAddress, safeFirst ? undefined : safe.address)
+		expect(await getSigningAddressPreferences()).toEqual([safeFirst
+			? { signerAddress: firstAddress.address, selection: 'signer' }
+			: { signerAddress: firstAddress.address, selection: 'safe', safeAddress: safe.address, chainId: safe.chainId },
+		])
+	})
+
+	test('settles an address change that prompts for access alongside an approval that selects another address', async () => {
+		installBrowserMock()
+		const { changeActiveAddressAndChain, changeSimulationMode, getSettings, updateUserAddressBookEntries, websiteSocketToString, requestAccessFromUser, getPendingAccessRequests, resolveInterceptorAccess } = await loadModules()
+		const originalAddress = { ...firstAddress, askForAddressAccess: true }
+		const selectedAddress = { ...secondAddress, askForAddressAccess: true }
+		await updateUserAddressBookEntries(() => [originalAddress, selectedAddress])
+		await changeSimulationMode({ simulationMode: true, activeSimulationAddress: originalAddress.address })
+		const websiteOrigin = 'example.test'
+		const socket = { tabId: 1, connectionName: 0n }
+		const { port } = createPort(socket.tabId)
+		const connections: WebsiteTabConnections = new Map([[socket.tabId, { connections: {
+			[websiteSocketToString(socket)]: { port, socket, websiteOrigin, approved: false, wantsToConnect: true },
+		} }]])
+		const { ethereum, tokenPriceService, resetSimulationServices } = createEthereumWithGetBlockCounter({ count: 0 })
+		await requestAccessFromUser(ethereum, tokenPriceService, resetSimulationServices, connections, socket, { websiteOrigin }, undefined, originalAddress, await getSettings(), originalAddress, undefined)
+		const pending = (await getPendingAccessRequests())[0]
+		if (pending === undefined) throw new Error('Missing pending access request')
+
+		const approvalHasDialogLock = createDeferredSignal()
+		const releaseApproval = createDeferredSignal()
+		const originalGet = browser.storage.local.get.bind(browser.storage.local)
+		let paused = false
+		Object.defineProperty(browser.storage.local, 'get', {
+			configurable: true,
+			value: async (...args: Parameters<typeof browser.storage.local.get>) => {
+				const result = await originalGet(...args)
+				const keys = args[0]
+				if (!paused && Array.isArray(keys) && keys.includes('pendingInterceptorAccessRequests')) {
+					paused = true
+					approvalHasDialogLock.resolve()
+					await releaseApproval.promise
+				}
+				return result
+			},
+		})
+		const approval = resolveInterceptorAccess(ethereum, tokenPriceService, resetSimulationServices, connections, {
+			userReply: 'Approved',
+			accessRequestId: pending.accessRequestId,
+			originalRequestAccessToAddress: originalAddress.address,
+			requestAccessToAddress: selectedAddress.address,
+		}, noopPublishRpcConnectionStatus)
+		await approvalHasDialogLock.promise
+		const transitionStarted = pauseAfterFirstStorageWrite('independentActiveSimulationAddress')
+		const transition = changeActiveAddressAndChain(ethereum, tokenPriceService, resetSimulationServices, connections, { simulationMode: true, activeAddress: originalAddress.address })
+		await transitionStarted
+		// Let the transition reach access prompting while the approval still owns the dialog lock.
+		await new Promise((resolve) => setTimeout(resolve, 0))
+		releaseApproval.resolve()
+		let timeout: ReturnType<typeof setTimeout> | undefined
+		try {
+			await Promise.race([
+				Promise.all([approval, transition]),
+				new Promise((_, reject) => { timeout = setTimeout(() => reject(new Error('Active settings and access approval deadlocked')), 1000) }),
+			])
+		} finally {
+			clearTimeout(timeout)
+			Object.defineProperty(browser.storage.local, 'get', { configurable: true, value: originalGet })
+		}
+		const settings = await getSettings()
+		assert.equal(settings.activeSimulationAddress, selectedAddress.address)
+		const access = settings.websiteAccess.find((entry) => entry.website.websiteOrigin === websiteOrigin)
+		assert.equal(access?.access, true)
+		expect(access?.addressAccess).toEqual([{ address: selectedAddress.address, access: true }])
+		expect(await getPendingAccessRequests()).toEqual([])
+	})
+
+	test.each(['direct', 'selection'])('reports a failed access prompt without rejecting a persisted %s address change', async (entryPoint) => {
+		installBrowserMock()
+		const { activateAddressSelection, changeActiveAddressAndChain, getSettings, getLatestUnexpectedError, updateUserAddressBookEntries, websiteSocketToString, updateWebsiteApprovalAccesses } = await loadModules()
+		const selectedAddress = { ...secondAddress, askForAddressAccess: true }
+		await updateUserAddressBookEntries(() => [selectedAddress])
+		const socket = { tabId: 1, connectionName: 0n }
+		const { port } = createPort(socket.tabId)
+		const connections: WebsiteTabConnections = new Map([[socket.tabId, { connections: {
+			[websiteSocketToString(socket)]: { port, socket, websiteOrigin: 'example.test', approved: false, wantsToConnect: true },
+		} }]])
+		Object.defineProperty(browser.windows, 'create', {
+			configurable: true,
+			value: async () => { throw new Error('Access popup failed to open') },
+		})
+		const { ethereum, tokenPriceService, resetSimulationServices } = createEthereumWithGetBlockCounter({ count: 0 })
+		if (entryPoint === 'direct') {
+			await changeActiveAddressAndChain(ethereum, tokenPriceService, resetSimulationServices, connections, { simulationMode: true, activeAddress: selectedAddress.address })
+		} else {
+			await activateAddressSelection(ethereum, tokenPriceService, resetSimulationServices, connections, { type: 'addressBookEntry', entry: selectedAddress }, { simulationMode: true, signerAddress: undefined })
+		}
+		assert.equal((await getSettings()).activeSimulationAddress, selectedAddress.address)
+		assert.equal((await getLatestUnexpectedError())?.data.message, 'Access popup failed to open')
+		await assert.rejects(updateWebsiteApprovalAccesses(ethereum, tokenPriceService, resetSimulationServices, connections, await getSettings(), true, true), /Access popup failed to open/u)
 	})
 })


### PR DESCRIPTION
Overlapping account or network changes could persist newer settings before an older transition reset services or emitted dapp events, leaving settings, live services, and notifications out of sync. This PR serializes the settings transition and keeps access dialogs and toolbar updates outside the settings lock.

## Changes

- Order settings reads and writes, website approval reconciliation, service resets, account/network notifications, and remembered signer/Safe preferences through one shared coordinator.
- Explicitly finalize access updates after releasing the lock, including when a later transition step fails. This avoids deadlocks when access approval activates another address.
- Recheck current settings before requesting website access, share the access policy with approval reconciliation, and report individual prompt failures while allowing other connections to proceed. Strict callers still receive errors.
- Serialize toolbar updates per tab so a slow older icon/title write cannot overwrite a newer update or block other settings transitions.
- Reject invalid signing selections before changing stored settings.

## Regression coverage

Covers overlapping network and account selections, signer/Safe preferences, access-approval overlap, prompt failures across connections, latest-address consent requests, delayed toolbar writes, invalid selections, and access finalization after service-reset failures.

## Validation

Passed on `ed03d47b`:

- `bun run test` — 1,282 tests passed, 0 failures across 151 files
- `bun run setup-chrome`
- `bun run typecheck`
- `bun run lint`
- `bun run test:chrome-communication` — reached `access-granted`
- `git diff --check`
