### PR TITLE
Audit 1: fix UI signal, hooks-order, and error-handling bugs

### DIFF
--- a/app/ts/background/popupMessageHandlerRegistries/settings.ts
+++ b/app/ts/background/popupMessageHandlerRegistries/settings.ts
@@ -7,7 +7,7 @@ import { getSettings } from '../settings.js'
 export const settingsPopupMessageHandlers = {
 	popup_changeActiveRpc: popupMessageHandler('popup_changeActiveRpc', async (context, request) => await popupChangeActiveRpc(context.ethereum, context.tokenPriceService, context.resetSimulationServices, context.websiteTabConnections, request, context.settings)),
 	popup_requestSettings: popupMessageHandler('popup_requestSettings', async () => await settingsOpened()),
-	popup_ChangeSettings: popupMessageHandler('popup_ChangeSettings', async (context, request) => await changeSettings(context.ethereum, context.tokenPriceService, context.resetSimulationServices, request, context.simulationAbortController)),
+	popup_ChangeSettings: popupMessageHandler('popup_ChangeSettings', async (context, request) => await changeSettings(context.ethereum, context.tokenPriceService, context.resetSimulationServices, context.websiteTabConnections, request, context.simulationAbortController)),
 	popup_openSettings: popupMessageHandler('popup_openSettings', async () => await openNewTab('settingsView')),
 	popup_import_settings: popupMessageHandler('popup_import_settings', async (context, request) => {
 		const importSettingsReply = await importSettings(request)

--- a/app/ts/background/popupMessageHandlers.ts
+++ b/app/ts/background/popupMessageHandlers.ts
@@ -867,13 +867,13 @@ export async function interceptorAccessChangeAddressOrRefresh(websiteTabConnecti
 	await requestAddressChange(websiteTabConnections, params)
 }
 
-export async function changeSettings(ethereum: EthereumClientService, _tokenPriceService: TokenPriceService, _resetSimulationServices: ResetSimulationServices, parsedRequest: ChangeSettings, requestAbortController: AbortController | undefined) {
+export async function changeSettings(ethereum: EthereumClientService, _tokenPriceService: TokenPriceService, _resetSimulationServices: ResetSimulationServices, websiteTabConnections: WebsiteTabConnections, parsedRequest: ChangeSettings, requestAbortController: AbortController | undefined) {
 	if (parsedRequest.data.useTabsInsteadOfPopup !== undefined) await setUseTabsInsteadOfPopup(parsedRequest.data.useTabsInsteadOfPopup)
 	if (parsedRequest.data.metamaskCompatibilityMode !== undefined) await setMetamaskCompatibilityMode(parsedRequest.data.metamaskCompatibilityMode)
 	if (parsedRequest.data.safeAppsCompatibilityMode !== undefined) {
 		await setSafeAppsCompatibilityMode(parsedRequest.data.safeAppsCompatibilityMode)
 	}
-	return await requestNewHomeData(ethereum, new Map(), false, true, requestAbortController, bumpPopupRefreshGeneration())
+	return await requestNewHomeData(ethereum, websiteTabConnections, false, true, requestAbortController, bumpPopupRefreshGeneration())
 }
 
 export async function simulateGovernanceContractExecutionOnPass(ethereum: EthereumClientService, tokenPriceService: TokenPriceService, request: SimulateGovernanceContractExecution) {

--- a/app/ts/background/windows/confirmTransaction.ts
+++ b/app/ts/background/windows/confirmTransaction.ts
@@ -236,7 +236,7 @@ const getPendingTransactionOrMessageByidentifier = async (uniqueRequestIdentifie
 	return (await getPendingTransactionsAndMessages()).find((tx) => doesUniqueRequestIdentifiersMatch(tx.uniqueRequestIdentifier, uniqueRequestIdentifier))
 }
 
-export const setGasLimitForTransaction = async (transactionIdentifier: BigInt, gasLimit: bigint) => {
+export const setGasLimitForTransaction = async (transactionIdentifier: bigint, gasLimit: bigint) => {
 	const pendingTransaction = (await getPendingTransactionsAndMessages()).find((tx) => tx.type === 'Transaction' && tx.transactionIdentifier === transactionIdentifier)
 	if (pendingTransaction === undefined) {
 		const theTransactionIsAlreadyInStack = (await getInterceptorTransactionStack()).operations.some((transaction) => transaction.type === 'Transaction' && transaction.preSimulationTransaction.transactionIdentifier === transactionIdentifier)

--- a/app/ts/components/pages/ConfirmTransaction.tsx
+++ b/app/ts/components/pages/ConfirmTransaction.tsx
@@ -192,8 +192,6 @@ export function getTransactionStatusLabel(status: PendingTransactionOrSignableMe
 }
 
 const TransactionNames = (param: TransactionNamesParams) => {
-	if (param.completeVisualizedSimulation.value.simulationResultState !== 'done' || param.completeVisualizedSimulation.value.simulationState.kind === 'passthrough') return <></>
-
 	const titleOfCurrentPendingTransaction = () => {
 		const currentPendingTransactionOrSignableMessage = param.currentPendingTransaction.value
 		if (currentPendingTransactionOrSignableMessage === undefined) return 'Loading...'
@@ -212,6 +210,8 @@ const TransactionNames = (param: TransactionNamesParams) => {
 		const names = transactionsAndMessages.map((transactionOrMessage) => 'transaction' in transactionOrMessage ? identifyTransaction(transactionOrMessage).title : identifySignature(transactionOrMessage).title)
 		return [...param.completeVisualizedSimulation.value.numberOfAddressesMadeRich > 0 ? [`Simply making ${ param.completeVisualizedSimulation.value.numberOfAddressesMadeRich } addresses rich`] : [], ...names, ...param.includeCurrentTransaction ? [titleOfCurrentPendingTransaction()] : [] ]
 	})
+
+	if (param.completeVisualizedSimulation.value.simulationResultState !== 'done' || param.completeVisualizedSimulation.value.simulationState.kind === 'passthrough') return <></>
 
 	return <nav class = 'breadcrumb has-succeeds-separator is-small'>
 		<ul>
@@ -389,9 +389,20 @@ function TransactionCardContent(param: TransactionCardContentParams) {
 			/>
 		</>
 	}
+	return <SuccessfulTransactionCardContent { ...param } simulatedPendingTransaction = { currentPendingTransaction } successfulPopupVisualisation = { popupVisualisation } />
+}
+
+type SuccessfulTransactionCardContentParams = TransactionCardContentParams & {
+	simulatedPendingTransaction: SimulatedPendingTransaction,
+	successfulPopupVisualisation: NonNullable<ReturnType<typeof getSuccessfulTransactionPopupVisualisation>>,
+}
+
+function SuccessfulTransactionCardContent(param: SuccessfulTransactionCardContentParams) {
 	const activeAddress = useComputed(() => getSuccessfulTransactionPopupVisualisation(param.currentPendingTransaction.value)?.data.activeAddress)
-	const addressMetaData = useComputed(() => getSuccessfulTransactionPopupVisualisation(param.currentPendingTransaction.value)?.data.addressBookEntries ?? popupVisualisation.data.addressBookEntries)
-	const rpcNetwork = useComputed(() => getSuccessfulTransactionPopupVisualisation(param.currentPendingTransaction.value)?.data.simulationState.rpcNetwork ?? popupVisualisation.data.simulationState.rpcNetwork)
+	const addressMetaData = useComputed(() => getSuccessfulTransactionPopupVisualisation(param.currentPendingTransaction.value)?.data.addressBookEntries ?? param.successfulPopupVisualisation.data.addressBookEntries)
+	const rpcNetwork = useComputed(() => getSuccessfulTransactionPopupVisualisation(param.currentPendingTransaction.value)?.data.simulationState.rpcNetwork ?? param.successfulPopupVisualisation.data.simulationState.rpcNetwork)
+	const currentPendingTransaction = param.simulatedPendingTransaction
+	const popupVisualisation = param.successfulPopupVisualisation
 	const simulationAndVisualisationResults = {
 		blockNumber: popupVisualisation.data.simulationState.blockNumber,
 		blockTimestamp: popupVisualisation.data.simulationState.blockTimestamp,
@@ -768,6 +779,7 @@ export function ConfirmTransaction() {
 	const modalState = useSignal<ModalState>({ page: 'noModal' })
 	const rpcConnectionStatus = useSignal<RpcConnectionStatus>(undefined)
 	const pendingTransactionAddedNotification = useSignal<boolean>(false)
+	const dismissedRawTransactionNotification = useSignal<bigint | undefined>(undefined)
 	const unexpectedError = useSignal<CaughtError | undefined>(undefined)
 	const rpcEntries = useSignal<RpcEntries>([])
 	const pendingTransactionsDataPriority = useSignal(0)
@@ -777,7 +789,9 @@ export function ConfirmTransaction() {
 	const applyPendingTransactions = (pendingTransactions: readonly PendingTransactionOrSignableMessage[], priority: number) => {
 		if (priority < pendingTransactionsDataPriority.value) return
 		pendingTransactionsDataPriority.value = priority
+		const previousPendingTransactions = pendingTransactionsAndSignableMessages.value
 		pendingTransactionsAndSignableMessages.value = pendingTransactions
+		if (previousPendingTransactions.length > 0 && pendingTransactions.length > previousPendingTransactions.length) pendingTransactionAddedNotification.value = true
 		const firstMessage = pendingTransactions[0]
 		if (firstMessage === undefined) return
 		currentPendingTransactionOrSignableMessage.value = firstMessage
@@ -948,6 +962,11 @@ export function ConfirmTransaction() {
 			if (deliveryError !== undefined) unexpectedError.value = deliveryError
 		})
 	}
+	const dismissRawTransactionNotification = () => {
+		const current = currentPendingTransactionOrSignableMessage.value
+		if (current?.type !== 'Transaction') return
+		dismissedRawTransactionNotification.value = current.transactionIdentifier
+	}
 	const refreshMetadata = async () => {
 		if (currentPendingTransactionOrSignableMessage.value === undefined) return
 		await sendPopupMessageToBackgroundPage({ method: 'popup_refreshConfirmTransactionMetadata'})
@@ -1022,6 +1041,8 @@ export function ConfirmTransaction() {
 		await sendPopupMessageToBackgroundPage( { method: 'popup_clearUnexpectedError' } )
 	}
 
+	const underTransactions = useComputed(() => pendingTransactionsAndSignableMessages.value.slice(1).reverse())
+
 	if (currentPendingTransactionOrSignableMessage.value === undefined || (currentPendingTransactionOrSignableMessage.value.transactionOrMessageCreationStatus !== 'Simulated' && currentPendingTransactionOrSignableMessage.value.transactionOrMessageCreationStatus !== 'FailedToSimulate')) {
 		return <>
 				<main>
@@ -1035,7 +1056,6 @@ export function ConfirmTransaction() {
 			</main>
 		</>
 	}
-	const underTransactions = useComputed(() => pendingTransactionsAndSignableMessages.value.slice(1).reverse())
 	return (
 			<main>
 				<Hint>
@@ -1046,12 +1066,12 @@ export function ConfirmTransaction() {
 					</div>
 					<div class = 'popup-contents'>
 						<div style = 'margin: 10px'>
-							{ currentPendingTransactionOrSignableMessage.value.originalRequestParameters.method === 'eth_sendRawTransaction' && currentPendingTransactionOrSignableMessage.value.type === 'Transaction'
+							{ currentPendingTransactionOrSignableMessage.value.originalRequestParameters.method === 'eth_sendRawTransaction' && currentPendingTransactionOrSignableMessage.value.type === 'Transaction' && currentPendingTransactionOrSignableMessage.value.transactionIdentifier !== dismissedRawTransactionNotification.value
 								? <DinoSaysNotification
 									text = { `This transaction is signed already. No extra signing required to forward it to ${ currentPendingTransactionOrSignableMessage.value.transactionOrMessageCreationStatus !== 'Simulated' || currentPendingTransactionOrSignableMessage.value.popupVisualisation.statusCode === 'failed' ?
 									'network' :
 									currentPendingTransactionOrSignableMessage.value.popupVisualisation.data.simulationState.rpcNetwork.name }.` }
-									close = { () => { pendingTransactionAddedNotification.value = false } }
+									close = { dismissRawTransactionNotification }
 								/>
 								: <></>
 							}

--- a/app/ts/components/simulationExplaining/SimulationSummary.tsx
+++ b/app/ts/components/simulationExplaining/SimulationSummary.tsx
@@ -350,7 +350,7 @@ type SummarizeAddressParams = {
 
 function SummarizeAddress(param: SummarizeAddressParams) {
 	const isOwnAddress = useComputed(() => param.balanceSummary.summaryFor.useAsActiveAddress || param.balanceSummary.summaryFor.address === param.activeAddress.value)
-	const positiveNegativeColors = isOwnAddress
+	const positiveNegativeColors = isOwnAddress.value
 		? {
 			textColor: 'var(--text-color)',
 			negativeColor: 'var(--text-color)'
@@ -361,7 +361,7 @@ function SummarizeAddress(param: SummarizeAddressParams) {
 		}
 
 	return <div>
-		{ isOwnAddress ?
+		{ isOwnAddress.value ?
 			<BigAddress
 				addressBookEntry = { param.balanceSummary.summaryFor }
 				renameAddressCallBack = { param.renameAddressCallBack }
@@ -824,6 +824,7 @@ function EnsChangesSummary({ ensEvents, editEnsNamedHashCallBack, renameAddressC
 }
 
 export function SimulationSummary(param: SimulationSummaryParams) {
+	const showOtherAccountChanges = useSignal<boolean>(false)
 	const currentResults = param.simulationAndVisualisationResults.value
 	if (currentResults.kind === 'passthrough') return <></>
 	const visualizedSimulationState = currentResults.value.visualizedSimulationState
@@ -833,7 +834,6 @@ export function SimulationSummary(param: SimulationSummaryParams) {
 	const addressMetaData = new Map(simulationAndVisualisationResults.addressBookEntries.map((x) => [addressString(x.address), x]))
 	const originalSummary = summarizeLogs(simulatedTransactions, addressMetaData, simulationAndVisualisationResults.tokenPriceEstimates, simulationAndVisualisationResults.namedTokenIds)
 	const [ownAddresses, notOwnAddresses] = splitToOwnAndNotOwnAndCleanSummary(originalSummary, param.activeAddress.value)
-	const showOtherAccountChanges = useSignal<boolean>(false)
 
 	if (ownAddresses === undefined || notOwnAddresses === undefined) throw new Error('addresses were undefined')
 

--- a/app/ts/components/simulationExplaining/SwapTransactions.tsx
+++ b/app/ts/components/simulationExplaining/SwapTransactions.tsx
@@ -175,11 +175,8 @@ export function identifyRoutes(simulatedAndVisualizedTransaction: SimulatedAndVi
 		if (!('amount' in result)) return false // cannot deal with nft's
 
 		const from = graph.get(fromAddress)
-		if(!from!.has(tokenAddress)) {
-			from!.set(tokenAddress, { to: toAddress, tokenResultIndex: tokenResultIndex } )
-		} else {
-			return false
-		}
+		if (from === undefined || from.has(tokenAddress)) return false
+		from.set(tokenAddress, { to: toAddress, tokenResultIndex: tokenResultIndex } )
 	}
 
 	// traverse chain

--- a/app/ts/components/simulationExplaining/customExplainers/GnosisSafeVisualizer.tsx
+++ b/app/ts/components/simulationExplaining/customExplainers/GnosisSafeVisualizer.tsx
@@ -35,11 +35,11 @@ const ShowSuccessOrFailure = ({ simulateExecutionReply, activeAddress, renameAdd
 		return lastBlock.simulatedAndVisualizedTransactions[lastBlock.simulatedAndVisualizedTransactions.length - 1]
 	})
 	const addressMetaData = useComputed(() => {
-		if (simulateExecutionReply.value === undefined || simulateExecutionReply.value.data.success === false) throw new Error('failed simulation')
+		if (simulateExecutionReply.value === undefined || simulateExecutionReply.value.data.success === false) return []
 		return simulateExecutionReply.value.data.result.addressBookEntries
 	})
 	const results = useComputed(() => {
-		if (simulateExecutionReply.value === undefined || simulateExecutionReply.value.data.success === false) throw new Error('failed simulation')
+		if (simulateExecutionReply.value === undefined || simulateExecutionReply.value.data.success === false || activeAddress.value === undefined) return undefined
 		return {
 			blockNumber: simulateExecutionReply.value.data.result.simulationState.blockNumber,
 			blockTimestamp: simulateExecutionReply.value.data.result.simulationState.blockTimestamp,
@@ -48,7 +48,7 @@ const ShowSuccessOrFailure = ({ simulateExecutionReply, activeAddress, renameAdd
 			addressBookEntries: simulateExecutionReply.value.data.result.addressBookEntries,
 			rpcNetwork: simulateExecutionReply.value.data.result.simulationState.rpcNetwork,
 			tokenPriceEstimates: simulateExecutionReply.value.data.result.tokenPriceEstimates,
-			activeAddress: activeAddress.value!,
+			activeAddress: activeAddress.value,
 			visualizedSimulationState: simulateExecutionReply.value.data.result.visualizedSimulationState,
 			namedTokenIds: simulateExecutionReply.value.data.result.namedTokenIds,
 		}
@@ -84,7 +84,7 @@ const ShowSuccessOrFailure = ({ simulateExecutionReply, activeAddress, renameAdd
 			<ErrorComponent text = { rpcErrorText }/>
 		</div>
 	}
-	if (simTx.value === undefined || activeAddress.value === undefined) return <></>
+	if (simTx.value === undefined || activeAddress.value === undefined || results.value === undefined) return <></>
 
 	return <div class = 'safe-outcome-panel__result'>
 		{ requestErrorText === undefined ? <></> : <ErrorComponent text = { requestErrorText }/> }

--- a/app/ts/components/simulationExplaining/customExplainers/GovernanceVoteVisualizer.tsx
+++ b/app/ts/components/simulationExplaining/customExplainers/GovernanceVoteVisualizer.tsx
@@ -104,11 +104,11 @@ const ShowSuccessOrFailure = ({ simulateExecutionReply, simTx, activeAddress, re
 		return lastBlock.simulatedAndVisualizedTransactions[lastBlock.simulatedAndVisualizedTransactions.length - 1]
 	})
 	const addressMetaData = useComputed(() => {
-		if (simulateExecutionReply.value === undefined || simulateExecutionReply.value.data.success === false) throw new Error('failed simulation')
+		if (simulateExecutionReply.value === undefined || simulateExecutionReply.value.data.success === false) return []
 		return simulateExecutionReply.value.data.result.addressBookEntries
 	})
 	const results = useComputed(() => {
-		if (simulateExecutionReply.value === undefined || simulateExecutionReply.value.data.success === false) throw new Error('failed simulation')
+		if (simulateExecutionReply.value === undefined || simulateExecutionReply.value.data.success === false || activeAddress.value === undefined) return undefined
 		return {
 			blockNumber: simulateExecutionReply.value.data.result.simulationState.blockNumber,
 			blockTimestamp: simulateExecutionReply.value.data.result.simulationState.blockTimestamp,
@@ -117,7 +117,7 @@ const ShowSuccessOrFailure = ({ simulateExecutionReply, simTx, activeAddress, re
 			addressBookEntries: simulateExecutionReply.value.data.result.addressBookEntries,
 			rpcNetwork: simulateExecutionReply.value.data.result.simulationState.rpcNetwork,
 			tokenPriceEstimates: simulateExecutionReply.value.data.result.tokenPriceEstimates,
-			activeAddress: activeAddress.value!,
+			activeAddress: activeAddress.value,
 			visualizedSimulationState: simulateExecutionReply.value.data.result.visualizedSimulationState,
 			namedTokenIds: simulateExecutionReply.value.data.result.namedTokenIds,
 		}
@@ -161,7 +161,7 @@ const ShowSuccessOrFailure = ({ simulateExecutionReply, simTx, activeAddress, re
 			<ErrorComponent text = { rpcErrorText }/>
 		</div>
 	}
-	if (govSimTx.value === undefined) return <></>
+	if (govSimTx.value === undefined || results.value === undefined) return <></>
 
 	return <div style = 'display: grid; grid-template-rows: max-content; row-gap: 10px;' >
 		{ requestErrorText === undefined ? <></> : <ErrorComponent text = { requestErrorText }/> }

--- a/app/ts/components/subcomponents/DynamicScroller.tsx
+++ b/app/ts/components/subcomponents/DynamicScroller.tsx
@@ -56,7 +56,8 @@ export const DynamicScroller = <T extends {}>({ items, renderItem, }: DynamicScr
 	useSignalEffect(() => {
 		if (!scrollViewRef.current) return
 		const containerObserver = new ResizeObserver(([entry]) => {
-			maxItems.value = itemHeight.value <= 0 ? 0 : Math.ceil(entry!.contentRect.height / itemHeight.value)
+			if (entry === undefined) return
+			maxItems.value = itemHeight.value <= 0 ? 0 : Math.ceil(entry.contentRect.height / itemHeight.value)
 		})
 		containerObserver.observe(scrollViewRef.current)
 		return () => { containerObserver.disconnect() }

--- a/app/ts/simulation/services/EthereumSubscriptionService.ts
+++ b/app/ts/simulation/services/EthereumSubscriptionService.ts
@@ -9,6 +9,8 @@ import { sendSubscriptionReplyOrCallBack } from '../../background/messageSending
 import type { WebsiteSocket } from '../../utils/requests.js'
 import { websiteSocketToString } from '../../background/backgroundUtils.js'
 import { createScopedKeyedSerialExecutor } from '../../utils/semaphore.js'
+import { JsonRpcResponseError } from '../../utils/errors.js'
+import { METAMASK_ERROR_METHOD_NOT_SUPPORTED_BY_PROVIDER } from '../../utils/constants.js'
 
 const dec2hex = (dec: number) => dec.toString(16).padStart(2, '0')
 
@@ -127,9 +129,17 @@ export async function createEthereumSubscription(params: EthSubscribeParams, sub
 			})
 			return subscriptionOrFilterId
 		}
-		case 'logs': throw `Dapp requested for 'logs' subscription but it's not implemented` //TODO: implement
-		case 'newPendingTransactions': throw `Dapp requested for 'newPendingTransactions' subscription but it's not implemented` //TODO: implement
-		case 'syncing': throw `Dapp requested for 'syncing' subscription but it's not implemented` //TODO: implement
+		case 'logs':
+		case 'newPendingTransactions':
+		case 'syncing':
+			throw new JsonRpcResponseError({
+				jsonrpc: '2.0',
+				id: 1,
+				error: {
+					code: METAMASK_ERROR_METHOD_NOT_SUPPORTED_BY_PROVIDER,
+					message: `Dapp requested for '${ params.params[0] }' subscription but it's not implemented`,
+				},
+			})
 	}
 }
 

--- a/test/tests/refreshHomeDataRpcStatus.test.ts
+++ b/test/tests/refreshHomeDataRpcStatus.test.ts
@@ -769,7 +769,7 @@ describe('refreshHomeData', () => {
 		const { messages } = createPort(1)
 
 		try {
-			await changeSettings(ethereum, tokenPriceService, {} as never, { method: 'popup_ChangeSettings', data: { safeAppsCompatibilityMode: false } } as never, undefined)
+			await changeSettings(ethereum, tokenPriceService, {} as never, new Map(), { method: 'popup_ChangeSettings', data: { safeAppsCompatibilityMode: false } } as never, undefined)
 		} finally {
 			ethereum.cleanup()
 		}


### PR DESCRIPTION
First PR of the 6-PR code-quality audit fix series. Fixes the confirmed bugs from Section 1 of the audit.

## Fixes

- **`app/ts/components/simulationExplaining/SimulationSummary.tsx` (`SummarizeAddress`)**: `isOwnAddress` is a `ReadonlySignal<boolean>` but was used directly in ternaries, where the signal object is always truthy. Every address in the simulation summary rendered as an "own address" (BigAddress with own-account colors). Now reads `.value`, so other accounts correctly render with the dimmed SmallAddress styling.
- **Rules-of-hooks violations** (Preact hooks are index-based; hooks after conditional early returns corrupt hook state when the guard flips between renders):
  - `ConfirmTransaction.tsx` (`ConfirmTransaction`): `useComputed` for `underTransactions` hoisted above the loading-state early return.
  - `ConfirmTransaction.tsx` (`TransactionCardContent`): the three `useComputed` calls after the failed-transaction early returns moved into a new `SuccessfulTransactionCardContent` child component that only mounts on the success path.
  - `ConfirmTransaction.tsx` (`TransactionNames`): early return moved below the `useComputed` (which already re-checks the same conditions internally).
  - `SimulationSummary.tsx` (`SimulationSummary`): `useSignal` for `showOtherAccountChanges` hoisted above the two early returns.
- **`ConfirmTransaction.tsx` dead notification + mis-wired close**: the "new transaction queued" DinoSays never appeared because `pendingTransactionAddedNotification` was only ever set to `false`. It is now set to `true` in `applyPendingTransactions` when the pending-transaction list grows while the dialog is already showing one. The raw-transaction ("signed already") notification's close button wrote to that unrelated signal (a no-op); it now uses its own per-transaction dismissal state, so the X button actually dismisses it.
- **`app/ts/background/popupMessageHandlers.ts` (`changeSettings`)**: passed a fabricated empty `new Map()` as `WebsiteTabConnections` to `requestNewHomeData`, so `activeSigningAddressInThisTab` could diverge from every other home-data path after a settings change. Now receives and passes the real `websiteTabConnections` from the handler context (test call site updated accordingly).
- **Latent-crash non-null assertions replaced with proper narrowing**:
  - `SwapTransactions.tsx` (`identifyRoutes`): `from!` twice in the graph builder.
  - `DynamicScroller.tsx`: `entry!` in the ResizeObserver callback.
  - `GovernanceVoteVisualizer.tsx` / `GnosisSafeVisualizer.tsx`: `useComputed`s that threw `new Error('failed simulation')` and asserted `activeAddress.value!` now return a safe value (`[]` / `undefined`) instead, with guards added at the render call sites. No behavior change when data is present; no crash paths when absent.
- **`app/ts/simulation/services/EthereumSubscriptionService.ts`**: unimplemented subscription types (`logs`, `newPendingTransactions`, `syncing`) threw raw template-string literals (no stack, breaks `instanceof Error` handling). Now throws a typed `JsonRpcResponseError` with the `METAMASK_ERROR_METHOD_NOT_SUPPORTED_BY_PROVIDER` code, matching the pattern used elsewhere, so dapps get a proper JSON-RPC error response. Stale `//TODO: implement` markers removed.
- **`app/ts/background/windows/confirmTransaction.ts` (`setGasLimitForTransaction`)**: parameter typed as the `BigInt` object wrapper type, now the primitive `bigint`.

## Validation

- `bun run test`: pass (1374 pass, 0 fail)
- `bun run setup-chrome`: pass
- `bun run typecheck`: pass
- `bun run lint`: pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)