### PR TITLE
Allow user-triggered retry after wallet signing errors

### DIFF
--- a/app/ts/background/providerMessageHandlers.ts
+++ b/app/ts/background/providerMessageHandlers.ts
@@ -22,6 +22,10 @@ import { beginSignerStateConfirmation, clearSignerDerivedTabState, confirmSigner
 import { getConfiguredSigningSafe, getSigningAddressSelectionTransition } from './signingAddressSelection.js'
 import { getWalletSelectedAccount } from '../utils/activeAddressSelection.js'
 
+const isRejectedSignerRequest = (error: { readonly code: number, readonly message: string }) => {
+	return error.code === METAMASK_ERROR_USER_REJECTED_REQUEST || error.message.endsWith('Scan cancelled')
+}
+
 function getSignerCallbackToken(websiteTabConnections: WebsiteTabConnections, port: browser.runtime.Port, signerProviderGeneration: number) {
 	const socket = getSocketFromPort(port)
 	if (socket === undefined) return undefined
@@ -307,7 +311,7 @@ export async function signerReply(ethereum: EthereumClientService, tokenPriceSer
 					}
 					return doNotReply
 				}
-				if (params.error.code === METAMASK_ERROR_USER_REJECTED_REQUEST) {
+				if (isRejectedSignerRequest(params.error)) {
 					await updatePendingTransactionOrMessage(uniqueRequestIdentifier, async (transaction) => modifyObject(transaction, { approvalStatus: { status: 'WaitingForUser' } }))
 					await updateConfirmTransactionView(ethereum, tokenPriceService)
 					return doNotReply

--- a/app/ts/background/providerMessageHandlers.ts
+++ b/app/ts/background/providerMessageHandlers.ts
@@ -22,10 +22,6 @@ import { beginSignerStateConfirmation, clearSignerDerivedTabState, confirmSigner
 import { getConfiguredSigningSafe, getSigningAddressSelectionTransition } from './signingAddressSelection.js'
 import { getWalletSelectedAccount } from '../utils/activeAddressSelection.js'
 
-const isRejectedSignerRequest = (error: { readonly code: number, readonly message: string }) => {
-	return error.code === METAMASK_ERROR_USER_REJECTED_REQUEST || error.message.endsWith('Scan cancelled')
-}
-
 function getSignerCallbackToken(websiteTabConnections: WebsiteTabConnections, port: browser.runtime.Port, signerProviderGeneration: number) {
 	const socket = getSocketFromPort(port)
 	if (socket === undefined) return undefined
@@ -311,7 +307,7 @@ export async function signerReply(ethereum: EthereumClientService, tokenPriceSer
 					}
 					return doNotReply
 				}
-				if (isRejectedSignerRequest(params.error)) {
+				if (params.error.code === METAMASK_ERROR_USER_REJECTED_REQUEST) {
 					await updatePendingTransactionOrMessage(uniqueRequestIdentifier, async (transaction) => modifyObject(transaction, { approvalStatus: { status: 'WaitingForUser' } }))
 					await updateConfirmTransactionView(ethereum, tokenPriceService)
 					return doNotReply

--- a/app/ts/components/pages/ConfirmTransaction.tsx
+++ b/app/ts/components/pages/ConfirmTransaction.tsx
@@ -722,6 +722,8 @@ export function ConfirmationActionButtons({ identified, signerName, simulationMo
 	</div>
 }
 
+export const shouldDisableConfirmForApprovalStatus = (approvalStatus: PendingTransactionOrSignableMessage['approvalStatus']) => approvalStatus.status === 'WaitingForSigner'
+
 function ConfirmationButtons({ currentPendingTransactionOrSignableMessage, reject, rejectButtonState, approve, approveButtonState, confirmDisabled, addToSafeStack, addToSafeStackButtonState, addToSafeStackDisabled }: ButtonsParams) {
 	if (currentPendingTransactionOrSignableMessage === undefined) return <RejectButton onClick = { reject } state = { rejectButtonState }/>
 	if (currentPendingTransactionOrSignableMessage.transactionOrMessageCreationStatus !== 'Simulated') return <RejectButton onClick = { reject } state = { rejectButtonState }/>
@@ -957,7 +959,7 @@ export function ConfirmTransaction() {
 	const isConfirmDisabled = useComputed(() => {
 		if (currentPendingTransactionOrSignableMessage.value === undefined) return true
 		if (currentPendingTransactionOrSignableMessage.value.transactionOrMessageCreationStatus !== 'Simulated') return true
-		if (currentPendingTransactionOrSignableMessage.value.approvalStatus.status !== 'WaitingForUser') return true
+		if (shouldDisableConfirmForApprovalStatus(currentPendingTransactionOrSignableMessage.value.approvalStatus)) return true
 		if (currentPendingTransactionOrSignableMessage.value.type !== 'Transaction') {
 			return shouldDisableSignableMessageConfirm({
 				isValidMessage: currentPendingTransactionOrSignableMessage.value.visualizedPersonalSignRequest.isValidMessage === true,

--- a/test/tests/popupHeaderMarkup.test.tsx
+++ b/test/tests/popupHeaderMarkup.test.tsx
@@ -4,7 +4,7 @@ import { h, render } from 'preact'
 import { act } from 'preact/test-utils'
 import { describe, test } from 'bun:test'
 import { SignatureHeader } from '../../app/ts/components/pages/PersonalSign.js'
-import { CheckBoxes, ConfirmationActionButtons } from '../../app/ts/components/pages/ConfirmTransaction.js'
+import { CheckBoxes, ConfirmationActionButtons, shouldDisableConfirmForApprovalStatus } from '../../app/ts/components/pages/ConfirmTransaction.js'
 import { TransactionHeader } from '../../app/ts/components/simulationExplaining/SimulationSummary.js'
 import { PendingStackHeader } from '../../app/ts/components/simulationExplaining/Transactions.js'
 import { identifyTransaction } from '../../app/ts/components/simulationExplaining/identifyTransaction.js'
@@ -163,6 +163,12 @@ function assertClasses(node: TestNode | undefined, expectedClasses: string[]) {
 }
 
 describe('popup header markup', () => {
+	test('allows user-triggered retries after signer errors while blocking duplicate pending requests', () => {
+		assert.equal(shouldDisableConfirmForApprovalStatus({ status: 'WaitingForUser' }), false)
+		assert.equal(shouldDisableConfirmForApprovalStatus({ status: 'WaitingForSigner' }), true)
+		assert.equal(shouldDisableConfirmForApprovalStatus({ status: 'SignerError', code: -32603, message: 'Signer request failed.' }), false)
+	})
+
 	test('TransactionHeader renders the fallback title inside the ellipsis target and composes the flush website class', async () => {
 		const dom = installDomMock()
 

--- a/test/tests/safeSignerRouting.suite.ts
+++ b/test/tests/safeSignerRouting.suite.ts
@@ -71,7 +71,7 @@ test('accepts a signer reply from the current approved child-frame port', async 
 	assert.equal(childReply.result, modules.EthereumBytes32.serialize(signedTransaction.hash))
 })
 
-test('allows retrying a Safe signature after MetaMask cancels a keyring scan', async () => {
+test('preserves a MetaMask keyring scan error on a retryable Safe signature', async () => {
 	const socket = uniqueRequestIdentifier.requestSocket
 	const safeTx = createSafeTx(fakeRpcNetwork.chainId, activeAddress, {
 		to: recipientAddress,
@@ -139,7 +139,11 @@ test('allows retrying a Safe signature after MetaMask cancels a keyring scan', a
 	}, 'hasAccess', activeAddress)
 
 	const [retryableTransaction] = await modules.getPendingTransactionsAndMessages()
-	assert.equal(retryableTransaction?.approvalStatus.status, 'WaitingForUser')
+	assert.deepEqual(retryableTransaction?.approvalStatus, {
+		status: 'SignerError',
+		code: -32603,
+		message: 'Keyring Controller signTypedMessage: Error: Scan cancelled',
+	})
 	assert.equal(retryableTransaction?.safeTransaction?.safeTxHash, safeTxHash)
 })
 

--- a/test/tests/safeSignerRouting.suite.ts
+++ b/test/tests/safeSignerRouting.suite.ts
@@ -71,6 +71,78 @@ test('accepts a signer reply from the current approved child-frame port', async 
 	assert.equal(childReply.result, modules.EthereumBytes32.serialize(signedTransaction.hash))
 })
 
+test('allows retrying a Safe signature after MetaMask cancels a keyring scan', async () => {
+	const socket = uniqueRequestIdentifier.requestSocket
+	const safeTx = createSafeTx(fakeRpcNetwork.chainId, activeAddress, {
+		to: recipientAddress,
+		value: 0n,
+		input: new Uint8Array(),
+	}, 0n)
+	const safeTxHash = BigInt(getSafeTxHash(safeTx))
+	const messages: unknown[] = []
+	const port = createWebsitePort(socket, 0, messages)
+	const websiteOrigin = 'https://example.com'
+	const websiteTabConnections = new Map([[socket.tabId, {
+		signerStateOwner: {
+			connectionName: socket.connectionName,
+			confirmed: true,
+			generation: 3,
+			providerGeneration: 8,
+		},
+		connections: {
+			[modules.websiteSocketToString(socket)]: { port, socket, websiteOrigin, approved: true, wantsToConnect: true },
+		},
+	}]])
+	await modules.browserStorageLocalSet2({
+		pendingTransactionsAndMessages: [{
+			...pendingTransaction,
+			simulationMode: false,
+			approvalStatus: { status: 'WaitingForSigner' },
+			safeTransaction: {
+				safeAddress: activeAddress,
+				safeSignerAddress: recipientAddress,
+				safeVersion: '1.4.1',
+				threshold: 2n,
+				reviewedSafeState: {
+					version: '1.4.1',
+					nonce: 0n,
+					owners: [recipientAddress],
+					threshold: 2n,
+				},
+				safeTxHash,
+				safeTx,
+			},
+		}],
+	})
+
+	await modules.signerReply(simulator.ethereum, simulator.tokenPriceService, () => undefined, websiteTabConnections, port, {
+		method: 'signer_reply',
+		params: [{
+			success: false,
+			signerProviderGeneration: 8,
+			forwardRequest: {
+				type: 'forwardToSigner',
+				replyWithSignersReply: true,
+				method: 'eth_signTypedData_v4',
+				params: [recipientAddress, EIP712Message.parse(safeTxToTypedDataJson(safeTx))],
+				requestId: uniqueRequestIdentifier.requestId,
+			},
+			error: {
+				code: -32603,
+				message: 'Keyring Controller signTypedMessage: Error: Scan cancelled',
+			},
+		}],
+		interceptorRequest: true,
+		interceptorInternalRequest: true,
+		usingInterceptorWithoutSigner: false,
+		uniqueRequestIdentifier: { requestId: 79, requestSocket: socket },
+	}, 'hasAccess', activeAddress)
+
+	const [retryableTransaction] = await modules.getPendingTransactionsAndMessages()
+	assert.equal(retryableTransaction?.approvalStatus.status, 'WaitingForUser')
+	assert.equal(retryableTransaction?.safeTransaction?.safeTxHash, safeTxHash)
+})
+
 test('forwards a Safe transaction to the wallet-selected Safe owner as EIP-712 typed data', async () => {
 	await modules.updateTabState(uniqueRequestIdentifier.requestSocket.tabId, (state) => ({
 		...state,


### PR DESCRIPTION
## Problem

When an external wallet returned a signing error, Interceptor left the confirmation action disabled. For example, cancelling a SAFE USDC transfer in MetaMask could return `Keyring Controller signTypedMessage: Error: Scan cancelled`, leaving the user able to reject the Interceptor request but unable to try signing again.

## Changes

- Enable the sign/transfer action after any settled signer error.
- Keep the signer error visible so the user can decide whether to retry or reject.
- Keep the action disabled while a wallet request is still pending, preventing duplicate requests.
- Keep signer routing provider-neutral: standard `4001` rejections return to `WaitingForUser`, while other errors remain visible `SignerError`s and are also retryable.
- Preserve pending SAFE transaction metadata across signer errors.
- Add regression coverage for the observed SAFE EIP-712 MetaMask scan error and all confirmation approval states.

Retries are never automatic. Interceptor contacts the wallet again only after the user clicks the sign/transfer action. All existing simulation, quarantine, RPC-support, and SAFE validation checks continue to apply before forwarding the retry.

## Validation

- `bun run test` — 1,278 passed, 0 failed
- `bun run setup-chrome`
- `bun run typecheck`
- `bun run lint`

`bun run test:chrome-communication` was not run because this change does not modify browser communication boundaries.