### PR TITLE
Preserve large state when IndexedDB reads fail

### DIFF
--- a/app/ts/background/simulationUpdating.ts
+++ b/app/ts/background/simulationUpdating.ts
@@ -139,8 +139,10 @@ export const getCurrentSimulationInput = async (): Promise<SimulationStateInput>
 }
 
 export async function getUpdatedSimulationState(ethereum: EthereumClientService, simulationInput?: SimulationStateInput) {
+	// An unreadable persisted stack must abort refresh, otherwise the simulation fallback could overwrite saved popup results.
+	const currentSimulationInput = simulationInput ?? await getCurrentSimulationInput()
 	try {
-		return toResolvedSimulationState(await createSimulationStateWithNonceAndBaseFeeFixing(simulationInput ?? await getCurrentSimulationInput(), ethereum))
+		return toResolvedSimulationState(await createSimulationStateWithNonceAndBaseFeeFixing(currentSimulationInput, ethereum))
 	} catch(error: unknown) {
 		if (isExpectedInfrastructureError(error)) return PASSTHROUGH_STATE
 		await reportUnexpectedError(error, { code: 'simulation_state_refresh_failed' })

--- a/app/ts/background/storageVariables.ts
+++ b/app/ts/background/storageVariables.ts
@@ -113,14 +113,7 @@ export const setPopupRefreshGeneration = popupRefreshGenerationRepository.set
 const simulationResultsSemaphore = new Semaphore(1)
 export async function getPopupVisualisationState() {
 	const emptyResults = createPassthroughCompleteVisualizedSimulation()
-	try {
-		return await getLargeStateValue('popupVisualisation', CompleteVisualizedSimulation) ?? emptyResults
-	} catch (error) {
-		console.warn('Simulation results were corrupt:')
-		console.warn(error)
-		await setLargeStateValue('popupVisualisation', CompleteVisualizedSimulation, emptyResults)
-		return emptyResults
-	}
+	return await getLargeStateValue('popupVisualisation', CompleteVisualizedSimulation) ?? emptyResults
 }
 
 export const setPopupVisualisationState = async (newResults: CompleteVisualizedSimulation) => await updatePopupVisualisationWithCallBack(async () => newResults)

--- a/app/ts/background/storageVariables.ts
+++ b/app/ts/background/storageVariables.ts
@@ -110,6 +110,7 @@ const popupRefreshGenerationRepository = createStoredValueRepository({
 export const getPopupRefreshGeneration = popupRefreshGenerationRepository.get
 export const setPopupRefreshGeneration = popupRefreshGenerationRepository.set
 
+// Large-state getters share getLargeStateValue's failure contract: defaults apply only to successful absent/invalid reads. Rejections abort updates and reach the owning request/task boundary (e.g. catchAllErrorsAndCall in background-startup.ts), which reports the error; recovery is a later retry, never an empty-state write.
 const simulationResultsSemaphore = new Semaphore(1)
 export async function getPopupVisualisationState() {
 	const emptyResults = createPassthroughCompleteVisualizedSimulation()

--- a/app/ts/utils/largeStateStore.ts
+++ b/app/ts/utils/largeStateStore.ts
@@ -38,6 +38,7 @@ export type PreparedLargeStateWrite = {
 
 let indexedDbPromise: Promise<IDBDatabase | undefined> | undefined
 let indexedDbSource: IDBFactory | undefined
+let indexedDbOpenError: unknown
 const largeStateSemaphore = new Semaphore(1)
 
 function canUseIndexedDb() {
@@ -49,6 +50,7 @@ async function openLargeStateDb() {
 	if (indexedDbSource !== indexedDB) {
 		indexedDbSource = indexedDB
 		indexedDbPromise = undefined
+		indexedDbOpenError = undefined
 	}
 	if (indexedDbPromise !== undefined) return indexedDbPromise
 	const openPromise = new Promise<IDBDatabase>((resolve, reject) => {
@@ -57,13 +59,17 @@ async function openLargeStateDb() {
 			const db = request.result
 			if (!db.objectStoreNames.contains(LARGE_STATE_STORE_NAME)) db.createObjectStore(LARGE_STATE_STORE_NAME)
 		}
-		request.onsuccess = () => resolve(request.result)
+		request.onsuccess = () => {
+			indexedDbOpenError = undefined
+			resolve(request.result)
+		}
 		request.onerror = () => reject(request.error ?? new Error('Failed to open large state IndexedDB database'))
 		request.onblocked = () => reject(new Error('Large state IndexedDB database open was blocked'))
 	})
 	const retryableOpenPromise = openPromise.catch((error) => {
-		console.warn('IndexedDB unavailable for large state persistence, falling back to storage.local.')
+		console.warn('IndexedDB unavailable for large state persistence.')
 		console.warn(error)
+		indexedDbOpenError = error
 		if (indexedDbPromise === retryableOpenPromise) indexedDbPromise = undefined
 		return undefined
 	})
@@ -95,20 +101,23 @@ async function runIndexedDbRequest<T>(mode: IDBTransactionMode, operation: (stor
 	})
 }
 
-function warnIndexedDbRequestFailure(action: string, error: unknown) {
-	console.warn(`IndexedDB ${ action } failed for large state persistence, falling back to storage.local.`)
+function warnIndexedDbRequestFailure(action: string, error: unknown, consequence = 'falling back to storage.local.') {
+	console.warn(`IndexedDB ${ action } failed for large state persistence, ${ consequence }`)
 	console.warn(error)
 }
 
 async function getIndexedDbValue(key: LargeStateStorageKey): Promise<IndexedDbLookup> {
 	try {
 		const result = await runIndexedDbRequest('readonly', (store) => store.get(key))
-		if (result.kind === 'unavailable') return result
+		if (result.kind === 'unavailable') {
+			if (canUseIndexedDb()) throw indexedDbOpenError ?? new Error('IndexedDB unavailable while reading large state')
+			return result
+		}
 		if (result.value === undefined) return { kind: 'available', found: false }
 		return { kind: 'available', found: true, value: result.value }
 	} catch (error) {
-		warnIndexedDbRequestFailure('read', error)
-		return { kind: 'unavailable' }
+		warnIndexedDbRequestFailure('read', error, 'leaving the stored state unchanged.')
+		throw error
 	}
 }
 

--- a/app/ts/utils/largeStateStore.ts
+++ b/app/ts/utils/largeStateStore.ts
@@ -38,7 +38,6 @@ export type PreparedLargeStateWrite = {
 
 let indexedDbPromise: Promise<IDBDatabase | undefined> | undefined
 let indexedDbSource: IDBFactory | undefined
-let indexedDbOpenError: unknown
 const largeStateSemaphore = new Semaphore(1)
 
 function canUseIndexedDb() {
@@ -50,7 +49,6 @@ async function openLargeStateDb() {
 	if (indexedDbSource !== indexedDB) {
 		indexedDbSource = indexedDB
 		indexedDbPromise = undefined
-		indexedDbOpenError = undefined
 	}
 	if (indexedDbPromise !== undefined) return indexedDbPromise
 	const openPromise = new Promise<IDBDatabase>((resolve, reject) => {
@@ -59,19 +57,13 @@ async function openLargeStateDb() {
 			const db = request.result
 			if (!db.objectStoreNames.contains(LARGE_STATE_STORE_NAME)) db.createObjectStore(LARGE_STATE_STORE_NAME)
 		}
-		request.onsuccess = () => {
-			indexedDbOpenError = undefined
-			resolve(request.result)
-		}
+		request.onsuccess = () => resolve(request.result)
 		request.onerror = () => reject(request.error ?? new Error('Failed to open large state IndexedDB database'))
 		request.onblocked = () => reject(new Error('Large state IndexedDB database open was blocked'))
 	})
 	const retryableOpenPromise = openPromise.catch((error) => {
-		console.warn('IndexedDB unavailable for large state persistence.')
-		console.warn(error)
-		indexedDbOpenError = error
 		if (indexedDbPromise === retryableOpenPromise) indexedDbPromise = undefined
-		return undefined
+		throw error
 	})
 	indexedDbPromise = retryableOpenPromise
 	return indexedDbPromise
@@ -109,10 +101,7 @@ function warnIndexedDbRequestFailure(action: string, error: unknown, consequence
 async function getIndexedDbValue(key: LargeStateStorageKey): Promise<IndexedDbLookup> {
 	try {
 		const result = await runIndexedDbRequest('readonly', (store) => store.get(key))
-		if (result.kind === 'unavailable') {
-			if (canUseIndexedDb()) throw indexedDbOpenError ?? new Error('IndexedDB unavailable while reading large state')
-			return result
-		}
+		if (result.kind === 'unavailable') return result
 		if (result.value === undefined) return { kind: 'available', found: false }
 		return { kind: 'available', found: true, value: result.value }
 	} catch (error) {
@@ -121,6 +110,7 @@ async function getIndexedDbValue(key: LargeStateStorageKey): Promise<IndexedDbLo
 	}
 }
 
+// A failed migration leaves the authoritative local value intact; callers may keep using it.
 async function setIndexedDbValue(key: LargeStateStorageKey, value: unknown) {
 	try {
 		const result = await runIndexedDbRequest('readwrite', (store) => store.put(value, key))
@@ -131,10 +121,11 @@ async function setIndexedDbValue(key: LargeStateStorageKey, value: unknown) {
 	}
 }
 
+// Failure is recoverable only by committing the requested values and authority markers to storage.local.
 async function setIndexedDbValues(writes: readonly PreparedLargeStateWrite[]) {
-	const db = await openLargeStateDb()
-	if (db === undefined) return false
 	try {
+		const db = await openLargeStateDb()
+		if (db === undefined) return false
 		await new Promise<void>((resolve, reject) => {
 			const transaction = db.transaction(LARGE_STATE_STORE_NAME, 'readwrite')
 			const store = transaction.objectStore(LARGE_STATE_STORE_NAME)
@@ -153,6 +144,7 @@ async function setIndexedDbValues(writes: readonly PreparedLargeStateWrite[]) {
 	}
 }
 
+// Mutation callers persist a local tombstone on failure; cleanup of already-invalid data may wait for a later read.
 async function removeIndexedDbValue(key: LargeStateStorageKey) {
 	try {
 		const result = await runIndexedDbRequest('readwrite', (store) => store.delete(key))
@@ -260,6 +252,14 @@ async function getLargeStateValueUnlocked<T>(key: LargeStateStorageKey, codec: f
 	return undefined
 }
 
+/**
+ * Reads authoritative state. Resolves undefined for missing or invalid data (or an absent IndexedDB API),
+ * and rejects when storage errors prevent determining the authoritative value. A migrated local backup
+ * cannot recover a failed IndexedDB read because it may be stale. Local-authoritative reads remain valid
+ * even if their optional migration fails. Callers must propagate rejection through read/modify/write
+ * operations; only a successful undefined result permits an empty default. Report failures at the owning
+ * request/task boundary and retry the operation after storage recovers; never persist an error default.
+ */
 export async function getLargeStateValue<T>(key: LargeStateStorageKey, codec: funtypes.Codec<T>): Promise<T | undefined> {
 	return await largeStateSemaphore.execute(async () => await getLargeStateValueUnlocked(key, codec))
 }
@@ -285,6 +285,7 @@ async function setLargeStateValuesUnlocked(writes: readonly PreparedLargeStateWr
 	await setLegacyLocalValues(writes)
 }
 
+/** Commits to IndexedDB or an authoritative local fallback; rejects if persistence cannot complete. */
 export async function setLargeStateValues(writes: readonly PreparedLargeStateWrite[]) {
 	await largeStateSemaphore.execute(async () => await setLargeStateValuesUnlocked(writes))
 }
@@ -304,6 +305,7 @@ async function removeLargeStateValueUnlocked(key: LargeStateStorageKey) {
 	await setLegacyLocalDeleted(key)
 }
 
+/** Deletes from IndexedDB or persists a local tombstone; rejects if persistence cannot complete. */
 export async function removeLargeStateValue(key: LargeStateStorageKey) {
 	await largeStateSemaphore.execute(async () => await removeLargeStateValueUnlocked(key))
 }

--- a/test/tests/largeStateStore.test.ts
+++ b/test/tests/largeStateStore.test.ts
@@ -405,6 +405,32 @@ describe('large state store helpers', () => {
 		assert.deepEqual(value, stack)
 	})
 
+	test('rejects IndexedDB read failures instead of returning a stale migrated backup', async () => {
+		const { indexedDbState, storageState } = installLargeStateEnvironment({ getError: new Error('get failed') })
+		indexedDbState.set('interceptorTransactionStack', serializedStack())
+		storageState.interceptorTransactionStack = serializedStack(staleStack)
+		storageState[transactionStackMigratedMarkerKey] = true
+
+		await assert.rejects(
+			getLargeStateValue('interceptorTransactionStack', InterceptorTransactionStack),
+			/get failed/,
+		)
+		assert.deepEqual(indexedDbState.get('interceptorTransactionStack'), serializedStack())
+		assert.deepEqual(storageState.interceptorTransactionStack, serializedStack(staleStack))
+	})
+
+	test('rejects IndexedDB open failures when state is not authoritative in storage.local', async () => {
+		const { indexedDbState, storageState } = installLargeStateEnvironment({ openErrors: [new Error('open failed')] })
+		indexedDbState.set('interceptorTransactionStack', serializedStack())
+		storageState[transactionStackMigratedMarkerKey] = true
+
+		await assert.rejects(
+			getLargeStateValue('interceptorTransactionStack', InterceptorTransactionStack),
+			/open failed/,
+		)
+		assert.deepEqual(indexedDbState.get('interceptorTransactionStack'), serializedStack())
+	})
+
 	test('keeps legacy storage.local value when IndexedDB migration writes fail', async () => {
 		const { indexedDbState, storageState } = installLargeStateEnvironment({ putError: new Error('put failed') })
 		storageState.interceptorTransactionStack = serializedStack()

--- a/test/tests/largeStateStore.test.ts
+++ b/test/tests/largeStateStore.test.ts
@@ -1,7 +1,8 @@
 import * as assert from 'assert'
 import { afterEach, describe, test } from 'bun:test'
 import { estimateSerializedStateBytes, formatEstimatedBytes, getLargeStateValue, prepareLargeStateWrite, removeLargeStateValue, setLargeStateValue, setLargeStateValues } from '../../app/ts/utils/largeStateStore.js'
-import { InterceptorTransactionStack } from '../../app/ts/types/visualizer-types.js'
+import { CompleteVisualizedSimulation, createPassthroughCompleteVisualizedSimulation, InterceptorTransactionStack } from '../../app/ts/types/visualizer-types.js'
+import { getPopupVisualisationState } from '../../app/ts/background/storageVariables.js'
 import { serialize } from '../../app/ts/types/wire-types.js'
 import { SafeTransactionStacks } from '../../app/ts/types/safeTypes.js'
 
@@ -430,6 +431,26 @@ describe('large state store helpers', () => {
 		)
 		assert.deepEqual(indexedDbState.get('interceptorTransactionStack'), serializedStack())
 	})
+
+	for (const failure of ['read', 'open']) {
+		test(`preserves persisted popup visualisation when IndexedDB ${ failure } fails`, async () => {
+			const error = new Error(`popup ${ failure } failed`)
+			const { indexedDbState, storageState } = installLargeStateEnvironment(failure === 'read' ? { getError: error } : { openErrors: [error] })
+			const savedResults = createPassthroughCompleteVisualizedSimulation(77, 'done', 2)
+			const serializedResults = serialize(CompleteVisualizedSimulation, savedResults)
+			indexedDbState.set('popupVisualisation', serializedResults)
+			storageState['interceptorLargeStateMigrated:popupVisualisation'] = true
+			const previousLocalState = { ...storageState }
+
+			await assert.rejects(getPopupVisualisationState(), (caught: unknown) => caught === error)
+			assert.deepEqual(indexedDbState.get('popupVisualisation'), serializedResults)
+			assert.deepEqual(storageState, previousLocalState)
+
+			// A later successful read must still return the saved results, not an empty replacement.
+			installFakeIndexedDb(indexedDbState, {})
+			assert.deepEqual(await getPopupVisualisationState(), savedResults)
+		})
+	}
 
 	test('keeps legacy storage.local value when IndexedDB migration writes fail', async () => {
 		const { indexedDbState, storageState } = installLargeStateEnvironment({ putError: new Error('put failed') })

--- a/test/tests/largeStateStore.test.ts
+++ b/test/tests/largeStateStore.test.ts
@@ -2,9 +2,12 @@ import * as assert from 'assert'
 import { afterEach, describe, test } from 'bun:test'
 import { estimateSerializedStateBytes, formatEstimatedBytes, getLargeStateValue, prepareLargeStateWrite, removeLargeStateValue, setLargeStateValue, setLargeStateValues } from '../../app/ts/utils/largeStateStore.js'
 import { CompleteVisualizedSimulation, createPassthroughCompleteVisualizedSimulation, InterceptorTransactionStack } from '../../app/ts/types/visualizer-types.js'
-import { getPopupVisualisationState } from '../../app/ts/background/storageVariables.js'
+import { getPopupVisualisationState, updateInterceptorTransactionStack, updatePopupVisualisationWithCallBack, updateTransactionState } from '../../app/ts/background/storageVariables.js'
 import { serialize } from '../../app/ts/types/wire-types.js'
 import { SafeTransactionStacks } from '../../app/ts/types/safeTypes.js'
+import { updatePopupVisualisationState } from '../../app/ts/background/popupVisualisationUpdater.js'
+import { EthereumClientService } from '../../app/ts/simulation/services/EthereumClientService.js'
+import { TokenPriceService } from '../../app/ts/simulation/services/priceEstimator.js'
 
 const stack: InterceptorTransactionStack = {
 	operations: [{
@@ -28,6 +31,7 @@ type StorageGetKeys = string | string[] | Record<string, unknown> | null | undef
 type FakeIndexedDbOptions = {
 	readonly openErrors?: readonly Error[]
 	readonly getError?: Error
+	readonly getErrorKey?: string
 	readonly putError?: Error
 	readonly deleteError?: Error
 	readonly putTransactionAbortAfterRequestSuccess?: Error
@@ -141,7 +145,7 @@ function installFakeIndexedDb(indexedDbState: Map<string, unknown>, options: Fak
 			store = {
 				get(key: string) {
 					const request = createFakeRequest(indexedDbState.get(key))
-					finishFakeRequest(request, transaction, options.getError, undefined)
+					finishFakeRequest(request, transaction, options.getErrorKey === undefined || options.getErrorKey === key ? options.getError : undefined, undefined)
 					return request
 				},
 				put(value: unknown, key: string) {
@@ -449,6 +453,70 @@ describe('large state store helpers', () => {
 			// A later successful read must still return the saved results, not an empty replacement.
 			installFakeIndexedDb(indexedDbState, {})
 			assert.deepEqual(await getPopupVisualisationState(), savedResults)
+		})
+	}
+
+	for (const key of ['interceptorTransactionStack', 'safeTransactionStacks']) {
+		test(`aborts transaction-state updates when ${ key } cannot be read`, async () => {
+			const error = new Error('read failed')
+			const { indexedDbState, storageState } = installLargeStateEnvironment({ getError: error })
+			if (key === 'safeTransactionStacks') {
+				storageState.interceptorTransactionStack = serializedStack()
+			} else {
+				indexedDbState.set('interceptorTransactionStack', serializedStack())
+			}
+			await assert.rejects(updateTransactionState(() => assert.fail('must not update unreadable state')), (caught: unknown) => caught === error)
+			if (key === 'interceptorTransactionStack') {
+				await assert.rejects(updateInterceptorTransactionStack(() => assert.fail('must not update unreadable stack')), (caught: unknown) => caught === error)
+			}
+			assert.deepEqual(indexedDbState.get('interceptorTransactionStack'), serializedStack())
+			assert.equal(indexedDbState.has('safeTransactionStacks'), false)
+		})
+	}
+
+	test('aborts popup updates when the previous visualisation cannot be read', async () => {
+		const error = new Error('read failed')
+		const { indexedDbState, storageState } = installLargeStateEnvironment({ getError: error })
+		const savedResults = serialize(CompleteVisualizedSimulation, createPassthroughCompleteVisualizedSimulation(77, 'done', 2))
+		indexedDbState.set('popupVisualisation', savedResults)
+
+		await assert.rejects(updatePopupVisualisationWithCallBack(async () => assert.fail('must not update unreadable visualisation')), (caught: unknown) => caught === error)
+		assert.deepEqual(indexedDbState.get('popupVisualisation'), savedResults)
+		assert.deepEqual(storageState, {})
+	})
+
+	test('preserves popup results when simulation refresh cannot read the transaction stack', async () => {
+		const error = new Error('transaction stack read failed')
+		const { indexedDbState, storageState } = installLargeStateEnvironment({ getError: error, getErrorKey: 'interceptorTransactionStack' })
+		const savedResults = serialize(CompleteVisualizedSimulation, createPassthroughCompleteVisualizedSimulation(77, 'done', 2))
+		indexedDbState.set('popupVisualisation', savedResults)
+		indexedDbState.set('interceptorTransactionStack', serializedStack())
+		const rpcNetwork = { name: 'Ethereum', chainId: 1n, httpsRpc: 'https://ethereum.example', currencyName: 'Ether', currencyTicker: 'ETH', primary: true, minimized: false }
+		const ethereum = new EthereumClientService({
+			rpcUrl: rpcNetwork.httpsRpc,
+			clearCache: () => undefined,
+			jsonRpcRequest: async () => assert.fail('must not simulate an unreadable stack'),
+		}, async () => undefined, async () => undefined, rpcNetwork)
+
+		await assert.rejects(updatePopupVisualisationState(ethereum, new TokenPriceService(ethereum, 0), undefined, true), (caught: unknown) => caught === error)
+		assert.deepEqual(indexedDbState.get('popupVisualisation'), savedResults)
+		assert.deepEqual(indexedDbState.get('interceptorTransactionStack'), serializedStack())
+		assert.deepEqual(storageState, {})
+	})
+
+	for (const operation of ['write', 'delete']) {
+		test(`rejects ${ operation } when the local fallback cannot persist the operation`, async () => {
+			const error = new Error('local persistence failed')
+			const { indexedDbState } = installLargeStateEnvironment({ putError: new Error('put failed'), deleteError: new Error('delete failed') }, async () => { throw error })
+			indexedDbState.set('interceptorTransactionStack', serializedStack())
+
+			await assert.rejects(
+				operation === 'write'
+					? setLargeStateValue('interceptorTransactionStack', InterceptorTransactionStack, staleStack)
+					: removeLargeStateValue('interceptorTransactionStack'),
+				(caught: unknown) => caught === error,
+			)
+			assert.deepEqual(indexedDbState.get('interceptorTransactionStack'), serializedStack())
 		})
 	}
 


### PR DESCRIPTION
## Summary

- propagate operational IndexedDB read and open failures instead of treating authoritative large state as missing
- preserve existing storage.local-authoritative fallback behavior
- prevent popup visualization reads from overwriting persisted results with an empty state after a transient read failure
- cover request and database-open failures with focused regression tests

## Impact

A transient IndexedDB failure could previously make transaction stacks, Safe stacks, or popup simulation results appear absent. Callers could then persist empty or replacement state, turning a temporary storage outage into durable data loss.

## Validation

- `bun run test` — 1261 tests passed
- `bun run setup-chrome` — passed
- `bun run typecheck` — passed
- `bun run lint` — passed

No open PR matched the affected IndexedDB/large-state read path when this branch was created.