### PR TITLE
Configure reviewer agents for gpt-6-astra

### DIFF
--- a/.codex/agents/reviewer.toml
+++ b/.codex/agents/reviewer.toml
@@ -1,7 +1,7 @@
 name = "reviewer"
 description = "Read-only final code reviewer for The Interceptor that checks the current worktree diff against origin/main, the stated task intent, validation results, extension behavior, generated-output policy, and long-term maintainability."
-model = "gpt-5.5"
-model_reasoning_effort = "high"
+model = "gpt-6-astra"
+model_reasoning_effort = "low"
 sandbox_mode = "read-only"
 nickname_candidates = ["Audit", "Inspect", "Review"]
 developer_instructions = """


### PR DESCRIPTION
## Summary
- configure reviewer agents to use gpt-6-astra
- set reviewer reasoning effort to low

## Validation
- `bun run lint` passed
- `bun run test`, `bun run setup-chrome`, and `bun run typecheck` remain blocked by existing compiler/dependency issues