### PR TITLE
Complete full transactions in simulated blocks

### DIFF
--- a/app/ts/simulation/services/SimulationModeEthereumClientService.ts
+++ b/app/ts/simulation/services/SimulationModeEthereumClientService.ts
@@ -989,7 +989,13 @@ const getSimulatedMockBlockFromPreparedContext = async (
 		uncles: [],
 		baseFeePerGas: block.baseFeePerGas,
 		transactionsRoot: parentBlock.transactionsRoot, // TODO: this is wrong
-		transactions: block.inputBlock.transactions.map((transaction) => transaction.signedTransaction),
+		transactions: block.inputBlock.transactions.map((transaction, transactionIndex) => getSignedTransactionWithBlockData(
+			transaction.signedTransaction,
+			block.blockHash,
+			block.blockNumber,
+			transactionIndex,
+			calculateRealizedEffectiveGasPrice(transaction.signedTransaction, block.baseFeePerGas ?? 0n),
+		)),
 		withdrawals: [],
 		withdrawalsRoot: 0n, // TODO: this is wrong
 	} as const
@@ -1213,21 +1219,12 @@ export const getSimulatedTransactionByHashFromInput = async (
 		for (const executionBlock of context.executionBlocks) {
 			for (const [transactionIndex, transaction] of executionBlock.inputBlock.transactions.entries()) {
 				if (transaction.signedTransaction.hash !== hash) continue
-				const v = getSignedTransactionV(transaction.signedTransaction)
 				const gasPrice = 'gasPrice' in transaction.signedTransaction
 					? transaction.signedTransaction.gasPrice
 					: calculateRealizedEffectiveGasPrice(transaction.signedTransaction, executionBlock.baseFeePerGas || 0n)
-				return {
-				...transaction.signedTransaction,
-				blockHash: executionBlock.blockHash,
-				blockNumber: executionBlock.blockNumber,
-				transactionIndex: BigInt(transactionIndex),
-				data: transaction.signedTransaction.input,
-				v,
-				gasPrice,
+				return getSignedTransactionWithBlockData(transaction.signedTransaction, executionBlock.blockHash, executionBlock.blockNumber, transactionIndex, gasPrice)
 			}
 		}
-	}
 	return await ethereumClientService.getTransactionByHash(hash, requestAbortController)
 }
 
@@ -1470,18 +1467,21 @@ async function getSimulatedMockBlock(ethereumClientService: EthereumClientServic
 	const simulatedBlock = simulationState.simulatedBlocks[blockDelta]
 	const blockHeaderTemplate = getSimulatedBlockHeaderTemplate(simulationState, blockDelta)
 	const parentHash = blockDelta === 0 ? blockHeaderTemplate?.parentHash ?? parentBlock.hash : getHashOfSimulatedBlock(simulationState, blockDelta - 1)
+	const blockHash = getHashOfSimulatedBlock(simulationState, blockDelta)
+	const blockNumber = getSimulationBlockNumber(simulationState, blockDelta)
+	const baseFeePerGas = simulatedBlock?.blockBaseFeePerGas ?? getNextBaseFeePerGas(parentBlock.gasUsed, parentBlock.gasLimit, parentBlock.baseFeePerGas)
 	return {
 		author: blockHeaderTemplate?.miner ?? parentBlock.miner,
 		difficulty: blockHeaderTemplate?.difficulty ?? parentBlock.difficulty,
 		extraData: blockHeaderTemplate?.extraData ?? parentBlock.extraData,
 		gasLimit: blockHeaderTemplate?.gasLimit ?? parentBlock.gasLimit,
 		gasUsed: blockHeaderTemplate?.gasUsed ?? transactionQueueTotalGasUsed(simulatedBlock?.simulatedTransactions || []),
-		hash: getHashOfSimulatedBlock(simulationState, blockDelta),
+		hash: blockHash,
 		logsBloom: blockHeaderTemplate?.logsBloom ?? parentBlock.logsBloom,
 		miner: blockHeaderTemplate?.miner ?? parentBlock.miner,
 		mixHash: blockHeaderTemplate?.mixHash ?? parentBlock.mixHash,
 		nonce: blockHeaderTemplate?.nonce ?? parentBlock.nonce,
-		number: getSimulationBlockNumber(simulationState, blockDelta),
+		number: blockNumber,
 		parentHash,
 		receiptsRoot: blockHeaderTemplate?.receiptsRoot ?? parentBlock.receiptsRoot,
 		sha3Uncles: blockHeaderTemplate?.sha3Uncles ?? parentBlock.sha3Uncles,
@@ -1490,9 +1490,15 @@ async function getSimulatedMockBlock(ethereumClientService: EthereumClientServic
 		size: blockHeaderTemplate?.size ?? parentBlock.size,
 		totalDifficulty: blockHeaderTemplate?.totalDifficulty ?? ((parentBlock.totalDifficulty ?? 0n) + parentBlock.difficulty),
 		uncles: blockHeaderTemplate?.uncles ?? [],
-		baseFeePerGas: simulatedBlock?.blockBaseFeePerGas ?? getNextBaseFeePerGas(parentBlock.gasUsed, parentBlock.gasLimit, parentBlock.baseFeePerGas),
+		baseFeePerGas,
 		transactionsRoot: blockHeaderTemplate?.transactionsRoot ?? parentBlock.transactionsRoot,
-		transactions: simulatedBlock?.simulatedTransactions.map((simulatedTransaction) => simulatedTransaction.preSimulationTransaction.signedTransaction) || [],
+		transactions: simulatedBlock?.simulatedTransactions.map((simulatedTransaction, transactionIndex) => getSignedTransactionWithBlockData(
+			simulatedTransaction.preSimulationTransaction.signedTransaction,
+			blockHash,
+			blockNumber,
+			transactionIndex,
+			simulatedTransaction.realizedGasPrice,
+		)) || [],
 		withdrawals: blockHeaderTemplate?.withdrawals ?? [],
 		...(blockHeaderTemplate?.blobGasUsed !== undefined ? { blobGasUsed: blockHeaderTemplate.blobGasUsed } : {}),
 		...(blockHeaderTemplate?.excessBlobGas !== undefined ? { excessBlobGas: blockHeaderTemplate.excessBlobGas } : {}),
@@ -1613,6 +1619,24 @@ function getSignedTransactionV(transaction: EthereumSendableSignedTransaction): 
 	return transaction.yParity === 'even' ? 0n : 1n
 }
 
+function getSignedTransactionWithBlockData(
+	transaction: EthereumSendableSignedTransaction,
+	blockHash: EthereumBytes32,
+	blockNumber: bigint,
+	transactionIndex: number,
+	realizedGasPrice: bigint,
+): EthereumSignedTransactionWithBlockData {
+	return {
+		...transaction,
+		blockHash,
+		blockNumber,
+		transactionIndex: BigInt(transactionIndex),
+		data: transaction.input,
+		v: getSignedTransactionV(transaction),
+		gasPrice: realizedGasPrice,
+	}
+}
+
 export const getSimulatedTransactionByHash = async (ethereumClientService: EthereumClientService, requestAbortController: AbortController | undefined, simulationState: ResolvedSimulationState, hash: bigint): Promise<EthereumSignedTransactionWithBlockData | null> => {
 	// try to see if the transaction is in our queue
 	if (simulationState.kind === 'passthrough') return await ethereumClientService.getTransactionByHash(hash, requestAbortController)
@@ -1621,25 +1645,13 @@ export const getSimulatedTransactionByHash = async (ethereumClientService: Ether
 	for (const [blockDelta, block] of currentState.simulatedBlocks.entries()) {
 		for (const [transactionIndex, simulatedTransaction] of block.simulatedTransactions.entries()) {
 			if (hash === simulatedTransaction.preSimulationTransaction.signedTransaction.hash) {
-				const v = getSignedTransactionV(simulatedTransaction.preSimulationTransaction.signedTransaction)
-				const additionalParams = {
-					blockHash: getHashOfSimulatedBlock(currentState, blockDelta),
-					blockNumber: currentState.blockNumber + BigInt(blockDelta) + 1n,
-					transactionIndex: BigInt(transactionIndex),
-					data: simulatedTransaction.preSimulationTransaction.signedTransaction.input,
-					v,
-				}
-				if ('gasPrice' in simulatedTransaction.preSimulationTransaction.signedTransaction) {
-					return {
-						...simulatedTransaction.preSimulationTransaction.signedTransaction,
-						...additionalParams,
-					}
-				}
-				return {
-					...simulatedTransaction.preSimulationTransaction.signedTransaction,
-					...additionalParams,
-					gasPrice: simulatedTransaction.realizedGasPrice,
-				}
+				return getSignedTransactionWithBlockData(
+					simulatedTransaction.preSimulationTransaction.signedTransaction,
+					getHashOfSimulatedBlock(currentState, blockDelta),
+					currentState.blockNumber + BigInt(blockDelta) + 1n,
+					transactionIndex,
+					simulatedTransaction.realizedGasPrice,
+				)
 			}
 		}
 	}

--- a/app/ts/simulation/services/SimulationModeEthereumClientService.ts
+++ b/app/ts/simulation/services/SimulationModeEthereumClientService.ts
@@ -1214,17 +1214,17 @@ export const getSimulatedTransactionByHashFromInput = async (
 	simulationStateInput: ResolvedSimulationInput,
 	hash: bigint,
 ): Promise<EthereumSignedTransactionWithBlockData | null> => {
-		const context = await createPreparedSimulationExecutionContext(ethereumClientService, requestAbortController, simulationStateInput)
-		if (context === undefined) return await ethereumClientService.getTransactionByHash(hash, requestAbortController)
-		for (const executionBlock of context.executionBlocks) {
-			for (const [transactionIndex, transaction] of executionBlock.inputBlock.transactions.entries()) {
-				if (transaction.signedTransaction.hash !== hash) continue
-				const gasPrice = 'gasPrice' in transaction.signedTransaction
-					? transaction.signedTransaction.gasPrice
-					: calculateRealizedEffectiveGasPrice(transaction.signedTransaction, executionBlock.baseFeePerGas || 0n)
-				return getSignedTransactionWithBlockData(transaction.signedTransaction, executionBlock.blockHash, executionBlock.blockNumber, transactionIndex, gasPrice)
-			}
+	const context = await createPreparedSimulationExecutionContext(ethereumClientService, requestAbortController, simulationStateInput)
+	if (context === undefined) return await ethereumClientService.getTransactionByHash(hash, requestAbortController)
+	for (const executionBlock of context.executionBlocks) {
+		for (const [transactionIndex, transaction] of executionBlock.inputBlock.transactions.entries()) {
+			if (transaction.signedTransaction.hash !== hash) continue
+			const gasPrice = 'gasPrice' in transaction.signedTransaction
+				? transaction.signedTransaction.gasPrice
+				: calculateRealizedEffectiveGasPrice(transaction.signedTransaction, executionBlock.baseFeePerGas || 0n)
+			return getSignedTransactionWithBlockData(transaction.signedTransaction, executionBlock.blockHash, executionBlock.blockNumber, transactionIndex, gasPrice)
 		}
+	}
 	return await ethereumClientService.getTransactionByHash(hash, requestAbortController)
 }
 

--- a/app/ts/types/wire-types.ts
+++ b/app/ts/types/wire-types.ts
@@ -612,7 +612,7 @@ const EthereumUnknownTransactionType = funtypes.ReadonlyObject({
 })
 
 export type EthereumBlockHeaderTransaction = funtypes.Static<typeof EthereumBlockHeaderTransaction>
-export const EthereumBlockHeaderTransaction = funtypes.Union(EthereumSignedTransaction, EthereumUnknownTransactionType)
+export const EthereumBlockHeaderTransaction = funtypes.Union(EthereumSignedTransactionWithBlockData, EthereumSignedTransactionOptimismDeposit, EthereumUnknownTransactionType)
 
 export type EthereumBlockHeader = funtypes.Static<typeof EthereumBlockHeader>
 export const EthereumBlockHeader = funtypes.Union(funtypes.Null, funtypes.Intersect(

--- a/app/ts/types/wire-types.ts
+++ b/app/ts/types/wire-types.ts
@@ -532,12 +532,15 @@ export const EthereumSendableSignedTransaction = funtypes.Union(EthereumSignedTr
 export type EthereumSignedTransaction = funtypes.Static<typeof EthereumSignedTransaction>
 export const EthereumSignedTransaction = funtypes.Union(EthereumSendableSignedTransaction, EthereumSignedTransactionOptimismDeposit)
 
-const EthereumSignedTransactionWithBlockReferences = funtypes.ReadonlyObject({
-	data: EthereumInput,
-	blockHash: funtypes.Union(EthereumBytes32, funtypes.Null),
-	blockNumber: funtypes.Union(EthereumQuantity, funtypes.Null),
-	transactionIndex: funtypes.Union(EthereumQuantity, funtypes.Null),
-})
+const EthereumSignedTransactionWithBlockReferences = funtypes.Intersect(
+	funtypes.ReadonlyObject({
+		blockHash: funtypes.Union(EthereumBytes32, funtypes.Null),
+		blockNumber: funtypes.Union(EthereumQuantity, funtypes.Null),
+		transactionIndex: funtypes.Union(EthereumQuantity, funtypes.Null),
+	}),
+	// RPC nodes may omit this calldata alias; do not synthesize empty data alongside nonempty input.
+	funtypes.ReadonlyPartial({ data: EthereumData }),
+)
 
 export type EthereumSignedTransactionWithBlockData = funtypes.Static<typeof EthereumSignedTransactionWithBlockData>
 export const EthereumSignedTransactionWithBlockData = funtypes.Union(

--- a/test/tests/SimulationModeEthereumClientService.test.ts
+++ b/test/tests/SimulationModeEthereumClientService.test.ts
@@ -1947,6 +1947,34 @@ describe('SimulationModeEthereumClientService', () => {
 				assert.equal(roundTripped.number, latestBlock.number)
 			})
 
+			test('input-based full blocks include transaction block data and realized gas price', async () => {
+				const latestBlock = await getBlockFromInput(createSimulationStateInput(), 'latest', true)
+				if (latestBlock === null) throw new Error('latest simulated block missing')
+				const transaction = latestBlock.transactions[0]
+				if (transaction === undefined || !('blockHash' in transaction)) throw new Error('full simulated transaction data missing')
+
+				assert.equal(transaction.blockHash, latestBlock.hash)
+				assert.equal(transaction.blockNumber, latestBlock.number)
+				assert.equal(transaction.transactionIndex, 0n)
+				assert.deepEqual(transaction.data, transaction.input)
+				assert.equal(transaction.gasPrice, 1n)
+			})
+
+			test('state-based full blocks include transaction block data and realized gas price', async () => {
+				const simulationState = await createSimulationState(ethereum, undefined, createSimulationStateInput())
+				if (simulationState.success === false) throw new Error('simulation unexpectedly failed')
+				const latestBlock = await getSimulatedBlock(ethereum, undefined, toResolvedSimulationState(simulationState), 'latest', true)
+				if (latestBlock === null) throw new Error('latest simulated block missing')
+				const transaction = latestBlock.transactions[0]
+				if (transaction === undefined || !('blockHash' in transaction)) throw new Error('full simulated transaction data missing')
+
+				assert.equal(transaction.blockHash, latestBlock.hash)
+				assert.equal(transaction.blockNumber, latestBlock.number)
+				assert.equal(transaction.transactionIndex, 0n)
+				assert.deepEqual(transaction.data, transaction.input)
+				assert.equal(transaction.gasPrice, simulationState.simulatedBlocks[0]?.simulatedTransactions[0]?.realizedGasPrice)
+			})
+
 			test('input-based simulated block hash changes when transaction contents change', async () => {
 				const baseSimulationStateInput = [{
 					stateOverrides: {},

--- a/test/tests/SimulationModeEthereumClientService.test.ts
+++ b/test/tests/SimulationModeEthereumClientService.test.ts
@@ -6,7 +6,7 @@ import { EthereumClientService } from '../../app/ts/simulation/services/Ethereum
 import { EthereumSignedTransactionToSignedTransaction, EthereumUnsignedTransactionToUnsignedTransaction, rlpEncode, serializeSignedTransactionToBytes, serializeUnsignedTransactionToBytes } from '../../app/ts/utils/ethereum.js'
 import { addressString, bigintToUint8Array, bytes32String, dataStringWith0xStart, stringToUint8Array } from '../../app/ts/utils/bigint.js'
 import { EthereumAddress, EthereumSignatureParity, EthereumSignedTransaction, EthereumSignedTransaction1559, EthereumSignedTransactionWithBlockData, EthereumUnsignedTransaction, serialize } from '../../app/ts/types/wire-types.js'
-import { createExecutionSimulationState, createSimulationCallParams, createSimulationState, ethSimulateV1FromInput, getBaseFeeAdjustedTransactions, getBaseFeeAdjustmentBalances, getDeployedContractAddress, getSimulatedBalanceFromInput, getSimulatedBlock, getSimulatedBlockByHashFromInput, getSimulatedBlockFromInput, getSimulatedBlockNumberFromInput, getSimulatedCode, getSimulatedCodeFromInput, getSimulatedFeeHistory, getSimulatedLogs, getSimulatedStorageAtFromInput, getSimulatedTransactionByHashFromInput, getSimulatedTransactionCount, getSimulatedTransactionCountFromInput, getSimulatedTransactionReceipt, groupEthSimulateV1ResultByInputBlocks, mockSignTransaction, simulateEstimateGas, simulateEstimateGasFromInput, simulatePersonalSign, simulatedCall, simulatedCallFromInput } from '../../app/ts/simulation/services/SimulationModeEthereumClientService.js'
+import { createExecutionSimulationState, createSimulationCallParams, createSimulationState, ethSimulateV1FromInput, getBaseFeeAdjustedTransactions, getBaseFeeAdjustmentBalances, getDeployedContractAddress, getSimulatedBalanceFromInput, getSimulatedBlock, getSimulatedBlockByHashFromInput, getSimulatedBlockFromInput, getSimulatedBlockNumberFromInput, getSimulatedCode, getSimulatedCodeFromInput, getSimulatedFeeHistory, getSimulatedLogs, getSimulatedStorageAtFromInput, getSimulatedTransactionByHash, getSimulatedTransactionByHashFromInput, getSimulatedTransactionCount, getSimulatedTransactionCountFromInput, getSimulatedTransactionReceipt, groupEthSimulateV1ResultByInputBlocks, mockSignTransaction, simulateEstimateGas, simulateEstimateGasFromInput, simulatePersonalSign, simulatedCall, simulatedCallFromInput } from '../../app/ts/simulation/services/SimulationModeEthereumClientService.js'
 import { EthTransactionReceiptResponse, EthereumJsonRpcRequest, JsonRpcResponse } from '../../app/ts/types/JsonRpc-types.js'
 import { RPCReply } from '../../app/ts/types/interceptor-messages.js'
 import type { EthSimulateV1BlockTag, EthSimulateV1Params, EthSimulateV1Result } from '../../app/ts/types/ethSimulate-types.js'
@@ -1973,6 +1973,63 @@ describe('SimulationModeEthereumClientService', () => {
 				assert.equal(transaction.transactionIndex, 0n)
 				assert.deepEqual(transaction.data, transaction.input)
 				assert.equal(transaction.gasPrice, simulationState.simulatedBlocks[0]?.simulatedTransactions[0]?.realizedGasPrice)
+			})
+
+			test('full blocks agree with transaction lookups across blocks, indexes, and fee caps', async () => {
+				const input = createTwoBlockSimulationStateInput().map((block, blockIndex) => ({
+					...block,
+					transactions: [1n, 1_000_000_000_000n].map((maxFeePerGas, transactionIndex) => ({
+						...block.transactions[0],
+						transactionIdentifier: BigInt(blockIndex * 2 + transactionIndex),
+						signedTransaction: mockSignTransaction({
+							...exampleTransaction,
+							nonce: BigInt(blockIndex * 2 + transactionIndex),
+							input: new Uint8Array([0x12, 0x34]),
+							maxFeePerGas,
+							maxPriorityFeePerGas: 1n,
+						}),
+					})),
+				}))
+				const template = await createSimulationState(ethereum, undefined, createTwoBlockSimulationStateInput())
+				if (template.success === false) throw new Error('simulation unexpectedly failed')
+				// Exercise the state reader with two included transactions per block and a nonzero base fee.
+				const state = toResolvedSimulationState({
+					...template,
+					simulatedBlocks: template.simulatedBlocks.map((block, blockIndex) => ({
+						...block,
+						blockBaseFeePerGas: 10n,
+						simulatedTransactions: (input[blockIndex]?.transactions ?? []).map((transaction, transactionIndex) => {
+							const simulatedTransaction = block.simulatedTransactions[0]
+							if (simulatedTransaction === undefined) throw new Error('template transaction missing')
+							return { ...simulatedTransaction, preSimulationTransaction: transaction, realizedGasPrice: transactionIndex === 0 ? 1n : 11n }
+						}),
+					})),
+				})
+				for (const blockIndex of [0, 1]) {
+					const number = blockNumber + BigInt(blockIndex) + 1n
+					for (const source of ['input', 'state']) {
+						const block = source === 'input'
+							? await getBlockFromInput(input, number, true)
+							: await getSimulatedBlock(ethereum, undefined, state, number, true)
+						if (block === null) throw new Error('full block missing')
+						assert.equal(block.transactions.length, 2)
+						assert.equal(block.number, number)
+						assert.ok(block.baseFeePerGas !== undefined && block.baseFeePerGas > 0n)
+						for (const [transactionIndex, transaction] of block.transactions.entries()) {
+							if (!('blockHash' in transaction)) throw new Error('transaction block data missing')
+							const lookup = source === 'input'
+								? await getSimulatedTransactionByHashFromInput(ethereum, undefined, toResolvedSimulationInput(input), transaction.hash)
+								: await getSimulatedTransactionByHash(ethereum, undefined, state, transaction.hash)
+							assert.deepStrictEqual(transaction, lookup)
+							assert.equal(transaction.blockHash, block.hash)
+							assert.equal(transaction.blockNumber, number)
+							assert.equal(transaction.transactionIndex, BigInt(transactionIndex))
+							assert.deepStrictEqual(transaction.data, new Uint8Array([0x12, 0x34]))
+							assert.equal(transaction.gasPrice, transactionIndex === 0 ? 1n : block.baseFeePerGas + 1n)
+							assert.ok(transaction.v === 0n || transaction.v === 1n)
+						}
+					}
+				}
 			})
 
 			test('input-based simulated block hash changes when transaction contents change', async () => {

--- a/test/tests/jsonRpcBoundaryValidation.test.ts
+++ b/test/tests/jsonRpcBoundaryValidation.test.ts
@@ -1,7 +1,9 @@
 import * as assert from 'assert'
 import { describe, test } from 'bun:test'
 import { EthereumJsonRpcRequest, FeeHistory, EthGetLogsRequest, EthNewFilter } from '../../app/ts/types/JsonRpc-types.js'
-import { CanonicalEthereumQuantity, EthereumAddress, EthereumBlockTag, EthereumBytes16, EthereumBytes256, EthereumBytes32, EthereumQuantity, serialize } from '../../app/ts/types/wire-types.js'
+import { CanonicalEthereumQuantity, EthereumAddress, EthereumBlockHeader, EthereumBlockTag, EthereumBytes16, EthereumBytes256, EthereumBytes32, EthereumQuantity, serialize } from '../../app/ts/types/wire-types.js'
+import { assertIsObject } from '../../app/ts/utils/typescript.js'
+import { eth_getBlockByNumber_goerli_8443561_true } from '../RPCResponses.js'
 
 const blockHash = `0x${ '12'.repeat(32) }`
 
@@ -60,5 +62,46 @@ describe('JSON-RPC boundary validation', () => {
 		assert.equal(FeeHistory.safeParse({ method: 'eth_feeHistory', params: ['0x5', 'latest', [-1]] }).success, false)
 		assert.equal(FeeHistory.safeParse({ method: 'eth_feeHistory', params: ['0x5', 'latest', [101]] }).success, false)
 		assert.equal(FeeHistory.safeParse({ method: 'eth_feeHistory', params: ['0x5', 'latest', [75, 25]] }).success, false)
+	})
+
+	test('requires block data on known transactions in full block responses', () => {
+		const response = JSON.parse(eth_getBlockByNumber_goerli_8443561_true)
+		assertIsObject(response)
+		assertIsObject(response.result)
+		if (!Array.isArray(response.result.transactions)) throw new Error('full block transactions missing')
+		const transaction = response.result.transactions[0]
+		assertIsObject(transaction)
+		const { blockHash: _blockHash, blockNumber: _blockNumber, transactionIndex: _transactionIndex, data: _data, ...transactionWithoutBlockData } = transaction
+
+		assert.equal(EthereumBlockHeader.safeParse({ ...response.result, transactions: [transactionWithoutBlockData] }).success, false)
+	})
+
+	test('keeps Optimism deposits and unknown future full block transactions compatible', () => {
+		const response = JSON.parse(eth_getBlockByNumber_goerli_8443561_true)
+		assertIsObject(response)
+		assertIsObject(response.result)
+		const parsedBlock = EthereumBlockHeader.parse({
+			...response.result,
+			transactions: [{
+				type: '0x7e',
+				sourceHash: blockHash,
+				from: '0x0000000000000000000000000000000000000001',
+				to: null,
+				mint: null,
+				value: '0x0',
+				gas: '0x5208',
+				data: '0x',
+				hash: `0x${ '34'.repeat(32) }`,
+				gasPrice: '0x1',
+				nonce: '0x0',
+			}, {
+				hash: `0x${ '56'.repeat(32) }`,
+				type: '0x5',
+			}],
+		})
+		if (parsedBlock === null) throw new Error('full block was null')
+
+		assert.equal(parsedBlock.transactions[0]?.type, 'optimismDeposit')
+		assert.equal(parsedBlock.transactions[1]?.type, '0x5')
 	})
 })

--- a/test/tests/jsonRpcBoundaryValidation.test.ts
+++ b/test/tests/jsonRpcBoundaryValidation.test.ts
@@ -1,7 +1,7 @@
 import * as assert from 'assert'
 import { describe, test } from 'bun:test'
 import { EthereumJsonRpcRequest, FeeHistory, EthGetLogsRequest, EthNewFilter } from '../../app/ts/types/JsonRpc-types.js'
-import { CanonicalEthereumQuantity, EthereumAddress, EthereumBlockHeader, EthereumBlockTag, EthereumBytes16, EthereumBytes256, EthereumBytes32, EthereumQuantity, serialize } from '../../app/ts/types/wire-types.js'
+import { CanonicalEthereumQuantity, EthereumAddress, EthereumBlockHeader, EthereumBlockTag, EthereumBytes16, EthereumBytes256, EthereumBytes32, EthereumQuantity, EthereumSignedTransactionWithBlockData, serialize } from '../../app/ts/types/wire-types.js'
 import { assertIsObject } from '../../app/ts/utils/typescript.js'
 import { eth_getBlockByNumber_goerli_8443561_true } from '../RPCResponses.js'
 
@@ -63,6 +63,29 @@ describe('JSON-RPC boundary validation', () => {
 		assert.equal(FeeHistory.safeParse({ method: 'eth_feeHistory', params: ['0x5', 'latest', [101]] }).success, false)
 		assert.equal(FeeHistory.safeParse({ method: 'eth_feeHistory', params: ['0x5', 'latest', [75, 25]] }).success, false)
 	})
+
+	for (const data of [undefined, '0x1234']) {
+		test(`preserves calldata and optional data alias through full-block and transaction round trips (${ data })`, () => {
+			const response = JSON.parse(eth_getBlockByNumber_goerli_8443561_true)
+			assertIsObject(response)
+			assertIsObject(response.result)
+			if (!Array.isArray(response.result.transactions)) throw new Error('full block transactions missing')
+			const original = response.result.transactions[0]
+			assertIsObject(original)
+			const { data: _data, ...withoutData } = original
+			const transaction = { ...withoutData, input: '0x1234', ...(data === undefined ? {} : { data }) }
+			const block = EthereumBlockHeader.parse({ ...response.result, transactions: [transaction] })
+			const serializedBlock = serialize(EthereumBlockHeader, block)
+			if (serializedBlock === null) throw new Error('full block missing')
+			const serializedTransaction = serialize(EthereumSignedTransactionWithBlockData, EthereumSignedTransactionWithBlockData.parse(transaction))
+			for (const result of [serializedBlock.transactions[0], serializedTransaction]) {
+				if (result === undefined || !('input' in result)) throw new Error('known transaction missing')
+				assert.equal(result.input, '0x1234')
+				assert.equal(result.data, data)
+				if (data === undefined) assert.equal(Object.hasOwn(JSON.parse(JSON.stringify(result)), 'data'), false)
+			}
+		})
+	}
 
 	test('requires block data on known transactions in full block responses', () => {
 		const response = JSON.parse(eth_getBlockByNumber_goerli_8443561_true)


### PR DESCRIPTION
## Summary

- enrich simulated full-block transactions with `blockHash`, `blockNumber`, `transactionIndex`, `data`, `v`, and realized `gasPrice`
- use one block-data helper for input-based blocks, state-based blocks, and transaction-by-hash lookups
- tighten the full-block codec for known transaction types while preserving Optimism deposit and unknown future transaction compatibility
- add regression coverage for both simulation paths and the codec compatibility boundary

## Impact

`eth_getBlockByNumber` and `eth_getBlockByHash` with full objects previously returned bare signed transactions for simulated blocks. Dapps expecting normal JSON-RPC transaction objects could not associate them with a block or determine their effective gas price.

## Validation

- `bun run test` — 1263 tests passed
- `bun run setup-chrome` — passed
- `bun run typecheck` — passed
- `bun run lint` — passed

No open PR matched the affected full-block transaction construction or validation paths when this branch was created.

## Non-goals

This PR does not change the separately known placeholder values for simulated block roots, bloom, mix hash, size, or withdrawal root.